### PR TITLE
P2: quantity-split WooCommerce adapter and stock side-effect proof

### DIFF
--- a/docs/p2-quantity-split-adapter.md
+++ b/docs/p2-quantity-split-adapter.md
@@ -18,16 +18,14 @@ Controllers must not instantiate or call the Split service directly.
 
 ### Request-local physical-stock proof
 
-`WCOS_Stock_Side_Effect_Guard` is active only inside the current mutation request.
-
-Normal WooCommerce product/variation stock writes are intercepted at the `before_set_stock` hooks before the product data store changes. The matching after-write hooks remain observed as fallback evidence for integrations that report a stock write after persistence.
+`WCOS_Stock_Side_Effect_Guard` is active only inside the current mutation request. Normal WooCommerce product/variation stock writes are intercepted at the `before_set_stock` hooks before the product data store changes. Matching after-write hooks remain observed as fallback evidence for integrations that report a stock write after persistence.
 
 Consequences:
 
 - concurrent checkout stock changes in another request do not create false Split failures;
-- a stock-write attempt inside the Split request is blocked before the WooCommerce data store write;
+- an in-request stock-write attempt is blocked before the normal WooCommerce data-store write;
 - a blocked attempt dirties the conservation proof and leaves the same idempotency operation safely retriable;
-- an observed after-write fallback is considered outside the order-only snapshot and must not be auto-compensated without explicit stock reconciliation.
+- a confirmed after-write fallback is outside the order-only snapshot and must not be auto-compensated without explicit stock reconciliation.
 
 The exact P1 before/after stock comparison remains available outside a P2 adapter scope.
 
@@ -103,12 +101,7 @@ The contract proves:
 
 Public line metadata is business configuration by default. Protected stock/refund/mutation metadata is always operational and cannot be promoted by filters.
 
-Private line metadata is fail-closed unless an integration explicitly declares it as either:
-
-- immutable business metadata, which is copied and participates in canonical line identity; or
-- known operational metadata, which is not copied.
-
-Classification must be consistent between Split-copy and identity contexts. The integration matrix proves that two same-product lines with different adapted business configuration remain distinct and do not collapse.
+Private line metadata is fail-closed unless an integration explicitly declares it as either immutable business metadata, which is copied and participates in canonical line identity, or known operational metadata, which is not copied. Classification must be consistent between Split-copy and identity contexts. The integration matrix proves that two same-product lines with different adapted business configuration remain distinct and do not collapse.
 
 ### Durable journal retention
 
@@ -119,21 +112,15 @@ Classification must be consistent between Split-copy and identity contexts. The 
 - only `completed`, `failed`, and `compensated` terminal records are eligible;
 - active/recovery/compensating/manual-reconciliation states are never eligible;
 - scheduling remains dormant while every production workflow gate is hard-off;
-- cleanup uses a persistent option-ID keyset cursor so an early batch of active/recent records cannot permanently starve expired records behind it.
+- cleanup runs in bounded option-ID high-water cycles: each cycle snapshots the current maximum matching option ID, scans only through that finite boundary, then resets so previously recent records are reconsidered in later cycles even on continuously active stores.
 
-The regression contract creates more than one full cleanup batch of ineligible records and proves an expired terminal record behind them is eventually reached while active records remain intact.
+Regression evidence covers both multi-batch starvation and re-evaluation of a journal that was recent in one cycle but later aged past retention while newer journal records continued to arrive.
 
 ## Current acceptance evidence
 
-The canonical CI executes the P2 contracts on:
+The canonical CI executes the P2 contracts on legacy order storage, HPOS-only, and HPOS compatibility/sync mode, with PHP 7.4/8.1/8.3 static/unit gates plus package and architecture/hard-off checks.
 
-- legacy order storage;
-- HPOS-only;
-- HPOS compatibility/sync mode;
-- PHP 7.4, 8.1, and 8.3 static/unit gates;
-- package and architecture/hard-off gates.
-
-The latest adapter-foundation head has passed `Required CI` with all three WooCommerce storage modes green.
+The adapter foundation remains intentionally non-runnable from production controllers.
 
 ## Remaining production-enable blockers
 
@@ -142,16 +129,11 @@ This foundation is safe to merge while production gates remain hard-off, but it 
 Before changing `WCOS_Feature_Gates::SPLIT`, the next P2 milestone must still provide:
 
 1. Persistent manual-reconciliation state for the extreme fallback where an integration bypasses the normal pre-write stock guard and only reports physical stock mutation after persistence, including behavior if the journal had already reached `completed`.
-2. Currency/price-precision evidence beyond the current two-decimal matrices, including zero-decimal and three-decimal precision (or an equivalent extension-filtered precision contract).
-3. Production transport/controller:
-   - nonce/CSRF protection;
-   - centralized authorization through `WCOS_Mutation_Gateway`;
-   - strict plan parsing and normalized source item IDs/quantities;
-   - client-supplied or server-issued idempotency/operation ID contract;
-   - explicit error/retry responses.
-4. Server-rendered preflight/confirmation UI with accessible labels, focus behavior, warnings, policy disclosure, and operation result/audit feedback.
-5. Concrete compatibility guidance/adapters for supported third-party configured-product ecosystems beyond the generic metadata adapter mechanism.
-6. Independent technical review and explicit human gate.
+2. Currency/price-precision evidence beyond the current two-decimal matrices, including zero-decimal and three-decimal precision or an equivalent extension-filtered precision contract.
+3. Production transport/controller with nonce/CSRF protection, centralized authorization, strict plan parsing, normalized source item IDs/quantities, an idempotency/operation-ID contract, and explicit error/retry responses.
+4. Server-rendered accessible preflight/confirmation UI with policy disclosure, warnings, focus behavior, and operation result/audit feedback.
+5. Concrete compatibility guidance/adapters for explicitly supported third-party configured-product ecosystems beyond the generic metadata adapter mechanism.
+6. Independent technical review and explicit human gate before production enablement.
 
 Coupons, refunds, and negative fees may remain intentionally unsupported for the first production release if the product policy keeps them fail-closed and the UI communicates that limitation before mutation.
 

--- a/docs/p2-quantity-split-adapter.md
+++ b/docs/p2-quantity-split-adapter.md
@@ -6,94 +6,155 @@
 
 ## Status
 
-Milestone 1 introduces the WooCommerce-facing adapter boundary for manual quantity split while every production mutation gate remains hard-off. No AJAX endpoint, order action, bulk action, UI control, or legacy mutation handler is registered by this milestone.
+The first P2 foundation milestone is technically implemented and exercised while every production mutation gate remains hard-off. No AJAX endpoint, order action, bulk action, UI control, or legacy mutation handler is registered by this milestone.
 
-The production write path is now designed as:
+The intended production write path is:
 
 `controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`
 
-Controllers must not call the service directly.
+Controllers must not instantiate or call the Split service directly.
 
-## Implemented in this milestone
+## Implemented foundations
 
-### Request-local physical-stock proof and pre-write blocking
+### Request-local physical-stock proof
 
-`WCOS_Stock_Side_Effect_Guard` is active only inside the current mutation request. Core WooCommerce product/variation stock writes are intercepted at the `before_set_stock` hooks before the product data store changes. The corresponding after-write hooks remain observed as fallback evidence for integration paths that report a stock write after it has occurred.
+`WCOS_Stock_Side_Effect_Guard` is active only inside the current mutation request.
 
-This replaces the production adapter's reliance on comparing catalog stock before and after the whole request, which can be invalidated by a concurrent checkout in another process.
+Normal WooCommerce product/variation stock writes are intercepted at the `before_set_stock` hooks before the product data store changes. The matching after-write hooks remain observed as fallback evidence for integrations that report a stock write after persistence.
 
-A stock mutation attempt in the current request:
+Consequences:
 
-- prevents the mutation conservation contract from being accepted;
-- cannot change physical stock through the normal WooCommerce stock-write path;
-- leaves an interrupted operation retriable with the same idempotency key and persisted child set.
+- concurrent checkout stock changes in another request do not create false Split failures;
+- a stock-write attempt inside the Split request is blocked before the WooCommerce data store write;
+- a blocked attempt dirties the conservation proof and leaves the same idempotency operation safely retriable;
+- an observed after-write fallback is considered outside the order-only snapshot and must not be auto-compensated without explicit stock reconciliation.
 
-A confirmed after-write fallback event is treated more conservatively:
-
-- persisted-state auto-finalization is rejected;
-- automatic order-only compensation is disabled;
-- the operation requires explicit stock reconciliation because physical stock is outside the order snapshot.
-
-The existing exact before/after product-stock comparison remains available outside the P2 adapter scope for legacy P1 integration contracts.
+The exact P1 before/after stock comparison remains available outside a P2 adapter scope.
 
 ### Read-only Split preflight
 
-`WCOS_Split_Preflight` returns a PII-free compatibility report and an explicit policy contract. The current narrow policy is:
+`WCOS_Split_Preflight` returns a PII-free compatibility report and a versioned policy contract.
+
+Current policy:
 
 - shipping: keep on source;
-- fees: keep on source;
-- coupons: reject until allocation policy exists;
-- refunds: reject until allocation policy exists;
-- payment transaction: keep on source;
+- positive fees: keep on source;
+- negative fees: reject;
+- coupons: reject;
+- refunds: reject;
+- payment/transaction ownership: source-only;
 - child status: `pending`;
-- tax: preserve historical amounts/rates;
+- tax: preserve historical values/rates;
 - physical stock: no write;
-- nested split: reject.
+- nested Split: reject;
+- unknown private line metadata: reject;
+- context-inconsistent private metadata classification: reject.
 
-The report exposes compatibility facts only: order type/status/currency/tax-inclusive mode, line/charge counts, transaction presence, deleted-product line count, fractional quantity line count, managed/unmanaged stock counts, and backorder count. Customer/address/payment plaintext is not returned.
+The report exposes compatibility facts only: order type/status/currency, `prices_include_tax`, paid state, line/charge/refund counts, transaction presence, deleted-product lines, fractional quantity lines, managed/unmanaged/backorder lines, and unclassified/inconsistent private metadata keys. Customer/address/payment plaintext is not returned.
 
-### Durable journal retention boundary
+### Stock lifecycle matrix
 
-`WCOS_Operation_Journal_Retention` defines bounded cleanup for authoritative mutation records:
+The canonical WooCommerce integration matrix proves:
+
+- managed stock: an already-reduced order redistributes `_reduced_stock` exactly without changing physical stock;
+- cancelling a child restores exactly the child share;
+- cancelling the residual source restores the remaining share exactly once;
+- unmanaged stock does not receive synthetic `_reduced_stock`;
+- variation-owned stock preserves variation identity and does not move physical stock;
+- parent-managed variation stock resolves the real stock owner and remains unchanged;
+- backorder lines are identified and remain safe under the no-write Split policy;
+- native WooCommerce integer quantity behavior is respected;
+- fractional quantity behavior is proven only when an explicit integration replaces WooCommerce's default integer stock-amount filter.
+
+### Historical tax, charge, payment, and rounding contracts
+
+Acceptance evidence covers:
+
+- tax-inclusive and tax-exclusive order contexts;
+- multiple historical tax rates;
+- two shipping packages retained on source;
+- positive taxable fee retained on source;
+- child receives only its historical line tax rows;
+- source retains historical fee/shipping tax rows;
+- aggregate financial conservation;
+- paid source keeps transaction ID and paid timestamp;
+- child keeps non-transaction payment context, remains `pending`, and receives no transaction ID or paid timestamp;
+- negative fees fail closed before journal or child persistence;
+- deterministic multi-child one-cent and tax-cent allocation;
+- idempotent retry returns the same child set.
+
+### Production side-effect contract
+
+A real active WooCommerce `order.created` webhook is exercised in CI with delivery scheduling intercepted so no external network call occurs.
+
+The contract proves:
+
+- exactly one `woocommerce_new_order` lifecycle event per child;
+- exactly one `order.created` webhook schedule per child;
+- completed retry emits neither event again;
+- no implicit child status transition;
+- no `wp_mail` attempt;
+- no product/variation stock-write hook on a safe Split;
+- exactly one operation note on source;
+- exactly one operation note on each child;
+- completed retry does not duplicate operation notes.
+
+### Metadata compatibility boundary
+
+Public line metadata is business configuration by default. Protected stock/refund/mutation metadata is always operational and cannot be promoted by filters.
+
+Private line metadata is fail-closed unless an integration explicitly declares it as either:
+
+- immutable business metadata, which is copied and participates in canonical line identity; or
+- known operational metadata, which is not copied.
+
+Classification must be consistent between Split-copy and identity contexts. The integration matrix proves that two same-product lines with different adapted business configuration remain distinct and do not collapse.
+
+### Durable journal retention
+
+`WCOS_Operation_Journal_Retention` defines bounded authoritative-journal cleanup:
 
 - default retention: 90 days;
 - configurable between 7 and 365 days;
-- only terminal `completed`, `failed`, and `compensated` records are eligible;
-- `started`, `committed`, `recovery_required`, and `compensating` records are never purged;
-- cleanup scheduling remains dormant while all production workflow gates are hard-off.
+- only `completed`, `failed`, and `compensated` terminal records are eligible;
+- active/recovery/compensating/manual-reconciliation states are never eligible;
+- scheduling remains dormant while every production workflow gate is hard-off;
+- cleanup uses a persistent option-ID keyset cursor so an early batch of active/recent records cannot permanently starve expired records behind it.
 
-## Acceptance evidence added
+The regression contract creates more than one full cleanup batch of ineligible records and proves an expired terminal record behind them is eventually reached while active records remain intact.
 
-The P2 integration contract is executed through the existing canonical WooCommerce CI matrix on legacy storage, HPOS-only, and HPOS compatibility/sync mode. It proves:
+## Current acceptance evidence
 
-- Split remains production hard-off;
-- fractional-quantity preflight and PII-free reporting;
-- safe adapter Split and retry are at-most-once and do not write physical stock;
-- coupon-bearing sources fail before journal/child persistence and remain unchanged;
-- historical order lines whose catalog product was deleted remain splittable;
-- normal WooCommerce stock writes are blocked before the data store changes while the Split guard is active;
-- ambient stock differences do not create false failures while a clean adapter proof is active;
-- a blocked stock attempt dirties the conservation contract, remains retriable, and does not duplicate children on retry;
-- an after-write fallback event is classified as requiring manual reconciliation;
-- journal retention stays dormant while production gates are off and never treats recovery-required state as purgeable.
+The canonical CI executes the P2 contracts on:
 
-## Explicit Gate B work still required
+- legacy order storage;
+- HPOS-only;
+- HPOS compatibility/sync mode;
+- PHP 7.4, 8.1, and 8.3 static/unit gates;
+- package and architecture/hard-off gates.
 
-This milestone does **not** satisfy the complete P2 production-enable gate. Before manual quantity Split can be enabled, the following still require implementation/evidence:
+The latest adapter-foundation head has passed `Required CI` with all three WooCommerce storage modes green.
 
-- managed stock, variation-managed stock, parent-managed variation stock, unmanaged stock, backorders, and fractional-stock matrix;
-- tax-inclusive and tax-exclusive prices with multiple historical tax rates and rounding combinations;
-- fee and shipping package/method matrix under the keep-on-source policy;
-- explicit paid-order/payment lifecycle policy;
-- refunds remain unsupported until an allocation/inverse policy exists;
-- coupons remain unsupported until an allocation policy exists;
-- duplicate commercial lines with distinct metadata/adapters for configured products;
-- exact email, webhook, analytics, fulfillment, stock-hook, and order-note counts;
-- third-party metadata adapters and compatibility policy;
-- production controller/nonce/idempotency transport;
-- server-rendered preflight/confirmation UX and accessibility;
-- independent technical review and human gate before changing `WCOS_Feature_Gates::SPLIT`.
+## Remaining production-enable blockers
 
-## Non-goal
+This foundation is safe to merge while production gates remain hard-off, but it is **not** sufficient to enable manual quantity Split yet.
+
+Before changing `WCOS_Feature_Gates::SPLIT`, the next P2 milestone must still provide:
+
+1. Persistent manual-reconciliation state for the extreme fallback where an integration bypasses the normal pre-write stock guard and only reports physical stock mutation after persistence, including behavior if the journal had already reached `completed`.
+2. Currency/price-precision evidence beyond the current two-decimal matrices, including zero-decimal and three-decimal precision (or an equivalent extension-filtered precision contract).
+3. Production transport/controller:
+   - nonce/CSRF protection;
+   - centralized authorization through `WCOS_Mutation_Gateway`;
+   - strict plan parsing and normalized source item IDs/quantities;
+   - client-supplied or server-issued idempotency/operation ID contract;
+   - explicit error/retry responses.
+4. Server-rendered preflight/confirmation UI with accessible labels, focus behavior, warnings, policy disclosure, and operation result/audit feedback.
+5. Concrete compatibility guidance/adapters for supported third-party configured-product ecosystems beyond the generic metadata adapter mechanism.
+6. Independent technical review and explicit human gate.
+
+Coupons, refunds, and negative fees may remain intentionally unsupported for the first production release if the product policy keeps them fail-closed and the UI communicates that limitation before mutation.
+
+## Non-goals of this milestone
 
 Duplicate, category split, stock-status split, Merge, Return, and Bulk Return remain outside this milestone and stay hard-off.

--- a/docs/p2-quantity-split-adapter.md
+++ b/docs/p2-quantity-split-adapter.md
@@ -16,16 +16,23 @@ Controllers must not call the service directly.
 
 ## Implemented in this milestone
 
-### Request-local physical-stock proof
+### Request-local physical-stock proof and pre-write blocking
 
-`WCOS_Stock_Side_Effect_Guard` observes WooCommerce product/variation stock writes only inside the current mutation request. This replaces the production adapter's reliance on comparing catalog stock before and after the whole request, which can be invalidated by a concurrent checkout in another process.
+`WCOS_Stock_Side_Effect_Guard` is active only inside the current mutation request. Core WooCommerce product/variation stock writes are intercepted at the `before_set_stock` hooks before the product data store changes. The corresponding after-write hooks remain observed as fallback evidence for integration paths that report a stock write after it has occurred.
 
-A stock write observed in the current mutation request:
+This replaces the production adapter's reliance on comparing catalog stock before and after the whole request, which can be invalidated by a concurrent checkout in another process.
+
+A stock mutation attempt in the current request:
 
 - prevents the mutation conservation contract from being accepted;
-- prevents persisted-state recovery from being auto-finalized as a valid order-only mutation;
-- leaves the operation journal in `recovery_required`;
-- marks `automatic_compensation_allowed=false`, because physical stock is outside the order snapshot and requires explicit reconciliation.
+- cannot change physical stock through the normal WooCommerce stock-write path;
+- leaves an interrupted operation retriable with the same idempotency key and persisted child set.
+
+A confirmed after-write fallback event is treated more conservatively:
+
+- persisted-state auto-finalization is rejected;
+- automatic order-only compensation is disabled;
+- the operation requires explicit stock reconciliation because physical stock is outside the order snapshot.
 
 The existing exact before/after product-stock comparison remains available outside the P2 adapter scope for legacy P1 integration contracts.
 
@@ -64,9 +71,10 @@ The P2 integration contract is executed through the existing canonical WooCommer
 - safe adapter Split and retry are at-most-once and do not write physical stock;
 - coupon-bearing sources fail before journal/child persistence and remain unchanged;
 - historical order lines whose catalog product was deleted remain splittable;
-- WooCommerce product stock writes are observed inside the request-local guard;
+- normal WooCommerce stock writes are blocked before the data store changes while the Split guard is active;
 - ambient stock differences do not create false failures while a clean adapter proof is active;
-- an actual stock write injected during Split blocks the commit path and disables automatic compensation;
+- a blocked stock attempt dirties the conservation contract, remains retriable, and does not duplicate children on retry;
+- an after-write fallback event is classified as requiring manual reconciliation;
 - journal retention stays dormant while production gates are off and never treats recovery-required state as purgeable.
 
 ## Explicit Gate B work still required

--- a/docs/p2-quantity-split-adapter.md
+++ b/docs/p2-quantity-split-adapter.md
@@ -1,0 +1,91 @@
+# P2 Quantity Split WooCommerce Adapter
+
+## Classification
+
+`P2_WOOCOMMERCE_ADAPTER`
+
+## Status
+
+Milestone 1 introduces the WooCommerce-facing adapter boundary for manual quantity split while every production mutation gate remains hard-off. No AJAX endpoint, order action, bulk action, UI control, or legacy mutation handler is registered by this milestone.
+
+The production write path is now designed as:
+
+`controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`
+
+Controllers must not call the service directly.
+
+## Implemented in this milestone
+
+### Request-local physical-stock proof
+
+`WCOS_Stock_Side_Effect_Guard` observes WooCommerce product/variation stock writes only inside the current mutation request. This replaces the production adapter's reliance on comparing catalog stock before and after the whole request, which can be invalidated by a concurrent checkout in another process.
+
+A stock write observed in the current mutation request:
+
+- prevents the mutation conservation contract from being accepted;
+- prevents persisted-state recovery from being auto-finalized as a valid order-only mutation;
+- leaves the operation journal in `recovery_required`;
+- marks `automatic_compensation_allowed=false`, because physical stock is outside the order snapshot and requires explicit reconciliation.
+
+The existing exact before/after product-stock comparison remains available outside the P2 adapter scope for legacy P1 integration contracts.
+
+### Read-only Split preflight
+
+`WCOS_Split_Preflight` returns a PII-free compatibility report and an explicit policy contract. The current narrow policy is:
+
+- shipping: keep on source;
+- fees: keep on source;
+- coupons: reject until allocation policy exists;
+- refunds: reject until allocation policy exists;
+- payment transaction: keep on source;
+- child status: `pending`;
+- tax: preserve historical amounts/rates;
+- physical stock: no write;
+- nested split: reject.
+
+The report exposes compatibility facts only: order type/status/currency/tax-inclusive mode, line/charge counts, transaction presence, deleted-product line count, fractional quantity line count, managed/unmanaged stock counts, and backorder count. Customer/address/payment plaintext is not returned.
+
+### Durable journal retention boundary
+
+`WCOS_Operation_Journal_Retention` defines bounded cleanup for authoritative mutation records:
+
+- default retention: 90 days;
+- configurable between 7 and 365 days;
+- only terminal `completed`, `failed`, and `compensated` records are eligible;
+- `started`, `committed`, `recovery_required`, and `compensating` records are never purged;
+- cleanup scheduling remains dormant while all production workflow gates are hard-off.
+
+## Acceptance evidence added
+
+The P2 integration contract is executed through the existing canonical WooCommerce CI matrix on legacy storage, HPOS-only, and HPOS compatibility/sync mode. It proves:
+
+- Split remains production hard-off;
+- fractional-quantity preflight and PII-free reporting;
+- safe adapter Split and retry are at-most-once and do not write physical stock;
+- coupon-bearing sources fail before journal/child persistence and remain unchanged;
+- historical order lines whose catalog product was deleted remain splittable;
+- WooCommerce product stock writes are observed inside the request-local guard;
+- ambient stock differences do not create false failures while a clean adapter proof is active;
+- an actual stock write injected during Split blocks the commit path and disables automatic compensation;
+- journal retention stays dormant while production gates are off and never treats recovery-required state as purgeable.
+
+## Explicit Gate B work still required
+
+This milestone does **not** satisfy the complete P2 production-enable gate. Before manual quantity Split can be enabled, the following still require implementation/evidence:
+
+- managed stock, variation-managed stock, parent-managed variation stock, unmanaged stock, backorders, and fractional-stock matrix;
+- tax-inclusive and tax-exclusive prices with multiple historical tax rates and rounding combinations;
+- fee and shipping package/method matrix under the keep-on-source policy;
+- explicit paid-order/payment lifecycle policy;
+- refunds remain unsupported until an allocation/inverse policy exists;
+- coupons remain unsupported until an allocation policy exists;
+- duplicate commercial lines with distinct metadata/adapters for configured products;
+- exact email, webhook, analytics, fulfillment, stock-hook, and order-note counts;
+- third-party metadata adapters and compatibility policy;
+- production controller/nonce/idempotency transport;
+- server-rendered preflight/confirmation UX and accessibility;
+- independent technical review and human gate before changing `WCOS_Feature_Gates::SPLIT`.
+
+## Non-goal
+
+Duplicate, category split, stock-status split, Merge, Return, and Bulk Return remain outside this milestone and stay hard-off.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -28,6 +28,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-amount-allocator.php';
 		include_once $root . 'domain/class-wcos-line-identity.php';
 		include_once $root . 'domain/class-wcos-mutation-fingerprint.php';
+		include_once $root . 'domain/class-wcos-stock-side-effect-guard.php';
 		include_once $root . 'domain/class-wcos-mutation-contract.php';
 		include_once $root . 'domain/class-wcos-operation-lock.php';
 		include_once $root . 'domain/class-wcos-feature-gates.php';
@@ -41,6 +42,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-copy-context.php';
 		include_once $root . 'domain/class-wcos-order-mutation-snapshot.php';
 		include_once $root . 'domain/class-wcos-operation-journal.php';
+		include_once $root . 'domain/class-wcos-operation-journal-retention.php';
+		WCOS_Operation_Journal_Retention::bootstrap();
 		include_once $root . 'domain/class-wcos-order-relation-repository.php';
 		WCOS_Order_Relation_Repository::bootstrap();
 		include_once $root . 'domain/class-wcos-mutation-commit-guard.php';
@@ -50,6 +53,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-split-compensator.php';
 		include_once $root . 'domain/class-wcos-mutation-recovery-coordinator.php';
 		WCOS_Mutation_Recovery_Coordinator::bootstrap();
+		include_once $root . 'domain/class-wcos-split-preflight.php';
+		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 
 		include_once $root . 'backend/settings.php';

--- a/inc/domain/class-wcos-mutation-contract.php
+++ b/inc/domain/class-wcos-mutation-contract.php
@@ -10,6 +10,15 @@ if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
 final class WCOS_Mutation_Contract {
 
 	public static function assert_conserved(array $before, array $after, $precision = 2) {
+		/*
+		 * P2 production adapters use request-local stock evidence. If a WooCommerce
+		 * stock write occurred in this mutation request, no conserved order-only
+		 * state may be accepted or auto-finalized even when order math still balances.
+		 */
+		if (class_exists('WCOS_Stock_Side_Effect_Guard') && WCOS_Stock_Side_Effect_Guard::has_active_scope()) {
+			WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+		}
+
 		$precision = (int) $precision;
 		$money_keys = array(
 			'line_subtotal',

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -7,14 +7,19 @@ defined('ABSPATH') || exit;
  *
  * Controllers must never instantiate mutation services directly. This gateway
  * applies the production feature gate first, then centralized authorization,
- * before delegating to a hardened service.
+ * before delegating to a hardened WooCommerce adapter/service.
  */
 final class WCOS_Mutation_Gateway {
 
 	public function split(WC_Order $source, array $plan, $operation_id) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::SPLIT);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
-		return (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
+		return (new WCOS_Split_WooCommerce_Adapter())->split($source, $plan, $operation_id);
+	}
+
+	public function split_preflight(WC_Order $source) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
+		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
 	}
 
 	public function duplicate(WC_Order $source, $operation_id) {

--- a/inc/domain/class-wcos-mutation-recovery-coordinator.php
+++ b/inc/domain/class-wcos-mutation-recovery-coordinator.php
@@ -29,8 +29,8 @@ final class WCOS_Mutation_Recovery_Coordinator {
 		if (array_key_exists('automatic_compensation_allowed', $context) && false === $context['automatic_compensation_allowed']) {
 			return;
 		}
-		/* Physical stock writes are outside the order snapshot and require manual reconciliation. */
-		if (class_exists('WCOS_Stock_Side_Effect_Guard') && WCOS_Stock_Side_Effect_Guard::has_dirty_active_scope()) {
+		/* A confirmed after-write stock event is outside the order snapshot. */
+		if (class_exists('WCOS_Stock_Side_Effect_Guard') && WCOS_Stock_Side_Effect_Guard::has_physical_write_active_scope()) {
 			return;
 		}
 		if (empty($context['source_snapshot']) || empty($context['source_recovery_signature_after'])) {

--- a/inc/domain/class-wcos-mutation-recovery-coordinator.php
+++ b/inc/domain/class-wcos-mutation-recovery-coordinator.php
@@ -26,6 +26,13 @@ final class WCOS_Mutation_Recovery_Coordinator {
 		}
 
 		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		if (array_key_exists('automatic_compensation_allowed', $context) && false === $context['automatic_compensation_allowed']) {
+			return;
+		}
+		/* Physical stock writes are outside the order snapshot and require manual reconciliation. */
+		if (class_exists('WCOS_Stock_Side_Effect_Guard') && WCOS_Stock_Side_Effect_Guard::has_dirty_active_scope()) {
+			return;
+		}
 		if (empty($context['source_snapshot']) || empty($context['source_recovery_signature_after'])) {
 			return;
 		}

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Operation_Journal_Retention {
 	const CRON_HOOK = 'wcos_cleanup_terminal_mutation_journals';
-	const CURSOR_OPTION = 'wcos_mutation_journal_cleanup_cursor';
+	const SCAN_STATE_OPTION = 'wcos_mutation_journal_cleanup_state';
 	const DEFAULT_RETENTION_DAYS = 90;
 	const BATCH_SIZE = 50;
 
@@ -31,32 +31,54 @@ final class WCOS_Operation_Journal_Retention {
 	}
 
 	/**
-	 * Scan one bounded keyset page and persist the option-id cursor. The cursor is
-	 * reset only after a later run reaches the end, so ineligible early records
-	 * cannot starve expired records with higher option IDs forever.
+	 * Scan one bounded keyset page inside a finite high-water cycle.
+	 *
+	 * A pure monotonic cursor is unsafe on an active store: a journal scanned while
+	 * still recent would never be reconsidered if new options keep arriving ahead
+	 * of the cursor. Each cycle therefore snapshots the current maximum matching
+	 * option_id, scans only through that high-water mark, then resets. Newer journal
+	 * rows wait for the next cycle, and older rows are revisited in later cycles as
+	 * they age into retention eligibility.
 	 */
 	public static function cleanup() {
 		global $wpdb;
 
 		$like = $wpdb->esc_like('wcos_mutation_op_') . '%';
-		$cursor = absint(get_option(self::CURSOR_OPTION, 0));
+		$state = self::scan_state();
+		if ($state['high_water'] <= 0) {
+			$state['high_water'] = absint(
+				$wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT MAX(option_id) FROM {$wpdb->options} WHERE option_name LIKE %s",
+						$like
+					)
+				)
+			);
+			$state['cursor'] = 0;
+			if ($state['high_water'] <= 0) {
+				delete_option(self::SCAN_STATE_OPTION);
+				return 0;
+			}
+		}
+
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT option_id, option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_id > %d ORDER BY option_id ASC LIMIT %d",
+				"SELECT option_id, option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_id > %d AND option_id <= %d ORDER BY option_id ASC LIMIT %d",
 				$like,
-				$cursor,
+				$state['cursor'],
+				$state['high_water'],
 				self::BATCH_SIZE
 			),
 			ARRAY_A
 		);
 		if (empty($rows)) {
-			delete_option(self::CURSOR_OPTION);
+			delete_option(self::SCAN_STATE_OPTION);
 			return 0;
 		}
 
 		$deleted = 0;
 		$now = time();
-		$last_option_id = $cursor;
+		$last_option_id = $state['cursor'];
 		foreach ($rows as $row) {
 			$last_option_id = max($last_option_id, absint($row['option_id']));
 			$key = isset($row['option_name']) ? (string) $row['option_name'] : '';
@@ -72,9 +94,19 @@ final class WCOS_Operation_Journal_Retention {
 			}
 		}
 
-		if ($last_option_id > $cursor) {
-			update_option(self::CURSOR_OPTION, $last_option_id, false);
+		if ($last_option_id >= $state['high_water']) {
+			delete_option(self::SCAN_STATE_OPTION);
+		} else {
+			update_option(
+				self::SCAN_STATE_OPTION,
+				array(
+					'cursor' => $last_option_id,
+					'high_water' => $state['high_water'],
+				),
+				false
+			);
 		}
+
 		return $deleted;
 	}
 
@@ -95,5 +127,16 @@ final class WCOS_Operation_Journal_Retention {
 		$days = max(7, min(365, $days));
 		$now = null === $now ? time() : (int) $now;
 		return $completed_timestamp <= ($now - ($days * DAY_IN_SECONDS));
+	}
+
+	private static function scan_state() {
+		$state = get_option(self::SCAN_STATE_OPTION, array());
+		if (!is_array($state)) {
+			$state = array();
+		}
+		return array(
+			'cursor' => isset($state['cursor']) ? absint($state['cursor']) : 0,
+			'high_water' => isset($state['high_water']) ? absint($state['high_water']) : 0,
+		);
 	}
 }

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -1,0 +1,78 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Bounded retention for authoritative mutation journals.
+ *
+ * Only terminal records are eligible for deletion. Active, committed-but-not-
+ * completed, recovery_required, and compensating records are never purged.
+ * Scheduling remains dormant while every production workflow gate is hard-off.
+ */
+final class WCOS_Operation_Journal_Retention {
+	const CRON_HOOK = 'wcos_cleanup_terminal_mutation_journals';
+	const DEFAULT_RETENTION_DAYS = 90;
+	const BATCH_SIZE = 50;
+
+	public static function bootstrap() {
+		add_action('init', array(__CLASS__, 'maybe_schedule'), 20);
+		add_action(self::CRON_HOOK, array(__CLASS__, 'cleanup'));
+	}
+
+	public static function maybe_schedule() {
+		if (!class_exists('WCOS_Feature_Gates') || !WCOS_Feature_Gates::any_enabled()) {
+			return;
+		}
+		if (!wp_next_scheduled(self::CRON_HOOK)) {
+			wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', self::CRON_HOOK);
+		}
+	}
+
+	public static function cleanup() {
+		global $wpdb;
+
+		$like = $wpdb->esc_like('wcos_mutation_op_') . '%';
+		$keys = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_id ASC LIMIT %d",
+				$like,
+				self::BATCH_SIZE
+			)
+		);
+		if (!is_array($keys)) {
+			return 0;
+		}
+
+		$deleted = 0;
+		$now = time();
+		foreach ($keys as $key) {
+			$record = get_option($key, null);
+			if (!is_array($record) || !self::is_expired_terminal_record($record, $now)) {
+				continue;
+			}
+			if (delete_option($key)) {
+				$deleted++;
+			}
+		}
+		return $deleted;
+	}
+
+	public static function is_expired_terminal_record(array $record, $now = null) {
+		$status = isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+		if (!in_array($status, array('completed', 'failed', 'compensated'), true)) {
+			return false;
+		}
+		$completed_at = isset($record['completed_at']) ? (string) $record['completed_at'] : '';
+		if ('' === $completed_at) {
+			return false;
+		}
+		$completed_timestamp = strtotime($completed_at);
+		if (false === $completed_timestamp) {
+			return false;
+		}
+		$days = (int) apply_filters('wcos_mutation_journal_retention_days', self::DEFAULT_RETENTION_DAYS, $record);
+		$days = max(7, min(365, $days));
+		$now = null === $now ? time() : (int) $now;
+		return $completed_timestamp <= ($now - ($days * DAY_IN_SECONDS));
+	}
+}

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -6,11 +6,13 @@ defined('ABSPATH') || exit;
  * Bounded retention for authoritative mutation journals.
  *
  * Only terminal records are eligible for deletion. Active, committed-but-not-
- * completed, recovery_required, and compensating records are never purged.
- * Scheduling remains dormant while every production workflow gate is hard-off.
+ * completed, recovery_required, compensating, and manual-reconciliation states
+ * are never purged. Scheduling remains dormant while every production workflow
+ * gate is hard-off.
  */
 final class WCOS_Operation_Journal_Retention {
 	const CRON_HOOK = 'wcos_cleanup_terminal_mutation_journals';
+	const CURSOR_OPTION = 'wcos_mutation_journal_cleanup_cursor';
 	const DEFAULT_RETENTION_DAYS = 90;
 	const BATCH_SIZE = 50;
 
@@ -28,24 +30,39 @@ final class WCOS_Operation_Journal_Retention {
 		}
 	}
 
+	/**
+	 * Scan one bounded keyset page and persist the option-id cursor. The cursor is
+	 * reset only after a later run reaches the end, so ineligible early records
+	 * cannot starve expired records with higher option IDs forever.
+	 */
 	public static function cleanup() {
 		global $wpdb;
 
 		$like = $wpdb->esc_like('wcos_mutation_op_') . '%';
-		$keys = $wpdb->get_col(
+		$cursor = absint(get_option(self::CURSOR_OPTION, 0));
+		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_id ASC LIMIT %d",
+				"SELECT option_id, option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_id > %d ORDER BY option_id ASC LIMIT %d",
 				$like,
+				$cursor,
 				self::BATCH_SIZE
-			)
+			),
+			ARRAY_A
 		);
-		if (!is_array($keys)) {
+		if (empty($rows)) {
+			delete_option(self::CURSOR_OPTION);
 			return 0;
 		}
 
 		$deleted = 0;
 		$now = time();
-		foreach ($keys as $key) {
+		$last_option_id = $cursor;
+		foreach ($rows as $row) {
+			$last_option_id = max($last_option_id, absint($row['option_id']));
+			$key = isset($row['option_name']) ? (string) $row['option_name'] : '';
+			if ('' === $key) {
+				continue;
+			}
 			$record = get_option($key, null);
 			if (!is_array($record) || !self::is_expired_terminal_record($record, $now)) {
 				continue;
@@ -53,6 +70,10 @@ final class WCOS_Operation_Journal_Retention {
 			if (delete_option($key)) {
 				$deleted++;
 			}
+		}
+
+		if ($last_option_id > $cursor) {
+			update_option(self::CURSOR_OPTION, $last_option_id, false);
 		}
 		return $deleted;
 	}

--- a/inc/domain/class-wcos-order-contract-snapshot.php
+++ b/inc/domain/class-wcos-order-contract-snapshot.php
@@ -175,6 +175,16 @@ final class WCOS_Order_Contract_Snapshot {
 	}
 
 	public static function assert_product_stock_equal(array $before, array $after) {
+		/*
+		 * A P2 adapter provides request-local evidence. Ambient stock changes from
+		 * concurrent checkouts occur in another request and must not make an
+		 * order-only mutation fail. Any stock write performed inside this request
+		 * is still rejected by the active guard.
+		 */
+		if (class_exists('WCOS_Stock_Side_Effect_Guard') && WCOS_Stock_Side_Effect_Guard::has_active_scope()) {
+			WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+			return;
+		}
 		if ($before !== $after) {
 			throw new RuntimeException(__('Physical product stock changed during an order-only mutation.', 'wc-order-splitter'));
 		}

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -205,6 +205,7 @@ final class WCOS_Order_Item_Meta_Policy {
 			if ($key !== $expected++) {
 				return true;
 			}
+		}
 		return false;
 	}
 }

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -72,11 +72,6 @@ final class WCOS_Order_Item_Meta_Policy {
 	/**
 	 * Private line metadata is ambiguous until an integration declares whether
 	 * it is immutable business configuration or known operational state.
-	 *
-	 * Business adapters should use `wcos_order_item_meta_classification` and
-	 * return `business`. Operational adapters should leave classification as
-	 * operational and return true from `wcos_order_item_private_meta_is_known_operational`.
-	 * Protected core/mutation keys never require adapter classification.
 	 */
 	public static function unknown_private_keys(WC_Order_Item $item, $context = self::CONTEXT_SPLIT) {
 		$context = sanitize_key((string) $context);
@@ -101,9 +96,29 @@ final class WCOS_Order_Item_Meta_Policy {
 				$unknown[] = $key;
 			}
 		}
-		$unknown = array_values(array_unique($unknown));
-		sort($unknown, SORT_STRING);
-		return $unknown;
+		return self::sorted_unique($unknown);
+	}
+
+	/**
+	 * Business-vs-operational classification must be stable between the copy
+	 * path and the canonical line-identity path. A context-sensitive adapter can
+	 * otherwise copy configuration that is absent from identity, making distinct
+	 * configured lines indistinguishable to conservation/recovery contracts.
+	 */
+	public static function inconsistent_private_keys(WC_Order_Item $item) {
+		$inconsistent = array();
+		foreach ($item->get_meta_data() as $meta) {
+			$key = (string) $meta->key;
+			if (0 !== strpos($key, '_') || self::is_protected($key)) {
+				continue;
+			}
+			$split = self::classify($key, $meta->value, self::CONTEXT_SPLIT, $item);
+			$identity = self::classify($key, $meta->value, self::CONTEXT_IDENTITY, $item);
+			if ($split !== $identity) {
+				$inconsistent[] = $key;
+			}
+		}
+		return self::sorted_unique($inconsistent);
 	}
 
 	public static function classify($key, $value, $context, WC_Order_Item $item = null) {
@@ -197,6 +212,12 @@ final class WCOS_Order_Item_Meta_Policy {
 		}
 
 		return $value;
+	}
+
+	private static function sorted_unique(array $keys) {
+		$keys = array_values(array_unique(array_map('strval', $keys)));
+		sort($keys, SORT_STRING);
+		return $keys;
 	}
 
 	private static function is_associative(array $value) {

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -20,12 +20,6 @@ final class WCOS_Order_Item_Meta_Policy {
 	const CLASS_BUSINESS = 'business';
 	const CLASS_OPERATIONAL = 'operational';
 
-	/**
-	 * Copy metadata according to the shared classification policy.
-	 *
-	 * The legacy should-copy filter can further restrict business metadata, but
-	 * cannot override a protected/operational classification.
-	 */
 	public static function copy(WC_Order_Item $source, WC_Order_Item $target, $context, array $excluded_keys = array()) {
 		$context = sanitize_key($context);
 		$excluded_keys = array_map('strval', $excluded_keys);
@@ -59,15 +53,9 @@ final class WCOS_Order_Item_Meta_Policy {
 			$copied[] = $key;
 		}
 
-		return array(
-			'copied' => $copied,
-			'excluded' => $excluded,
-		);
+		return array('copied' => $copied, 'excluded' => $excluded);
 	}
 
-	/**
-	 * Return canonical business metadata used by line identity/snapshots.
-	 */
 	public static function business_metadata(WC_Order_Item $item) {
 		$metadata = array();
 		foreach ($item->get_meta_data() as $meta) {
@@ -82,12 +70,42 @@ final class WCOS_Order_Item_Meta_Policy {
 	}
 
 	/**
-	 * Classify one metadata key.
+	 * Private line metadata is ambiguous until an integration declares whether
+	 * it is immutable business configuration or known operational state.
 	 *
-	 * Integrations that own private immutable configuration can opt individual
-	 * keys into business metadata with `wcos_order_item_meta_classification`.
-	 * Protected keys are resolved before filters and are never overridable.
+	 * Business adapters should use `wcos_order_item_meta_classification` and
+	 * return `business`. Operational adapters should leave classification as
+	 * operational and return true from `wcos_order_item_private_meta_is_known_operational`.
+	 * Protected core/mutation keys never require adapter classification.
 	 */
+	public static function unknown_private_keys(WC_Order_Item $item, $context = self::CONTEXT_SPLIT) {
+		$context = sanitize_key((string) $context);
+		$unknown = array();
+		foreach ($item->get_meta_data() as $meta) {
+			$key = (string) $meta->key;
+			if (0 !== strpos($key, '_') || self::is_protected($key)) {
+				continue;
+			}
+			if (self::CLASS_BUSINESS === self::classify($key, $meta->value, $context, $item)) {
+				continue;
+			}
+			$known_operational = (bool) apply_filters(
+				'wcos_order_item_private_meta_is_known_operational',
+				false,
+				$key,
+				$meta->value,
+				$context,
+				$item
+			);
+			if (!$known_operational) {
+				$unknown[] = $key;
+			}
+		}
+		$unknown = array_values(array_unique($unknown));
+		sort($unknown, SORT_STRING);
+		return $unknown;
+	}
+
 	public static function classify($key, $value, $context, WC_Order_Item $item = null) {
 		$key = (string) $key;
 		$context = sanitize_key($context);
@@ -112,10 +130,6 @@ final class WCOS_Order_Item_Meta_Policy {
 			$classification = self::CLASS_OPERATIONAL;
 		}
 
-		/*
-		 * Compatibility hook for early foundation adopters. This is deliberately
-		 * evaluated only for non-protected keys.
-		 */
 		$is_operational = self::CLASS_OPERATIONAL === $classification;
 		$is_operational = (bool) apply_filters(
 			'wcos_order_item_meta_is_operational',
@@ -167,7 +181,6 @@ final class WCOS_Order_Item_Meta_Policy {
 		if (is_object($value) || is_resource($value)) {
 			throw new RuntimeException(
 				sprintf(
-					/* translators: %s: order item metadata key. */
 					__('Business metadata "%s" contains a non-canonical object or resource value. Classify it as operational or normalize it before order mutation.', 'wc-order-splitter'),
 					(string) $meta_key
 				)
@@ -177,7 +190,6 @@ final class WCOS_Order_Item_Meta_Policy {
 		if (is_float($value) && !is_finite($value)) {
 			throw new RuntimeException(
 				sprintf(
-					/* translators: %s: order item metadata key. */
 					__('Business metadata "%s" contains a non-finite numeric value and cannot form a stable line identity.', 'wc-order-splitter'),
 					(string) $meta_key
 				)
@@ -193,7 +205,6 @@ final class WCOS_Order_Item_Meta_Policy {
 			if ($key !== $expected++) {
 				return true;
 			}
-		}
 		return false;
 	}
 }

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -1,0 +1,167 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Split_Preflight_Exception extends RuntimeException {
+	private $reason;
+	private $report;
+
+	public function __construct($reason, $message, array $report = array()) {
+		$this->reason = sanitize_key((string) $reason);
+		$this->report = $report;
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+
+	public function get_report() {
+		return $this->report;
+	}
+}
+
+/**
+ * Read-only production preflight for the first P2 quantity-split surface.
+ *
+ * Reports intentionally contain no customer/address/payment plaintext. They
+ * expose only compatibility facts needed by a future confirmation UI.
+ */
+final class WCOS_Split_Preflight {
+	const POLICY_VERSION = 1;
+
+	public static function policy() {
+		return array(
+			'policy_version' => self::POLICY_VERSION,
+			'shipping' => 'keep_on_source',
+			'fees' => 'keep_on_source',
+			'coupons' => 'reject',
+			'refunds' => 'reject',
+			'payment_transaction' => 'keep_on_source',
+			'child_status' => 'pending',
+			'tax' => 'preserve_historical',
+			'physical_stock' => 'no_write',
+			'nested_split' => 'reject',
+		);
+	}
+
+	public static function assert_supported(WC_Order $source) {
+		$report = self::report($source);
+		if (empty($report['supported'])) {
+			throw new WCOS_Split_Preflight_Exception(
+				isset($report['reason']) ? $report['reason'] : 'unsupported',
+				isset($report['message']) ? $report['message'] : __('This order is not supported by the quantity-split adapter.', 'wc-order-splitter'),
+				$report
+			);
+		}
+		return $report;
+	}
+
+	public static function report(WC_Order $source) {
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'order_id' => absint($source->get_id()),
+			'order_type' => sanitize_key((string) $source->get_type()),
+			'status' => sanitize_key((string) $source->get_status()),
+			'currency' => (string) $source->get_currency(),
+			'prices_include_tax' => (bool) $source->get_prices_include_tax(),
+			'line_count' => count($source->get_items('line_item')),
+			'shipping_count' => count($source->get_items('shipping')),
+			'fee_count' => count($source->get_items('fee')),
+			'coupon_count' => count($source->get_items('coupon')),
+			'refund_count' => count($source->get_refunds()),
+			'has_transaction' => '' !== (string) $source->get_transaction_id(),
+			'deleted_product_lines' => 0,
+			'fractional_quantity_lines' => 0,
+			'managed_stock_lines' => 0,
+			'unmanaged_stock_lines' => 0,
+			'backorder_lines' => 0,
+			'policy' => self::policy(),
+		);
+
+		if (!$source->get_id()) {
+			return self::reject($report, 'unpersisted_order', __('The source order must be persisted before it can be split.', 'wc-order-splitter'));
+		}
+		if ('shop_order' !== $source->get_type()) {
+			return self::reject($report, 'unsupported_order_type', __('Only WooCommerce shop orders can be split.', 'wc-order-splitter'));
+		}
+		if (!in_array($source->get_status(), array('pending', 'on-hold', 'processing'), true)) {
+			return self::reject($report, 'unsupported_status', __('This order status is not supported by the quantity-split policy.', 'wc-order-splitter'));
+		}
+		if ('' === (string) $source->get_currency()) {
+			return self::reject($report, 'missing_currency', __('The source order does not have a currency.', 'wc-order-splitter'));
+		}
+		if ($report['coupon_count'] > 0) {
+			return self::reject($report, 'coupon_policy_missing', __('Orders containing coupon rows are not supported until a coupon allocation policy is implemented.', 'wc-order-splitter'));
+		}
+		if ($source->get_total_refunded() != 0 || $report['refund_count'] > 0) {
+			return self::reject($report, 'refund_policy_missing', __('Refunded or partially refunded orders are not supported until a refund allocation policy is implemented.', 'wc-order-splitter'));
+		}
+		if (!empty($source->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true)) || !empty($source->get_meta('yoos_original_order', true))) {
+			return self::reject($report, 'nested_split', __('Nested splitting of an existing split child is not supported.', 'wc-order-splitter'));
+		}
+		if (0 === $report['line_count']) {
+			return self::reject($report, 'no_line_items', __('An order without product line items cannot be split.', 'wc-order-splitter'));
+		}
+
+		$order_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source->get_id());
+		foreach ($source->get_items('line_item') as $item) {
+			try {
+				$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			} catch (Throwable $throwable) {
+				return self::reject($report, 'invalid_line_quantity', __('A source line contains an invalid quantity.', 'wc-order-splitter'));
+			}
+			if ($quantity_units <= 0) {
+				return self::reject($report, 'invalid_line_quantity', __('Every source line must have a positive quantity.', 'wc-order-splitter'));
+			}
+			if (0 !== ($quantity_units % 1000000)) {
+				$report['fractional_quantity_lines']++;
+			}
+
+			$product = $item->get_product();
+			if (!$product) {
+				$report['deleted_product_lines']++;
+			} elseif ($product->managing_stock()) {
+				$report['managed_stock_lines']++;
+				if ($product->is_on_backorder($item->get_quantity())) {
+					$report['backorder_lines']++;
+				}
+			} else {
+				$report['unmanaged_stock_lines']++;
+			}
+
+			$reduced = $item->get_meta('_reduced_stock', true);
+			if ('' === $reduced) {
+				continue;
+			}
+			try {
+				$reduced_units = WCOS_Decimal::to_units($reduced, 6);
+			} catch (Throwable $throwable) {
+				return self::reject($report, 'invalid_stock_marker', __('A source line contains a non-numeric reduced-stock marker.', 'wc-order-splitter'));
+			}
+			if (!$order_stock_reduced || $reduced_units < 0 || $reduced_units > $quantity_units) {
+				return self::reject($report, 'invalid_stock_marker', __('The source order contains inconsistent reduced-stock markers.', 'wc-order-splitter'));
+			}
+		}
+
+		try {
+			WCOS_Order_Totals_Rebuilder::assert_consistent($source, wc_get_price_decimals());
+		} catch (Throwable $throwable) {
+			return self::reject($report, 'inconsistent_totals', __('The source order totals are internally inconsistent and cannot be split safely.', 'wc-order-splitter'));
+		}
+
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('This order is compatible with the current quantity-split policy.', 'wc-order-splitter');
+		return $report;
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -23,12 +23,10 @@ final class WCOS_Split_Preflight_Exception extends RuntimeException {
 
 /**
  * Read-only production preflight for the first P2 quantity-split surface.
- *
- * Reports intentionally contain no customer/address/payment plaintext. They
- * expose only compatibility facts needed by a future confirmation UI.
+ * Reports intentionally contain no customer/address/payment plaintext.
  */
 final class WCOS_Split_Preflight {
-	const POLICY_VERSION = 2;
+	const POLICY_VERSION = 3;
 
 	public static function policy() {
 		return array(
@@ -44,6 +42,7 @@ final class WCOS_Split_Preflight {
 			'tax' => 'preserve_historical',
 			'physical_stock' => 'no_write',
 			'nested_split' => 'reject',
+			'unknown_private_line_meta' => 'reject',
 		);
 	}
 
@@ -82,6 +81,7 @@ final class WCOS_Split_Preflight {
 			'managed_stock_lines' => 0,
 			'unmanaged_stock_lines' => 0,
 			'backorder_lines' => 0,
+			'unknown_private_meta_keys' => array(),
 			'policy' => self::policy(),
 		);
 
@@ -120,6 +120,7 @@ final class WCOS_Split_Preflight {
 		}
 
 		$order_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source->get_id());
+		$unknown_private_meta = array();
 		foreach ($source->get_items('line_item') as $item) {
 			try {
 				$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
@@ -132,6 +133,11 @@ final class WCOS_Split_Preflight {
 			if (0 !== ($quantity_units % 1000000)) {
 				$report['fractional_quantity_lines']++;
 			}
+
+			$unknown_private_meta = array_merge(
+				$unknown_private_meta,
+				WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT)
+			);
 
 			$product = $item->get_product();
 			if (!$product) {
@@ -157,6 +163,17 @@ final class WCOS_Split_Preflight {
 			if (!$order_stock_reduced || $reduced_units < 0 || $reduced_units > $quantity_units) {
 				return self::reject($report, 'invalid_stock_marker', __('The source order contains inconsistent reduced-stock markers.', 'wc-order-splitter'));
 			}
+		}
+
+		$unknown_private_meta = array_values(array_unique(array_map('strval', $unknown_private_meta)));
+		sort($unknown_private_meta, SORT_STRING);
+		$report['unknown_private_meta_keys'] = $unknown_private_meta;
+		if (!empty($unknown_private_meta)) {
+			return self::reject(
+				$report,
+				'unclassified_private_metadata',
+				__('The source order contains private line-item metadata that has not been classified by a compatibility adapter.', 'wc-order-splitter')
+			);
 		}
 
 		try {

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -28,15 +28,17 @@ final class WCOS_Split_Preflight_Exception extends RuntimeException {
  * expose only compatibility facts needed by a future confirmation UI.
  */
 final class WCOS_Split_Preflight {
-	const POLICY_VERSION = 1;
+	const POLICY_VERSION = 2;
 
 	public static function policy() {
 		return array(
 			'policy_version' => self::POLICY_VERSION,
 			'shipping' => 'keep_on_source',
 			'fees' => 'keep_on_source',
+			'negative_fees' => 'reject',
 			'coupons' => 'reject',
 			'refunds' => 'reject',
+			'payment' => 'source_only',
 			'payment_transaction' => 'keep_on_source',
 			'child_status' => 'pending',
 			'tax' => 'preserve_historical',
@@ -67,9 +69,11 @@ final class WCOS_Split_Preflight {
 			'status' => sanitize_key((string) $source->get_status()),
 			'currency' => (string) $source->get_currency(),
 			'prices_include_tax' => (bool) $source->get_prices_include_tax(),
+			'is_paid' => (bool) $source->is_paid(),
 			'line_count' => count($source->get_items('line_item')),
 			'shipping_count' => count($source->get_items('shipping')),
 			'fee_count' => count($source->get_items('fee')),
+			'negative_fee_count' => 0,
 			'coupon_count' => count($source->get_items('coupon')),
 			'refund_count' => count($source->get_refunds()),
 			'has_transaction' => '' !== (string) $source->get_transaction_id(),
@@ -80,6 +84,12 @@ final class WCOS_Split_Preflight {
 			'backorder_lines' => 0,
 			'policy' => self::policy(),
 		);
+
+		foreach ($source->get_items('fee') as $fee) {
+			if (WCOS_Decimal::to_units($fee->get_total(), wc_get_price_decimals()) < 0) {
+				$report['negative_fee_count']++;
+			}
+		}
 
 		if (!$source->get_id()) {
 			return self::reject($report, 'unpersisted_order', __('The source order must be persisted before it can be split.', 'wc-order-splitter'));
@@ -92,6 +102,9 @@ final class WCOS_Split_Preflight {
 		}
 		if ('' === (string) $source->get_currency()) {
 			return self::reject($report, 'missing_currency', __('The source order does not have a currency.', 'wc-order-splitter'));
+		}
+		if ($report['negative_fee_count'] > 0) {
+			return self::reject($report, 'negative_fee_policy_missing', __('Orders containing negative fee rows are not supported until an explicit discount-like fee policy is implemented.', 'wc-order-splitter'));
 		}
 		if ($report['coupon_count'] > 0) {
 			return self::reject($report, 'coupon_policy_missing', __('Orders containing coupon rows are not supported until a coupon allocation policy is implemented.', 'wc-order-splitter'));

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -26,7 +26,7 @@ final class WCOS_Split_Preflight_Exception extends RuntimeException {
  * Reports intentionally contain no customer/address/payment plaintext.
  */
 final class WCOS_Split_Preflight {
-	const POLICY_VERSION = 3;
+	const POLICY_VERSION = 4;
 
 	public static function policy() {
 		return array(
@@ -43,6 +43,7 @@ final class WCOS_Split_Preflight {
 			'physical_stock' => 'no_write',
 			'nested_split' => 'reject',
 			'unknown_private_line_meta' => 'reject',
+			'context_inconsistent_private_meta' => 'reject',
 		);
 	}
 
@@ -82,6 +83,7 @@ final class WCOS_Split_Preflight {
 			'unmanaged_stock_lines' => 0,
 			'backorder_lines' => 0,
 			'unknown_private_meta_keys' => array(),
+			'inconsistent_private_meta_keys' => array(),
 			'policy' => self::policy(),
 		);
 
@@ -121,6 +123,7 @@ final class WCOS_Split_Preflight {
 
 		$order_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source->get_id());
 		$unknown_private_meta = array();
+		$inconsistent_private_meta = array();
 		foreach ($source->get_items('line_item') as $item) {
 			try {
 				$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
@@ -137,6 +140,10 @@ final class WCOS_Split_Preflight {
 			$unknown_private_meta = array_merge(
 				$unknown_private_meta,
 				WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT)
+			);
+			$inconsistent_private_meta = array_merge(
+				$inconsistent_private_meta,
+				WCOS_Order_Item_Meta_Policy::inconsistent_private_keys($item)
 			);
 
 			$product = $item->get_product();
@@ -167,7 +174,18 @@ final class WCOS_Split_Preflight {
 
 		$unknown_private_meta = array_values(array_unique(array_map('strval', $unknown_private_meta)));
 		sort($unknown_private_meta, SORT_STRING);
+		$inconsistent_private_meta = array_values(array_unique(array_map('strval', $inconsistent_private_meta)));
+		sort($inconsistent_private_meta, SORT_STRING);
 		$report['unknown_private_meta_keys'] = $unknown_private_meta;
+		$report['inconsistent_private_meta_keys'] = $inconsistent_private_meta;
+
+		if (!empty($inconsistent_private_meta)) {
+			return self::reject(
+				$report,
+				'inconsistent_private_metadata_classification',
+				__('A private line-item metadata adapter classifies the same key differently for Split copying and canonical line identity.', 'wc-order-splitter')
+			);
+		}
 		if (!empty($unknown_private_meta)) {
 			return self::reject(
 				$report,

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -1,0 +1,70 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * WooCommerce-facing adapter for the first P2 manual quantity-split workflow.
+ *
+ * The production gateway owns authorization/gating; this adapter owns
+ * WooCommerce compatibility preflight and request-local side-effect evidence.
+ * Integration tests may instantiate it directly while the production gate is
+ * still hard-off.
+ */
+final class WCOS_Split_WooCommerce_Adapter {
+
+	public function split(WC_Order $source, array $plan, $operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		if ('' === $operation_id) {
+			throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
+		}
+
+		WCOS_Split_Preflight::assert_supported($source);
+		$token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+
+		try {
+			$children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
+			WCOS_Stock_Side_Effect_Guard::assert_clean($token);
+			return $children;
+		} catch (Throwable $throwable) {
+			$events = WCOS_Stock_Side_Effect_Guard::events($token);
+			if (!empty($events)) {
+				$this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
+				if (!$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+					throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
+				}
+			}
+			throw $throwable;
+		} finally {
+			WCOS_Stock_Side_Effect_Guard::end($token);
+		}
+	}
+
+	public function preflight(WC_Order $source) {
+		return WCOS_Split_Preflight::report($source);
+	}
+
+	private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {
+		$fresh = wc_get_order(absint($source_id));
+		if (!$fresh instanceof WC_Order) {
+			return;
+		}
+		$record = WCOS_Operation_Journal::get($fresh, $operation_id);
+		if (!is_array($record)) {
+			return;
+		}
+		$status = isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+		if (in_array($status, array('completed', 'compensated'), true)) {
+			return;
+		}
+		WCOS_Operation_Journal::require_recovery(
+			$fresh,
+			$operation_id,
+			array(
+				'reason' => 'unexpected_physical_stock_write',
+				'automatic_compensation_allowed' => false,
+				'stock_side_effects' => array_values($events),
+				'error' => $throwable->getMessage(),
+			)
+		);
+	}
+}

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -27,11 +27,11 @@ final class WCOS_Split_WooCommerce_Adapter {
 			return $children;
 		} catch (Throwable $throwable) {
 			$events = WCOS_Stock_Side_Effect_Guard::events($token);
-			if (!empty($events)) {
+			if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
 				$this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
-				if (!$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
-					throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
-				}
+			}
+			if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+				throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
 			}
 			throw $throwable;
 		} finally {

--- a/inc/domain/class-wcos-stock-side-effect-guard.php
+++ b/inc/domain/class-wcos-stock-side-effect-guard.php
@@ -1,0 +1,139 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Raised when the current order-only mutation request writes physical product stock.
+ */
+final class WCOS_Unexpected_Stock_Mutation_Exception extends RuntimeException {
+	private $events;
+
+	public function __construct(array $events, Throwable $previous = null) {
+		$this->events = array_values($events);
+		parent::__construct(
+			__('Physical product stock was changed by the current order-mutation request.', 'wc-order-splitter'),
+			0,
+			$previous
+		);
+	}
+
+	public function get_events() {
+		return $this->events;
+	}
+}
+
+/**
+ * Request-local observer for WooCommerce stock writes.
+ *
+ * A concurrent checkout runs in another request/process and therefore does not
+ * dirty this guard. Stock writes caused by hooks executing inside the mutation
+ * request do dirty it, including parent-managed variation stock writes because
+ * WooCommerce emits the set-stock hook for the actual stock-owning product.
+ */
+final class WCOS_Stock_Side_Effect_Guard {
+	private static $bootstrapped = false;
+	private static $scopes = array();
+	private static $stack = array();
+
+	public static function bootstrap() {
+		if (self::$bootstrapped) {
+			return;
+		}
+		self::$bootstrapped = true;
+		add_action('woocommerce_product_set_stock', array(__CLASS__, 'record_product_stock_write'), PHP_INT_MAX, 1);
+		add_action('woocommerce_variation_set_stock', array(__CLASS__, 'record_product_stock_write'), PHP_INT_MAX, 1);
+	}
+
+	public static function begin($operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		if ('' === $operation_id) {
+			throw new InvalidArgumentException(__('A stock-observer operation ID is required.', 'wc-order-splitter'));
+		}
+		self::bootstrap();
+		$token = hash('sha256', $operation_id . '|' . wp_generate_uuid4() . '|' . microtime(true));
+		self::$scopes[$token] = array(
+			'operation_id' => $operation_id,
+			'events' => array(),
+		);
+		self::$stack[] = $token;
+		return $token;
+	}
+
+	public static function end($token) {
+		$token = (string) $token;
+		if (!isset(self::$scopes[$token])) {
+			return false;
+		}
+		unset(self::$scopes[$token]);
+		self::$stack = array_values(
+			array_filter(
+				self::$stack,
+				static function($active_token) use ($token) {
+					return $active_token !== $token;
+				}
+			)
+		);
+		return true;
+	}
+
+	public static function has_active_scope() {
+		return !empty(self::$stack);
+	}
+
+	public static function has_dirty_active_scope() {
+		$token = self::current_token();
+		return null !== $token && !empty(self::$scopes[$token]['events']);
+	}
+
+	public static function current_events() {
+		$token = self::current_token();
+		return null === $token ? array() : self::events($token);
+	}
+
+	public static function events($token) {
+		$token = (string) $token;
+		return isset(self::$scopes[$token]['events']) ? array_values(self::$scopes[$token]['events']) : array();
+	}
+
+	public static function assert_current_clean() {
+		$events = self::current_events();
+		if (!empty($events)) {
+			throw new WCOS_Unexpected_Stock_Mutation_Exception($events);
+		}
+	}
+
+	public static function assert_clean($token) {
+		$events = self::events($token);
+		if (!empty($events)) {
+			throw new WCOS_Unexpected_Stock_Mutation_Exception($events);
+		}
+	}
+
+	public static function record_product_stock_write($product) {
+		if (empty(self::$scopes) || !$product instanceof WC_Product) {
+			return;
+		}
+		$managed_id = method_exists($product, 'get_stock_managed_by_id')
+			? absint($product->get_stock_managed_by_id())
+			: absint($product->get_id());
+		$quantity = $product->get_stock_quantity();
+		$event = array(
+			'product_id' => absint($product->get_id()),
+			'stock_owner_id' => $managed_id,
+			'product_type' => sanitize_key((string) $product->get_type()),
+			'stock_quantity' => null === $quantity ? null : WCOS_Decimal::normalize($quantity, 6),
+		);
+		foreach (array_keys(self::$scopes) as $token) {
+			self::$scopes[$token]['events'][] = $event;
+		}
+	}
+
+	private static function current_token() {
+		if (empty(self::$stack)) {
+			return null;
+		}
+		$token = end(self::$stack);
+		reset(self::$stack);
+		return isset(self::$scopes[$token]) ? $token : null;
+	}
+}

--- a/inc/domain/class-wcos-stock-side-effect-guard.php
+++ b/inc/domain/class-wcos-stock-side-effect-guard.php
@@ -3,7 +3,8 @@
 defined('ABSPATH') || exit;
 
 /**
- * Raised when the current order-only mutation request writes physical product stock.
+ * Raised when the current order-only mutation request attempts or performs a
+ * physical product-stock write.
  */
 final class WCOS_Unexpected_Stock_Mutation_Exception extends RuntimeException {
 	private $events;
@@ -11,7 +12,7 @@ final class WCOS_Unexpected_Stock_Mutation_Exception extends RuntimeException {
 	public function __construct(array $events, Throwable $previous = null) {
 		$this->events = array_values($events);
 		parent::__construct(
-			__('Physical product stock was changed by the current order-mutation request.', 'wc-order-splitter'),
+			__('A physical product-stock write was attempted during the current order-mutation request.', 'wc-order-splitter'),
 			0,
 			$previous
 		);
@@ -23,14 +24,18 @@ final class WCOS_Unexpected_Stock_Mutation_Exception extends RuntimeException {
 }
 
 /**
- * Request-local observer for WooCommerce stock writes.
+ * Request-local guard for WooCommerce stock writes.
  *
- * A concurrent checkout runs in another request/process and therefore does not
- * dirty this guard. Stock writes caused by hooks executing inside the mutation
- * request do dirty it, including parent-managed variation stock writes because
- * WooCommerce emits the set-stock hook for the actual stock-owning product.
+ * Core WooCommerce stock writes are blocked at the before-set-stock hook, before
+ * the data store is changed. The corresponding after-set-stock hooks remain
+ * observed as a fallback for integrations that somehow enter the active request
+ * after a physical stock write. Concurrent checkouts are different requests and
+ * therefore cannot dirty this scope.
  */
 final class WCOS_Stock_Side_Effect_Guard {
+	const PHASE_BLOCKED_BEFORE_WRITE = 'blocked_before_write';
+	const PHASE_OBSERVED_AFTER_WRITE = 'observed_after_write';
+
 	private static $bootstrapped = false;
 	private static $scopes = array();
 	private static $stack = array();
@@ -40,6 +45,8 @@ final class WCOS_Stock_Side_Effect_Guard {
 			return;
 		}
 		self::$bootstrapped = true;
+		add_action('woocommerce_product_before_set_stock', array(__CLASS__, 'block_product_stock_write'), PHP_INT_MIN, 1);
+		add_action('woocommerce_variation_before_set_stock', array(__CLASS__, 'block_product_stock_write'), PHP_INT_MIN, 1);
 		add_action('woocommerce_product_set_stock', array(__CLASS__, 'record_product_stock_write'), PHP_INT_MAX, 1);
 		add_action('woocommerce_variation_set_stock', array(__CLASS__, 'record_product_stock_write'), PHP_INT_MAX, 1);
 	}
@@ -47,7 +54,7 @@ final class WCOS_Stock_Side_Effect_Guard {
 	public static function begin($operation_id) {
 		$operation_id = sanitize_key((string) $operation_id);
 		if ('' === $operation_id) {
-			throw new InvalidArgumentException(__('A stock-observer operation ID is required.', 'wc-order-splitter'));
+			throw new InvalidArgumentException(__('A stock-guard operation ID is required.', 'wc-order-splitter'));
 		}
 		self::bootstrap();
 		$token = hash('sha256', $operation_id . '|' . wp_generate_uuid4() . '|' . microtime(true));
@@ -81,8 +88,11 @@ final class WCOS_Stock_Side_Effect_Guard {
 	}
 
 	public static function has_dirty_active_scope() {
-		$token = self::current_token();
-		return null !== $token && !empty(self::$scopes[$token]['events']);
+		return !empty(self::current_events());
+	}
+
+	public static function has_physical_write_active_scope() {
+		return self::events_require_manual_reconciliation(self::current_events());
 	}
 
 	public static function current_events() {
@@ -93,6 +103,15 @@ final class WCOS_Stock_Side_Effect_Guard {
 	public static function events($token) {
 		$token = (string) $token;
 		return isset(self::$scopes[$token]['events']) ? array_values(self::$scopes[$token]['events']) : array();
+	}
+
+	public static function events_require_manual_reconciliation(array $events) {
+		foreach ($events as $event) {
+			if (isset($event['phase']) && self::PHASE_OBSERVED_AFTER_WRITE === $event['phase']) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public static function assert_current_clean() {
@@ -109,20 +128,36 @@ final class WCOS_Stock_Side_Effect_Guard {
 		}
 	}
 
+	public static function block_product_stock_write($product) {
+		if (empty(self::$scopes) || !$product instanceof WC_Product) {
+			return;
+		}
+		self::append_event(self::event($product, self::PHASE_BLOCKED_BEFORE_WRITE));
+		throw new WCOS_Unexpected_Stock_Mutation_Exception(self::current_events());
+	}
+
 	public static function record_product_stock_write($product) {
 		if (empty(self::$scopes) || !$product instanceof WC_Product) {
 			return;
 		}
+		self::append_event(self::event($product, self::PHASE_OBSERVED_AFTER_WRITE));
+	}
+
+	private static function event(WC_Product $product, $phase) {
 		$managed_id = method_exists($product, 'get_stock_managed_by_id')
 			? absint($product->get_stock_managed_by_id())
 			: absint($product->get_id());
 		$quantity = $product->get_stock_quantity();
-		$event = array(
+		return array(
+			'phase' => sanitize_key((string) $phase),
 			'product_id' => absint($product->get_id()),
 			'stock_owner_id' => $managed_id,
 			'product_type' => sanitize_key((string) $product->get_type()),
 			'stock_quantity' => null === $quantity ? null : WCOS_Decimal::normalize($quantity, 6),
 		);
+	}
+
+	private static function append_event(array $event) {
 		foreach (array_keys(self::$scopes) as $token) {
 			self::$scopes[$token]['events'][] = $event;
 		}
@@ -132,8 +167,8 @@ final class WCOS_Stock_Side_Effect_Guard {
 		if (empty(self::$stack)) {
 			return null;
 		}
-		$token = end(self::$stack);
-		reset(self::$stack);
+		$stack = self::$stack;
+		$token = end($stack);
 		return isset(self::$scopes[$token]) ? $token : null;
 	}
 }

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -22,13 +22,11 @@ wcos_control_assert(is_string($lease_one) && '' !== $lease_one, 'First mutation 
 wcos_control_assert(false === WCOS_Operation_Lock::acquire($order_id, $operation_two, 30), 'A concurrent mutation acquired the same order lease.');
 wcos_control_assert(WCOS_Operation_Lock::is_owned($order_id, $lease_one), 'The first worker did not own its lease.');
 
-/* Consecutive refreshes in one second must remain successful and monotonic. */
 wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'The first rapid lease refresh failed.');
 wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'The second rapid lease refresh was mistaken for a lost lease.');
 $rapid = get_option('wcos_mutation_lock_' . $order_id);
 wcos_control_assert(is_array($rapid) && isset($rapid['revision']) && (int) $rapid['revision'] >= 3, 'Lease refresh revision did not advance monotonically.');
 
-/* Expire the first lease: the stale owner cannot refresh it. */
 $lock_key = 'wcos_mutation_lock_' . $order_id;
 $expired = get_option($lock_key);
 wcos_control_assert(is_array($expired), 'Mutation lease option is missing.');
@@ -36,7 +34,6 @@ $expired['expires_at'] = time() - 1;
 update_option($lock_key, $expired, false);
 wcos_control_assert(false === WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'An expired worker refreshed its stale lease.');
 
-/* A new operation may take over, and stale release cannot delete its successor. */
 $lease_two = WCOS_Operation_Lock::acquire($order_id, $operation_two, 30);
 wcos_control_assert(is_string($lease_two) && '' !== $lease_two && $lease_two !== $lease_one, 'Expired lease was not replaced with a unique successor.');
 wcos_control_assert(false === WCOS_Operation_Lock::release($order_id, $lease_one), 'A stale worker released the successor lease.');
@@ -47,14 +44,8 @@ wcos_control_assert(false === get_option($lock_key, false), 'Mutation lease opti
 
 $journal_operation = 'integration-journal-' . wp_generate_uuid4();
 $fingerprint = WCOS_Mutation_Fingerprint::create('split', $order_id, array('plan' => array('child-a' => array(1 => '1.000000'))));
-wcos_control_assert(
-	WCOS_Operation_Journal::start($order, $journal_operation, 'split', array('test' => true), $fingerprint),
-	'Operation journal could not be started.'
-);
-wcos_control_assert(
-	false === WCOS_Operation_Journal::start($order, $journal_operation, 'split', array(), $fingerprint),
-	'Duplicate journal start was accepted.'
-);
+wcos_control_assert(WCOS_Operation_Journal::start($order, $journal_operation, 'split', array('test' => true), $fingerprint), 'Operation journal could not be started.');
+wcos_control_assert(false === WCOS_Operation_Journal::start($order, $journal_operation, 'split', array(), $fingerprint), 'Duplicate journal start was accepted.');
 
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert(is_array($record) && 'started' === $record['status'], 'Durable journal was not readable through a fresh order object.');
@@ -63,42 +54,24 @@ wcos_control_assert($fingerprint === $record['fingerprint'], 'Journal fingerprin
 
 $fingerprint_rejected = false;
 try {
-	WCOS_Operation_Journal::assert_fingerprint(
-		$record,
-		WCOS_Mutation_Fingerprint::create('split', $order_id, array('plan' => array('child-b' => array(1 => '1.000000'))))
-	);
+	WCOS_Operation_Journal::assert_fingerprint($record, WCOS_Mutation_Fingerprint::create('split', $order_id, array('plan' => array('child-b' => array(1 => '1.000000')))));
 } catch (RuntimeException $exception) {
 	$fingerprint_rejected = false !== strpos($exception->getMessage(), 'different mutation request');
 }
 wcos_control_assert($fingerprint_rejected, 'Journal accepted a different mutation fingerprint.');
 
-wcos_control_assert(
-	WCOS_Operation_Journal::checkpoint($order, $journal_operation, 'child_persisted', array('target_order_ids' => array(123))),
-	'Journal checkpoint failed.'
-);
-wcos_control_assert(
-	WCOS_Operation_Journal::fail($order, $journal_operation, array('error' => 'injected failure')),
-	'Journal failure transition failed.'
-);
+wcos_control_assert(WCOS_Operation_Journal::checkpoint($order, $journal_operation, 'child_persisted', array('target_order_ids' => array(123))), 'Journal checkpoint failed.');
+wcos_control_assert(WCOS_Operation_Journal::fail($order, $journal_operation, array('error' => 'injected failure')), 'Journal failure transition failed.');
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('failed' === $record['status'] && !empty($record['completed_at']), 'Failed journal state did not receive a terminal timestamp.');
 
-wcos_control_assert(
-	WCOS_Operation_Journal::resume($order, $journal_operation, array('retry' => true)),
-	'Journal resume transition failed.'
-);
+wcos_control_assert(WCOS_Operation_Journal::resume($order, $journal_operation, array('retry' => true)), 'Journal resume transition failed.');
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('started' === $record['status'] && 'resumed' === $record['stage'], 'Journal did not return to an active state.');
 wcos_control_assert(null === $record['completed_at'], 'Resumed journal retained a terminal timestamp.');
 
-wcos_control_assert(
-	WCOS_Operation_Journal::mark_committed($order, $journal_operation, array('target_order_ids' => array(123))),
-	'Journal commit marker failed.'
-);
-wcos_control_assert(
-	WCOS_Operation_Journal::complete($order, $journal_operation, array('verified' => true)),
-	'Journal completion failed.'
-);
+wcos_control_assert(WCOS_Operation_Journal::mark_committed($order, $journal_operation, array('target_order_ids' => array(123))), 'Journal commit marker failed.');
+wcos_control_assert(WCOS_Operation_Journal::complete($order, $journal_operation, array('verified' => true)), 'Journal completion failed.');
 
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('completed' === $record['status'] && 'completed' === $record['stage'], 'Journal did not persist terminal state.');
@@ -121,7 +94,7 @@ wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is mi
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
-/* P2 quantity-split adapter contracts run in every WooCommerce storage mode. */
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
+require __DIR__ . '/p2-stock-matrix-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -87,5 +87,6 @@ $order->delete(true);
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
+require __DIR__ . '/p2-production-side-effect-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -121,4 +121,7 @@ wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is mi
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
+/* P2 quantity-split adapter contracts run in every WooCommerce storage mode. */
+require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
+
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -88,5 +88,6 @@ require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';
 require __DIR__ . '/p2-metadata-compatibility-smoke.php';
+require __DIR__ . '/p2-journal-retention-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -25,7 +25,6 @@ wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $ope
 wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'The second rapid lease refresh was mistaken for a lost lease.');
 $rapid = get_option('wcos_mutation_lock_' . $order_id);
 wcos_control_assert(is_array($rapid) && isset($rapid['revision']) && (int) $rapid['revision'] >= 3, 'Lease refresh revision did not advance monotonically.');
-
 $lock_key = 'wcos_mutation_lock_' . $order_id;
 $expired = get_option($lock_key);
 wcos_control_assert(is_array($expired), 'Mutation lease option is missing.');
@@ -88,5 +87,6 @@ require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';
+require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -21,7 +21,6 @@ $lease_one = WCOS_Operation_Lock::acquire($order_id, $operation_one, 30);
 wcos_control_assert(is_string($lease_one) && '' !== $lease_one, 'First mutation lease was not acquired.');
 wcos_control_assert(false === WCOS_Operation_Lock::acquire($order_id, $operation_two, 30), 'A concurrent mutation acquired the same order lease.');
 wcos_control_assert(WCOS_Operation_Lock::is_owned($order_id, $lease_one), 'The first worker did not own its lease.');
-
 wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'The first rapid lease refresh failed.');
 wcos_control_assert(WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'The second rapid lease refresh was mistaken for a lost lease.');
 $rapid = get_option('wcos_mutation_lock_' . $order_id);
@@ -33,7 +32,6 @@ wcos_control_assert(is_array($expired), 'Mutation lease option is missing.');
 $expired['expires_at'] = time() - 1;
 update_option($lock_key, $expired, false);
 wcos_control_assert(false === WCOS_Operation_Lock::refresh($order_id, $lease_one, 30, $operation_one), 'An expired worker refreshed its stale lease.');
-
 $lease_two = WCOS_Operation_Lock::acquire($order_id, $operation_two, 30);
 wcos_control_assert(is_string($lease_two) && '' !== $lease_two && $lease_two !== $lease_one, 'Expired lease was not replaced with a unique successor.');
 wcos_control_assert(false === WCOS_Operation_Lock::release($order_id, $lease_one), 'A stale worker released the successor lease.');
@@ -46,12 +44,10 @@ $journal_operation = 'integration-journal-' . wp_generate_uuid4();
 $fingerprint = WCOS_Mutation_Fingerprint::create('split', $order_id, array('plan' => array('child-a' => array(1 => '1.000000'))));
 wcos_control_assert(WCOS_Operation_Journal::start($order, $journal_operation, 'split', array('test' => true), $fingerprint), 'Operation journal could not be started.');
 wcos_control_assert(false === WCOS_Operation_Journal::start($order, $journal_operation, 'split', array(), $fingerprint), 'Duplicate journal start was accepted.');
-
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert(is_array($record) && 'started' === $record['status'], 'Durable journal was not readable through a fresh order object.');
 wcos_control_assert(null === $record['completed_at'], 'A new journal unexpectedly has a terminal timestamp.');
 wcos_control_assert($fingerprint === $record['fingerprint'], 'Journal fingerprint was not preserved.');
-
 $fingerprint_rejected = false;
 try {
 	WCOS_Operation_Journal::assert_fingerprint($record, WCOS_Mutation_Fingerprint::create('split', $order_id, array('plan' => array('child-b' => array(1 => '1.000000')))));
@@ -59,26 +55,21 @@ try {
 	$fingerprint_rejected = false !== strpos($exception->getMessage(), 'different mutation request');
 }
 wcos_control_assert($fingerprint_rejected, 'Journal accepted a different mutation fingerprint.');
-
 wcos_control_assert(WCOS_Operation_Journal::checkpoint($order, $journal_operation, 'child_persisted', array('target_order_ids' => array(123))), 'Journal checkpoint failed.');
 wcos_control_assert(WCOS_Operation_Journal::fail($order, $journal_operation, array('error' => 'injected failure')), 'Journal failure transition failed.');
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('failed' === $record['status'] && !empty($record['completed_at']), 'Failed journal state did not receive a terminal timestamp.');
-
 wcos_control_assert(WCOS_Operation_Journal::resume($order, $journal_operation, array('retry' => true)), 'Journal resume transition failed.');
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('started' === $record['status'] && 'resumed' === $record['stage'], 'Journal did not return to an active state.');
 wcos_control_assert(null === $record['completed_at'], 'Resumed journal retained a terminal timestamp.');
-
 wcos_control_assert(WCOS_Operation_Journal::mark_committed($order, $journal_operation, array('target_order_ids' => array(123))), 'Journal commit marker failed.');
 wcos_control_assert(WCOS_Operation_Journal::complete($order, $journal_operation, array('verified' => true)), 'Journal completion failed.');
-
 $record = WCOS_Operation_Journal::get(wc_get_order($order_id), $journal_operation);
 wcos_control_assert('completed' === $record['status'] && 'completed' === $record['stage'], 'Journal did not persist terminal state.');
 wcos_control_assert(!empty($record['completed_at']), 'Completed journal is missing its terminal timestamp.');
 wcos_control_assert(true === $record['context']['verified'], 'Journal context was not merged across transitions.');
 wcos_control_assert(count($record['checkpoints']) >= 6, 'Journal checkpoints were not retained.');
-
 $fresh_order = wc_get_order($order_id);
 $summary = (array) $fresh_order->get_meta(WCOS_Operation_Journal::SUMMARY_META_KEY, true);
 $summary_entry = null;
@@ -90,11 +81,11 @@ foreach ($summary as $entry) {
 }
 wcos_control_assert(is_array($summary_entry) && 'completed' === $summary_entry['status'], 'Bounded order-meta audit summary was not updated.');
 wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is missing the terminal timestamp.');
-
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
+require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/p2-charge-tax-matrix-smoke.php
+++ b/tests/integration/p2-charge-tax-matrix-smoke.php
@@ -1,0 +1,268 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_charge_units($value, $precision = 2) {
+	return WCOS_Decimal::to_units($value, (int) $precision);
+}
+
+function wcos_p2_charge_tax_rows(WC_Order $order) {
+	$rows = array();
+	foreach ($order->get_items('tax') as $item) {
+		$rows[(int) $item->get_rate_id()] = array(
+			'cart' => wcos_p2_charge_units($item->get_tax_total()),
+			'shipping' => wcos_p2_charge_units($item->get_shipping_tax_total()),
+		);
+	}
+	ksort($rows, SORT_NUMERIC);
+	return $rows;
+}
+
+function wcos_p2_charge_order_ids(array $orders) {
+	return array_values(array_map(static function($order) {
+		return $order instanceof WC_Order ? $order->get_id() : 0;
+	}, $orders));
+}
+
+function wcos_p2_charge_build_order($prices_include_tax, $paid = false) {
+	$product = wcos_p2_adapter_product('WCOS P2 charge matrix ' . ($prices_include_tax ? 'incl' : 'excl'), '10.00');
+	$order = wc_create_order();
+	$order->set_status($paid ? 'processing' : 'pending');
+	$order->set_currency('USD');
+	$order->set_prices_include_tax((bool) $prices_include_tax);
+	if ($paid) {
+		$order->set_payment_method('bacs');
+		$order->set_payment_method_title('Bank transfer');
+		$order->set_transaction_id('wcos-p2-source-transaction');
+		$order->set_date_paid(time());
+	}
+
+	$line = new WC_Order_Item_Product();
+	$result = $line->set_props(array(
+		'name' => 'Historical taxable line',
+		'product_id' => $product->get_id(),
+		'variation_id' => 0,
+		'quantity' => '2.000000',
+		'tax_class' => '',
+		'subtotal' => '20.00',
+		'total' => '20.00',
+		'taxes' => array(
+			'subtotal' => array(101 => '2.00'),
+			'total' => array(101 => '2.00'),
+		),
+		'subtotal_tax' => '2.00',
+		'total_tax' => '2.00',
+	));
+	wcos_p2_adapter_assert(!is_wp_error($result), 'Unable to create the P2 historical line item.');
+	$order->add_item($line);
+
+	$fee = new WC_Order_Item_Fee();
+	$fee->set_name('Historical service fee');
+	$fee->set_amount('5.00');
+	$fee->set_total('5.00');
+	$fee->set_tax_status('taxable');
+	$fee->set_tax_class('');
+	$fee->set_taxes(array('total' => array(202 => '0.50')));
+	$order->add_item($fee);
+
+	$shipping_a = new WC_Order_Item_Shipping();
+	$shipping_a->set_method_title('Historical package A');
+	$shipping_a->set_method_id('flat_rate');
+	$shipping_a->set_instance_id(1);
+	$shipping_a->set_total('4.00');
+	$shipping_a->set_taxes(array('total' => array(303 => '0.40')));
+	$order->add_item($shipping_a);
+
+	$shipping_b = new WC_Order_Item_Shipping();
+	$shipping_b->set_method_title('Historical package B');
+	$shipping_b->set_method_id('local_pickup');
+	$shipping_b->set_instance_id(2);
+	$shipping_b->set_total('6.00');
+	$shipping_b->set_taxes(array('total' => array(304 => '0.60')));
+	$order->add_item($shipping_b);
+
+	foreach (array(
+		101 => array('label' => 'Historical line rate', 'cart' => '2.00', 'shipping' => '0.00'),
+		202 => array('label' => 'Historical fee rate', 'cart' => '0.50', 'shipping' => '0.00'),
+		303 => array('label' => 'Historical package A rate', 'cart' => '0.00', 'shipping' => '0.40'),
+		304 => array('label' => 'Historical package B rate', 'cart' => '0.00', 'shipping' => '0.60'),
+	) as $rate_id => $state) {
+		$tax = new WC_Order_Item_Tax();
+		$tax_result = $tax->set_props(array(
+			'rate_id' => $rate_id,
+			'label' => $state['label'],
+			'compound' => false,
+			'tax_total' => $state['cart'],
+			'shipping_tax_total' => $state['shipping'],
+			'rate_percent' => 10,
+		));
+		wcos_p2_adapter_assert(!is_wp_error($tax_result), 'Unable to create a historical tax row.');
+		$order->add_item($tax);
+	}
+
+	$order_result = $order->set_props(array(
+		'discount_total' => '0.00',
+		'discount_tax' => '0.00',
+		'shipping_total' => '10.00',
+		'shipping_tax' => '1.00',
+		'cart_tax' => '2.50',
+		'total_tax' => '3.50',
+		'total' => '38.50',
+	));
+	wcos_p2_adapter_assert(!is_wp_error($order_result), 'Unable to set historical order charge totals.');
+	$order->save();
+	return array(wc_get_order($order->get_id()), $product, $line->get_id());
+}
+
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+
+foreach (array(false, true) as $prices_include_tax) {
+	foreach (array(false, true) as $paid) {
+		list($source, $product, $line_id) = wcos_p2_charge_build_order($prices_include_tax, $paid);
+		WCOS_Order_Totals_Rebuilder::assert_consistent($source, 2);
+		$report = $adapter->preflight($source);
+		wcos_p2_adapter_assert(!empty($report['supported']), 'P2 preflight rejected a supported historical charge fixture.');
+		wcos_p2_adapter_assert((bool) $prices_include_tax === (bool) $report['prices_include_tax'], 'P2 preflight lost the prices-include-tax context.');
+		wcos_p2_adapter_assert((bool) $paid === (bool) $report['is_paid'], 'P2 preflight reported the wrong paid-state fact.');
+		wcos_p2_adapter_assert(2 === (int) $report['shipping_count'] && 1 === (int) $report['fee_count'], 'P2 preflight lost the charge-row counts.');
+
+		$source_shipping_ids = array_keys($source->get_items('shipping'));
+		$source_fee_ids = array_keys($source->get_items('fee'));
+		$before = WCOS_Order_Contract_Snapshot::aggregate(array($source), 2);
+		$operation_id = 'p2-charge-tax-' . ($prices_include_tax ? 'incl-' : 'excl-') . ($paid ? 'paid-' : 'unpaid-') . wp_generate_uuid4();
+		$children = $adapter->split($source, array('child-one' => array($line_id => '1.000000')), $operation_id);
+		wcos_p2_adapter_assert(1 === count($children), 'Historical charge Split did not create exactly one child.');
+		$source = wc_get_order($source->get_id());
+		$child = wc_get_order($children[0]->get_id());
+
+		wcos_p2_adapter_assert($source_shipping_ids === array_keys($source->get_items('shipping')), 'Shipping row ownership changed on the source.');
+		wcos_p2_adapter_assert($source_fee_ids === array_keys($source->get_items('fee')), 'Fee row ownership changed on the source.');
+		wcos_p2_adapter_assert(0 === count($child->get_items('shipping')), 'A child received a duplicated shipping package.');
+		wcos_p2_adapter_assert(0 === count($child->get_items('fee')), 'A child received a duplicated fee row.');
+		wcos_p2_adapter_assert(1000 === wcos_p2_charge_units($source->get_shipping_total()), 'Source shipping total changed under keep-on-source policy.');
+		$source_fees = $source->get_items('fee');
+		$source_fee = reset($source_fees);
+		wcos_p2_adapter_assert($source_fee instanceof WC_Order_Item_Fee && 500 === wcos_p2_charge_units($source_fee->get_total()), 'Source fee total changed under keep-on-source policy.');
+		wcos_p2_adapter_assert((bool) $prices_include_tax === (bool) $child->get_prices_include_tax(), 'Child lost prices-include-tax context.');
+		wcos_p2_adapter_assert('USD' === $child->get_currency(), 'Child lost the source currency.');
+
+		$expected_source_tax = array(
+			101 => array('cart' => 100, 'shipping' => 0),
+			202 => array('cart' => 50, 'shipping' => 0),
+			303 => array('cart' => 0, 'shipping' => 40),
+			304 => array('cart' => 0, 'shipping' => 60),
+		);
+		$expected_child_tax = array(101 => array('cart' => 100, 'shipping' => 0));
+		wcos_p2_adapter_assert($expected_source_tax === wcos_p2_charge_tax_rows($source), 'Source historical tax rows drifted across line/fee/shipping rates.');
+		wcos_p2_adapter_assert($expected_child_tax === wcos_p2_charge_tax_rows($child), 'Child tax rows include non-child charges or lost the line rate.');
+		wcos_p2_adapter_assert(2750 === wcos_p2_charge_units($source->get_total()), 'Source grand total is wrong after keep-on-source charge allocation.');
+		wcos_p2_adapter_assert(1100 === wcos_p2_charge_units($child->get_total()), 'Child grand total is wrong after historical line allocation.');
+		WCOS_Mutation_Contract::assert_conserved($before, WCOS_Order_Contract_Snapshot::aggregate(array($source, $child), 2), 2);
+
+		if ($paid) {
+			wcos_p2_adapter_assert('wcos-p2-source-transaction' === $source->get_transaction_id(), 'Paid source lost its transaction ID.');
+			wcos_p2_adapter_assert('' === $child->get_transaction_id(), 'Child duplicated the source transaction ID.');
+			wcos_p2_adapter_assert('bacs' === $child->get_payment_method(), 'Child lost non-transaction payment context.');
+			wcos_p2_adapter_assert('pending' === $child->get_status(), 'Paid source produced a paid-status child.');
+			wcos_p2_adapter_assert(null === $child->get_date_paid(), 'Child duplicated the source paid timestamp.');
+		}
+
+		wcos_p2_adapter_cleanup($source->get_id(), $operation_id);
+		wp_delete_post($product->get_id(), true);
+	}
+}
+
+/* Negative fees are discount-like and remain explicitly unsupported. */
+$negative_product = wcos_p2_adapter_product('WCOS P2 negative fee reject', '10.00');
+list($negative_source, $negative_line_id) = wcos_p2_adapter_order($negative_product, 2);
+$negative_fee = new WC_Order_Item_Fee();
+$negative_fee->set_name('Legacy negative fee');
+$negative_fee->set_amount('-2.00');
+$negative_fee->set_total('-2.00');
+$negative_fee->set_tax_status('none');
+$negative_source->add_item($negative_fee);
+$negative_source->set_total('18.00');
+$negative_source->save();
+$negative_source = wc_get_order($negative_source->get_id());
+$negative_report = $adapter->preflight($negative_source);
+wcos_p2_adapter_assert(empty($negative_report['supported']) && 'negative_fee_policy_missing' === $negative_report['reason'], 'Negative fee did not fail closed with a stable policy reason.');
+wcos_p2_adapter_assert(1 === (int) $negative_report['negative_fee_count'], 'Negative fee was not reported by preflight.');
+$negative_operation = 'p2-negative-fee-' . wp_generate_uuid4();
+$negative_before = WCOS_Order_Contract_Snapshot::source_signature($negative_source);
+$negative_rejected = false;
+try {
+	$adapter->split($negative_source, array('child-one' => array($negative_line_id => '1.000000')), $negative_operation);
+} catch (WCOS_Split_Preflight_Exception $exception) {
+	$negative_rejected = 'negative_fee_policy_missing' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($negative_rejected, 'Negative-fee Split was not rejected before mutation.');
+wcos_p2_adapter_assert($negative_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($negative_source->get_id())), 'Negative-fee rejection changed the source order.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($negative_source->get_id()), $negative_operation), 'Negative-fee rejection created a journal.');
+wcos_p2_adapter_cleanup($negative_source->get_id());
+wp_delete_post($negative_product->get_id(), true);
+
+/* Multi-child rounding: every cent and tax cent is conserved deterministically. */
+$round_product = wcos_p2_adapter_product('WCOS P2 rounding line', '3.33');
+$round_source = wc_create_order();
+$round_source->set_status('pending');
+$round_source->set_currency('USD');
+$round_line = new WC_Order_Item_Product();
+$round_result = $round_line->set_props(array(
+	'name' => 'Rounding line',
+	'product_id' => $round_product->get_id(),
+	'quantity' => '3.000000',
+	'subtotal' => '10.00',
+	'total' => '10.00',
+	'taxes' => array('subtotal' => array(401 => '1.00'), 'total' => array(401 => '1.00')),
+	'subtotal_tax' => '1.00',
+	'total_tax' => '1.00',
+));
+wcos_p2_adapter_assert(!is_wp_error($round_result), 'Unable to build multi-child rounding line.');
+$round_source->add_item($round_line);
+$round_tax = new WC_Order_Item_Tax();
+$round_tax_result = $round_tax->set_props(array('rate_id' => 401, 'label' => 'Rounding tax', 'tax_total' => '1.00', 'shipping_tax_total' => '0.00', 'compound' => false, 'rate_percent' => 10));
+wcos_p2_adapter_assert(!is_wp_error($round_tax_result), 'Unable to build multi-child rounding tax row.');
+$round_source->add_item($round_tax);
+$round_order_result = $round_source->set_props(array('cart_tax' => '1.00', 'total_tax' => '1.00', 'total' => '11.00'));
+wcos_p2_adapter_assert(!is_wp_error($round_order_result), 'Unable to set multi-child rounding totals.');
+$round_source->save();
+$round_source = wc_get_order($round_source->get_id());
+$round_line_ids = array_keys($round_source->get_items('line_item'));
+$round_line_id = reset($round_line_ids);
+$round_before = WCOS_Order_Contract_Snapshot::aggregate(array($round_source), 2);
+$round_operation = 'p2-rounding-' . wp_generate_uuid4();
+$round_plan = array(
+	'child-a' => array($round_line_id => '1.000000'),
+	'child-b' => array($round_line_id => '1.000000'),
+);
+$round_children = $adapter->split($round_source, $round_plan, $round_operation);
+wcos_p2_adapter_assert(2 === count($round_children), 'Multi-child rounding Split did not create two children.');
+$round_source = wc_get_order($round_source->get_id());
+$round_child_ids = wcos_p2_charge_order_ids(array_values($round_children));
+$round_orders = array($round_source);
+foreach ($round_child_ids as $round_child_id) {
+	$round_orders[] = wc_get_order($round_child_id);
+}
+$subtotal_parts = array();
+$tax_parts = array();
+foreach ($round_orders as $round_order) {
+	$round_items = $round_order->get_items('line_item');
+	$round_item = reset($round_items);
+	wcos_p2_adapter_assert($round_item instanceof WC_Order_Item_Product, 'Multi-child rounding destination lost its line item.');
+	wcos_p2_adapter_assert(1000000 === wcos_p2_charge_units($round_item->get_quantity(), 6), 'Multi-child rounding changed a destination quantity.');
+	$subtotal_parts[] = wcos_p2_charge_units($round_item->get_subtotal());
+	$tax_parts[] = wcos_p2_charge_units($round_item->get_total_tax());
+}
+sort($subtotal_parts, SORT_NUMERIC);
+sort($tax_parts, SORT_NUMERIC);
+wcos_p2_adapter_assert(array(333, 333, 334) === $subtotal_parts, 'Ten-dollar line was not allocated by deterministic one-cent remainder.');
+wcos_p2_adapter_assert(array(33, 33, 34) === $tax_parts, 'One-dollar tax was not allocated by deterministic one-cent remainder.');
+WCOS_Mutation_Contract::assert_conserved($round_before, WCOS_Order_Contract_Snapshot::aggregate($round_orders, 2), 2);
+$retry_children = $adapter->split(wc_get_order($round_source->get_id()), $round_plan, $round_operation);
+wcos_p2_adapter_assert($round_child_ids === wcos_p2_charge_order_ids(array_values($retry_children)), 'Multi-child rounding retry did not reuse the same child set.');
+wcos_p2_adapter_cleanup($round_source->get_id(), $round_operation);
+wp_delete_post($round_product->get_id(), true);
+
+echo "p2-charge-tax-payment-rounding-matrix-ok\n";

--- a/tests/integration/p2-journal-retention-smoke.php
+++ b/tests/integration/p2-journal-retention-smoke.php
@@ -1,0 +1,70 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+/* Scheduling stays dormant while all production mutation gates are hard-off. */
+wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);
+delete_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION);
+WCOS_Operation_Journal_Retention::maybe_schedule();
+wcos_p2_adapter_assert(false === wp_next_scheduled(WCOS_Operation_Journal_Retention::CRON_HOOK), 'Journal cleanup was scheduled while every production workflow gate is hard-off.');
+
+$now = time();
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'completed', 'completed_at' => gmdate('c', $now - (100 * DAY_IN_SECONDS))), $now),
+	'Expired completed mutation journal was not eligible for retention cleanup.'
+);
+wcos_p2_adapter_assert(
+	!WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'completed', 'completed_at' => gmdate('c', $now - DAY_IN_SECONDS)), $now),
+	'Recent completed mutation journal was eligible for premature cleanup.'
+);
+wcos_p2_adapter_assert(
+	!WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'recovery_required', 'completed_at' => gmdate('c', $now - (200 * DAY_IN_SECONDS))), $now),
+	'Recovery-required mutation journal was eligible for destructive cleanup.'
+);
+
+/*
+ * Cursor starvation regression: more than one full batch of ineligible active
+ * records must not permanently hide an expired terminal record behind them.
+ */
+$fixture_prefix = 'wcos_mutation_op_retention_' . str_replace('-', '', wp_generate_uuid4()) . '_';
+$fixture_keys = array();
+for ($index = 0; $index < 60; $index++) {
+	$key = $fixture_prefix . sprintf('active_%03d', $index);
+	add_option(
+		$key,
+		array(
+			'status' => 'started',
+			'completed_at' => null,
+		),
+		'',
+		false
+	);
+	$fixture_keys[] = $key;
+}
+$expired_key = $fixture_prefix . 'expired_terminal';
+add_option(
+	$expired_key,
+	array(
+		'status' => 'completed',
+		'completed_at' => gmdate('c', $now - (120 * DAY_IN_SECONDS)),
+	),
+	'',
+	false
+);
+$fixture_keys[] = $expired_key;
+
+for ($pass = 0; $pass < 10 && false !== get_option($expired_key, false); $pass++) {
+	WCOS_Operation_Journal_Retention::cleanup();
+}
+wcos_p2_adapter_assert(false === get_option($expired_key, false), 'Retention cursor never reached an expired journal behind ineligible active records.');
+wcos_p2_adapter_assert(false !== get_option($fixture_keys[0], false), 'Retention cleanup deleted an active mutation journal.');
+wcos_p2_adapter_assert(absint(get_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION, 0)) > 0, 'Retention cleanup did not persist its scan cursor.');
+
+foreach ($fixture_keys as $fixture_key) {
+	delete_option($fixture_key);
+}
+delete_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION);
+
+echo "p2-journal-retention-pagination-ok\n";

--- a/tests/integration/p2-journal-retention-smoke.php
+++ b/tests/integration/p2-journal-retention-smoke.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 
 /* Scheduling stays dormant while all production mutation gates are hard-off. */
 wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);
-delete_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION);
+delete_option(WCOS_Operation_Journal_Retention::SCAN_STATE_OPTION);
 WCOS_Operation_Journal_Retention::maybe_schedule();
 wcos_p2_adapter_assert(false === wp_next_scheduled(WCOS_Operation_Journal_Retention::CRON_HOOK), 'Journal cleanup was scheduled while every production workflow gate is hard-off.');
 
@@ -25,24 +25,30 @@ wcos_p2_adapter_assert(
 );
 
 /*
- * Cursor starvation regression: more than one full batch of ineligible active
- * records must not permanently hide an expired terminal record behind them.
+ * High-water-cycle regression: more than one full batch of active records must
+ * not hide an expired record, and a record scanned while recent must be revisited
+ * in a later cycle even if newer journal options keep arriving continuously.
  */
 $fixture_prefix = 'wcos_mutation_op_retention_' . str_replace('-', '', wp_generate_uuid4()) . '_';
 $fixture_keys = array();
+$recent_key = $fixture_prefix . 'recent_then_expired';
+add_option(
+	$recent_key,
+	array(
+		'status' => 'completed',
+		'completed_at' => gmdate('c', $now - DAY_IN_SECONDS),
+	),
+	'',
+	false
+);
+$fixture_keys[] = $recent_key;
+
 for ($index = 0; $index < 60; $index++) {
 	$key = $fixture_prefix . sprintf('active_%03d', $index);
-	add_option(
-		$key,
-		array(
-			'status' => 'started',
-			'completed_at' => null,
-		),
-		'',
-		false
-	);
+	add_option($key, array('status' => 'started', 'completed_at' => null), '', false);
 	$fixture_keys[] = $key;
 }
+
 $expired_key = $fixture_prefix . 'expired_terminal';
 add_option(
 	$expired_key,
@@ -55,16 +61,40 @@ add_option(
 );
 $fixture_keys[] = $expired_key;
 
+/* First cycle spans multiple bounded pages and must eventually delete expired_key. */
 for ($pass = 0; $pass < 10 && false !== get_option($expired_key, false); $pass++) {
 	WCOS_Operation_Journal_Retention::cleanup();
 }
-wcos_p2_adapter_assert(false === get_option($expired_key, false), 'Retention cursor never reached an expired journal behind ineligible active records.');
-wcos_p2_adapter_assert(false !== get_option($fixture_keys[0], false), 'Retention cleanup deleted an active mutation journal.');
-wcos_p2_adapter_assert(absint(get_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION, 0)) > 0, 'Retention cleanup did not persist its scan cursor.');
+wcos_p2_adapter_assert(false === get_option($expired_key, false), 'Retention high-water cycle never reached an expired journal behind active records.');
+wcos_p2_adapter_assert(false !== get_option($recent_key, false), 'Retention cleanup deleted a recent terminal journal.');
+wcos_p2_adapter_assert(false !== get_option($fixture_keys[1], false), 'Retention cleanup deleted an active mutation journal.');
+wcos_p2_adapter_assert(false === get_option(WCOS_Operation_Journal_Retention::SCAN_STATE_OPTION, false), 'Retention scan state did not reset after reaching the first high-water mark.');
+
+/* Age the previously scanned recent journal after cycle completion. */
+update_option(
+	$recent_key,
+	array(
+		'status' => 'completed',
+		'completed_at' => gmdate('c', $now - (120 * DAY_IN_SECONDS)),
+	),
+	false
+);
+
+/* Add newer rows before the next cleanup cycle to simulate continuous traffic. */
+for ($index = 0; $index < 10; $index++) {
+	$key = $fixture_prefix . sprintf('new_%03d', $index);
+	add_option($key, array('status' => 'started', 'completed_at' => null), '', false);
+	$fixture_keys[] = $key;
+}
+
+for ($pass = 0; $pass < 10 && false !== get_option($recent_key, false); $pass++) {
+	WCOS_Operation_Journal_Retention::cleanup();
+}
+wcos_p2_adapter_assert(false === get_option($recent_key, false), 'A journal scanned while recent was never reconsidered after it aged, despite a new high-water cycle.');
 
 foreach ($fixture_keys as $fixture_key) {
 	delete_option($fixture_key);
 }
-delete_option(WCOS_Operation_Journal_Retention::CURSOR_OPTION);
+delete_option(WCOS_Operation_Journal_Retention::SCAN_STATE_OPTION);
 
-echo "p2-journal-retention-pagination-ok\n";
+echo "p2-journal-retention-high-water-cycle-ok\n";

--- a/tests/integration/p2-metadata-compatibility-smoke.php
+++ b/tests/integration/p2-metadata-compatibility-smoke.php
@@ -1,0 +1,120 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_meta_line(WC_Order $order) {
+	$items = $order->get_items('line_item');
+	$item = reset($items);
+	if (!$item instanceof WC_Order_Item_Product) {
+		throw new RuntimeException('P2 metadata fixture lost its line item.');
+	}
+	return $item;
+}
+
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+
+/* Unknown private metadata must fail closed before any mutation record exists. */
+$business_product = wcos_p2_adapter_product('WCOS P2 private business adapter', '9.00');
+list($business_source, $business_item_id) = wcos_p2_adapter_order($business_product, 3);
+$business_line = $business_source->get_item($business_item_id);
+$business_line->add_meta_data('engraving', 'YES', true);
+$business_line->add_meta_data('_third_party_bundle_config', array('bundle' => 17, 'slot' => 'a'), true);
+$business_line->add_meta_data('_wcos_probe_internal', 'must-not-copy', true);
+$business_line->save();
+$business_source = wc_get_order($business_source->get_id());
+$unknown_report = $adapter->preflight($business_source);
+wcos_p2_adapter_assert(empty($unknown_report['supported']), 'Unknown private business metadata was silently accepted.');
+wcos_p2_adapter_assert('unclassified_private_metadata' === $unknown_report['reason'], 'Unknown private metadata used the wrong preflight rejection reason.');
+wcos_p2_adapter_assert(array('_third_party_bundle_config') === $unknown_report['unknown_private_meta_keys'], 'Protected mutation metadata leaked into the unknown-private compatibility report.');
+$unknown_operation = 'p2-unknown-private-' . wp_generate_uuid4();
+$unknown_rejected = false;
+try {
+	$adapter->split($business_source, array('child-one' => array($business_item_id => '1.000000')), $unknown_operation);
+} catch (WCOS_Split_Preflight_Exception $exception) {
+	$unknown_rejected = 'unclassified_private_metadata' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($unknown_rejected, 'Unknown private metadata did not block Split before persistence.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($business_source->get_id()), $unknown_operation), 'Unknown private metadata rejection created a journal.');
+
+/* A third-party adapter may explicitly classify immutable private configuration as business. */
+$business_adapter = static function($classification, $key) {
+	return '_third_party_bundle_config' === $key ? WCOS_Order_Item_Meta_Policy::CLASS_BUSINESS : $classification;
+};
+add_filter('wcos_order_item_meta_classification', $business_adapter, 10, 6);
+$adapted_report = $adapter->preflight(wc_get_order($business_source->get_id()));
+wcos_p2_adapter_assert(!empty($adapted_report['supported']), 'Explicit private-business metadata adapter did not satisfy preflight.');
+wcos_p2_adapter_assert(empty($adapted_report['unknown_private_meta_keys']), 'Explicit private-business key remained unclassified.');
+$business_operation = 'p2-private-business-' . wp_generate_uuid4();
+$business_children = $adapter->split(
+	wc_get_order($business_source->get_id()),
+	array('child-one' => array($business_item_id => '1.000000')),
+	$business_operation
+);
+$business_child_line = wcos_p2_meta_line($business_children[0]);
+wcos_p2_adapter_assert('YES' === $business_child_line->get_meta('engraving', true), 'Public business metadata was not copied to the child.');
+wcos_p2_adapter_assert(
+	array('bundle' => 17, 'slot' => 'a') === $business_child_line->get_meta('_third_party_bundle_config', true),
+	'Explicit private business configuration was not copied exactly.'
+);
+wcos_p2_adapter_assert('' === $business_child_line->get_meta('_wcos_probe_internal', true), 'Protected mutation metadata was copied to the child.');
+remove_filter('wcos_order_item_meta_classification', $business_adapter, 10);
+wcos_p2_adapter_cleanup($business_source->get_id(), $business_operation);
+wp_delete_post($business_product->get_id(), true);
+
+/* A third-party adapter may instead declare private cache/state as known operational. */
+$operational_product = wcos_p2_adapter_product('WCOS P2 private operational adapter', '7.00');
+list($operational_source, $operational_item_id) = wcos_p2_adapter_order($operational_product, 3);
+$operational_line = $operational_source->get_item($operational_item_id);
+$operational_line->add_meta_data('_third_party_render_cache', 'opaque-cache', true);
+$operational_line->save();
+$operational_source = wc_get_order($operational_source->get_id());
+$operational_unknown = $adapter->preflight($operational_source);
+wcos_p2_adapter_assert('unclassified_private_metadata' === $operational_unknown['reason'], 'Unknown operational private metadata did not fail closed initially.');
+$operational_adapter = static function($known, $key) {
+	return '_third_party_render_cache' === $key ? true : $known;
+};
+add_filter('wcos_order_item_private_meta_is_known_operational', $operational_adapter, 10, 6);
+$operational_report = $adapter->preflight(wc_get_order($operational_source->get_id()));
+wcos_p2_adapter_assert(!empty($operational_report['supported']), 'Known-operational metadata adapter did not satisfy preflight.');
+$operational_operation = 'p2-private-operational-' . wp_generate_uuid4();
+$operational_children = $adapter->split(
+	wc_get_order($operational_source->get_id()),
+	array('child-one' => array($operational_item_id => '1.000000')),
+	$operational_operation
+);
+$operational_child_line = wcos_p2_meta_line($operational_children[0]);
+wcos_p2_adapter_assert('' === $operational_child_line->get_meta('_third_party_render_cache', true), 'Known operational cache metadata was copied to the child.');
+remove_filter('wcos_order_item_private_meta_is_known_operational', $operational_adapter, 10);
+wcos_p2_adapter_cleanup($operational_source->get_id(), $operational_operation);
+wp_delete_post($operational_product->get_id(), true);
+
+/* Protected keys remain operational even if a hostile/buggy adapter tries to promote them. */
+$protected_product = wcos_p2_adapter_product('WCOS P2 protected metadata', '5.00');
+list($protected_source, $protected_item_id) = wcos_p2_adapter_order($protected_product, 3);
+$protected_line = $protected_source->get_item($protected_item_id);
+$protected_line->add_meta_data('_wcos_protected_probe', 'secret-internal', true);
+$protected_line->save();
+$promote_all = static function($classification) {
+	return WCOS_Order_Item_Meta_Policy::CLASS_BUSINESS;
+};
+add_filter('wcos_order_item_meta_classification', $promote_all, PHP_INT_MAX, 6);
+wcos_p2_adapter_assert(
+	WCOS_Order_Item_Meta_Policy::CLASS_OPERATIONAL === WCOS_Order_Item_Meta_Policy::classify('_wcos_protected_probe', 'secret-internal', WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT, wcos_p2_meta_line(wc_get_order($protected_source->get_id()))),
+	'Protected metadata was promoted to business by an adapter filter.'
+);
+$protected_report = $adapter->preflight(wc_get_order($protected_source->get_id()));
+wcos_p2_adapter_assert(!empty($protected_report['supported']), 'Protected mutation metadata incorrectly required a third-party adapter.');
+$protected_operation = 'p2-protected-meta-' . wp_generate_uuid4();
+$protected_children = $adapter->split(
+	wc_get_order($protected_source->get_id()),
+	array('child-one' => array($protected_item_id => '1.000000')),
+	$protected_operation
+);
+wcos_p2_adapter_assert('' === wcos_p2_meta_line($protected_children[0])->get_meta('_wcos_protected_probe', true), 'Protected metadata entered a split child after forced promotion.');
+remove_filter('wcos_order_item_meta_classification', $promote_all, PHP_INT_MAX);
+wcos_p2_adapter_cleanup($protected_source->get_id(), $protected_operation);
+wp_delete_post($protected_product->get_id(), true);
+
+echo "p2-metadata-compatibility-policy-ok\n";

--- a/tests/integration/p2-metadata-compatibility-smoke.php
+++ b/tests/integration/p2-metadata-compatibility-smoke.php
@@ -38,7 +38,21 @@ try {
 wcos_p2_adapter_assert($unknown_rejected, 'Unknown private metadata did not block Split before persistence.');
 wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($business_source->get_id()), $unknown_operation), 'Unknown private metadata rejection created a journal.');
 
-/* A third-party adapter may explicitly classify immutable private configuration as business. */
+/* Context-sensitive adapters are invalid: copy and identity classification must agree. */
+$contextual_adapter = static function($classification, $key, $value, $context) {
+	if ('_third_party_bundle_config' === $key && WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT === $context) {
+		return WCOS_Order_Item_Meta_Policy::CLASS_BUSINESS;
+	}
+	return $classification;
+};
+add_filter('wcos_order_item_meta_classification', $contextual_adapter, 10, 6);
+$contextual_report = $adapter->preflight(wc_get_order($business_source->get_id()));
+wcos_p2_adapter_assert(empty($contextual_report['supported']), 'Context-sensitive private metadata adapter was accepted.');
+wcos_p2_adapter_assert('inconsistent_private_metadata_classification' === $contextual_report['reason'], 'Context-sensitive adapter used the wrong rejection reason.');
+wcos_p2_adapter_assert(array('_third_party_bundle_config') === $contextual_report['inconsistent_private_meta_keys'], 'Context-sensitive adapter key was not reported.');
+remove_filter('wcos_order_item_meta_classification', $contextual_adapter, 10);
+
+/* A third-party adapter may explicitly classify immutable private configuration as business in every relevant context. */
 $business_adapter = static function($classification, $key) {
 	return '_third_party_bundle_config' === $key ? WCOS_Order_Item_Meta_Policy::CLASS_BUSINESS : $classification;
 };
@@ -46,6 +60,7 @@ add_filter('wcos_order_item_meta_classification', $business_adapter, 10, 6);
 $adapted_report = $adapter->preflight(wc_get_order($business_source->get_id()));
 wcos_p2_adapter_assert(!empty($adapted_report['supported']), 'Explicit private-business metadata adapter did not satisfy preflight.');
 wcos_p2_adapter_assert(empty($adapted_report['unknown_private_meta_keys']), 'Explicit private-business key remained unclassified.');
+wcos_p2_adapter_assert(empty($adapted_report['inconsistent_private_meta_keys']), 'Explicit private-business key remained context-inconsistent.');
 $business_operation = 'p2-private-business-' . wp_generate_uuid4();
 $business_children = $adapter->split(
 	wc_get_order($business_source->get_id()),
@@ -89,6 +104,61 @@ wcos_p2_adapter_assert('' === $operational_child_line->get_meta('_third_party_re
 remove_filter('wcos_order_item_private_meta_is_known_operational', $operational_adapter, 10);
 wcos_p2_adapter_cleanup($operational_source->get_id(), $operational_operation);
 wp_delete_post($operational_product->get_id(), true);
+
+/* Two lines with the same product but different adapted business configuration must never collapse. */
+$configured_product = wcos_p2_adapter_product('WCOS P2 configured duplicate lines', '5.00');
+$configured_order = wc_create_order();
+$configured_order->set_status('pending');
+$configured_order->set_currency('USD');
+$configured_line_ids = array();
+foreach (array('A', 'B') as $slot) {
+	$line = new WC_Order_Item_Product();
+	$line->set_props(array(
+		'name' => 'Configured line ' . $slot,
+		'product_id' => $configured_product->get_id(),
+		'quantity' => 2,
+		'subtotal' => '10.00',
+		'total' => '10.00',
+	));
+	$line->add_meta_data('_third_party_bundle_config', array('bundle' => 42, 'slot' => $slot), true);
+	$configured_order->add_item($line);
+}
+$configured_order->calculate_totals(false);
+$configured_order->save();
+$configured_order = wc_get_order($configured_order->get_id());
+$configured_items = $configured_order->get_items('line_item');
+foreach ($configured_items as $configured_item_id => $configured_item) {
+	$configured_line_ids[$configured_item->get_meta('_third_party_bundle_config', true)['slot']] = (int) $configured_item_id;
+}
+ksort($configured_line_ids, SORT_STRING);
+add_filter('wcos_order_item_meta_classification', $business_adapter, 10, 6);
+$configured_report = $adapter->preflight($configured_order);
+wcos_p2_adapter_assert(!empty($configured_report['supported']), 'Configured duplicate-line order failed adapted preflight.');
+$configured_operation = 'p2-configured-lines-' . wp_generate_uuid4();
+$configured_children = $adapter->split(
+	$configured_order,
+	array('child-one' => array($configured_line_ids['A'] => 1, $configured_line_ids['B'] => 1)),
+	$configured_operation
+);
+wcos_p2_adapter_assert(1 === count($configured_children), 'Configured duplicate-line Split did not create one child.');
+$configured_child_items = array_values($configured_children[0]->get_items('line_item'));
+wcos_p2_adapter_assert(2 === count($configured_child_items), 'Configured lines with the same product collapsed in the child.');
+$configured_slots = array();
+$configured_identities = array();
+foreach ($configured_child_items as $configured_child_item) {
+	$config = $configured_child_item->get_meta('_third_party_bundle_config', true);
+	$configured_slots[] = $config['slot'];
+	$configured_identities[] = WCOS_Line_Identity::from_item($configured_child_item);
+}
+sort($configured_slots, SORT_STRING);
+$configured_unique_identities = array_values(array_unique($configured_identities));
+wcos_p2_adapter_assert(array('A', 'B') === $configured_slots, 'Configured business metadata was not preserved per child line.');
+wcos_p2_adapter_assert(2 === count($configured_unique_identities), 'Distinct configured lines produced the same canonical identity.');
+$reloaded_configured_source = wc_get_order($configured_order->get_id());
+wcos_p2_adapter_assert(2 === count($reloaded_configured_source->get_items('line_item')), 'Configured source lines collapsed after Split.');
+remove_filter('wcos_order_item_meta_classification', $business_adapter, 10);
+wcos_p2_adapter_cleanup($configured_order->get_id(), $configured_operation);
+wp_delete_post($configured_product->get_id(), true);
 
 /* Protected keys remain operational even if a hostile/buggy adapter tries to promote them. */
 $protected_product = wcos_p2_adapter_product('WCOS P2 protected metadata', '5.00');

--- a/tests/integration/p2-production-side-effect-smoke.php
+++ b/tests/integration/p2-production-side-effect-smoke.php
@@ -1,0 +1,174 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_side_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_p2_side_note_count($order_id) {
+	return count(wc_get_order_notes(array('order_id' => absint($order_id), 'limit' => -1)));
+}
+
+$product = new WC_Product_Simple();
+$product->set_name('WCOS P2 production side-effect product');
+$product->set_regular_price('10.00');
+$product_id = $product->save();
+
+$source = wc_create_order();
+$source->set_status('pending');
+$source->set_currency('USD');
+$item_id = $source->add_product($product, 4);
+$source->calculate_totals(false);
+$source->save();
+$source_id = $source->get_id();
+$source_note_before = wcos_p2_side_note_count($source_id);
+
+/* Use a real active WooCommerce order.created webhook but intercept delivery scheduling. */
+$webhook = new WC_Webhook();
+$webhook->set_name('WCOS P2 order-created contract');
+$webhook->set_status('active');
+$webhook->set_topic('order.created');
+$webhook->set_delivery_url('https://example.invalid/wcos-p2-webhook');
+$webhook->set_secret('wcos-p2-test-secret');
+$webhook->set_user_id(1);
+$webhook->save();
+$webhook->enqueue();
+
+$core_webhook_scheduler_registered = false !== has_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery');
+if ($core_webhook_scheduler_registered) {
+	remove_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10);
+}
+
+$new_order_ids = array();
+$status_events = array();
+$webhook_args = array();
+$mail_calls = array();
+$stock_before_writes = array();
+$stock_after_writes = array();
+
+$new_order_callback = static function($order_id, $order = null) use (&$new_order_ids) {
+	if (!$order instanceof WC_Order) {
+		$order = wc_get_order($order_id);
+	}
+	if ($order instanceof WC_Order && 'wc-order-splitter-split' === $order->get_created_via()) {
+		$new_order_ids[] = absint($order_id);
+	}
+};
+$status_callback = static function($order_id, $from, $to, $order) use (&$status_events) {
+	if ($order instanceof WC_Order && 'wc-order-splitter-split' === $order->get_created_via()) {
+		$status_events[] = array(absint($order_id), (string) $from, (string) $to);
+	}
+};
+$webhook_callback = static function($active_webhook, $arg) use (&$webhook_args, $webhook) {
+	if ($active_webhook instanceof WC_Webhook && $active_webhook->get_id() === $webhook->get_id()) {
+		$webhook_args[] = absint($arg);
+	}
+};
+$mail_callback = static function($return, $atts) use (&$mail_calls) {
+	$mail_calls[] = is_array($atts) ? $atts : array();
+	return true;
+};
+$stock_before_callback = static function($stock_product) use (&$stock_before_writes) {
+	if ($stock_product instanceof WC_Product) {
+		$stock_before_writes[] = $stock_product->get_id();
+	}
+};
+$stock_after_callback = static function($stock_product) use (&$stock_after_writes) {
+	if ($stock_product instanceof WC_Product) {
+		$stock_after_writes[] = $stock_product->get_id();
+	}
+};
+
+add_action('woocommerce_new_order', $new_order_callback, PHP_INT_MAX, 2);
+add_action('woocommerce_order_status_changed', $status_callback, PHP_INT_MAX, 4);
+add_action('woocommerce_webhook_process_delivery', $webhook_callback, PHP_INT_MAX, 2);
+add_filter('pre_wp_mail', $mail_callback, PHP_INT_MAX, 2);
+add_action('woocommerce_product_before_set_stock', $stock_before_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_variation_before_set_stock', $stock_before_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_product_set_stock', $stock_after_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_variation_set_stock', $stock_after_callback, PHP_INT_MAX, 1);
+
+$operation_id = 'p2-side-effect-contract-' . wp_generate_uuid4();
+$plan = array(
+	'child-one' => array($item_id => '1.000000'),
+	'child-two' => array($item_id => '1.000000'),
+);
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+$children = $adapter->split(wc_get_order($source_id), $plan, $operation_id);
+wcos_p2_side_assert(2 === count($children), 'P2 side-effect contract did not create exactly two children.');
+$child_ids = array_values(array_map(static function($child) { return $child->get_id(); }, $children));
+sort($child_ids, SORT_NUMERIC);
+$new_order_sorted = $new_order_ids;
+sort($new_order_sorted, SORT_NUMERIC);
+$webhook_sorted = $webhook_args;
+sort($webhook_sorted, SORT_NUMERIC);
+
+wcos_p2_side_assert($child_ids === $new_order_sorted, 'P2 Split did not emit exactly one WooCommerce new-order event per child.');
+wcos_p2_side_assert($child_ids === $webhook_sorted, 'Active order.created webhook was not scheduled exactly once per child.');
+wcos_p2_side_assert(empty($status_events), 'P2 Split emitted an implicit child status transition.');
+wcos_p2_side_assert(empty($mail_calls), 'P2 Split attempted to send an email for pending children or operation notes.');
+wcos_p2_side_assert(empty($stock_before_writes) && empty($stock_after_writes), 'P2 safe Split invoked a physical stock-write hook.');
+wcos_p2_side_assert($source_note_before + 1 === wcos_p2_side_note_count($source_id), 'P2 Split did not add exactly one operation note to the source.');
+foreach ($child_ids as $child_id) {
+	wcos_p2_side_assert(1 === wcos_p2_side_note_count($child_id), 'P2 Split did not add exactly one operation note to a child.');
+}
+
+$counts_before_retry = array(
+	'new_order' => count($new_order_ids),
+	'webhook' => count($webhook_args),
+	'status' => count($status_events),
+	'mail' => count($mail_calls),
+	'source_notes' => wcos_p2_side_note_count($source_id),
+);
+$child_notes_before_retry = array();
+foreach ($child_ids as $child_id) {
+	$child_notes_before_retry[$child_id] = wcos_p2_side_note_count($child_id);
+}
+$retry = $adapter->split(wc_get_order($source_id), $plan, $operation_id);
+$retry_ids = array_values(array_map(static function($child) { return $child->get_id(); }, $retry));
+sort($retry_ids, SORT_NUMERIC);
+wcos_p2_side_assert($child_ids === $retry_ids, 'P2 completed retry returned a different child set.');
+wcos_p2_side_assert($counts_before_retry['new_order'] === count($new_order_ids), 'P2 completed retry emitted another new-order event.');
+wcos_p2_side_assert($counts_before_retry['webhook'] === count($webhook_args), 'P2 completed retry scheduled another webhook delivery.');
+wcos_p2_side_assert($counts_before_retry['status'] === count($status_events), 'P2 completed retry emitted a status transition.');
+wcos_p2_side_assert($counts_before_retry['mail'] === count($mail_calls), 'P2 completed retry attempted to send email.');
+wcos_p2_side_assert($counts_before_retry['source_notes'] === wcos_p2_side_note_count($source_id), 'P2 completed retry duplicated the source operation note.');
+foreach ($child_ids as $child_id) {
+	wcos_p2_side_assert($child_notes_before_retry[$child_id] === wcos_p2_side_note_count($child_id), 'P2 completed retry duplicated a child operation note.');
+}
+
+remove_action('woocommerce_new_order', $new_order_callback, PHP_INT_MAX);
+remove_action('woocommerce_order_status_changed', $status_callback, PHP_INT_MAX);
+remove_action('woocommerce_webhook_process_delivery', $webhook_callback, PHP_INT_MAX);
+remove_filter('pre_wp_mail', $mail_callback, PHP_INT_MAX);
+remove_action('woocommerce_product_before_set_stock', $stock_before_callback, PHP_INT_MAX);
+remove_action('woocommerce_variation_before_set_stock', $stock_before_callback, PHP_INT_MAX);
+remove_action('woocommerce_product_set_stock', $stock_after_callback, PHP_INT_MAX);
+remove_action('woocommerce_variation_set_stock', $stock_after_callback, PHP_INT_MAX);
+if ($core_webhook_scheduler_registered) {
+	add_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10, 2);
+}
+foreach ((array) $webhook->get_hooks() as $hook) {
+	remove_action($hook, array($webhook, 'process'));
+}
+$webhook->delete(true);
+
+$source = wc_get_order($source_id);
+WCOS_Operation_Journal::delete($source, $operation_id);
+foreach ($child_ids as $child_id) {
+	$child = wc_get_order($child_id);
+	if ($child) {
+		$child->delete(true);
+	}
+}
+if ($source) {
+	$source->delete(true);
+}
+wp_delete_post($product_id, true);
+
+echo "p2-production-side-effect-contract-ok\n";

--- a/tests/integration/p2-quantity-split-adapter-smoke.php
+++ b/tests/integration/p2-quantity-split-adapter-smoke.php
@@ -164,21 +164,25 @@ $deleted_children = $adapter->split(
 wcos_p2_adapter_assert(1 === count($deleted_children) && 1 === count($deleted_children[0]->get_items('line_item')), 'P2 adapter did not preserve a deleted-product order line.');
 wcos_p2_adapter_cleanup($deleted_source->get_id(), $deleted_operation);
 
-/* Request-local observer sees the exact WooCommerce stock-write path. */
-$guard_product = wcos_p2_adapter_product('WCOS P2 stock observer product', '5.00', 10);
+/* Core WooCommerce stock writes are blocked before the data store changes. */
+$guard_product = wcos_p2_adapter_product('WCOS P2 stock guard product', '5.00', 10);
 $guard_stock_before = wc_get_product($guard_product->get_id())->get_stock_quantity();
 $guard_token = WCOS_Stock_Side_Effect_Guard::begin('p2-stock-guard-' . wp_generate_uuid4());
-wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
 $guard_detected = false;
 try {
-	WCOS_Stock_Side_Effect_Guard::assert_clean($guard_token);
+	wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
 } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
 	$events = $exception->get_events();
-	$guard_detected = !empty($events) && absint($events[0]['stock_owner_id']) === $guard_product->get_id();
+	$guard_detected = !empty($events)
+		&& WCOS_Stock_Side_Effect_Guard::PHASE_BLOCKED_BEFORE_WRITE === $events[0]['phase']
+		&& absint($events[0]['stock_owner_id']) === $guard_product->get_id();
 }
 WCOS_Stock_Side_Effect_Guard::end($guard_token);
-wcos_p2_adapter_assert($guard_detected, 'P2 request-local guard missed a WooCommerce physical stock write.');
-wc_update_product_stock($guard_product->get_id(), $guard_stock_before, 'set');
+wcos_p2_adapter_assert($guard_detected, 'P2 request-local guard missed a WooCommerce stock-write attempt.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($guard_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($guard_product->get_id())->get_stock_quantity(), 6),
+	'P2 pre-write guard allowed physical stock to change.'
+);
 
 /* Ambient catalog differences are ignored only while a clean request-local proof is active. */
 $ambient_token = WCOS_Stock_Side_Effect_Guard::begin('p2-ambient-proof-' . wp_generate_uuid4());
@@ -192,9 +196,13 @@ try {
 }
 wcos_p2_adapter_assert($ambient_rejected_without_guard, 'P1 fallback stock comparison was unexpectedly disabled outside a P2 adapter scope.');
 
-/* A dirty request cannot pass the core conservation contract or auto-finalize. */
+/* A blocked stock-write attempt dirties the request and cannot pass conservation. */
 $contract_token = WCOS_Stock_Side_Effect_Guard::begin('p2-contract-proof-' . wp_generate_uuid4());
-wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
+try {
+	wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	/* Expected: the attempt is recorded and physical stock is unchanged. */
+}
 $contract_blocked = false;
 try {
 	WCOS_Mutation_Contract::assert_conserved(array(), array(), wc_get_price_decimals());
@@ -202,14 +210,17 @@ try {
 	$contract_blocked = true;
 }
 WCOS_Stock_Side_Effect_Guard::end($contract_token);
-wcos_p2_adapter_assert($contract_blocked, 'A request-local physical stock write passed the mutation conservation contract.');
-wc_update_product_stock($guard_product->get_id(), $guard_stock_before, 'set');
+wcos_p2_adapter_assert($contract_blocked, 'A request-local stock-write attempt passed the mutation conservation contract.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($guard_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($guard_product->get_id())->get_stock_quantity(), 6),
+	'Conservation stock-write proof changed physical stock.'
+);
 wp_delete_post($guard_product->get_id(), true);
 
-/* Actual adapter injection: own-request stock write blocks commit and auto compensation. */
-$dirty_product = wcos_p2_adapter_product('WCOS P2 dirty split product', '7.00', 20);
+/* Actual adapter injection: stock attempt is blocked, journal stays retriable, then retry completes at-most-once. */
+$dirty_product = wcos_p2_adapter_product('WCOS P2 blocked split product', '7.00', 20);
 list($dirty_source, $dirty_item_id) = wcos_p2_adapter_order($dirty_product, 4);
-$dirty_operation = 'p2-dirty-split-' . wp_generate_uuid4();
+$dirty_operation = 'p2-blocked-split-' . wp_generate_uuid4();
 $dirty_stock_before = wc_get_product($dirty_product->get_id())->get_stock_quantity();
 $dirty_injected = false;
 $dirty_callback = static function($stage) use (&$dirty_injected, $dirty_product) {
@@ -227,17 +238,37 @@ try {
 		$dirty_operation
 	);
 } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
-	$dirty_blocked = !empty($exception->get_events());
+	$events = $exception->get_events();
+	$dirty_blocked = !empty($events) && !WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events);
 }
 remove_action('wcos_split_mutation_checkpoint', $dirty_callback, 10);
-wcos_p2_adapter_assert($dirty_injected && $dirty_blocked, 'P2 adapter accepted a split request that wrote physical stock.');
+wcos_p2_adapter_assert($dirty_injected && $dirty_blocked, 'P2 adapter did not block an in-request stock-write attempt.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($dirty_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($dirty_product->get_id())->get_stock_quantity(), 6),
+	'Injected Split stock attempt changed physical stock.'
+);
 $dirty_record = WCOS_Operation_Journal::get(wc_get_order($dirty_source->get_id()), $dirty_operation);
-wcos_p2_adapter_assert(is_array($dirty_record) && 'recovery_required' === $dirty_record['status'], 'Unexpected stock write did not leave a durable recovery-required journal.');
-wcos_p2_adapter_assert(isset($dirty_record['context']['automatic_compensation_allowed']) && false === $dirty_record['context']['automatic_compensation_allowed'], 'Unexpected stock write remained eligible for unsafe automatic compensation.');
-wcos_p2_adapter_assert('unexpected_physical_stock_write' === $dirty_record['context']['reason'], 'Unexpected stock write did not record its stable recovery reason.');
-wc_update_product_stock($dirty_product->get_id(), $dirty_stock_before, 'set');
+wcos_p2_adapter_assert(is_array($dirty_record) && 'failed' === $dirty_record['status'], 'Blocked stock attempt did not leave the Split operation in a retriable failed state.');
+$existing_children = wcos_p2_adapter_children($dirty_source->get_id(), $dirty_operation);
+wcos_p2_adapter_assert(1 === count($existing_children), 'Interrupted Split did not preserve exactly one reusable child.');
+$dirty_retry = $adapter->split(
+	wc_get_order($dirty_source->get_id()),
+	array('child-one' => array($dirty_item_id => '1.000000')),
+	$dirty_operation
+);
+wcos_p2_adapter_assert(1 === count($dirty_retry) && $dirty_retry[0]->get_id() === $existing_children[0]->get_id(), 'Blocked stock-attempt retry duplicated the child order.');
+$dirty_record = WCOS_Operation_Journal::get(wc_get_order($dirty_source->get_id()), $dirty_operation);
+wcos_p2_adapter_assert('completed' === $dirty_record['status'], 'Blocked stock-attempt retry did not complete the original operation.');
 wcos_p2_adapter_cleanup($dirty_source->get_id(), $dirty_operation);
 wp_delete_post($dirty_product->get_id(), true);
+
+/* A confirmed after-write fallback event disables automatic order-only compensation. */
+$fallback_product = wcos_p2_adapter_product('WCOS P2 fallback stock evidence', '6.00', 11);
+$fallback_token = WCOS_Stock_Side_Effect_Guard::begin('p2-after-write-fallback-' . wp_generate_uuid4());
+WCOS_Stock_Side_Effect_Guard::record_product_stock_write($fallback_product);
+wcos_p2_adapter_assert(WCOS_Stock_Side_Effect_Guard::has_physical_write_active_scope(), 'P2 fallback after-write evidence was not classified for manual reconciliation.');
+WCOS_Stock_Side_Effect_Guard::end($fallback_token);
+wp_delete_post($fallback_product->get_id(), true);
 
 /* Retention remains dormant while production gates are hard-off and never purges active recovery. */
 wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);

--- a/tests/integration/p2-quantity-split-adapter-smoke.php
+++ b/tests/integration/p2-quantity-split-adapter-smoke.php
@@ -1,0 +1,260 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_adapter_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_p2_adapter_product($name, $price = '10.00', $stock = null) {
+	$product = new WC_Product_Simple();
+	$product->set_name($name);
+	$product->set_regular_price($price);
+	if (null !== $stock) {
+		$product->set_manage_stock(true);
+		$product->set_stock_quantity($stock);
+		$product->set_stock_status('instock');
+	}
+	$product->save();
+	return $product;
+}
+
+function wcos_p2_adapter_order(WC_Product $product, $quantity, $status = 'pending') {
+	$order = wc_create_order();
+	$order->set_status($status);
+	$order->set_currency('USD');
+	$item_id = $order->add_product($product, $quantity);
+	$order->calculate_totals(false);
+	$order->save();
+	return array($order, (int) $item_id);
+}
+
+function wcos_p2_adapter_children($source_id, $operation_id) {
+	return WCOS_Order_Relation_Repository::find(
+		array(
+			array('key' => WCOS_Split_Order_Service::OPERATION_META, 'value' => sanitize_key($operation_id)),
+			array('key' => WCOS_Split_Order_Service::RELATION_PARENT_META, 'value' => absint($source_id), 'type' => 'NUMERIC'),
+		),
+		-1
+	);
+}
+
+function wcos_p2_adapter_cleanup($source_id, $operation_id = '') {
+	$source = wc_get_order(absint($source_id));
+	if ('' !== $operation_id) {
+		foreach (wcos_p2_adapter_children($source_id, $operation_id) as $child) {
+			$child->delete(true);
+		}
+		if ($source instanceof WC_Order) {
+			WCOS_Operation_Journal::delete($source, $operation_id);
+		}
+	}
+	if ($source instanceof WC_Order) {
+		$source->delete(true);
+	}
+}
+
+wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'P2 quantity Split was production-enabled before its acceptance gate.');
+
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+
+/* Read-only preflight: fractional quantities are supported and PII is not returned. */
+$product = wcos_p2_adapter_product('WCOS P2 fractional product', '12.50', 50);
+list($source, $item_id) = wcos_p2_adapter_order($product, '3.500000');
+$source->set_billing_email('p2-private-preflight@example.test');
+$source->save();
+$report = $adapter->preflight(wc_get_order($source->get_id()));
+wcos_p2_adapter_assert(!empty($report['supported']), 'A valid fractional-quantity source failed P2 preflight.');
+wcos_p2_adapter_assert(1 === (int) $report['fractional_quantity_lines'], 'P2 preflight did not identify the fractional line.');
+wcos_p2_adapter_assert('keep_on_source' === $report['policy']['shipping'], 'P2 preflight exposed the wrong shipping policy.');
+wcos_p2_adapter_assert('no_write' === $report['policy']['physical_stock'], 'P2 preflight exposed the wrong stock policy.');
+wcos_p2_adapter_assert(false === strpos(wp_json_encode($report), 'p2-private-preflight@example.test'), 'P2 preflight leaked customer PII.');
+
+/* Production Gateway remains hard-off even though the adapter is testable internally. */
+$gateway_blocked = false;
+try {
+	(new WCOS_Mutation_Gateway())->split(
+		wc_get_order($source->get_id()),
+		array('child-gateway' => array($item_id => '1.000000')),
+		'p2-gateway-hard-off-' . wp_generate_uuid4()
+	);
+} catch (RuntimeException $exception) {
+	$gateway_blocked = false !== strpos($exception->getMessage(), 'not enabled for production use');
+}
+wcos_p2_adapter_assert($gateway_blocked, 'The P2 Gateway allowed quantity Split while the production gate is hard-off.');
+
+/* Safe adapter path: physical stock remains unchanged and retry is at-most-once. */
+$safe_operation = 'p2-safe-split-' . wp_generate_uuid4();
+$stock_before = wc_get_product($product->get_id())->get_stock_quantity();
+$children = $adapter->split(
+	wc_get_order($source->get_id()),
+	array('child-one' => array($item_id => '1.250000')),
+	$safe_operation
+);
+wcos_p2_adapter_assert(1 === count($children), 'P2 adapter did not create exactly one safe split child.');
+wcos_p2_adapter_assert('pending' === $children[0]->get_status(), 'P2 adapter child did not remain pending.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('2.250000', 6) === WCOS_Decimal::to_units(wc_get_order($source->get_id())->get_item($item_id)->get_quantity(), 6),
+	'P2 adapter did not preserve the expected source residual quantity.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($product->get_id())->get_stock_quantity(), 6),
+	'P2 adapter changed physical stock during a safe split.'
+);
+$retry = $adapter->split(
+	wc_get_order($source->get_id()),
+	array('child-one' => array($item_id => '1.250000')),
+	$safe_operation
+);
+wcos_p2_adapter_assert($retry[0]->get_id() === $children[0]->get_id(), 'P2 adapter retry created a second child.');
+$record = WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $safe_operation);
+wcos_p2_adapter_assert(is_array($record) && 'completed' === $record['status'], 'P2 safe split did not finish with a completed durable journal.');
+wcos_p2_adapter_cleanup($source->get_id(), $safe_operation);
+wp_delete_post($product->get_id(), true);
+
+/* Unsupported coupon policy fails before journal/children and leaves the source unchanged. */
+$coupon_product = wcos_p2_adapter_product('WCOS P2 coupon rejection product');
+list($coupon_source, $coupon_item_id) = wcos_p2_adapter_order($coupon_product, 3);
+$coupon = new WC_Order_Item_Coupon();
+$coupon->set_code('p2-coupon');
+$coupon->set_discount('0');
+$coupon->set_discount_tax('0');
+$coupon_source->add_item($coupon);
+$coupon_source->save();
+$coupon_operation = 'p2-coupon-reject-' . wp_generate_uuid4();
+$coupon_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($coupon_source->get_id()));
+$coupon_rejected = false;
+try {
+	$adapter->split(
+		wc_get_order($coupon_source->get_id()),
+		array('child-one' => array($coupon_item_id => '1.000000')),
+		$coupon_operation
+	);
+} catch (WCOS_Split_Preflight_Exception $exception) {
+	$coupon_rejected = 'coupon_policy_missing' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($coupon_rejected, 'P2 adapter did not fail closed on a coupon-bearing source.');
+wcos_p2_adapter_assert(
+	$coupon_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($coupon_source->get_id())),
+	'Coupon preflight rejection changed the source order.'
+);
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($coupon_source->get_id()), $coupon_operation), 'Coupon preflight rejection created a mutation journal.');
+wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($coupon_source->get_id(), $coupon_operation)), 'Coupon preflight rejection created a split child.');
+wcos_p2_adapter_cleanup($coupon_source->get_id());
+wp_delete_post($coupon_product->get_id(), true);
+
+/* Deleted catalog products remain splittable because order-time line state is authoritative. */
+$deleted_product = wcos_p2_adapter_product('WCOS P2 deleted product', '9.00');
+list($deleted_source, $deleted_item_id) = wcos_p2_adapter_order($deleted_product, 3);
+$deleted_product_id = $deleted_product->get_id();
+wp_delete_post($deleted_product_id, true);
+$deleted_report = $adapter->preflight(wc_get_order($deleted_source->get_id()));
+wcos_p2_adapter_assert(!empty($deleted_report['supported']), 'P2 preflight rejected a historical line whose catalog product was deleted.');
+wcos_p2_adapter_assert(1 === (int) $deleted_report['deleted_product_lines'], 'P2 preflight did not identify the deleted-product line.');
+$deleted_operation = 'p2-deleted-product-' . wp_generate_uuid4();
+$deleted_children = $adapter->split(
+	wc_get_order($deleted_source->get_id()),
+	array('child-one' => array($deleted_item_id => '1.000000')),
+	$deleted_operation
+);
+wcos_p2_adapter_assert(1 === count($deleted_children) && 1 === count($deleted_children[0]->get_items('line_item')), 'P2 adapter did not preserve a deleted-product order line.');
+wcos_p2_adapter_cleanup($deleted_source->get_id(), $deleted_operation);
+
+/* Request-local observer sees the exact WooCommerce stock-write path. */
+$guard_product = wcos_p2_adapter_product('WCOS P2 stock observer product', '5.00', 10);
+$guard_stock_before = wc_get_product($guard_product->get_id())->get_stock_quantity();
+$guard_token = WCOS_Stock_Side_Effect_Guard::begin('p2-stock-guard-' . wp_generate_uuid4());
+wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
+$guard_detected = false;
+try {
+	WCOS_Stock_Side_Effect_Guard::assert_clean($guard_token);
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	$events = $exception->get_events();
+	$guard_detected = !empty($events) && absint($events[0]['stock_owner_id']) === $guard_product->get_id();
+}
+WCOS_Stock_Side_Effect_Guard::end($guard_token);
+wcos_p2_adapter_assert($guard_detected, 'P2 request-local guard missed a WooCommerce physical stock write.');
+wc_update_product_stock($guard_product->get_id(), $guard_stock_before, 'set');
+
+/* Ambient catalog differences are ignored only while a clean request-local proof is active. */
+$ambient_token = WCOS_Stock_Side_Effect_Guard::begin('p2-ambient-proof-' . wp_generate_uuid4());
+WCOS_Order_Contract_Snapshot::assert_product_stock_equal(array(100 => '10.000000'), array(100 => '9.000000'));
+WCOS_Stock_Side_Effect_Guard::end($ambient_token);
+$ambient_rejected_without_guard = false;
+try {
+	WCOS_Order_Contract_Snapshot::assert_product_stock_equal(array(100 => '10.000000'), array(100 => '9.000000'));
+} catch (RuntimeException $exception) {
+	$ambient_rejected_without_guard = true;
+}
+wcos_p2_adapter_assert($ambient_rejected_without_guard, 'P1 fallback stock comparison was unexpectedly disabled outside a P2 adapter scope.');
+
+/* A dirty request cannot pass the core conservation contract or auto-finalize. */
+$contract_token = WCOS_Stock_Side_Effect_Guard::begin('p2-contract-proof-' . wp_generate_uuid4());
+wc_update_product_stock($guard_product->get_id(), 1, 'decrease');
+$contract_blocked = false;
+try {
+	WCOS_Mutation_Contract::assert_conserved(array(), array(), wc_get_price_decimals());
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	$contract_blocked = true;
+}
+WCOS_Stock_Side_Effect_Guard::end($contract_token);
+wcos_p2_adapter_assert($contract_blocked, 'A request-local physical stock write passed the mutation conservation contract.');
+wc_update_product_stock($guard_product->get_id(), $guard_stock_before, 'set');
+wp_delete_post($guard_product->get_id(), true);
+
+/* Actual adapter injection: own-request stock write blocks commit and auto compensation. */
+$dirty_product = wcos_p2_adapter_product('WCOS P2 dirty split product', '7.00', 20);
+list($dirty_source, $dirty_item_id) = wcos_p2_adapter_order($dirty_product, 4);
+$dirty_operation = 'p2-dirty-split-' . wp_generate_uuid4();
+$dirty_stock_before = wc_get_product($dirty_product->get_id())->get_stock_quantity();
+$dirty_injected = false;
+$dirty_callback = static function($stage) use (&$dirty_injected, $dirty_product) {
+	if (!$dirty_injected && 'before_source_save' === $stage) {
+		$dirty_injected = true;
+		wc_update_product_stock($dirty_product->get_id(), 1, 'decrease');
+	}
+};
+add_action('wcos_split_mutation_checkpoint', $dirty_callback, 10, 4);
+$dirty_blocked = false;
+try {
+	$adapter->split(
+		wc_get_order($dirty_source->get_id()),
+		array('child-one' => array($dirty_item_id => '1.000000')),
+		$dirty_operation
+	);
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	$dirty_blocked = !empty($exception->get_events());
+}
+remove_action('wcos_split_mutation_checkpoint', $dirty_callback, 10);
+wcos_p2_adapter_assert($dirty_injected && $dirty_blocked, 'P2 adapter accepted a split request that wrote physical stock.');
+$dirty_record = WCOS_Operation_Journal::get(wc_get_order($dirty_source->get_id()), $dirty_operation);
+wcos_p2_adapter_assert(is_array($dirty_record) && 'recovery_required' === $dirty_record['status'], 'Unexpected stock write did not leave a durable recovery-required journal.');
+wcos_p2_adapter_assert(isset($dirty_record['context']['automatic_compensation_allowed']) && false === $dirty_record['context']['automatic_compensation_allowed'], 'Unexpected stock write remained eligible for unsafe automatic compensation.');
+wcos_p2_adapter_assert('unexpected_physical_stock_write' === $dirty_record['context']['reason'], 'Unexpected stock write did not record its stable recovery reason.');
+wc_update_product_stock($dirty_product->get_id(), $dirty_stock_before, 'set');
+wcos_p2_adapter_cleanup($dirty_source->get_id(), $dirty_operation);
+wp_delete_post($dirty_product->get_id(), true);
+
+/* Retention remains dormant while production gates are hard-off and never purges active recovery. */
+wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);
+WCOS_Operation_Journal_Retention::maybe_schedule();
+wcos_p2_adapter_assert(false === wp_next_scheduled(WCOS_Operation_Journal_Retention::CRON_HOOK), 'Journal cleanup was scheduled while every production workflow gate is hard-off.');
+$now = time();
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'completed', 'completed_at' => gmdate('c', $now - (100 * DAY_IN_SECONDS))), $now),
+	'Expired completed mutation journal was not eligible for retention cleanup.'
+);
+wcos_p2_adapter_assert(
+	!WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'completed', 'completed_at' => gmdate('c', $now - DAY_IN_SECONDS)), $now),
+	'Recent completed mutation journal was eligible for premature cleanup.'
+);
+wcos_p2_adapter_assert(
+	!WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'recovery_required', 'completed_at' => gmdate('c', $now - (200 * DAY_IN_SECONDS))), $now),
+	'Recovery-required mutation journal was eligible for destructive cleanup.'
+);
+
+echo "p2-quantity-split-adapter-foundation-ok\n";

--- a/tests/integration/p2-quantity-split-adapter-smoke.php
+++ b/tests/integration/p2-quantity-split-adapter-smoke.php
@@ -62,14 +62,30 @@ wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 
 
 $adapter = new WCOS_Split_WooCommerce_Adapter();
 
-/* Read-only preflight: fractional quantities are supported and PII is not returned. */
+/* Core WooCommerce intentionally normalizes stock/order quantities to integers by default. */
+$integer_product = wcos_p2_adapter_product('WCOS P2 default integer quantity', '4.00');
+list($integer_source, $integer_item_id) = wcos_p2_adapter_order($integer_product, '3.500000');
+$integer_item = wc_get_order($integer_source->get_id())->get_item($integer_item_id);
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('3.000000', 6) === WCOS_Decimal::to_units($integer_item->get_quantity(), 6),
+	'WooCommerce default stock-amount policy unexpectedly preserved a fractional order quantity.'
+);
+$integer_report = $adapter->preflight(wc_get_order($integer_source->get_id()));
+wcos_p2_adapter_assert(0 === (int) $integer_report['fractional_quantity_lines'], 'P2 preflight reported a fraction after WooCommerce default integer normalization.');
+wcos_p2_adapter_cleanup($integer_source->get_id());
+wp_delete_post($integer_product->get_id(), true);
+
+/* Simulate the explicit integration contract used by fractional-quantity extensions. */
+remove_filter('woocommerce_stock_amount', 'intval');
+add_filter('woocommerce_stock_amount', 'floatval');
+
 $product = wcos_p2_adapter_product('WCOS P2 fractional product', '12.50', 50);
 list($source, $item_id) = wcos_p2_adapter_order($product, '3.500000');
 $source->set_billing_email('p2-private-preflight@example.test');
 $source->save();
 $report = $adapter->preflight(wc_get_order($source->get_id()));
 wcos_p2_adapter_assert(!empty($report['supported']), 'A valid fractional-quantity source failed P2 preflight.');
-wcos_p2_adapter_assert(1 === (int) $report['fractional_quantity_lines'], 'P2 preflight did not identify the fractional line.');
+wcos_p2_adapter_assert(1 === (int) $report['fractional_quantity_lines'], 'P2 preflight did not identify the fractional line when the integration allows decimals.');
 wcos_p2_adapter_assert('keep_on_source' === $report['policy']['shipping'], 'P2 preflight exposed the wrong shipping policy.');
 wcos_p2_adapter_assert('no_write' === $report['policy']['physical_stock'], 'P2 preflight exposed the wrong stock policy.');
 wcos_p2_adapter_assert(false === strpos(wp_json_encode($report), 'p2-private-preflight@example.test'), 'P2 preflight leaked customer PII.');
@@ -262,7 +278,7 @@ wcos_p2_adapter_assert('completed' === $dirty_record['status'], 'Blocked stock-a
 wcos_p2_adapter_cleanup($dirty_source->get_id(), $dirty_operation);
 wp_delete_post($dirty_product->get_id(), true);
 
-/* A confirmed after-write fallback event disables automatic order-only compensation. */
+/* A confirmed after-write fallback event is classified for manual reconciliation. */
 $fallback_product = wcos_p2_adapter_product('WCOS P2 fallback stock evidence', '6.00', 11);
 $fallback_token = WCOS_Stock_Side_Effect_Guard::begin('p2-after-write-fallback-' . wp_generate_uuid4());
 WCOS_Stock_Side_Effect_Guard::record_product_stock_write($fallback_product);
@@ -287,5 +303,8 @@ wcos_p2_adapter_assert(
 	!WCOS_Operation_Journal_Retention::is_expired_terminal_record(array('status' => 'recovery_required', 'completed_at' => gmdate('c', $now - (200 * DAY_IN_SECONDS))), $now),
 	'Recovery-required mutation journal was eligible for destructive cleanup.'
 );
+
+remove_filter('woocommerce_stock_amount', 'floatval');
+add_filter('woocommerce_stock_amount', 'intval');
 
 echo "p2-quantity-split-adapter-foundation-ok\n";

--- a/tests/integration/p2-stock-matrix-smoke.php
+++ b/tests/integration/p2-stock-matrix-smoke.php
@@ -1,0 +1,197 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_stock_variable_pair($name, $parent_managed, $variation_managed, $parent_stock = 20, $variation_stock = 20) {
+	$parent = new WC_Product_Variable();
+	$parent->set_name($name . ' parent');
+	if ($parent_managed) {
+		$parent->set_manage_stock(true);
+		$parent->set_stock_quantity($parent_stock);
+		$parent->set_stock_status('instock');
+	}
+	$parent->save();
+
+	$variation = new WC_Product_Variation();
+	$variation->set_parent_id($parent->get_id());
+	$variation->set_regular_price('10.00');
+	$variation->set_manage_stock((bool) $variation_managed);
+	if ($variation_managed) {
+		$variation->set_stock_quantity($variation_stock);
+		$variation->set_stock_status('instock');
+	}
+	$variation->save();
+	WC_Product_Variable::sync($parent->get_id());
+
+	return array(wc_get_product($parent->get_id()), wc_get_product($variation->get_id()));
+}
+
+function wcos_p2_stock_delete_product($product) {
+	if ($product instanceof WC_Product && $product->get_id()) {
+		wp_delete_post($product->get_id(), true);
+	}
+}
+
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+$manage_stock_before = get_option('woocommerce_manage_stock', 'yes');
+update_option('woocommerce_manage_stock', 'yes');
+
+/* Managed stock lifecycle: an already-reduced processing order redistributes markers but not physical stock. */
+$managed = wcos_p2_adapter_product('WCOS P2 managed lifecycle', '10.00', 30);
+list($managed_source, $managed_item_id) = wcos_p2_adapter_order($managed, 4);
+$managed_source->update_status('processing');
+$managed_source = wc_get_order($managed_source->get_id());
+$managed_item = $managed_source->get_item($managed_item_id);
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('26', 6) === WCOS_Decimal::to_units(wc_get_product($managed->get_id())->get_stock_quantity(), 6),
+	'WooCommerce did not reduce the managed-stock fixture before Split.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('4', 6) === WCOS_Decimal::to_units($managed_item->get_meta('_reduced_stock', true), 6),
+	'Managed-stock fixture does not have the expected reduced-stock marker.'
+);
+wcos_p2_adapter_assert((bool) $managed_source->get_data_store()->get_stock_reduced($managed_source->get_id()), 'Managed-stock fixture is not marked stock-reduced.');
+
+$managed_operation = 'p2-managed-lifecycle-' . wp_generate_uuid4();
+$managed_children = $adapter->split(
+	$managed_source,
+	array('child-one' => array($managed_item_id => '1.000000')),
+	$managed_operation
+);
+$managed_source = wc_get_order($managed_source->get_id());
+$managed_child = wc_get_order($managed_children[0]->get_id());
+$managed_source_item = $managed_source->get_item($managed_item_id);
+$managed_child_items = array_values($managed_child->get_items('line_item'));
+wcos_p2_adapter_assert(1 === count($managed_child_items), 'Managed-stock child line count is invalid.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('3', 6) === WCOS_Decimal::to_units($managed_source_item->get_meta('_reduced_stock', true), 6),
+	'Managed-stock source marker was not reduced to the residual quantity.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('1', 6) === WCOS_Decimal::to_units($managed_child_items[0]->get_meta('_reduced_stock', true), 6),
+	'Managed-stock child marker was not allocated exactly.'
+);
+wcos_p2_adapter_assert((bool) $managed_child->get_data_store()->get_stock_reduced($managed_child->get_id()), 'Managed-stock child did not inherit the stock-reduced lifecycle flag.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('26', 6) === WCOS_Decimal::to_units(wc_get_product($managed->get_id())->get_stock_quantity(), 6),
+	'Split changed physical stock for an already-reduced managed order.'
+);
+
+/* Cancelling child then source must restore exactly the original four sold units once. */
+$managed_child->update_status('cancelled');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('27', 6) === WCOS_Decimal::to_units(wc_get_product($managed->get_id())->get_stock_quantity(), 6),
+	'Cancelling the managed-stock child did not restore exactly its allocated unit.'
+);
+$managed_source->update_status('cancelled');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units('30', 6) === WCOS_Decimal::to_units(wc_get_product($managed->get_id())->get_stock_quantity(), 6),
+	'Cancelling the managed-stock source did not restore the residual units exactly once.'
+);
+wcos_p2_adapter_cleanup($managed_source->get_id(), $managed_operation);
+wcos_p2_stock_delete_product($managed);
+
+/* Unmanaged stock: Split must preserve order quantities without creating stock markers. */
+$unmanaged = wcos_p2_adapter_product('WCOS P2 unmanaged stock', '8.00');
+list($unmanaged_source, $unmanaged_item_id) = wcos_p2_adapter_order($unmanaged, 4);
+$unmanaged_report = $adapter->preflight(wc_get_order($unmanaged_source->get_id()));
+wcos_p2_adapter_assert(1 === (int) $unmanaged_report['unmanaged_stock_lines'], 'P2 preflight did not classify an unmanaged-stock line.');
+$unmanaged_operation = 'p2-unmanaged-' . wp_generate_uuid4();
+$unmanaged_children = $adapter->split(
+	wc_get_order($unmanaged_source->get_id()),
+	array('child-one' => array($unmanaged_item_id => '1.000000')),
+	$unmanaged_operation
+);
+$unmanaged_child_item = current($unmanaged_children[0]->get_items('line_item'));
+wcos_p2_adapter_assert('' === $unmanaged_child_item->get_meta('_reduced_stock', true), 'Unmanaged-stock child received a synthetic reduced-stock marker.');
+wcos_p2_adapter_cleanup($unmanaged_source->get_id(), $unmanaged_operation);
+wcos_p2_stock_delete_product($unmanaged);
+
+/* Variation-owned stock: exact variation identity is preserved and variation stock is untouched. */
+list($variation_parent, $variation) = wcos_p2_stock_variable_pair('WCOS P2 variation managed', false, true, 0, 18);
+list($variation_source, $variation_item_id) = wcos_p2_adapter_order($variation, 4);
+$variation_report = $adapter->preflight(wc_get_order($variation_source->get_id()));
+wcos_p2_adapter_assert(1 === (int) $variation_report['managed_stock_lines'], 'P2 preflight did not classify a variation-managed line.');
+$variation_stock_before = wc_get_product($variation->get_id())->get_stock_quantity();
+$variation_operation = 'p2-variation-managed-' . wp_generate_uuid4();
+$variation_children = $adapter->split(
+	wc_get_order($variation_source->get_id()),
+	array('child-one' => array($variation_item_id => '1.000000')),
+	$variation_operation
+);
+$variation_child_item = current($variation_children[0]->get_items('line_item'));
+wcos_p2_adapter_assert($variation->get_id() === $variation_child_item->get_variation_id(), 'Split collapsed a variation-managed line to its parent product.');
+wcos_p2_adapter_assert($variation_parent->get_id() === $variation_child_item->get_product_id(), 'Split lost the variation parent product ID.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($variation_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($variation->get_id())->get_stock_quantity(), 6),
+	'Split changed variation-owned physical stock.'
+);
+wcos_p2_adapter_cleanup($variation_source->get_id(), $variation_operation);
+wcos_p2_stock_delete_product($variation);
+wcos_p2_stock_delete_product($variation_parent);
+
+/* Parent-managed variation: WooCommerce stock ownership must resolve to the parent and remain untouched. */
+list($parent_managed, $parent_variation) = wcos_p2_stock_variable_pair('WCOS P2 parent managed', true, false, 25, 0);
+wcos_p2_adapter_assert($parent_managed->get_id() === $parent_variation->get_stock_managed_by_id(), 'WooCommerce fixture did not resolve variation stock ownership to the parent.');
+list($parent_source, $parent_item_id) = wcos_p2_adapter_order($parent_variation, 4);
+$parent_report = $adapter->preflight(wc_get_order($parent_source->get_id()));
+wcos_p2_adapter_assert(1 === (int) $parent_report['managed_stock_lines'], 'P2 preflight did not classify a parent-managed variation as managed stock.');
+$parent_stock_before = wc_get_product($parent_managed->get_id())->get_stock_quantity();
+$parent_operation = 'p2-parent-managed-' . wp_generate_uuid4();
+$parent_children = $adapter->split(
+	wc_get_order($parent_source->get_id()),
+	array('child-one' => array($parent_item_id => '1.000000')),
+	$parent_operation
+);
+$parent_child_item = current($parent_children[0]->get_items('line_item'));
+wcos_p2_adapter_assert($parent_variation->get_id() === $parent_child_item->get_variation_id(), 'Split lost parent-managed variation identity.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($parent_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($parent_managed->get_id())->get_stock_quantity(), 6),
+	'Split changed parent-managed physical stock.'
+);
+$parent_guard = WCOS_Stock_Side_Effect_Guard::begin('p2-parent-owner-guard-' . wp_generate_uuid4());
+$parent_owner_detected = false;
+try {
+	wc_update_product_stock($parent_variation->get_id(), 1, 'decrease');
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	$events = $exception->get_events();
+	$parent_owner_detected = !empty($events) && absint($events[0]['stock_owner_id']) === $parent_managed->get_id();
+}
+WCOS_Stock_Side_Effect_Guard::end($parent_guard);
+wcos_p2_adapter_assert($parent_owner_detected, 'P2 stock guard did not identify the parent stock owner for a variation.');
+wcos_p2_adapter_assert(
+	WCOS_Decimal::to_units($parent_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($parent_managed->get_id())->get_stock_quantity(), 6),
+	'Parent-managed stock changed despite the pre-write guard.'
+);
+wcos_p2_adapter_cleanup($parent_source->get_id(), $parent_operation);
+wcos_p2_stock_delete_product($parent_variation);
+wcos_p2_stock_delete_product($parent_managed);
+
+/* Backorders: a backordered managed line is identified and Split itself does not move stock. */
+$backorder = wcos_p2_adapter_product('WCOS P2 backorder', '5.00', 0);
+$backorder->set_backorders('yes');
+$backorder->set_stock_status('onbackorder');
+$backorder->save();
+list($backorder_source, $backorder_item_id) = wcos_p2_adapter_order($backorder, 3);
+$backorder_report = $adapter->preflight(wc_get_order($backorder_source->get_id()));
+wcos_p2_adapter_assert(1 === (int) $backorder_report['managed_stock_lines'], 'P2 preflight did not classify the backorder as managed stock.');
+wcos_p2_adapter_assert(1 === (int) $backorder_report['backorder_lines'], 'P2 preflight did not identify an on-backorder line.');
+$backorder_operation = 'p2-backorder-' . wp_generate_uuid4();
+$backorder_children = $adapter->split(
+	wc_get_order($backorder_source->get_id()),
+	array('child-one' => array($backorder_item_id => '1.000000')),
+	$backorder_operation
+);
+wcos_p2_adapter_assert(1 === count($backorder_children), 'P2 adapter failed to split an allowed backorder line.');
+wcos_p2_adapter_assert(
+	0 === WCOS_Decimal::to_units(wc_get_product($backorder->get_id())->get_stock_quantity(), 6),
+	'Split changed physical stock for a pending backorder.'
+);
+wcos_p2_adapter_cleanup($backorder_source->get_id(), $backorder_operation);
+wcos_p2_stock_delete_product($backorder);
+
+update_option('woocommerce_manage_stock', $manage_stock_before);
+
+echo "p2-stock-matrix-ok\n";


### PR DESCRIPTION
## Classification

`P2_WOOCOMMERCE_ADAPTER`

## Mission

Establish the WooCommerce-facing production adapter foundation for the first reintroduced mutation workflow: manual quantity Split. Every production mutation gate remains hard-off; this PR does not register a production controller, AJAX endpoint, order action, bulk action, or UI control.

## Architecture

Future production writes must follow:

`controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`

The adapter owns read-only compatibility preflight and request-local WooCommerce side-effect evidence. The shared Split service remains the mutation engine.

## Completed foundation

### Stock safety

- request-local `WCOS_Stock_Side_Effect_Guard`;
- normal WooCommerce product/variation stock writes blocked at `before_set_stock` before data-store persistence;
- after-write hooks retained as fallback evidence;
- ambient concurrent stock differences no longer create false Split failure inside a clean P2 adapter scope;
- managed `_reduced_stock` redistribution and exact simple-product cancellation restoration;
- unmanaged stock;
- variation-owned and parent-managed variation ownership/no-write evidence;
- backorders;
- explicit fractional-quantity integration contract.

### Read-only preflight and policy

`WCOS_Split_Preflight` produces a PII-free compatibility report. Current policy keeps shipping/positive fees/payment transaction on source, children pending, historical tax preserved, and physical stock immutable. Coupons, refunds, negative fees, nested Split, unknown private metadata, and context-inconsistent metadata adapters fail closed before mutation.

### Financial/tax/payment contracts

- tax-inclusive and tax-exclusive contexts;
- multiple historical tax rates;
- multiple shipping packages retained on source;
- positive taxable fee retained on source;
- child receives only historical line-tax rows;
- source retains fee/shipping tax rows;
- paid source retains transaction ID/date paid while child remains pending with no transaction/paid date;
- deterministic multi-child cent/tax-cent rounding and retry identity.

### Side-effect contract

Using a real active WooCommerce `order.created` webhook with network delivery scheduling intercepted, CI proves exactly one new-order/webhook schedule per child, no repeat on completed retry, zero implicit child status transitions, zero `wp_mail` attempts, zero stock-write hooks on a safe Split, and exactly-once source/child operation notes.

### Metadata compatibility

- public metadata is business configuration by default;
- protected stock/refund/mutation keys remain operational and non-overridable;
- unknown private line metadata fails closed;
- private adapters must explicitly classify business or known operational state;
- business classification must remain stable across Split-copy and canonical identity contexts;
- same-product configured lines with different adapted business metadata remain distinct and do not collapse.

### Durable journal retention

- default 90-day terminal retention, filterable from 7–365 days;
- only completed/failed/compensated terminal records are purgeable;
- active/recovery states are not purgeable;
- scheduling remains dormant while all workflow gates are hard-off;
- bounded high-water scan cycles prevent both front-of-list starvation and the one-way-cursor bug where a record scanned while recent would never be revisited on a continuously active store.

## Acceptance evidence

Final foundation head `c47e60e1e9fdff7dbee80eca0c177c0810be1172` passed canonical `CI` run #481 and `Required CI`, including:

- PHP 7.4 / 8.1 / 8.3;
- architecture/hard-off contract;
- package safety;
- legacy storage;
- HPOS-only;
- HPOS compatibility/sync;
- P1 regression/recovery/failure/concurrency suites;
- P2 adapter, stock lifecycle, tax/charge/payment/rounding, side-effect, metadata compatibility, and journal-retention contracts.

## Independent review findings / remaining production-enable blockers

The hard-off foundation is merge-safe, but manual quantity Split must **not** be production-enabled yet. Before `WCOS_Feature_Gates::SPLIT` changes, a later P2 milestone must still provide:

1. persistent `manual_reconciliation` handling for the extreme after-write fallback, including evidence arriving after a journal reached `completed`;
2. zero-decimal and three-decimal (or equivalent extension-filtered) currency/price precision matrices;
3. processing/cancellation restoration evidence for variation-owned, parent-managed, and fractional managed-stock lifecycles, not only ownership/no-write checks;
4. explicit policy that direct DB/meta stock mutation bypassing WooCommerce stock hooks is unsupported unless an adapter provides equivalent evidence;
5. production controller/transport with nonce/CSRF protection, centralized authorization, strict plan parsing, normalized item IDs/quantities, operation/idempotency contract, and explicit retry/error responses;
6. server-rendered accessible preflight/confirmation UI with policy disclosure, warnings, focus behavior, and operation result/audit feedback;
7. concrete compatibility guidance/adapters for explicitly supported configured-product ecosystems;
8. final independent review and explicit human gate for production enablement.

Coupons, refunds, and negative fees may remain intentionally unsupported in the first production-enabled quantity Split if they remain fail-closed and are disclosed before mutation.

## Scope boundary

No production mutation workflow is enabled by this PR. Duplicate, category Split, stock-status Split, Merge, Return, and Bulk Return remain hard-off.