### PR TITLE
P2: quantity Split production enablement gates

### DIFF
--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -1,0 +1,130 @@
+body.wcos-split-modal-open {
+    overflow: hidden;
+}
+
+.wcos-split-launcher-description {
+    margin-left: 8px;
+}
+
+.wcos-split-dialog[hidden] {
+    display: none;
+}
+
+.wcos-split-dialog {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.wcos-split-dialog__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.wcos-split-dialog__panel {
+    position: relative;
+    width: min(980px, 100%);
+    max-height: calc(100vh - 48px);
+    overflow: auto;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    padding: 24px;
+}
+
+.wcos-split-dialog__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.wcos-split-dialog__header h2 {
+    margin-top: 0;
+}
+
+.wcos-split-close {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 28px;
+    line-height: 1;
+}
+
+.wcos-split-table-wrap {
+    overflow-x: auto;
+    margin: 20px 0;
+}
+
+.wcos-split-table select,
+.wcos-split-table input[type="number"] {
+    min-width: 130px;
+    max-width: 100%;
+}
+
+.wcos-split-policy {
+    padding: 12px 16px;
+    border-left: 4px solid #646970;
+    background: #f6f7f7;
+}
+
+.wcos-split-policy h3,
+.wcos-split-review h3 {
+    margin-top: 0;
+}
+
+.wcos-split-confirm-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-weight: 600;
+}
+
+.wcos-split-status,
+.wcos-split-error,
+.wcos-split-result,
+.wcos-split-review {
+    margin-top: 16px;
+}
+
+.wcos-split-error,
+.wcos-split-result {
+    padding: 10px 12px;
+}
+
+.wcos-split-result ul {
+    margin-left: 20px;
+}
+
+.wcos-split-dialog__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #dcdcde;
+}
+
+@media (max-width: 782px) {
+    .wcos-split-dialog {
+        padding: 12px;
+    }
+
+    .wcos-split-dialog__panel {
+        max-height: calc(100vh - 24px);
+        padding: 16px;
+    }
+
+    .wcos-split-dialog__actions {
+        flex-direction: column-reverse;
+    }
+
+    .wcos-split-dialog__actions .button {
+        width: 100%;
+        min-height: 44px;
+    }
+}

--- a/docs/p2-production-enablement.md
+++ b/docs/p2-production-enablement.md
@@ -14,18 +14,42 @@ The controller must never instantiate the mutation service directly.
 
 ## Persistent manual reconciliation
 
-A confirmed physical-stock write observed after WooCommerce's normal pre-write guard is outside the order-only mutation snapshot. Such an incident is persisted as the authoritative journal state `manual_reconciliation`, even if the operation had already reached `completed`.
+A confirmed physical-stock write observed after WooCommerce's normal pre-write guard is outside the order-only mutation snapshot. Such an incident is fail-closed and must block every subsequent Split on that source until a human has reconciled stock.
 
-While unresolved:
+### Two-phase fail-closed persistence
+
+`WCOS_Manual_Reconciliation_Blocker` is persisted **before** the authoritative journal transitions to `manual_reconciliation`.
+
+This ordering is intentional. The blocker is a non-autoloaded, PII-free source-order record containing only operation identifiers, timestamps, and the journal revision observed when the stock incident was recorded. If the PHP process dies after the blocker write but before the journal transition, preflight still rejects the source. The crash window therefore produces a safe false-positive block rather than a false-negative that could permit another Split.
+
+After the journal transition succeeds:
 
 - `completed_at` is cleared;
 - automatic compensation is disabled;
 - the journal is not retention-purgeable;
-- the source order carries only a PII-free operation-ID index for lookup;
-- preflight blocks retry and every new Split on the source;
+- the existing order-meta operation-ID index remains available for audit visibility;
+- preflight reports the unresolved operation ID(s) directly in its PII-free message;
+- retry and every new Split on the same source are rejected;
 - the operation cannot auto-resume or auto-finalize.
 
-Only the explicit `manual_reconciled` transition clears the blocking index and returns the journal to normal terminal retention.
+A blocker is considered resolved only when the authoritative journal reaches `manual_reconciled` at a **newer journal revision** than the revision recorded by that stock incident. This prevents an older reconciliation from accidentally clearing a later incident on the same operation.
+
+### Manual reconciliation operating procedure
+
+The first production-enabled quantity Split must never automatically modify physical stock to resolve this state and must not expose a one-click "resolve" action.
+
+Before an operation may be marked `manual_reconciled`, an authorized operator/developer must:
+
+1. identify the operation ID reported by Split preflight;
+2. inspect the authoritative journal and its `stock_side_effects` evidence;
+3. identify the actual stock owner for every affected product/variation, including parent-managed variations;
+4. compare current physical stock with the intended post-order stock state;
+5. inspect the source and child `_reduced_stock` markers and order-level stock-reduced flags;
+6. correct stock externally only when the reconciliation evidence proves a correction is required;
+7. record who performed the reconciliation and a meaningful audit note;
+8. only then perform the explicit `WCOS_Operation_Journal::mark_manual_reconciled()` transition.
+
+The transition records resolution; it does **not** perform or infer a stock correction. If the operator cannot prove the correct physical-stock state, the source remains blocked and the operation must be escalated for manual support investigation.
 
 ## Price precision
 
@@ -37,7 +61,20 @@ Precision authority is:
 2. server confirmation record created by the review step;
 3. current store setting for a new review.
 
-A retry continues under the captured precision even if the ambient store setting changed after an interruption. Acceptance covers zero-decimal and three-decimal monetary/tax conservation.
+A retry continues under the captured precision even if the ambient store setting changes after an interruption. Acceptance covers zero-decimal and three-decimal monetary/tax conservation as well as the default two-decimal case.
+
+## Safety-policy version authority
+
+A reviewed Split confirmation is bound to `WCOS_Split_Preflight::POLICY_VERSION`. When the first durable journal is created, that policy version is persisted alongside `price_precision` and becomes immutable journal context.
+
+Consequences:
+
+- a live confirmation must match the durable journal's policy version once a journal exists;
+- journal checkpoint/state transitions cannot rewrite the captured policy version;
+- durable replay after the confirmation TTL requires a stored policy version;
+- a durable operation whose recorded policy version differs from current code fails closed with `policy_changed` rather than resuming under new semantics.
+
+This prevents an interrupted mutation reviewed under one safety policy from silently continuing after deployment of a different policy.
 
 ## Stock lifecycle
 
@@ -90,7 +127,7 @@ The temporary confirmation record contains no customer/address plaintext. It bin
 - Split policy version;
 - expiry.
 
-Before mutation begins, execution rejects changed source state, changed policy, invalid/expired tokens, user/order mismatch, or precision mismatch. Once a durable journal exists, that journal is authoritative for idempotent retry of the same operation.
+Before mutation begins, execution rejects changed source state, changed policy, invalid/expired tokens, user/order mismatch, or precision mismatch. Once a durable journal exists, that journal is authoritative for idempotent retry of the same operation and carries the immutable replay plan, price precision, and safety-policy version.
 
 ### Execute
 
@@ -129,6 +166,19 @@ The server-rendered dialog provides a line-by-child allocation matrix so one sou
 - result links built with DOM APIs and text nodes;
 - server-side policy disclosure, including intentionally unsupported cases.
 
+### Client state authority
+
+The client is never authoritative for quantities or financial validation, but its review state must accurately represent what the human confirmed.
+
+Therefore:
+
+- all quantity fields are frozen while an asynchronous review or execute request is in flight, preventing the visible matrix from diverging from the plan the server reviewed;
+- quantity edits invalidate the previous confirmation;
+- successful execution enters a terminal client state;
+- `finally`/busy-state cleanup cannot re-enable Review, acknowledgement, Execute, or quantity inputs after success;
+- reopening the dialog after success focuses the result region instead of a disabled quantity field;
+- non-retryable execute errors invalidate the reviewed confirmation state.
+
 The launcher and assets remain hidden while `SPLIT` is hard-off.
 
 ## Intentionally unsupported in first quantity-Split release
@@ -155,6 +205,9 @@ Changing `WCOS_Feature_Gates::SPLIT` to `true` requires all of the following on 
 - HPOS compatibility/sync green;
 - all P1 recovery/concurrency/failure contracts green;
 - all P2 adapter, manual-reconciliation, precision, stock lifecycle, tax/charge/payment, side-effect, metadata, retention, transport and accessibility contracts green;
+- fail-closed manual-reconciliation crash-window contract green;
+- durable replay policy-version binding contract green;
+- client terminal-state and review/quantity TOCTOU contracts green;
 - independent technical/security/accessibility review;
 - explicit Human Gate approving production enablement.
 

--- a/docs/p2-production-enablement.md
+++ b/docs/p2-production-enablement.md
@@ -1,0 +1,161 @@
+# P2 Manual Quantity Split — Production Enablement Contract
+
+## Status
+
+This milestone completes the production-facing transport and safety gates for manual quantity Split while `WCOS_Feature_Gates::SPLIT` remains hard-off. The code in this milestone must not make Split executable until a separate Human Gate changes the internal feature gate.
+
+## Production path
+
+All production writes must follow:
+
+`WCOS_Split_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`
+
+The controller must never instantiate the mutation service directly.
+
+## Persistent manual reconciliation
+
+A confirmed physical-stock write observed after WooCommerce's normal pre-write guard is outside the order-only mutation snapshot. Such an incident is persisted as the authoritative journal state `manual_reconciliation`, even if the operation had already reached `completed`.
+
+While unresolved:
+
+- `completed_at` is cleared;
+- automatic compensation is disabled;
+- the journal is not retention-purgeable;
+- the source order carries only a PII-free operation-ID index for lookup;
+- preflight blocks retry and every new Split on the source;
+- the operation cannot auto-resume or auto-finalize.
+
+Only the explicit `manual_reconciled` transition clears the blocking index and returns the journal to normal terminal retention.
+
+## Price precision
+
+WooCommerce order-item hydration can invoke tax rounding through `wc_get_price_decimals`. Each Split therefore captures its price precision in the durable journal and enters a request-local `WCOS_Price_Precision_Scope` before reloading the order.
+
+Precision authority is:
+
+1. existing durable operation journal;
+2. server confirmation record created by the review step;
+3. current store setting for a new review.
+
+A retry continues under the captured precision even if the ambient store setting changed after an interruption. Acceptance covers zero-decimal and three-decimal monetary/tax conservation.
+
+## Stock lifecycle
+
+The P2 acceptance matrix covers:
+
+- simple managed stock;
+- unmanaged stock;
+- variation-owned managed stock;
+- parent-managed variation stock;
+- backorders;
+- fractional managed stock when an integration explicitly enables fractional WooCommerce stock amounts;
+- processing -> Split -> child cancellation -> residual source cancellation, with exact `_reduced_stock` redistribution and exact restoration to the correct stock owner.
+
+The Split request itself must not change physical stock.
+
+### Direct database/meta stock mutation
+
+The request-local guard proves stock safety only for integrations that participate in WooCommerce stock APIs/hooks or provide equivalent explicit evidence. An extension that mutates product stock directly in the database or raw metadata, bypassing WooCommerce stock hooks, is unsupported by the first production-enabled quantity Split unless a compatibility adapter provides an equivalent fail-closed contract.
+
+## Fractional quantities
+
+WooCommerce uses integer stock amounts by default. Fractional transport quantities are rejected unless the active `woocommerce_stock_amount` integration actually preserves fractional values. Preflight exposes whether fractional quantity support is active and the server parser enforces the same policy.
+
+## Review -> confirmation -> execute transport
+
+### Review
+
+The review endpoint is read-only. It requires:
+
+- signed-in user;
+- order-specific nonce;
+- centralized mutation authorization;
+- configured allowed order status;
+- strict JSON plan parser;
+- PII-free Split preflight.
+
+The server generates the operation UUID and a short-lived confirmation token. Client-supplied operation IDs are never accepted for a new operation.
+
+### Confirmation record
+
+The temporary confirmation record contains no customer/address plaintext. It binds:
+
+- operation ID;
+- HMAC of the confirmation token;
+- source order ID;
+- current user ID;
+- source signature;
+- canonical plan;
+- reviewed price precision;
+- Split policy version;
+- expiry.
+
+Before mutation begins, execution rejects changed source state, changed policy, invalid/expired tokens, user/order mismatch, or precision mismatch. Once a durable journal exists, that journal is authoritative for idempotent retry of the same operation.
+
+### Execute
+
+Execution verifies the same nonce/authorization/status boundary, verifies the confirmation record, then enters `WCOS_Mutation_Gateway`. Errors are returned as structured codes with HTTP status and retryability. The execute path remains `workflow_disabled` while the feature gate is false.
+
+## Plan grammar
+
+The production parser is intentionally narrow:
+
+- JSON object only;
+- `child-1` through `child-10` only;
+- maximum 10 children;
+- maximum 500 line assignments;
+- maximum request size 64 KiB;
+- positive integer item IDs belonging to the source order;
+- quantities must be decimal strings, never JSON numeric values;
+- maximum six quantity decimals;
+- no scientific notation;
+- fractional quantities require active fractional WooCommerce quantity support;
+- aggregate child allocation for every source line must leave a positive residual on the source;
+- numeric overflow is a validation error, not a server error.
+
+## Accessible admin UI
+
+The server-rendered dialog provides a line-by-child allocation matrix so one source line can be distributed among multiple children. It includes:
+
+- semantic table headers and row headers;
+- explicit labels for every quantity field;
+- `role="dialog"`, `aria-modal`, labelled/described dialog;
+- review-before-execute flow;
+- explicit acknowledgement checkbox;
+- `role="status"` live region and `role="alert"` error region;
+- focus trap, Escape close, and focus return;
+- no blocking `alert()`;
+- no `innerHTML` rendering of server data;
+- result links built with DOM APIs and text nodes;
+- server-side policy disclosure, including intentionally unsupported cases.
+
+The launcher and assets remain hidden while `SPLIT` is hard-off.
+
+## Intentionally unsupported in first quantity-Split release
+
+The following may remain unsupported at first enablement because preflight rejects them before mutation and the UI discloses the policy:
+
+- coupons;
+- refunds/partial refunds;
+- negative fees;
+- nested Split;
+- unclassified private line-item metadata;
+- private metadata whose business/identity classification is inconsistent;
+- direct DB/meta stock integrations without a compatibility adapter.
+
+## Enablement gate
+
+Changing `WCOS_Feature_Gates::SPLIT` to `true` requires all of the following on the final enablement diff:
+
+- PHP 7.4 / 8.1 / 8.3 checks green;
+- architecture/hard-off contract green before the gate-changing PR;
+- package safety green;
+- legacy order storage green;
+- HPOS-only green;
+- HPOS compatibility/sync green;
+- all P1 recovery/concurrency/failure contracts green;
+- all P2 adapter, manual-reconciliation, precision, stock lifecycle, tax/charge/payment, side-effect, metadata, retention, transport and accessibility contracts green;
+- independent technical/security/accessibility review;
+- explicit Human Gate approving production enablement.
+
+This milestone does not itself authorize the gate change.

--- a/inc/backend/class-wcos-split-admin-controller.php
+++ b/inc/backend/class-wcos-split-admin-controller.php
@@ -1,0 +1,406 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Split_Transport_Exception extends RuntimeException {
+    private $error_code;
+    private $http_status;
+    private $retryable;
+    private $context;
+
+    public function __construct($error_code, $message, $http_status = 400, $retryable = false, array $context = array()) {
+        $this->error_code = sanitize_key((string) $error_code);
+        $this->http_status = max(400, min(599, (int) $http_status));
+        $this->retryable = (bool) $retryable;
+        $this->context = $context;
+        parent::__construct((string) $message);
+    }
+
+    public function get_error_code() { return $this->error_code; }
+    public function get_http_status() { return $this->http_status; }
+    public function is_retryable() { return $this->retryable; }
+    public function get_context() { return $this->context; }
+}
+
+/**
+ * Production admin transport for manual quantity Split.
+ *
+ * The controller is safe to bootstrap while the feature gate is hard-off:
+ * review remains read-only, execute reaches the mandatory gateway and is
+ * rejected until the final human gate enables Split.
+ */
+final class WCOS_Split_Admin_Controller {
+    const REVIEW_ACTION = 'wcos_split_review';
+    const EXECUTE_ACTION = 'wcos_split_execute';
+
+    private $current_order = null;
+    private $current_preflight = null;
+    private $current_surface_supported = false;
+
+    public function __construct() {
+        add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+        add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+        add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 20, 1);
+        add_action('admin_footer', array($this, 'render_dialog'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+    }
+
+    public function review_request(array $request) {
+        $order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+        $order = $this->authorized_order($request, $order_id);
+        $raw_plan = isset($request['plan']) ? (string) $request['plan'] : '';
+
+        try {
+            $plan = WCOS_Split_Request_Parser::parse_json($raw_plan, $order);
+        } catch (InvalidArgumentException $exception) {
+            throw new WCOS_Split_Transport_Exception('invalid_plan', $exception->getMessage(), 422, false);
+        }
+
+        $preflight = (new WCOS_Mutation_Gateway())->split_preflight($order);
+        if (empty($preflight['supported'])) {
+            throw new WCOS_Split_Transport_Exception(
+                'preflight_' . (isset($preflight['reason']) ? $preflight['reason'] : 'unsupported'),
+                isset($preflight['message']) ? $preflight['message'] : __('This order is not supported by the current Split policy.', 'wc-order-splitter'),
+                409,
+                false,
+                array('preflight' => $preflight)
+            );
+        }
+
+        $confirmation = WCOS_Split_Confirmation_Store::create($order, $plan, $preflight, get_current_user_id());
+        return array(
+            'operation_id' => $confirmation['operation_id'],
+            'confirmation_token' => $confirmation['confirmation_token'],
+            'expires_at' => $confirmation['expires_at'],
+            'preflight' => $preflight,
+            'summary' => $this->plan_summary($plan),
+        );
+    }
+
+    public function execute_request(array $request) {
+        $order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+        $order = $this->authorized_order($request, $order_id);
+        $operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
+        $confirmation_token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
+
+        try {
+            $confirmation = WCOS_Split_Confirmation_Store::verify(
+                $order,
+                $operation_id,
+                $confirmation_token,
+                get_current_user_id()
+            );
+        } catch (WCOS_Split_Confirmation_Exception $exception) {
+            throw new WCOS_Split_Transport_Exception(
+                'confirmation_' . $exception->get_reason(),
+                $exception->getMessage(),
+                'source_changed' === $exception->get_reason() ? 409 : 403,
+                false
+            );
+        }
+
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) {
+            throw new WCOS_Split_Transport_Exception(
+                'workflow_disabled',
+                __('Manual quantity Split is not enabled for production use yet.', 'wc-order-splitter'),
+                503,
+                false
+            );
+        }
+
+        try {
+            $children = (new WCOS_Mutation_Gateway())->split(
+                $order,
+                $confirmation['plan'],
+                $operation_id,
+                $confirmation['price_precision']
+            );
+        } catch (WCOS_Split_Preflight_Exception $exception) {
+            throw new WCOS_Split_Transport_Exception(
+                'preflight_' . $exception->get_reason(),
+                $exception->getMessage(),
+                409,
+                false,
+                array('preflight' => $exception->get_report())
+            );
+        } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+            throw new WCOS_Split_Transport_Exception(
+                'manual_reconciliation_required',
+                __('The Split request detected an unexpected physical-stock side effect and now requires manual reconciliation.', 'wc-order-splitter'),
+                409,
+                false
+            );
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+            if (false !== strpos($message, 'Another order mutation is already in progress')) {
+                throw new WCOS_Split_Transport_Exception('operation_busy', $message, 409, true);
+            }
+            throw new WCOS_Split_Transport_Exception('split_failed', $message, 409, true);
+        }
+
+        $result_children = array();
+        foreach ($children as $child) {
+            if (!$child instanceof WC_Order) {
+                continue;
+            }
+            $result_children[] = array(
+                'id' => $child->get_id(),
+                'number' => (string) $child->get_order_number(),
+                'status' => (string) $child->get_status(),
+                'edit_url' => method_exists($child, 'get_edit_order_url') ? (string) $child->get_edit_order_url() : '',
+            );
+        }
+
+        return array(
+            'operation_id' => $operation_id,
+            'status' => 'completed',
+            'source_order_id' => $order->get_id(),
+            'children' => $result_children,
+        );
+    }
+
+    public function ajax_review() {
+        try {
+            wp_send_json_success($this->review_request(wp_unslash($_POST)));
+        } catch (WCOS_Split_Transport_Exception $exception) {
+            $this->send_transport_error($exception);
+        } catch (Throwable $throwable) {
+            $this->send_transport_error(new WCOS_Split_Transport_Exception('review_failed', __('Unable to review the Split plan.', 'wc-order-splitter'), 500, true));
+        }
+    }
+
+    public function ajax_execute() {
+        try {
+            wp_send_json_success($this->execute_request(wp_unslash($_POST)));
+        } catch (WCOS_Split_Transport_Exception $exception) {
+            $this->send_transport_error($exception);
+        } catch (Throwable $throwable) {
+            $this->send_transport_error(new WCOS_Split_Transport_Exception('execute_failed', __('Unable to execute the Split operation.', 'wc-order-splitter'), 500, true));
+        }
+    }
+
+    public function render_launcher($order) {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT) || !$order instanceof WC_Order) {
+            return;
+        }
+
+        try {
+            WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
+            $this->assert_status_enabled($order);
+            $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($order);
+        } catch (Throwable $throwable) {
+            return;
+        }
+
+        $this->current_order = $order;
+        $this->current_preflight = $preflight;
+        $this->current_surface_supported = !empty($preflight['supported']);
+        $dialog_id = 'wcos-split-dialog-' . $order->get_id();
+        $disabled = !$this->current_surface_supported;
+        $description_id = 'wcos-split-launcher-description-' . $order->get_id();
+
+        echo '<button type="button" class="button wcos-split-launcher" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '"' . disabled($disabled, true, false) . '>';
+        echo esc_html__('Split order', 'wc-order-splitter');
+        echo '</button>';
+        echo '<span id="' . esc_attr($description_id) . '" class="description wcos-split-launcher-description">';
+        echo esc_html($disabled ? $preflight['message'] : __('Review quantities and policies before creating pending split orders.', 'wc-order-splitter'));
+        echo '</span>';
+    }
+
+    public function enqueue_assets() {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT) || !$this->is_order_edit_screen()) {
+            return;
+        }
+        wp_enqueue_style('wcos-split-admin', plugins_url('../../css/p2-split-admin.css', __FILE__), array(), WC_ORDER_SPLITTER_VERSION);
+        wp_enqueue_script('wcos-split-admin', plugins_url('../../js/p2-split-admin.js', __FILE__), array(), WC_ORDER_SPLITTER_VERSION, true);
+        wp_localize_script(
+            'wcos-split-admin',
+            'wcosSplitAdminStrings',
+            array(
+                'reviewing' => __('Reviewing Split plan…', 'wc-order-splitter'),
+                'reviewReady' => __('The plan passed server review. Confirm the acknowledgement to execute it.', 'wc-order-splitter'),
+                'executing' => __('Executing Split…', 'wc-order-splitter'),
+                'completed' => __('Split completed successfully.', 'wc-order-splitter'),
+                'invalidPlan' => __('Enter at least one quantity smaller than its source line quantity.', 'wc-order-splitter'),
+                'requestFailed' => __('The Split request could not be completed.', 'wc-order-splitter'),
+                'childOrder' => __('Child order', 'wc-order-splitter'),
+                'reloadOrder' => __('Reload source order', 'wc-order-splitter'),
+                'reviewSummary' => __('Reviewed children / affected lines / moved quantity:', 'wc-order-splitter'),
+            )
+        );
+    }
+
+    public function render_dialog() {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)
+            || !$this->current_surface_supported
+            || !$this->current_order instanceof WC_Order) {
+            return;
+        }
+        echo $this->dialog_html($this->current_order, $this->current_preflight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    public function dialog_html(WC_Order $order, array $preflight = array()) {
+        if (empty($preflight)) {
+            $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($order);
+        }
+        $dialog_id = 'wcos-split-dialog-' . $order->get_id();
+        $title_id = $dialog_id . '-title';
+        $description_id = $dialog_id . '-description';
+        $nonce = wp_create_nonce('wcos_split_order_' . $order->get_id());
+
+        ob_start();
+        ?>
+        <div id="<?php echo esc_attr($dialog_id); ?>" class="wcos-split-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($title_id); ?>" aria-describedby="<?php echo esc_attr($description_id); ?>" data-order-id="<?php echo esc_attr($order->get_id()); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" hidden>
+            <div class="wcos-split-dialog__backdrop" aria-hidden="true"></div>
+            <div class="wcos-split-dialog__panel" tabindex="-1">
+                <div class="wcos-split-dialog__header">
+                    <div>
+                        <h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Review quantity split', 'wc-order-splitter'); ?></h2>
+                        <p id="<?php echo esc_attr($description_id); ?>"><?php esc_html_e('Choose quantities to move into up to ten pending child orders. Every affected source line must retain a positive quantity.', 'wc-order-splitter'); ?></p>
+                    </div>
+                    <button type="button" class="button-link wcos-split-close" aria-label="<?php esc_attr_e('Close Split dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
+                </div>
+
+                <form class="wcos-split-form" novalidate>
+                    <div class="wcos-split-table-wrap" tabindex="0" aria-label="<?php esc_attr_e('Order lines available for splitting', 'wc-order-splitter'); ?>">
+                        <table class="widefat striped wcos-split-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col"><?php esc_html_e('Product', 'wc-order-splitter'); ?></th>
+                                    <th scope="col"><?php esc_html_e('Current quantity', 'wc-order-splitter'); ?></th>
+                                    <th scope="col"><?php esc_html_e('Target child', 'wc-order-splitter'); ?></th>
+                                    <th scope="col"><?php esc_html_e('Quantity to move', 'wc-order-splitter'); ?></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($order->get_items('line_item') as $item_id => $item) :
+                                    $quantity = WCOS_Decimal::normalize($item->get_quantity(), 6);
+                                    $fractional = 0 !== (WCOS_Decimal::to_units($item->get_quantity(), 6) % 1000000);
+                                    $quantity_id = 'wcos-split-quantity-' . $order->get_id() . '-' . $item_id;
+                                    $target_id = 'wcos-split-target-' . $order->get_id() . '-' . $item_id;
+                                    ?>
+                                    <tr data-item-id="<?php echo esc_attr($item_id); ?>" data-source-quantity="<?php echo esc_attr($quantity); ?>">
+                                        <td><?php echo esc_html($item->get_name()); ?></td>
+                                        <td><?php echo esc_html($quantity); ?></td>
+                                        <td>
+                                            <label class="screen-reader-text" for="<?php echo esc_attr($target_id); ?>"><?php echo esc_html(sprintf(__('Target child for %s', 'wc-order-splitter'), $item->get_name())); ?></label>
+                                            <select id="<?php echo esc_attr($target_id); ?>" class="wcos-split-target">
+                                                <?php for ($child_index = 1; $child_index <= 10; $child_index++) : ?>
+                                                    <option value="child-<?php echo esc_attr($child_index); ?>"><?php echo esc_html(sprintf(__('Child %d', 'wc-order-splitter'), $child_index)); ?></option>
+                                                <?php endfor; ?>
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php echo esc_html(sprintf(__('Quantity to move for %s', 'wc-order-splitter'), $item->get_name())); ?></label>
+                                            <input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" type="number" min="0" max="<?php echo esc_attr($quantity); ?>" step="<?php echo esc_attr($fractional ? '0.000001' : '1'); ?>" inputmode="decimal" value="0" />
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="wcos-split-policy" aria-labelledby="<?php echo esc_attr($dialog_id . '-policy-title'); ?>">
+                        <h3 id="<?php echo esc_attr($dialog_id . '-policy-title'); ?>"><?php esc_html_e('Current safety policy', 'wc-order-splitter'); ?></h3>
+                        <ul>
+                            <li><?php esc_html_e('Shipping and positive fees remain on the source order.', 'wc-order-splitter'); ?></li>
+                            <li><?php esc_html_e('Child orders are created as Pending payment and do not inherit the payment transaction.', 'wc-order-splitter'); ?></li>
+                            <li><?php esc_html_e('Historical line taxes are preserved; current catalog prices and tax rates are not recalculated.', 'wc-order-splitter'); ?></li>
+                            <li><?php esc_html_e('The Split request must not write physical product stock.', 'wc-order-splitter'); ?></li>
+                            <li><?php esc_html_e('Coupons, refunds, negative fees, nested splits, and unclassified private line metadata are rejected before mutation.', 'wc-order-splitter'); ?></li>
+                            <li><?php esc_html_e('Extensions that change stock directly in the database instead of WooCommerce stock APIs are unsupported unless they provide an explicit compatibility adapter.', 'wc-order-splitter'); ?></li>
+                        </ul>
+                    </div>
+
+                    <div class="wcos-split-review" hidden>
+                        <h3><?php esc_html_e('Reviewed plan', 'wc-order-splitter'); ?></h3>
+                        <p class="wcos-split-review-summary"></p>
+                        <label class="wcos-split-confirm-label">
+                            <input type="checkbox" class="wcos-split-confirm-checkbox" />
+                            <span><?php esc_html_e('I reviewed the quantities and understand that this will create new pending orders and modify the source order.', 'wc-order-splitter'); ?></span>
+                        </label>
+                    </div>
+
+                    <div class="wcos-split-status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
+                    <div class="wcos-split-error notice notice-error inline" role="alert" tabindex="-1" hidden></div>
+                    <div class="wcos-split-result notice notice-success inline" tabindex="-1" hidden></div>
+
+                    <div class="wcos-split-dialog__actions">
+                        <button type="button" class="button wcos-split-cancel"><?php esc_html_e('Cancel', 'wc-order-splitter'); ?></button>
+                        <button type="button" class="button button-secondary wcos-split-review-button"><?php esc_html_e('Review split', 'wc-order-splitter'); ?></button>
+                        <button type="button" class="button button-primary wcos-split-execute-button" disabled><?php esc_html_e('Confirm and split', 'wc-order-splitter'); ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    private function authorized_order(array $request, $order_id) {
+        if (!$order_id) {
+            throw new WCOS_Split_Transport_Exception('invalid_order', __('A valid order ID is required.', 'wc-order-splitter'), 400, false);
+        }
+        $nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
+        if (!wp_verify_nonce($nonce, 'wcos_split_order_' . $order_id)) {
+            throw new WCOS_Split_Transport_Exception('invalid_nonce', __('The Split request failed nonce verification.', 'wc-order-splitter'), 403, false);
+        }
+
+        $order = wc_get_order($order_id);
+        if (!$order instanceof WC_Order) {
+            throw new WCOS_Split_Transport_Exception('order_not_found', __('The source order could not be found.', 'wc-order-splitter'), 404, false);
+        }
+        try {
+            WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
+        } catch (Throwable $throwable) {
+            throw new WCOS_Split_Transport_Exception('authorization_failed', __('You are not allowed to split this order.', 'wc-order-splitter'), 403, false);
+        }
+        $this->assert_status_enabled($order);
+        return $order;
+    }
+
+    private function assert_status_enabled(WC_Order $order) {
+        $allowed = (array) get_option('order_splitter_status_allowed', array('wc-processing'));
+        $status = 'wc-' . $order->get_status();
+        if (!in_array($status, $allowed, true)) {
+            throw new WCOS_Split_Transport_Exception('status_disabled', __('This order status is disabled in the Order Splitter settings.', 'wc-order-splitter'), 409, false);
+        }
+    }
+
+    private function plan_summary(array $plan) {
+        $affected = array();
+        $moved_units = 0;
+        foreach ($plan as $items) {
+            foreach ($items as $item_id => $quantity) {
+                $affected[absint($item_id)] = true;
+                $moved_units += WCOS_Decimal::to_units($quantity, 6);
+            }
+        }
+        return array(
+            'child_count' => count($plan),
+            'affected_line_count' => count($affected),
+            'moved_quantity' => WCOS_Decimal::from_units($moved_units, 6),
+        );
+    }
+
+    private function send_transport_error(WCOS_Split_Transport_Exception $exception) {
+        wp_send_json_error(
+            array(
+                'code' => $exception->get_error_code(),
+                'message' => $exception->getMessage(),
+                'retryable' => $exception->is_retryable(),
+                'context' => $exception->get_context(),
+            ),
+            $exception->get_http_status()
+        );
+    }
+
+    private function is_order_edit_screen() {
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if (!$screen) {
+            return false;
+        }
+        $hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+        return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && !empty($_GET['id']));
+    }
+}

--- a/inc/backend/class-wcos-split-admin-controller.php
+++ b/inc/backend/class-wcos-split-admin-controller.php
@@ -91,10 +91,21 @@ final class WCOS_Split_Admin_Controller {
                 get_current_user_id()
             );
         } catch (WCOS_Split_Confirmation_Exception $exception) {
+            $http_statuses = array(
+                'invalid_identity' => 400,
+                'invalid_token' => 403,
+                'owner_mismatch' => 403,
+                'expired' => 410,
+                'source_changed' => 409,
+                'source_missing' => 404,
+                'policy_changed' => 409,
+                'precision_mismatch' => 409,
+            );
+            $reason = $exception->get_reason();
             throw new WCOS_Split_Transport_Exception(
-                'confirmation_' . $exception->get_reason(),
+                'confirmation_' . $reason,
                 $exception->getMessage(),
-                'source_changed' === $exception->get_reason() ? 409 : 403,
+                isset($http_statuses[$reason]) ? $http_statuses[$reason] : 403,
                 false
             );
         }
@@ -199,7 +210,7 @@ final class WCOS_Split_Admin_Controller {
         $disabled = !$this->current_surface_supported;
         $description_id = 'wcos-split-launcher-description-' . $order->get_id();
 
-        echo '<button type="button" class="button wcos-split-launcher" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '"' . disabled($disabled, true, false) . '>';
+        echo '<button type="button" class="button wcos-split-launcher" aria-haspopup="dialog"' . ($disabled ? '' : ' aria-controls="' . esc_attr($dialog_id) . '"') . ' aria-describedby="' . esc_attr($description_id) . '"' . disabled($disabled, true, false) . '>';
         echo esc_html__('Split order', 'wc-order-splitter');
         echo '</button>';
         echo '<span id="' . esc_attr($description_id) . '" class="description wcos-split-launcher-description">';
@@ -211,8 +222,9 @@ final class WCOS_Split_Admin_Controller {
         if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT) || !$this->is_order_edit_screen()) {
             return;
         }
-        wp_enqueue_style('wcos-split-admin', plugins_url('../../css/p2-split-admin.css', __FILE__), array(), WC_ORDER_SPLITTER_VERSION);
-        wp_enqueue_script('wcos-split-admin', plugins_url('../../js/p2-split-admin.js', __FILE__), array(), WC_ORDER_SPLITTER_VERSION, true);
+        $plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+        wp_enqueue_style('wcos-split-admin', plugins_url('css/p2-split-admin.css', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION);
+        wp_enqueue_script('wcos-split-admin', plugins_url('js/p2-split-admin.js', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION, true);
         wp_localize_script(
             'wcos-split-admin',
             'wcosSplitAdminStrings',
@@ -221,7 +233,7 @@ final class WCOS_Split_Admin_Controller {
                 'reviewReady' => __('The plan passed server review. Confirm the acknowledgement to execute it.', 'wc-order-splitter'),
                 'executing' => __('Executing Split…', 'wc-order-splitter'),
                 'completed' => __('Split completed successfully.', 'wc-order-splitter'),
-                'invalidPlan' => __('Enter at least one quantity smaller than its source line quantity.', 'wc-order-splitter'),
+                'invalidPlan' => __('Enter at least one quantity and keep a positive residual quantity on every affected source line.', 'wc-order-splitter'),
                 'requestFailed' => __('The Split request could not be completed.', 'wc-order-splitter'),
                 'childOrder' => __('Child order', 'wc-order-splitter'),
                 'reloadOrder' => __('Reload source order', 'wc-order-splitter'),
@@ -247,6 +259,8 @@ final class WCOS_Split_Admin_Controller {
         $title_id = $dialog_id . '-title';
         $description_id = $dialog_id . '-description';
         $nonce = wp_create_nonce('wcos_split_order_' . $order->get_id());
+        $fractional_supported = !empty($preflight['fractional_quantity_supported']);
+        $step = $fractional_supported ? '0.000001' : '1';
 
         ob_start();
         ?>
@@ -256,44 +270,39 @@ final class WCOS_Split_Admin_Controller {
                 <div class="wcos-split-dialog__header">
                     <div>
                         <h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Review quantity split', 'wc-order-splitter'); ?></h2>
-                        <p id="<?php echo esc_attr($description_id); ?>"><?php esc_html_e('Choose quantities to move into up to ten pending child orders. Every affected source line must retain a positive quantity.', 'wc-order-splitter'); ?></p>
+                        <p id="<?php echo esc_attr($description_id); ?>"><?php esc_html_e('Enter the quantity from each source line to move into each pending child order. Every affected source line must retain a positive quantity.', 'wc-order-splitter'); ?></p>
                     </div>
                     <button type="button" class="button-link wcos-split-close" aria-label="<?php esc_attr_e('Close Split dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
                 </div>
 
                 <form class="wcos-split-form" novalidate>
-                    <div class="wcos-split-table-wrap" tabindex="0" aria-label="<?php esc_attr_e('Order lines available for splitting', 'wc-order-splitter'); ?>">
+                    <div class="wcos-split-table-wrap" tabindex="0" aria-label="<?php esc_attr_e('Order line quantities allocated to child orders', 'wc-order-splitter'); ?>">
                         <table class="widefat striped wcos-split-table">
                             <thead>
                                 <tr>
                                     <th scope="col"><?php esc_html_e('Product', 'wc-order-splitter'); ?></th>
                                     <th scope="col"><?php esc_html_e('Current quantity', 'wc-order-splitter'); ?></th>
-                                    <th scope="col"><?php esc_html_e('Target child', 'wc-order-splitter'); ?></th>
-                                    <th scope="col"><?php esc_html_e('Quantity to move', 'wc-order-splitter'); ?></th>
+                                    <?php for ($child_index = 1; $child_index <= 10; $child_index++) : ?>
+                                        <th scope="col"><?php echo esc_html(sprintf(__('Child %d', 'wc-order-splitter'), $child_index)); ?></th>
+                                    <?php endfor; ?>
                                 </tr>
                             </thead>
                             <tbody>
                                 <?php foreach ($order->get_items('line_item') as $item_id => $item) :
                                     $quantity = WCOS_Decimal::normalize($item->get_quantity(), 6);
-                                    $fractional = 0 !== (WCOS_Decimal::to_units($item->get_quantity(), 6) % 1000000);
-                                    $quantity_id = 'wcos-split-quantity-' . $order->get_id() . '-' . $item_id;
-                                    $target_id = 'wcos-split-target-' . $order->get_id() . '-' . $item_id;
                                     ?>
                                     <tr data-item-id="<?php echo esc_attr($item_id); ?>" data-source-quantity="<?php echo esc_attr($quantity); ?>">
-                                        <td><?php echo esc_html($item->get_name()); ?></td>
+                                        <th scope="row"><?php echo esc_html($item->get_name()); ?></th>
                                         <td><?php echo esc_html($quantity); ?></td>
-                                        <td>
-                                            <label class="screen-reader-text" for="<?php echo esc_attr($target_id); ?>"><?php echo esc_html(sprintf(__('Target child for %s', 'wc-order-splitter'), $item->get_name())); ?></label>
-                                            <select id="<?php echo esc_attr($target_id); ?>" class="wcos-split-target">
-                                                <?php for ($child_index = 1; $child_index <= 10; $child_index++) : ?>
-                                                    <option value="child-<?php echo esc_attr($child_index); ?>"><?php echo esc_html(sprintf(__('Child %d', 'wc-order-splitter'), $child_index)); ?></option>
-                                                <?php endfor; ?>
-                                            </select>
-                                        </td>
-                                        <td>
-                                            <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php echo esc_html(sprintf(__('Quantity to move for %s', 'wc-order-splitter'), $item->get_name())); ?></label>
-                                            <input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" type="number" min="0" max="<?php echo esc_attr($quantity); ?>" step="<?php echo esc_attr($fractional ? '0.000001' : '1'); ?>" inputmode="decimal" value="0" />
-                                        </td>
+                                        <?php for ($child_index = 1; $child_index <= 10; $child_index++) :
+                                            $child_key = 'child-' . $child_index;
+                                            $quantity_id = 'wcos-split-quantity-' . $order->get_id() . '-' . $item_id . '-' . $child_index;
+                                            ?>
+                                            <td>
+                                                <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php echo esc_html(sprintf(__('Quantity of %1$s to move to Child %2$d', 'wc-order-splitter'), $item->get_name(), $child_index)); ?></label>
+                                                <input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" data-child-key="<?php echo esc_attr($child_key); ?>" type="number" min="0" max="<?php echo esc_attr($quantity); ?>" step="<?php echo esc_attr($step); ?>" inputmode="decimal" value="0" />
+                                            </td>
+                                        <?php endfor; ?>
                                     </tr>
                                 <?php endforeach; ?>
                             </tbody>
@@ -309,6 +318,7 @@ final class WCOS_Split_Admin_Controller {
                             <li><?php esc_html_e('The Split request must not write physical product stock.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('Coupons, refunds, negative fees, nested splits, and unclassified private line metadata are rejected before mutation.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('Extensions that change stock directly in the database instead of WooCommerce stock APIs are unsupported unless they provide an explicit compatibility adapter.', 'wc-order-splitter'); ?></li>
+                            <li><?php echo esc_html($fractional_supported ? __('Fractional quantities are enabled by the active WooCommerce quantity integration.', 'wc-order-splitter') : __('The active WooCommerce quantity integration only supports integer Split quantities.', 'wc-order-splitter')); ?></li>
                         </ul>
                     </div>
 
@@ -401,6 +411,7 @@ final class WCOS_Split_Admin_Controller {
             return false;
         }
         $hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
-        return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && !empty($_GET['id']));
+        $hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+        return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
     }
 }

--- a/inc/backend/class-wcos-split-admin-controller.php
+++ b/inc/backend/class-wcos-split-admin-controller.php
@@ -52,6 +52,7 @@ final class WCOS_Split_Admin_Controller {
 
         try {
             $plan = WCOS_Split_Request_Parser::parse_json($raw_plan, $order);
+            $summary = $this->plan_summary($plan);
         } catch (InvalidArgumentException $exception) {
             throw new WCOS_Split_Transport_Exception('invalid_plan', $exception->getMessage(), 422, false);
         }
@@ -73,7 +74,7 @@ final class WCOS_Split_Admin_Controller {
             'confirmation_token' => $confirmation['confirmation_token'],
             'expires_at' => $confirmation['expires_at'],
             'preflight' => $preflight,
-            'summary' => $this->plan_summary($plan),
+            'summary' => $summary,
         );
     }
 
@@ -100,6 +101,10 @@ final class WCOS_Split_Admin_Controller {
                 'source_missing' => 404,
                 'policy_changed' => 409,
                 'precision_mismatch' => 409,
+                'journal_mismatch' => 409,
+                'manual_reconciliation' => 409,
+                'operation_closed' => 409,
+                'journal_incomplete' => 409,
             );
             $reason = $exception->get_reason();
             throw new WCOS_Split_Transport_Exception(
@@ -146,6 +151,9 @@ final class WCOS_Split_Admin_Controller {
             if (false !== strpos($message, 'Another order mutation is already in progress')) {
                 throw new WCOS_Split_Transport_Exception('operation_busy', $message, 409, true);
             }
+            if (false !== strpos($message, 'different mutation request')) {
+                throw new WCOS_Split_Transport_Exception('operation_conflict', $message, 409, false);
+            }
             throw new WCOS_Split_Transport_Exception('split_failed', $message, 409, true);
         }
 
@@ -158,7 +166,7 @@ final class WCOS_Split_Admin_Controller {
                 'id' => $child->get_id(),
                 'number' => (string) $child->get_order_number(),
                 'status' => (string) $child->get_status(),
-                'edit_url' => method_exists($child, 'get_edit_order_url') ? (string) $child->get_edit_order_url() : '',
+                'edit_url' => method_exists($child, 'get_edit_order_url') ? esc_url_raw((string) $child->get_edit_order_url()) : '',
             );
         }
 
@@ -383,7 +391,11 @@ final class WCOS_Split_Admin_Controller {
         foreach ($plan as $items) {
             foreach ($items as $item_id => $quantity) {
                 $affected[absint($item_id)] = true;
-                $moved_units += WCOS_Decimal::to_units($quantity, 6);
+                $part = WCOS_Decimal::to_units($quantity, 6);
+                if ($part > 0 && $moved_units > PHP_INT_MAX - $part) {
+                    throw new InvalidArgumentException(__('The reviewed Split quantity total exceeds the supported numeric range.', 'wc-order-splitter'));
+                }
+                $moved_units += $part;
             }
         }
         return array(

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -39,13 +39,21 @@ final class WCOS_Split_Confirmation_Store {
         try {
             /*
              * Review preflight was evaluated under this precision. Rehydrate the
-             * source under the same precision before capturing its confirmation
-             * signature so tax rounding during order-item hydration cannot make
-             * the execute step report a false source_changed conflict.
+             * source under the same precision, then require it to match the
+             * PII-free signature captured by preflight. This closes the narrow
+             * Review -> confirmation TOCTOU window before a token is issued.
              */
             $scoped_source = wc_get_order($source->get_id());
             if (!$scoped_source instanceof WC_Order) {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
+            $reviewed_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
+            $current_signature = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+            if ('' === $reviewed_signature || !hash_equals($reviewed_signature, $current_signature)) {
+                throw new WCOS_Split_Confirmation_Exception(
+                    'source_changed',
+                    __('The order changed while the Split plan was being reviewed. Review the current order state again before creating a confirmation.', 'wc-order-splitter')
+                );
             }
 
             $now = time();
@@ -55,7 +63,7 @@ final class WCOS_Split_Confirmation_Store {
                 'token_hash' => self::token_hash($token),
                 'source_order_id' => $scoped_source->get_id(),
                 'user_id' => $user_id,
-                'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($scoped_source),
+                'source_signature' => $current_signature,
                 'plan' => WCOS_Split_Plan::canonicalize_request($plan),
                 'price_precision' => $precision,
                 'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -17,6 +17,10 @@ final class WCOS_Split_Confirmation_Exception extends RuntimeException {
 
 /**
  * Short-lived non-PII confirmation record for review -> execute transport.
+ *
+ * The confirmation token is mandatory before the first mutation write. Once a
+ * durable journal exists, that journal becomes the replay authority so an
+ * interrupted operation can be resumed after the confirmation TTL expires.
  */
 final class WCOS_Split_Confirmation_Store {
     const SCHEMA_VERSION = 1;
@@ -62,15 +66,15 @@ final class WCOS_Split_Confirmation_Store {
         $operation_id = sanitize_key((string) $operation_id);
         $token = (string) $token;
         $user_id = absint($user_id);
-        if (!self::is_uuid($operation_id) || '' === $token || !$user_id) {
+        if (!self::is_uuid($operation_id) || !$user_id) {
             throw new WCOS_Split_Confirmation_Exception('invalid_identity', __('The Split confirmation identity is invalid.', 'wc-order-splitter'));
         }
 
         $record = get_transient(self::key($operation_id));
         if (!is_array($record)) {
-            throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+            return self::durable_replay($source, $operation_id);
         }
-        if (!isset($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+        if ('' === $token || !isset($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
             throw new WCOS_Split_Confirmation_Exception('invalid_token', __('The Split confirmation token is invalid.', 'wc-order-splitter'));
         }
         if (absint($record['source_order_id']) !== $source->get_id() || absint($record['user_id']) !== $user_id) {
@@ -78,7 +82,7 @@ final class WCOS_Split_Confirmation_Store {
         }
         if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
             self::delete($operation_id);
-            throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+            return self::durable_replay($source, $operation_id);
         }
         if (!isset($record['policy_version']) || (int) $record['policy_version'] !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
             throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
@@ -87,11 +91,6 @@ final class WCOS_Split_Confirmation_Store {
         $precision = WCOS_Price_Precision_Scope::validate(isset($record['price_precision']) ? $record['price_precision'] : null);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
         try {
-            /*
-             * The caller may have loaded this order under a different ambient
-             * precision. Rehydrate inside the reviewed precision before source
-             * signature validation for the same reason the Split adapter does.
-             */
             $scoped_source = wc_get_order($source->get_id());
             if (!$scoped_source instanceof WC_Order) {
                 throw new WCOS_Split_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
@@ -112,6 +111,7 @@ final class WCOS_Split_Confirmation_Store {
             $record['operation_id'] = $operation_id;
             $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
             $record['price_precision'] = $precision;
+            $record['replay_authority'] = is_array($journal) ? 'journal' : 'confirmation';
             return $record;
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);
@@ -124,6 +124,40 @@ final class WCOS_Split_Confirmation_Store {
             return false;
         }
         return delete_transient(self::key($operation_id));
+    }
+
+    private static function durable_replay(WC_Order $source, $operation_id) {
+        $journal = WCOS_Operation_Journal::get($source, $operation_id);
+        if (!is_array($journal)) {
+            throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+        }
+        if (!isset($journal['type']) || 'split' !== sanitize_key((string) $journal['type'])
+            || !isset($journal['source_order_id']) || absint($journal['source_order_id']) !== $source->get_id()) {
+            throw new WCOS_Split_Confirmation_Exception('journal_mismatch', __('The durable Split operation does not match this source order.', 'wc-order-splitter'));
+        }
+
+        $status = isset($journal['status']) ? sanitize_key((string) $journal['status']) : '';
+        if ('manual_reconciliation' === $status) {
+            throw new WCOS_Split_Confirmation_Exception('manual_reconciliation', __('This Split operation requires manual reconciliation before it can continue.', 'wc-order-splitter'));
+        }
+        if (in_array($status, array('manual_reconciled', 'compensated'), true)) {
+            throw new WCOS_Split_Confirmation_Exception('operation_closed', __('This Split operation has been closed and cannot be replayed.', 'wc-order-splitter'));
+        }
+
+        $context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+        if (empty($context['plan']) || !is_array($context['plan']) || !array_key_exists('price_precision', $context)) {
+            throw new WCOS_Split_Confirmation_Exception('journal_incomplete', __('The durable Split operation is missing replay information and requires manual review.', 'wc-order-splitter'));
+        }
+
+        return array(
+            'schema_version' => self::SCHEMA_VERSION,
+            'operation_id' => $operation_id,
+            'source_order_id' => $source->get_id(),
+            'plan' => WCOS_Split_Plan::canonicalize_request($context['plan']),
+            'price_precision' => WCOS_Price_Precision_Scope::validate($context['price_precision']),
+            'policy_version' => isset($context['policy_version']) ? absint($context['policy_version']) : 0,
+            'replay_authority' => 'journal',
+        );
     }
 
     private static function token_hash($token) {

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -35,20 +35,36 @@ final class WCOS_Split_Confirmation_Store {
         $operation_id = wp_generate_uuid4();
         $token = wp_generate_password(48, false, false);
         $precision = WCOS_Price_Precision_Scope::validate(isset($preflight['price_precision']) ? $preflight['price_precision'] : wc_get_price_decimals());
-        $now = time();
-        $record = array(
-            'schema_version' => self::SCHEMA_VERSION,
-            'operation_id' => $operation_id,
-            'token_hash' => self::token_hash($token),
-            'source_order_id' => $source->get_id(),
-            'user_id' => $user_id,
-            'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
-            'plan' => WCOS_Split_Plan::canonicalize_request($plan),
-            'price_precision' => $precision,
-            'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,
-            'created_at' => $now,
-            'expires_at' => $now + self::TTL,
-        );
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            /*
+             * Review preflight was evaluated under this precision. Rehydrate the
+             * source under the same precision before capturing its confirmation
+             * signature so tax rounding during order-item hydration cannot make
+             * the execute step report a false source_changed conflict.
+             */
+            $scoped_source = wc_get_order($source->get_id());
+            if (!$scoped_source instanceof WC_Order) {
+                throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
+
+            $now = time();
+            $record = array(
+                'schema_version' => self::SCHEMA_VERSION,
+                'operation_id' => $operation_id,
+                'token_hash' => self::token_hash($token),
+                'source_order_id' => $scoped_source->get_id(),
+                'user_id' => $user_id,
+                'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($scoped_source),
+                'plan' => WCOS_Split_Plan::canonicalize_request($plan),
+                'price_precision' => $precision,
+                'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,
+                'created_at' => $now,
+                'expires_at' => $now + self::TTL,
+            );
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
 
         if (!set_transient(self::key($operation_id), $record, self::TTL)) {
             throw new RuntimeException(__('Unable to create the temporary Split confirmation record.', 'wc-order-splitter'));

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -1,0 +1,113 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Split_Confirmation_Exception extends RuntimeException {
+    private $reason;
+
+    public function __construct($reason, $message) {
+        $this->reason = sanitize_key((string) $reason);
+        parent::__construct((string) $message);
+    }
+
+    public function get_reason() {
+        return $this->reason;
+    }
+}
+
+/**
+ * Short-lived non-PII confirmation record for review -> execute transport.
+ */
+final class WCOS_Split_Confirmation_Store {
+    const SCHEMA_VERSION = 1;
+    const TTL = 1800;
+
+    public static function create(WC_Order $source, array $plan, array $preflight, $user_id) {
+        $user_id = absint($user_id);
+        if (!$source->get_id() || !$user_id) {
+            throw new InvalidArgumentException(__('A persisted order and signed-in user are required to confirm a Split plan.', 'wc-order-splitter'));
+        }
+
+        $operation_id = wp_generate_uuid4();
+        $token = wp_generate_password(48, false, false);
+        $precision = WCOS_Price_Precision_Scope::validate(isset($preflight['price_precision']) ? $preflight['price_precision'] : wc_get_price_decimals());
+        $now = time();
+        $record = array(
+            'schema_version' => self::SCHEMA_VERSION,
+            'operation_id' => $operation_id,
+            'token_hash' => self::token_hash($token),
+            'source_order_id' => $source->get_id(),
+            'user_id' => $user_id,
+            'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
+            'plan' => WCOS_Split_Plan::canonicalize_request($plan),
+            'price_precision' => $precision,
+            'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,
+            'created_at' => $now,
+            'expires_at' => $now + self::TTL,
+        );
+
+        if (!set_transient(self::key($operation_id), $record, self::TTL)) {
+            throw new RuntimeException(__('Unable to create the temporary Split confirmation record.', 'wc-order-splitter'));
+        }
+
+        return array(
+            'operation_id' => $operation_id,
+            'confirmation_token' => $token,
+            'expires_at' => $record['expires_at'],
+            'record' => $record,
+        );
+    }
+
+    public static function verify(WC_Order $source, $operation_id, $token, $user_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $token = (string) $token;
+        $user_id = absint($user_id);
+        if (!self::is_uuid($operation_id) || '' === $token || !$user_id) {
+            throw new WCOS_Split_Confirmation_Exception('invalid_identity', __('The Split confirmation identity is invalid.', 'wc-order-splitter'));
+        }
+
+        $record = get_transient(self::key($operation_id));
+        if (!is_array($record)) {
+            throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+        }
+        if (!isset($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+            throw new WCOS_Split_Confirmation_Exception('invalid_token', __('The Split confirmation token is invalid.', 'wc-order-splitter'));
+        }
+        if (absint($record['source_order_id']) !== $source->get_id() || absint($record['user_id']) !== $user_id) {
+            throw new WCOS_Split_Confirmation_Exception('owner_mismatch', __('The Split confirmation does not belong to this user and order.', 'wc-order-splitter'));
+        }
+        if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+            delete_transient(self::key($operation_id));
+            throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+        }
+
+        $journal = WCOS_Operation_Journal::get($source, $operation_id);
+        if (!is_array($journal)) {
+            $expected = isset($record['source_signature']) ? (string) $record['source_signature'] : '';
+            $actual = WCOS_Order_Contract_Snapshot::source_signature($source);
+            if ('' === $expected || !hash_equals($expected, $actual)) {
+                throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
+            }
+        } elseif (isset($journal['context']['price_precision'])
+            && (int) $journal['context']['price_precision'] !== (int) $record['price_precision']) {
+            throw new WCOS_Split_Confirmation_Exception('precision_mismatch', __('The Split confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
+        }
+
+        $record['operation_id'] = $operation_id;
+        $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
+        $record['price_precision'] = WCOS_Price_Precision_Scope::validate($record['price_precision']);
+        return $record;
+    }
+
+    private static function token_hash($token) {
+        return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+    }
+
+    private static function key($operation_id) {
+        return 'wcos_split_confirm_' . hash('sha256', sanitize_key((string) $operation_id));
+    }
+
+    private static function is_uuid($value) {
+        return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+    }
+}

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -84,22 +84,38 @@ final class WCOS_Split_Confirmation_Store {
             throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
         }
 
-        $journal = WCOS_Operation_Journal::get($source, $operation_id);
-        if (!is_array($journal)) {
-            $expected = isset($record['source_signature']) ? (string) $record['source_signature'] : '';
-            $actual = WCOS_Order_Contract_Snapshot::source_signature($source);
-            if ('' === $expected || !hash_equals($expected, $actual)) {
-                throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
+        $precision = WCOS_Price_Precision_Scope::validate(isset($record['price_precision']) ? $record['price_precision'] : null);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            /*
+             * The caller may have loaded this order under a different ambient
+             * precision. Rehydrate inside the reviewed precision before source
+             * signature validation for the same reason the Split adapter does.
+             */
+            $scoped_source = wc_get_order($source->get_id());
+            if (!$scoped_source instanceof WC_Order) {
+                throw new WCOS_Split_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
             }
-        } elseif (isset($journal['context']['price_precision'])
-            && (int) $journal['context']['price_precision'] !== (int) $record['price_precision']) {
-            throw new WCOS_Split_Confirmation_Exception('precision_mismatch', __('The Split confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
-        }
 
-        $record['operation_id'] = $operation_id;
-        $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
-        $record['price_precision'] = WCOS_Price_Precision_Scope::validate($record['price_precision']);
-        return $record;
+            $journal = WCOS_Operation_Journal::get($scoped_source, $operation_id);
+            if (!is_array($journal)) {
+                $expected = isset($record['source_signature']) ? (string) $record['source_signature'] : '';
+                $actual = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+                if ('' === $expected || !hash_equals($expected, $actual)) {
+                    throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
+                }
+            } elseif (isset($journal['context']['price_precision'])
+                && (int) $journal['context']['price_precision'] !== $precision) {
+                throw new WCOS_Split_Confirmation_Exception('precision_mismatch', __('The Split confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
+            }
+
+            $record['operation_id'] = $operation_id;
+            $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
+            $record['price_precision'] = $precision;
+            return $record;
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
     }
 
     public static function delete($operation_id) {

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -77,8 +77,11 @@ final class WCOS_Split_Confirmation_Store {
             throw new WCOS_Split_Confirmation_Exception('owner_mismatch', __('The Split confirmation does not belong to this user and order.', 'wc-order-splitter'));
         }
         if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
-            delete_transient(self::key($operation_id));
+            self::delete($operation_id);
             throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));
+        }
+        if (!isset($record['policy_version']) || (int) $record['policy_version'] !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
+            throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
         }
 
         $journal = WCOS_Operation_Journal::get($source, $operation_id);
@@ -97,6 +100,14 @@ final class WCOS_Split_Confirmation_Store {
         $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
         $record['price_precision'] = WCOS_Price_Precision_Scope::validate($record['price_precision']);
         return $record;
+    }
+
+    public static function delete($operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if (!self::is_uuid($operation_id)) {
+            return false;
+        }
+        return delete_transient(self::key($operation_id));
     }
 
     private static function token_hash($token) {

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -119,9 +119,16 @@ final class WCOS_Split_Confirmation_Store {
                 if ('' === $expected || !hash_equals($expected, $actual)) {
                     throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
                 }
-            } elseif (isset($journal['context']['price_precision'])
-                && (int) $journal['context']['price_precision'] !== $precision) {
-                throw new WCOS_Split_Confirmation_Exception('precision_mismatch', __('The Split confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
+            } else {
+                $journal_context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+                if (!array_key_exists('price_precision', $journal_context)
+                    || (int) $journal_context['price_precision'] !== $precision) {
+                    throw new WCOS_Split_Confirmation_Exception('precision_mismatch', __('The Split confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
+                }
+                if (!array_key_exists('policy_version', $journal_context)
+                    || (int) $journal_context['policy_version'] !== (int) $record['policy_version']) {
+                    throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The durable Split operation no longer matches the safety policy that was reviewed.', 'wc-order-splitter'));
+                }
             }
 
             $record['operation_id'] = $operation_id;
@@ -161,8 +168,14 @@ final class WCOS_Split_Confirmation_Store {
         }
 
         $context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
-        if (empty($context['plan']) || !is_array($context['plan']) || !array_key_exists('price_precision', $context)) {
+        if (empty($context['plan'])
+            || !is_array($context['plan'])
+            || !array_key_exists('price_precision', $context)
+            || !array_key_exists('policy_version', $context)) {
             throw new WCOS_Split_Confirmation_Exception('journal_incomplete', __('The durable Split operation is missing replay information and requires manual review.', 'wc-order-splitter'));
+        }
+        if ((int) $context['policy_version'] !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
+            throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this durable operation started. Review the operation manually before continuing it.', 'wc-order-splitter'));
         }
 
         return array(
@@ -171,7 +184,7 @@ final class WCOS_Split_Confirmation_Store {
             'source_order_id' => $source->get_id(),
             'plan' => WCOS_Split_Plan::canonicalize_request($context['plan']),
             'price_precision' => WCOS_Price_Precision_Scope::validate($context['price_precision']),
-            'policy_version' => isset($context['policy_version']) ? absint($context['policy_version']) : 0,
+            'policy_version' => (int) $context['policy_version'],
             'replay_authority' => 'journal',
         );
     }

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -37,22 +37,35 @@ final class WCOS_Split_Confirmation_Store {
         $precision = WCOS_Price_Precision_Scope::validate(isset($preflight['price_precision']) ? $preflight['price_precision'] : wc_get_price_decimals());
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
         try {
+            $reviewed_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
+
             /*
-             * Review preflight was evaluated under this precision. Rehydrate the
-             * source under the same precision, then require it to match the
-             * PII-free signature captured by preflight. This closes the narrow
-             * Review -> confirmation TOCTOU window before a token is issued.
+             * The passed source is the exact object the strict request parser
+             * validated. Require it to match the fresh preflight snapshot first,
+             * closing parser -> preflight races inside one Review request.
+             */
+            $parsed_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+            if ('' === $reviewed_signature || !hash_equals($reviewed_signature, $parsed_signature)) {
+                throw new WCOS_Split_Confirmation_Exception(
+                    'source_changed',
+                    __('The order changed while the Split plan was being reviewed. Review the current order state again before creating a confirmation.', 'wc-order-splitter')
+                );
+            }
+
+            /*
+             * Rehydrate again under the same reviewed precision and require the
+             * database state to remain identical before issuing an operation ID
+             * and token. Any later edit is caught by verify() before mutation.
              */
             $scoped_source = wc_get_order($source->get_id());
             if (!$scoped_source instanceof WC_Order) {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
-            $reviewed_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
             $current_signature = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
-            if ('' === $reviewed_signature || !hash_equals($reviewed_signature, $current_signature)) {
+            if (!hash_equals($reviewed_signature, $current_signature)) {
                 throw new WCOS_Split_Confirmation_Exception(
                     'source_changed',
-                    __('The order changed while the Split plan was being reviewed. Review the current order state again before creating a confirmation.', 'wc-order-splitter')
+                    __('The order changed while the Split confirmation was being created. Review the current order state again.', 'wc-order-splitter')
                 );
             }
 

--- a/inc/backend/class-wcos-split-request-parser.php
+++ b/inc/backend/class-wcos-split-request-parser.php
@@ -36,6 +36,7 @@ final class WCOS_Split_Request_Parser {
 
         $strict = array();
         $assignments = 0;
+        $fractional_supported = WCOS_Split_Preflight::fractional_quantities_supported();
         foreach ($plan as $raw_child_key => $items) {
             $child_key = (string) $raw_child_key;
             if (!preg_match('/^child-(?:[1-9]|10)$/D', $child_key)) {
@@ -59,6 +60,9 @@ final class WCOS_Split_Request_Parser {
                 $quantity_units = WCOS_Decimal::to_units($quantity, 6);
                 if (!$item_id || $quantity_units <= 0) {
                     throw new InvalidArgumentException(__('Split item IDs and quantities must be positive.', 'wc-order-splitter'));
+                }
+                if (0 !== ($quantity_units % 1000000) && !$fractional_supported) {
+                    throw new InvalidArgumentException(__('Fractional Split quantities require an integration that enables fractional WooCommerce stock amounts.', 'wc-order-splitter'));
                 }
                 if (!$source->get_item($item_id) instanceof WC_Order_Item_Product) {
                     throw new InvalidArgumentException(__('The Split plan references an item outside the source order.', 'wc-order-splitter'));

--- a/inc/backend/class-wcos-split-request-parser.php
+++ b/inc/backend/class-wcos-split-request-parser.php
@@ -57,7 +57,11 @@ final class WCOS_Split_Request_Parser {
                 }
 
                 $item_id = absint($item_key);
-                $quantity_units = WCOS_Decimal::to_units($quantity, 6);
+                try {
+                    $quantity_units = WCOS_Decimal::to_units($quantity, 6);
+                } catch (OverflowException $exception) {
+                    throw new InvalidArgumentException(__('A Split quantity exceeds the supported numeric range.', 'wc-order-splitter'), 0, $exception);
+                }
                 if (!$item_id || $quantity_units <= 0) {
                     throw new InvalidArgumentException(__('Split item IDs and quantities must be positive.', 'wc-order-splitter'));
                 }
@@ -79,6 +83,10 @@ final class WCOS_Split_Request_Parser {
             }
         }
 
-        return WCOS_Split_Plan::normalize($source, $strict);
+        try {
+            return WCOS_Split_Plan::normalize($source, $strict);
+        } catch (OverflowException $exception) {
+            throw new InvalidArgumentException(__('The Split plan exceeds the supported numeric range.', 'wc-order-splitter'), 0, $exception);
+        }
     }
 }

--- a/inc/backend/class-wcos-split-request-parser.php
+++ b/inc/backend/class-wcos-split-request-parser.php
@@ -1,0 +1,80 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Strict parser for the manual quantity-Split admin transport.
+ *
+ * JSON quantities must be decimal strings so binary floating-point values never
+ * enter the idempotency or allocation contract.
+ */
+final class WCOS_Split_Request_Parser {
+    const MAX_PAYLOAD_BYTES = 65536;
+    const MAX_CHILDREN = 10;
+    const MAX_LINE_ASSIGNMENTS = 500;
+
+    public static function parse_json($raw_plan, WC_Order $source) {
+        if (!is_string($raw_plan)) {
+            throw new InvalidArgumentException(__('The Split plan must be a JSON string.', 'wc-order-splitter'));
+        }
+        $raw_plan = trim($raw_plan);
+        if ('' === $raw_plan || strlen($raw_plan) > self::MAX_PAYLOAD_BYTES) {
+            throw new InvalidArgumentException(__('The Split plan is empty or exceeds the supported request size.', 'wc-order-splitter'));
+        }
+
+        $decoded = json_decode($raw_plan, true);
+        if (JSON_ERROR_NONE !== json_last_error() || !is_array($decoded)) {
+            throw new InvalidArgumentException(__('The Split plan contains invalid JSON.', 'wc-order-splitter'));
+        }
+        return self::parse_array($decoded, $source);
+    }
+
+    public static function parse_array(array $plan, WC_Order $source) {
+        if (empty($plan) || count($plan) > self::MAX_CHILDREN) {
+            throw new InvalidArgumentException(__('A Split plan must contain between one and ten child orders.', 'wc-order-splitter'));
+        }
+
+        $strict = array();
+        $assignments = 0;
+        foreach ($plan as $raw_child_key => $items) {
+            $child_key = (string) $raw_child_key;
+            if (!preg_match('/^child-(?:[1-9]|10)$/D', $child_key)) {
+                throw new InvalidArgumentException(__('Split child keys must use the server-supported child-1 through child-10 format.', 'wc-order-splitter'));
+            }
+            if (!is_array($items) || empty($items)) {
+                throw new InvalidArgumentException(__('Every Split child must contain at least one line quantity.', 'wc-order-splitter'));
+            }
+
+            $strict[$child_key] = array();
+            foreach ($items as $raw_item_id => $quantity) {
+                $item_key = (string) $raw_item_id;
+                if (!preg_match('/^[1-9][0-9]*$/D', $item_key)) {
+                    throw new InvalidArgumentException(__('Split item IDs must be positive decimal integers.', 'wc-order-splitter'));
+                }
+                if (!is_string($quantity) || !preg_match('/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,6})?$/D', $quantity)) {
+                    throw new InvalidArgumentException(__('Split quantities must be decimal strings with at most six decimal places.', 'wc-order-splitter'));
+                }
+
+                $item_id = absint($item_key);
+                $quantity_units = WCOS_Decimal::to_units($quantity, 6);
+                if (!$item_id || $quantity_units <= 0) {
+                    throw new InvalidArgumentException(__('Split item IDs and quantities must be positive.', 'wc-order-splitter'));
+                }
+                if (!$source->get_item($item_id) instanceof WC_Order_Item_Product) {
+                    throw new InvalidArgumentException(__('The Split plan references an item outside the source order.', 'wc-order-splitter'));
+                }
+                if (isset($strict[$child_key][$item_id])) {
+                    throw new InvalidArgumentException(__('The Split plan contains a duplicate item assignment for one child.', 'wc-order-splitter'));
+                }
+
+                $strict[$child_key][$item_id] = WCOS_Decimal::from_units($quantity_units, 6);
+                $assignments++;
+                if ($assignments > self::MAX_LINE_ASSIGNMENTS) {
+                    throw new InvalidArgumentException(__('The Split plan contains too many line assignments.', 'wc-order-splitter'));
+                }
+            }
+        }
+
+        return WCOS_Split_Plan::normalize($source, $strict);
+    }
+}

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -28,6 +28,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-amount-allocator.php';
 		include_once $root . 'domain/class-wcos-line-identity.php';
 		include_once $root . 'domain/class-wcos-mutation-fingerprint.php';
+		include_once $root . 'domain/class-wcos-price-precision-scope.php';
 		include_once $root . 'domain/class-wcos-stock-side-effect-guard.php';
 		include_once $root . 'domain/class-wcos-mutation-contract.php';
 		include_once $root . 'domain/class-wcos-operation-lock.php';

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -43,6 +43,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-copy-context.php';
 		include_once $root . 'domain/class-wcos-order-mutation-snapshot.php';
 		include_once $root . 'domain/class-wcos-operation-journal.php';
+		include_once $root . 'domain/class-wcos-manual-reconciliation-blocker.php';
 		include_once $root . 'domain/class-wcos-operation-journal-retention.php';
 		WCOS_Operation_Journal_Retention::bootstrap();
 		include_once $root . 'domain/class-wcos-order-relation-repository.php';

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -58,15 +58,20 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 
+		include_once $root . 'backend/class-wcos-split-request-parser.php';
+		include_once $root . 'backend/class-wcos-split-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-split-admin-controller.php';
+		new WCOS_Split_Admin_Controller();
+
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';
 		include_once $root . 'backend/yoohw-woo-settings-tabs-reorder.php';
 		include_once plugin_dir_path(__FILE__) . 'safety.php';
 
 		/*
-		 * Legacy mutation handlers are deliberately never loaded here. Future
-		 * controllers must call WCOS_Mutation_Gateway so workflow gates and the
-		 * centralized authorizer cannot be bypassed by controller code.
+		 * Legacy mutation handlers are deliberately never loaded here. Production
+		 * Split transport is isolated behind WCOS_Mutation_Gateway and remains
+		 * non-runnable while WCOS_Feature_Gates::SPLIT is hard-off.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -188,6 +188,19 @@ final class WCOS_Manual_Reconciliation_Blocker {
                 return true;
             }
 
+            /*
+             * Re-read and re-validate the exact current incident on every CAS
+             * attempt. A concurrent block() may replace incident A with a newer
+             * incident B between the caller's resolution check and this clear.
+             * An older reconciliation must never delete that newer blocker.
+             */
+            $journal = class_exists('WCOS_Operation_Journal')
+                ? WCOS_Operation_Journal::get($order, $operation_id)
+                : null;
+            if (!self::journal_resolves_incident($journal, $current['operations'][$operation_id])) {
+                return false;
+            }
+
             $replacement = $current;
             unset($replacement['operations'][$operation_id]);
             if (empty($replacement['operations'])) {

--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -23,13 +23,14 @@ final class WCOS_Manual_Reconciliation_Blocker {
         $key = self::key($order->get_id());
         for ($attempt = 0; $attempt < 5; $attempt++) {
             $current = get_option($key, null);
+            $incident = self::incident($order, $operation_id);
             if (!is_array($current)) {
                 $record = array(
                     'schema_version' => self::SCHEMA_VERSION,
                     'source_order_id' => $order->get_id(),
                     'revision' => 1,
                     'operations' => array(
-                        $operation_id => array('blocked_at' => gmdate('c')),
+                        $operation_id => $incident,
                     ),
                 );
                 if (add_option($key, $record, '', false)) {
@@ -39,10 +40,6 @@ final class WCOS_Manual_Reconciliation_Blocker {
                 continue;
             }
 
-            if (isset($current['operations'][$operation_id])) {
-                return true;
-            }
-
             $replacement = $current;
             $replacement['schema_version'] = self::SCHEMA_VERSION;
             $replacement['source_order_id'] = $order->get_id();
@@ -50,7 +47,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
             $replacement['operations'] = isset($current['operations']) && is_array($current['operations'])
                 ? $current['operations']
                 : array();
-            $replacement['operations'][$operation_id] = array('blocked_at' => gmdate('c'));
+            $replacement['operations'][$operation_id] = $incident;
             ksort($replacement['operations'], SORT_STRING);
 
             if (self::compare_and_swap($key, $current, $replacement)) {
@@ -65,6 +62,11 @@ final class WCOS_Manual_Reconciliation_Blocker {
      * Return unresolved operation IDs. Missing/non-manual journals are still
      * treated as unresolved because they can represent a crash after the blocker
      * was durably written but before the journal transition completed.
+     *
+     * A manual_reconciled journal clears a blocker only when its journal revision
+     * is newer than the revision captured by that stock incident. This prevents a
+     * later incident on the same operation from being mistaken for an older
+     * reconciliation merely because both happened in the same wall-clock second.
      */
     public static function active_operation_ids(WC_Order $order) {
         if (!$order->get_id()) {
@@ -78,7 +80,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
 
         $active = array();
         $resolved = array();
-        foreach (array_keys($record['operations']) as $operation_id) {
+        foreach ($record['operations'] as $operation_id => $incident) {
             $operation_id = sanitize_key((string) $operation_id);
             if ('' === $operation_id) {
                 continue;
@@ -89,8 +91,12 @@ final class WCOS_Manual_Reconciliation_Blocker {
             $status = is_array($journal) && isset($journal['status'])
                 ? sanitize_key((string) $journal['status'])
                 : '';
+            $journal_revision = is_array($journal) && isset($journal['revision']) ? (int) $journal['revision'] : 0;
+            $blocked_revision = is_array($incident) && isset($incident['journal_revision_at_block'])
+                ? (int) $incident['journal_revision_at_block']
+                : PHP_INT_MAX;
 
-            if ('manual_reconciled' === $status) {
+            if ('manual_reconciled' === $status && $journal_revision > $blocked_revision) {
                 $resolved[] = $operation_id;
                 continue;
             }
@@ -109,6 +115,18 @@ final class WCOS_Manual_Reconciliation_Blocker {
 
     public static function has_active(WC_Order $order) {
         return !empty(self::active_operation_ids($order));
+    }
+
+    private static function incident(WC_Order $order, $operation_id) {
+        $journal = class_exists('WCOS_Operation_Journal')
+            ? WCOS_Operation_Journal::get($order, $operation_id)
+            : null;
+        return array(
+            'blocked_at' => gmdate('c'),
+            'journal_revision_at_block' => is_array($journal) && isset($journal['revision'])
+                ? (int) $journal['revision']
+                : 0,
+        );
     }
 
     private static function clear_resolved(WC_Order $order, $operation_id) {

--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -88,15 +88,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
             $journal = class_exists('WCOS_Operation_Journal')
                 ? WCOS_Operation_Journal::get($order, $operation_id)
                 : null;
-            $status = is_array($journal) && isset($journal['status'])
-                ? sanitize_key((string) $journal['status'])
-                : '';
-            $journal_revision = is_array($journal) && isset($journal['revision']) ? (int) $journal['revision'] : 0;
-            $blocked_revision = is_array($incident) && isset($incident['journal_revision_at_block'])
-                ? (int) $incident['journal_revision_at_block']
-                : PHP_INT_MAX;
-
-            if ('manual_reconciled' === $status && $journal_revision > $blocked_revision) {
+            if (self::journal_resolves_incident($journal, $incident)) {
                 $resolved[] = $operation_id;
                 continue;
             }
@@ -105,7 +97,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
         }
 
         foreach ($resolved as $operation_id) {
-            self::clear_resolved($order, $operation_id);
+            self::clear($order, $operation_id);
         }
 
         $active = array_values(array_unique($active));
@@ -115,6 +107,47 @@ final class WCOS_Manual_Reconciliation_Blocker {
 
     public static function has_active(WC_Order $order) {
         return !empty(self::active_operation_ids($order));
+    }
+
+    /**
+     * Eagerly clear one blocker only after the authoritative journal proves that
+     * this exact incident has a newer manual_reconciled transition.
+     */
+    public static function resolve_if_reconciled(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return false;
+        }
+
+        $record = get_option(self::key($order->get_id()), null);
+        if (!is_array($record) || empty($record['operations']) || !is_array($record['operations'])) {
+            return true;
+        }
+        if (!isset($record['operations'][$operation_id])) {
+            return true;
+        }
+
+        $journal = class_exists('WCOS_Operation_Journal')
+            ? WCOS_Operation_Journal::get($order, $operation_id)
+            : null;
+        if (!self::journal_resolves_incident($journal, $record['operations'][$operation_id])) {
+            return false;
+        }
+
+        return self::clear($order, $operation_id);
+    }
+
+    /**
+     * Retention uses this to avoid deleting the authoritative resolution proof
+     * while a blocker record still exists because an eager clear failed.
+     */
+    public static function contains_operation($source_order_id, $operation_id) {
+        $source_order_id = absint($source_order_id);
+        $operation_id = sanitize_key((string) $operation_id);
+        if (!$source_order_id || '' === $operation_id) {
+            return false;
+        }
+        return self::contains($source_order_id, $operation_id);
     }
 
     private static function incident(WC_Order $order, $operation_id) {
@@ -129,7 +162,20 @@ final class WCOS_Manual_Reconciliation_Blocker {
         );
     }
 
-    private static function clear_resolved(WC_Order $order, $operation_id) {
+    private static function journal_resolves_incident($journal, $incident) {
+        if (!is_array($journal) || !isset($journal['status']) || !isset($journal['revision'])) {
+            return false;
+        }
+        $status = sanitize_key((string) $journal['status']);
+        $journal_revision = (int) $journal['revision'];
+        $blocked_revision = is_array($incident) && isset($incident['journal_revision_at_block'])
+            ? (int) $incident['journal_revision_at_block']
+            : PHP_INT_MAX;
+
+        return 'manual_reconciled' === $status && $journal_revision > $blocked_revision;
+    }
+
+    private static function clear(WC_Order $order, $operation_id) {
         $operation_id = sanitize_key((string) $operation_id);
         $key = self::key($order->get_id());
 

--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -1,0 +1,180 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Fail-closed source-order blocker for physical-stock incidents.
+ *
+ * This record is intentionally persisted before the journal transitions into
+ * manual_reconciliation. If the process dies between those two writes, the
+ * source remains blocked rather than creating a false-negative preflight gap.
+ * The record contains only source/operation identifiers and timestamps.
+ */
+final class WCOS_Manual_Reconciliation_Blocker {
+    const SCHEMA_VERSION = 1;
+    const KEY_PREFIX = 'wcos_manual_reconcile_block_';
+
+    public static function block(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return false;
+        }
+
+        $key = self::key($order->get_id());
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $current = get_option($key, null);
+            if (!is_array($current)) {
+                $record = array(
+                    'schema_version' => self::SCHEMA_VERSION,
+                    'source_order_id' => $order->get_id(),
+                    'revision' => 1,
+                    'operations' => array(
+                        $operation_id => array('blocked_at' => gmdate('c')),
+                    ),
+                );
+                if (add_option($key, $record, '', false)) {
+                    return self::contains($order->get_id(), $operation_id);
+                }
+                wp_cache_delete($key, 'options');
+                continue;
+            }
+
+            if (isset($current['operations'][$operation_id])) {
+                return true;
+            }
+
+            $replacement = $current;
+            $replacement['schema_version'] = self::SCHEMA_VERSION;
+            $replacement['source_order_id'] = $order->get_id();
+            $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
+            $replacement['operations'] = isset($current['operations']) && is_array($current['operations'])
+                ? $current['operations']
+                : array();
+            $replacement['operations'][$operation_id] = array('blocked_at' => gmdate('c'));
+            ksort($replacement['operations'], SORT_STRING);
+
+            if (self::compare_and_swap($key, $current, $replacement)) {
+                return self::contains($order->get_id(), $operation_id);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return unresolved operation IDs. Missing/non-manual journals are still
+     * treated as unresolved because they can represent a crash after the blocker
+     * was durably written but before the journal transition completed.
+     */
+    public static function active_operation_ids(WC_Order $order) {
+        if (!$order->get_id()) {
+            return array();
+        }
+
+        $record = get_option(self::key($order->get_id()), null);
+        if (!is_array($record) || empty($record['operations']) || !is_array($record['operations'])) {
+            return array();
+        }
+
+        $active = array();
+        $resolved = array();
+        foreach (array_keys($record['operations']) as $operation_id) {
+            $operation_id = sanitize_key((string) $operation_id);
+            if ('' === $operation_id) {
+                continue;
+            }
+            $journal = class_exists('WCOS_Operation_Journal')
+                ? WCOS_Operation_Journal::get($order, $operation_id)
+                : null;
+            $status = is_array($journal) && isset($journal['status'])
+                ? sanitize_key((string) $journal['status'])
+                : '';
+
+            if ('manual_reconciled' === $status) {
+                $resolved[] = $operation_id;
+                continue;
+            }
+
+            $active[] = $operation_id;
+        }
+
+        foreach ($resolved as $operation_id) {
+            self::clear_resolved($order, $operation_id);
+        }
+
+        $active = array_values(array_unique($active));
+        sort($active, SORT_STRING);
+        return $active;
+    }
+
+    public static function has_active(WC_Order $order) {
+        return !empty(self::active_operation_ids($order));
+    }
+
+    private static function clear_resolved(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $key = self::key($order->get_id());
+
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $current = get_option($key, null);
+            if (!is_array($current) || empty($current['operations']) || !is_array($current['operations'])) {
+                return true;
+            }
+            if (!isset($current['operations'][$operation_id])) {
+                return true;
+            }
+
+            $replacement = $current;
+            unset($replacement['operations'][$operation_id]);
+            if (empty($replacement['operations'])) {
+                global $wpdb;
+                $deleted = $wpdb->query(
+                    $wpdb->prepare(
+                        "DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+                        $key,
+                        maybe_serialize($current)
+                    )
+                );
+                wp_cache_delete($key, 'options');
+                if (1 === $deleted || null === get_option($key, null)) {
+                    return true;
+                }
+                continue;
+            }
+
+            $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
+            if (self::compare_and_swap($key, $current, $replacement)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function contains($order_id, $operation_id) {
+        $record = get_option(self::key($order_id), null);
+        return is_array($record)
+            && isset($record['operations'])
+            && is_array($record['operations'])
+            && isset($record['operations'][$operation_id]);
+    }
+
+    private static function compare_and_swap($key, array $current, array $replacement) {
+        global $wpdb;
+
+        $updated = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
+                maybe_serialize($replacement),
+                $key,
+                maybe_serialize($current)
+            )
+        );
+        wp_cache_delete($key, 'options');
+        return 1 === $updated;
+    }
+
+    private static function key($order_id) {
+        return self::KEY_PREFIX . absint($order_id);
+    }
+}

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -17,9 +17,9 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Split_WooCommerce_Adapter())->split($source, $plan, $operation_id);
 	}
 
-	public function split_preflight(WC_Order $source) {
+	public function split_preflight(WC_Order $source, $operation_id = '') {
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
-		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id);
 	}
 
 	public function duplicate(WC_Order $source, $operation_id) {

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -11,15 +11,15 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Mutation_Gateway {
 
-	public function split(WC_Order $source, array $plan, $operation_id) {
+	public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::SPLIT);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
-		return (new WCOS_Split_WooCommerce_Adapter())->split($source, $plan, $operation_id);
+		return (new WCOS_Split_WooCommerce_Adapter())->split($source, $plan, $operation_id, $confirmed_precision);
 	}
 
-	public function split_preflight(WC_Order $source, $operation_id = '') {
+	public function split_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
-		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id);
+		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
 	public function duplicate(WC_Order $source, $operation_id) {

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -11,132 +11,122 @@ defined('ABSPATH') || exit;
  * gate is hard-off.
  */
 final class WCOS_Operation_Journal_Retention {
-	const CRON_HOOK = 'wcos_cleanup_terminal_mutation_journals';
-	const SCAN_STATE_OPTION = 'wcos_mutation_journal_cleanup_state';
-	const DEFAULT_RETENTION_DAYS = 90;
-	const BATCH_SIZE = 50;
+    const CRON_HOOK = 'wcos_cleanup_terminal_mutation_journals';
+    const SCAN_STATE_OPTION = 'wcos_mutation_journal_cleanup_state';
+    const DEFAULT_RETENTION_DAYS = 90;
+    const BATCH_SIZE = 50;
 
-	public static function bootstrap() {
-		add_action('init', array(__CLASS__, 'maybe_schedule'), 20);
-		add_action(self::CRON_HOOK, array(__CLASS__, 'cleanup'));
-	}
+    public static function bootstrap() {
+        add_action('init', array(__CLASS__, 'maybe_schedule'), 20);
+        add_action(self::CRON_HOOK, array(__CLASS__, 'cleanup'));
+    }
 
-	public static function maybe_schedule() {
-		if (!class_exists('WCOS_Feature_Gates') || !WCOS_Feature_Gates::any_enabled()) {
-			return;
-		}
-		if (!wp_next_scheduled(self::CRON_HOOK)) {
-			wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', self::CRON_HOOK);
-		}
-	}
+    public static function maybe_schedule() {
+        if (!class_exists('WCOS_Feature_Gates') || !WCOS_Feature_Gates::any_enabled()) {
+            return;
+        }
+        if (!wp_next_scheduled(self::CRON_HOOK)) {
+            wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', self::CRON_HOOK);
+        }
+    }
 
-	/**
-	 * Scan one bounded keyset page inside a finite high-water cycle.
-	 *
-	 * A pure monotonic cursor is unsafe on an active store: a journal scanned while
-	 * still recent would never be reconsidered if new options keep arriving ahead
-	 * of the cursor. Each cycle therefore snapshots the current maximum matching
-	 * option_id, scans only through that high-water mark, then resets. Newer journal
-	 * rows wait for the next cycle, and older rows are revisited in later cycles as
-	 * they age into retention eligibility.
-	 */
-	public static function cleanup() {
-		global $wpdb;
+    public static function cleanup() {
+        global $wpdb;
 
-		$like = $wpdb->esc_like('wcos_mutation_op_') . '%';
-		$state = self::scan_state();
-		if ($state['high_water'] <= 0) {
-			$state['high_water'] = absint(
-				$wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT MAX(option_id) FROM {$wpdb->options} WHERE option_name LIKE %s",
-						$like
-					)
-				)
-			);
-			$state['cursor'] = 0;
-			if ($state['high_water'] <= 0) {
-				delete_option(self::SCAN_STATE_OPTION);
-				return 0;
-			}
-		}
+        $like = $wpdb->esc_like('wcos_mutation_op_') . '%';
+        $state = self::scan_state();
+        if ($state['high_water'] <= 0) {
+            $state['high_water'] = absint(
+                $wpdb->get_var(
+                    $wpdb->prepare(
+                        "SELECT MAX(option_id) FROM {$wpdb->options} WHERE option_name LIKE %s",
+                        $like
+                    )
+                )
+            );
+            $state['cursor'] = 0;
+            if ($state['high_water'] <= 0) {
+                delete_option(self::SCAN_STATE_OPTION);
+                return 0;
+            }
+        }
 
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT option_id, option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_id > %d AND option_id <= %d ORDER BY option_id ASC LIMIT %d",
-				$like,
-				$state['cursor'],
-				$state['high_water'],
-				self::BATCH_SIZE
-			),
-			ARRAY_A
-		);
-		if (empty($rows)) {
-			delete_option(self::SCAN_STATE_OPTION);
-			return 0;
-		}
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT option_id, option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_id > %d AND option_id <= %d ORDER BY option_id ASC LIMIT %d",
+                $like,
+                $state['cursor'],
+                $state['high_water'],
+                self::BATCH_SIZE
+            ),
+            ARRAY_A
+        );
+        if (empty($rows)) {
+            delete_option(self::SCAN_STATE_OPTION);
+            return 0;
+        }
 
-		$deleted = 0;
-		$now = time();
-		$last_option_id = $state['cursor'];
-		foreach ($rows as $row) {
-			$last_option_id = max($last_option_id, absint($row['option_id']));
-			$key = isset($row['option_name']) ? (string) $row['option_name'] : '';
-			if ('' === $key) {
-				continue;
-			}
-			$record = get_option($key, null);
-			if (!is_array($record) || !self::is_expired_terminal_record($record, $now)) {
-				continue;
-			}
-			if (delete_option($key)) {
-				$deleted++;
-			}
-		}
+        $deleted = 0;
+        $now = time();
+        $last_option_id = $state['cursor'];
+        foreach ($rows as $row) {
+            $last_option_id = max($last_option_id, absint($row['option_id']));
+            $key = isset($row['option_name']) ? (string) $row['option_name'] : '';
+            if ('' === $key) {
+                continue;
+            }
+            $record = get_option($key, null);
+            if (!is_array($record) || !self::is_expired_terminal_record($record, $now)) {
+                continue;
+            }
+            if (delete_option($key)) {
+                $deleted++;
+            }
+        }
 
-		if ($last_option_id >= $state['high_water']) {
-			delete_option(self::SCAN_STATE_OPTION);
-		} else {
-			update_option(
-				self::SCAN_STATE_OPTION,
-				array(
-					'cursor' => $last_option_id,
-					'high_water' => $state['high_water'],
-				),
-				false
-			);
-		}
+        if ($last_option_id >= $state['high_water']) {
+            delete_option(self::SCAN_STATE_OPTION);
+        } else {
+            update_option(
+                self::SCAN_STATE_OPTION,
+                array(
+                    'cursor' => $last_option_id,
+                    'high_water' => $state['high_water'],
+                ),
+                false
+            );
+        }
 
-		return $deleted;
-	}
+        return $deleted;
+    }
 
-	public static function is_expired_terminal_record(array $record, $now = null) {
-		$status = isset($record['status']) ? sanitize_key((string) $record['status']) : '';
-		if (!in_array($status, array('completed', 'failed', 'compensated'), true)) {
-			return false;
-		}
-		$completed_at = isset($record['completed_at']) ? (string) $record['completed_at'] : '';
-		if ('' === $completed_at) {
-			return false;
-		}
-		$completed_timestamp = strtotime($completed_at);
-		if (false === $completed_timestamp) {
-			return false;
-		}
-		$days = (int) apply_filters('wcos_mutation_journal_retention_days', self::DEFAULT_RETENTION_DAYS, $record);
-		$days = max(7, min(365, $days));
-		$now = null === $now ? time() : (int) $now;
-		return $completed_timestamp <= ($now - ($days * DAY_IN_SECONDS));
-	}
+    public static function is_expired_terminal_record(array $record, $now = null) {
+        $status = isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+        if (!in_array($status, array('completed', 'failed', 'compensated', 'manual_reconciled'), true)) {
+            return false;
+        }
+        $completed_at = isset($record['completed_at']) ? (string) $record['completed_at'] : '';
+        if ('' === $completed_at) {
+            return false;
+        }
+        $completed_timestamp = strtotime($completed_at);
+        if (false === $completed_timestamp) {
+            return false;
+        }
+        $days = (int) apply_filters('wcos_mutation_journal_retention_days', self::DEFAULT_RETENTION_DAYS, $record);
+        $days = max(7, min(365, $days));
+        $now = null === $now ? time() : (int) $now;
+        return $completed_timestamp <= ($now - ($days * DAY_IN_SECONDS));
+    }
 
-	private static function scan_state() {
-		$state = get_option(self::SCAN_STATE_OPTION, array());
-		if (!is_array($state)) {
-			$state = array();
-		}
-		return array(
-			'cursor' => isset($state['cursor']) ? absint($state['cursor']) : 0,
-			'high_water' => isset($state['high_water']) ? absint($state['high_water']) : 0,
-		);
-	}
+    private static function scan_state() {
+        $state = get_option(self::SCAN_STATE_OPTION, array());
+        if (!is_array($state)) {
+            $state = array();
+        }
+        return array(
+            'cursor' => isset($state['cursor']) ? absint($state['cursor']) : 0,
+            'high_water' => isset($state['high_water']) ? absint($state['high_water']) : 0,
+        );
+    }
 }

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -105,6 +105,22 @@ final class WCOS_Operation_Journal_Retention {
         if (!in_array($status, array('completed', 'failed', 'compensated', 'manual_reconciled'), true)) {
             return false;
         }
+
+        /*
+         * A resolved reconciliation journal remains the authoritative proof that
+         * permits a source-level fail-closed blocker to be cleared. Never delete
+         * that proof while the blocker option still contains this operation.
+         */
+        if ('manual_reconciled' === $status
+            && class_exists('WCOS_Manual_Reconciliation_Blocker')
+            && isset($record['source_order_id'], $record['operation_id'])
+            && WCOS_Manual_Reconciliation_Blocker::contains_operation(
+                absint($record['source_order_id']),
+                sanitize_key((string) $record['operation_id'])
+            )) {
+            return false;
+        }
+
         $completed_at = isset($record['completed_at']) ? (string) $record['completed_at'] : '';
         if ('' === $completed_at) {
             return false;

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -31,6 +31,9 @@ final class WCOS_Operation_Journal {
             $context['source_snapshot_fingerprint'] = $snapshot['recovery_fingerprint'];
             $context['source_copy_context_signature'] = $snapshot['copy_context_signature'];
         }
+        if (class_exists('WCOS_Price_Precision_Scope')) {
+            $context['price_precision'] = WCOS_Price_Precision_Scope::current_or_store_precision();
+        }
 
         $now = gmdate('c');
         $record = array(
@@ -180,11 +183,6 @@ final class WCOS_Operation_Journal {
         return $updated;
     }
 
-    /**
-     * Persist a non-automatic reconciliation incident, even if the mutation had
-     * already reached completed/compensated. This state is deliberately not
-     * purgeable and can only leave via mark_manual_reconciled().
-     */
     public static function mark_manual_reconciliation(WC_Order $order, $operation_id, array $context = array()) {
         $operation_id = sanitize_key($operation_id);
         $current = self::get($order, $operation_id);
@@ -245,10 +243,6 @@ final class WCOS_Operation_Journal {
         return $updated;
     }
 
-    /**
-     * Return authoritative manual-reconciliation records referenced by the
-     * order-level operation-ID index.
-     */
     public static function manual_reconciliation_records(WC_Order $order) {
         if (!$order->get_id()) {
             return array();
@@ -424,6 +418,16 @@ final class WCOS_Operation_Journal {
                 return false;
             }
         }
+
+        $current_context = isset($current['context']) && is_array($current['context']) ? $current['context'] : array();
+        $replacement_context = isset($replacement['context']) && is_array($replacement['context']) ? $replacement['context'] : array();
+        if (array_key_exists('price_precision', $current_context)) {
+            if (!array_key_exists('price_precision', $replacement_context)
+                || (int) $current_context['price_precision'] !== (int) $replacement_context['price_precision']) {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -12,377 +12,507 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Operation_Journal {
 
-	const SCHEMA_VERSION = 2;
-	const SUMMARY_META_KEY = '_wcos_operation_journal';
-	const MAX_SUMMARY_ENTRIES = 20;
+    const SCHEMA_VERSION = 2;
+    const SUMMARY_META_KEY = '_wcos_operation_journal';
+    const MANUAL_RECONCILIATION_META_KEY = '_wcos_manual_reconciliation_operations';
+    const MAX_SUMMARY_ENTRIES = 20;
 
-	public static function start(WC_Order $order, $operation_id, $type, array $context = array(), $fingerprint = '') {
-		$operation_id = sanitize_key($operation_id);
-		$type = sanitize_key($type);
-		$fingerprint = sanitize_key($fingerprint);
-		if (!$order->get_id() || '' === $operation_id || '' === $type || '' === $fingerprint) {
-			return false;
-		}
+    public static function start(WC_Order $order, $operation_id, $type, array $context = array(), $fingerprint = '') {
+        $operation_id = sanitize_key($operation_id);
+        $type = sanitize_key($type);
+        $fingerprint = sanitize_key($fingerprint);
+        if (!$order->get_id() || '' === $operation_id || '' === $type || '' === $fingerprint) {
+            return false;
+        }
 
-		if ('split' === $type && class_exists('WCOS_Order_Mutation_Snapshot')) {
-			$snapshot = WCOS_Order_Mutation_Snapshot::capture_split_source($order);
-			$context['source_snapshot'] = $snapshot;
-			$context['source_snapshot_fingerprint'] = $snapshot['recovery_fingerprint'];
-			$context['source_copy_context_signature'] = $snapshot['copy_context_signature'];
-		}
+        if ('split' === $type && class_exists('WCOS_Order_Mutation_Snapshot')) {
+            $snapshot = WCOS_Order_Mutation_Snapshot::capture_split_source($order);
+            $context['source_snapshot'] = $snapshot;
+            $context['source_snapshot_fingerprint'] = $snapshot['recovery_fingerprint'];
+            $context['source_copy_context_signature'] = $snapshot['copy_context_signature'];
+        }
 
-		$now = gmdate('c');
-		$record = array(
-			'schema_version' => self::SCHEMA_VERSION,
-			'revision' => 1,
-			'source_order_id' => $order->get_id(),
-			'operation_id' => $operation_id,
-			'type' => $type,
-			'fingerprint' => $fingerprint,
-			'status' => 'started',
-			'stage' => 'started',
-			'started_at' => $now,
-			'updated_at' => $now,
-			'completed_at' => null,
-			'context' => $context,
-			'checkpoints' => array(
-				array(
-					'sequence' => 1,
-					'stage' => 'started',
-					'at' => $now,
-					'context' => array(),
-				),
-			),
-		);
+        $now = gmdate('c');
+        $record = array(
+            'schema_version' => self::SCHEMA_VERSION,
+            'revision' => 1,
+            'source_order_id' => $order->get_id(),
+            'operation_id' => $operation_id,
+            'type' => $type,
+            'fingerprint' => $fingerprint,
+            'status' => 'started',
+            'stage' => 'started',
+            'started_at' => $now,
+            'updated_at' => $now,
+            'completed_at' => null,
+            'context' => $context,
+            'checkpoints' => array(
+                array(
+                    'sequence' => 1,
+                    'stage' => 'started',
+                    'at' => $now,
+                    'context' => array(),
+                ),
+            ),
+        );
 
-		if (!add_option(self::key($order->get_id(), $operation_id), $record, '', false)) {
-			return false;
-		}
+        if (!add_option(self::key($order->get_id(), $operation_id), $record, '', false)) {
+            return false;
+        }
 
-		self::write_summary($order, $record);
-		return true;
-	}
+        self::write_summary($order, $record);
+        return true;
+    }
 
-	public static function get(WC_Order $order, $operation_id) {
-		$operation_id = sanitize_key($operation_id);
-		if (!$order->get_id() || '' === $operation_id) {
-			return null;
-		}
+    public static function get(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key($operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return null;
+        }
 
-		$record = get_option(self::key($order->get_id(), $operation_id), null);
-		return is_array($record) ? $record : null;
-	}
+        $record = get_option(self::key($order->get_id(), $operation_id), null);
+        return is_array($record) ? $record : null;
+    }
 
-	public static function assert_fingerprint(array $record, $fingerprint) {
-		$stored = isset($record['fingerprint']) ? (string) $record['fingerprint'] : '';
-		$fingerprint = sanitize_key($fingerprint);
-		if ('' === $stored || '' === $fingerprint || !hash_equals($stored, $fingerprint)) {
-			throw new RuntimeException(__('This operation ID was already used for a different mutation request.', 'wc-order-splitter'));
-		}
-	}
+    public static function assert_fingerprint(array $record, $fingerprint) {
+        $stored = isset($record['fingerprint']) ? (string) $record['fingerprint'] : '';
+        $fingerprint = sanitize_key($fingerprint);
+        if ('' === $stored || '' === $fingerprint || !hash_equals($stored, $fingerprint)) {
+            throw new RuntimeException(__('This operation ID was already used for a different mutation request.', 'wc-order-splitter'));
+        }
+    }
 
-	public static function checkpoint(WC_Order $order, $operation_id, $stage, array $context = array()) {
-		$stage = sanitize_key($stage);
-		if ('' === $stage) {
-			return false;
-		}
-		$context = self::enrich_recovery_context($order, $stage, $context);
+    public static function checkpoint(WC_Order $order, $operation_id, $stage, array $context = array()) {
+        $stage = sanitize_key($stage);
+        if ('' === $stage) {
+            return false;
+        }
+        $context = self::enrich_recovery_context($order, $stage, $context);
 
-		return self::mutate(
-			$order,
-			$operation_id,
-			static function(array $record) use ($stage, $context) {
-				$status = isset($record['status']) ? sanitize_key($record['status']) : '';
-				if (!in_array($status, array('started', 'recovery_required', 'committed', 'compensating'), true)) {
-					return false;
-				}
-				return self::append_checkpoint($record, $stage, $context);
-			}
-		);
-	}
+        return self::mutate(
+            $order,
+            $operation_id,
+            static function(array $record) use ($stage, $context) {
+                $status = isset($record['status']) ? sanitize_key($record['status']) : '';
+                if (!in_array($status, array('started', 'recovery_required', 'committed', 'compensating', 'manual_reconciliation'), true)) {
+                    return false;
+                }
+                return self::append_checkpoint($record, $stage, $context);
+            }
+        );
+    }
 
-	public static function mark_committed(WC_Order $order, $operation_id, array $context = array()) {
-		$context = self::enrich_recovery_context($order, 'source_committed', $context);
-		return self::set_status(
-			$order,
-			$operation_id,
-			'committed',
-			'source_committed',
-			$context,
-			false,
-			array('started', 'recovery_required', 'committed')
-		);
-	}
+    public static function mark_committed(WC_Order $order, $operation_id, array $context = array()) {
+        $context = self::enrich_recovery_context($order, 'source_committed', $context);
+        return self::set_status(
+            $order,
+            $operation_id,
+            'committed',
+            'source_committed',
+            $context,
+            false,
+            array('started', 'recovery_required', 'committed')
+        );
+    }
 
-	public static function complete(WC_Order $order, $operation_id, array $context = array()) {
-		$context = self::enrich_recovery_context($order, 'completed', $context);
-		return self::set_status(
-			$order,
-			$operation_id,
-			'completed',
-			'completed',
-			$context,
-			true,
-			array('committed', 'completed')
-		);
-	}
+    public static function complete(WC_Order $order, $operation_id, array $context = array()) {
+        $context = self::enrich_recovery_context($order, 'completed', $context);
+        return self::set_status(
+            $order,
+            $operation_id,
+            'completed',
+            'completed',
+            $context,
+            true,
+            array('committed', 'completed')
+        );
+    }
 
-	public static function fail(WC_Order $order, $operation_id, array $context = array()) {
-		$current = self::get($order, $operation_id);
-		if (!is_array($current)) {
-			return false;
-		}
-		$status = isset($current['status']) ? sanitize_key($current['status']) : '';
-		if (in_array($status, array('recovery_required', 'compensating'), true)) {
-			self::dispatch_recovery($order, $operation_id, $current);
-			return true;
-		}
-		if (in_array($status, array('failed', 'committed', 'completed', 'compensated'), true)) {
-			return true;
-		}
-		return self::set_status(
-			$order,
-			$operation_id,
-			'failed',
-			'failed',
-			$context,
-			true,
-			array('started')
-		);
-	}
+    public static function fail(WC_Order $order, $operation_id, array $context = array()) {
+        $current = self::get($order, $operation_id);
+        if (!is_array($current)) {
+            return false;
+        }
+        $status = isset($current['status']) ? sanitize_key($current['status']) : '';
+        if (in_array($status, array('recovery_required', 'compensating'), true)) {
+            self::dispatch_recovery($order, $operation_id, $current);
+            return true;
+        }
+        if (in_array($status, array('failed', 'committed', 'completed', 'compensated', 'manual_reconciliation', 'manual_reconciled'), true)) {
+            return true;
+        }
+        return self::set_status(
+            $order,
+            $operation_id,
+            'failed',
+            'failed',
+            $context,
+            true,
+            array('started')
+        );
+    }
 
-	public static function require_recovery(WC_Order $order, $operation_id, array $context = array()) {
-		$current = self::get($order, $operation_id);
-		if (!is_array($current)) {
-			return false;
-		}
-		$status = isset($current['status']) ? sanitize_key($current['status']) : '';
-		if (in_array($status, array('completed', 'compensated'), true)) {
-			return true;
-		}
-		$updated = self::set_status(
-			$order,
-			$operation_id,
-			'recovery_required',
-			'recovery_required',
-			$context,
-			false,
-			array('started', 'failed', 'recovery_required', 'committed')
-		);
-		if ($updated) {
-			$fresh = self::get(wc_get_order($order->get_id()), $operation_id);
-			if (is_array($fresh)) {
-				self::dispatch_recovery(wc_get_order($order->get_id()), $operation_id, $fresh);
-			}
-		}
-		return $updated;
-	}
+    public static function require_recovery(WC_Order $order, $operation_id, array $context = array()) {
+        $current = self::get($order, $operation_id);
+        if (!is_array($current)) {
+            return false;
+        }
+        $status = isset($current['status']) ? sanitize_key($current['status']) : '';
+        if (in_array($status, array('completed', 'compensated', 'manual_reconciliation', 'manual_reconciled'), true)) {
+            return true;
+        }
+        $updated = self::set_status(
+            $order,
+            $operation_id,
+            'recovery_required',
+            'recovery_required',
+            $context,
+            false,
+            array('started', 'failed', 'recovery_required', 'committed')
+        );
+        if ($updated) {
+            $fresh_order = wc_get_order($order->get_id());
+            $fresh = $fresh_order ? self::get($fresh_order, $operation_id) : null;
+            if (is_array($fresh) && $fresh_order) {
+                self::dispatch_recovery($fresh_order, $operation_id, $fresh);
+            }
+        }
+        return $updated;
+    }
 
-	public static function resume(WC_Order $order, $operation_id, array $context = array()) {
-		return self::set_status(
-			$order,
-			$operation_id,
-			'started',
-			'resumed',
-			$context,
-			false,
-			array('started', 'failed', 'recovery_required')
-		);
-	}
+    /**
+     * Persist a non-automatic reconciliation incident, even if the mutation had
+     * already reached completed/compensated. This state is deliberately not
+     * purgeable and can only leave via mark_manual_reconciled().
+     */
+    public static function mark_manual_reconciliation(WC_Order $order, $operation_id, array $context = array()) {
+        $operation_id = sanitize_key($operation_id);
+        $current = self::get($order, $operation_id);
+        if (!is_array($current)) {
+            return false;
+        }
 
-	public static function mark_compensating(WC_Order $order, $operation_id, array $context = array()) {
-		return self::set_status(
-			$order,
-			$operation_id,
-			'compensating',
-			'compensating',
-			$context,
-			false,
-			array('started', 'failed', 'recovery_required', 'compensating')
-		);
-	}
+        $status = isset($current['status']) ? sanitize_key($current['status']) : '';
+        if ('manual_reconciliation' === $status) {
+            $updated = self::checkpoint($order, $operation_id, 'manual_reconciliation_evidence', $context);
+            if ($updated) {
+                self::update_manual_reconciliation_index($order, $operation_id, true);
+            }
+            return $updated;
+        }
+        if ('manual_reconciled' === $status) {
+            return false;
+        }
 
-	public static function mark_compensated(WC_Order $order, $operation_id, array $context = array()) {
-		return self::set_status(
-			$order,
-			$operation_id,
-			'compensated',
-			'compensated',
-			$context,
-			true,
-			array('compensating', 'compensated')
-		);
-	}
+        $context = array_merge(
+            array(
+                'previous_status' => $status,
+                'previous_completed_at' => isset($current['completed_at']) ? $current['completed_at'] : null,
+                'automatic_compensation_allowed' => false,
+            ),
+            $context
+        );
 
-	public static function delete(WC_Order $order, $operation_id) {
-		$operation_id = sanitize_key($operation_id);
-		if (!$order->get_id() || '' === $operation_id) {
-			return false;
-		}
-		return delete_option(self::key($order->get_id(), $operation_id));
-	}
+        $updated = self::set_status(
+            $order,
+            $operation_id,
+            'manual_reconciliation',
+            'manual_reconciliation',
+            $context,
+            false,
+            array('started', 'failed', 'recovery_required', 'committed', 'completed', 'compensating', 'compensated')
+        );
+        if ($updated) {
+            self::update_manual_reconciliation_index($order, $operation_id, true);
+        }
+        return $updated;
+    }
 
-	private static function set_status(WC_Order $order, $operation_id, $status, $stage, array $context, $terminal, array $allowed_from) {
-		$status = sanitize_key($status);
-		$stage = sanitize_key($stage);
-		return self::mutate(
-			$order,
-			$operation_id,
-			static function(array $record) use ($status, $stage, $context, $terminal, $allowed_from) {
-				$current_status = isset($record['status']) ? sanitize_key($record['status']) : '';
-				if (!in_array($current_status, $allowed_from, true)) {
-					return false;
-				}
-				$record['status'] = $status;
-				$record['completed_at'] = $terminal ? gmdate('c') : null;
-				return self::append_checkpoint($record, $stage, $context);
-			}
-		);
-	}
+    public static function mark_manual_reconciled(WC_Order $order, $operation_id, array $context = array()) {
+        $operation_id = sanitize_key($operation_id);
+        $updated = self::set_status(
+            $order,
+            $operation_id,
+            'manual_reconciled',
+            'manual_reconciled',
+            $context,
+            true,
+            array('manual_reconciliation')
+        );
+        if ($updated) {
+            self::update_manual_reconciliation_index($order, $operation_id, false);
+        }
+        return $updated;
+    }
 
-	private static function enrich_recovery_context(WC_Order $order, $stage, array $context) {
-		$stage = sanitize_key($stage);
-		$target_ids = isset($context['target_order_ids'])
-			? array_values(array_unique(array_filter(array_map('absint', (array) $context['target_order_ids']))))
-			: array();
-		if (!empty($target_ids) && class_exists('WCOS_Order_Contract_Snapshot')) {
-			$signatures = array();
-			foreach ($target_ids as $target_id) {
-				$target = wc_get_order($target_id);
-				if ($target instanceof WC_Order) {
-					$signatures[$target_id] = WCOS_Order_Contract_Snapshot::source_signature($target);
-				}
-			}
-			ksort($signatures, SORT_NUMERIC);
-			$context['target_order_ids'] = $target_ids;
-			$context['child_signatures'] = $signatures;
-		}
+    /**
+     * Return authoritative manual-reconciliation records referenced by the
+     * order-level operation-ID index.
+     */
+    public static function manual_reconciliation_records(WC_Order $order) {
+        if (!$order->get_id()) {
+            return array();
+        }
+        $operation_ids = $order->get_meta(self::MANUAL_RECONCILIATION_META_KEY, true);
+        $operation_ids = array_values(array_unique(array_filter(array_map('sanitize_key', (array) $operation_ids))));
+        $records = array();
+        foreach ($operation_ids as $operation_id) {
+            $record = self::get($order, $operation_id);
+            if (is_array($record) && isset($record['status']) && 'manual_reconciliation' === sanitize_key($record['status'])) {
+                $records[$operation_id] = $record;
+            }
+        }
+        ksort($records, SORT_STRING);
+        return $records;
+    }
 
-		if (in_array($stage, array('source_persisted', 'stock_flags_synchronized', 'source_committed', 'completed'), true)
-			&& class_exists('WCOS_Order_Mutation_Snapshot')) {
-			$fresh = wc_get_order($order->get_id());
-			if ($fresh instanceof WC_Order) {
-				$context['source_signature_after'] = WCOS_Order_Contract_Snapshot::source_signature($fresh);
-				$context['source_recovery_signature_after'] = WCOS_Order_Mutation_Snapshot::split_owned_signature($fresh);
-			}
-		}
-		return $context;
-	}
+    public static function has_manual_reconciliation(WC_Order $order) {
+        return !empty(self::manual_reconciliation_records($order));
+    }
 
-	private static function append_checkpoint(array $record, $stage, array $context) {
-		$now = gmdate('c');
-		$record['stage'] = sanitize_key($stage);
-		$record['updated_at'] = $now;
-		$record['context'] = array_merge(
-			isset($record['context']) && is_array($record['context']) ? $record['context'] : array(),
-			$context
-		);
-		$checkpoints = isset($record['checkpoints']) && is_array($record['checkpoints']) ? $record['checkpoints'] : array();
-		$checkpoints[] = array(
-			'sequence' => count($checkpoints) + 1,
-			'stage' => sanitize_key($stage),
-			'at' => $now,
-			'context' => $context,
-		);
-		$record['checkpoints'] = $checkpoints;
-		return $record;
-	}
+    public static function resume(WC_Order $order, $operation_id, array $context = array()) {
+        return self::set_status(
+            $order,
+            $operation_id,
+            'started',
+            'resumed',
+            $context,
+            false,
+            array('started', 'failed', 'recovery_required')
+        );
+    }
 
-	private static function mutate(WC_Order $order, $operation_id, callable $mutator) {
-		$operation_id = sanitize_key($operation_id);
-		if (!$order->get_id() || '' === $operation_id) {
-			return false;
-		}
+    public static function mark_compensating(WC_Order $order, $operation_id, array $context = array()) {
+        return self::set_status(
+            $order,
+            $operation_id,
+            'compensating',
+            'compensating',
+            $context,
+            false,
+            array('started', 'failed', 'recovery_required', 'compensating')
+        );
+    }
 
-		$key = self::key($order->get_id(), $operation_id);
-		for ($attempt = 0; $attempt < 5; $attempt++) {
-			$current = get_option($key, null);
-			if (!is_array($current)) {
-				return false;
-			}
+    public static function mark_compensated(WC_Order $order, $operation_id, array $context = array()) {
+        return self::set_status(
+            $order,
+            $operation_id,
+            'compensated',
+            'compensated',
+            $context,
+            true,
+            array('compensating', 'compensated')
+        );
+    }
 
-			$replacement = $mutator($current);
-			if (!is_array($replacement)) {
-				return false;
-			}
-			if (!self::immutable_fields_match($current, $replacement)) {
-				return false;
-			}
+    public static function delete(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key($operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return false;
+        }
+        $deleted = delete_option(self::key($order->get_id(), $operation_id));
+        if ($deleted) {
+            self::update_manual_reconciliation_index($order, $operation_id, false);
+        }
+        return $deleted;
+    }
 
-			$replacement['schema_version'] = self::SCHEMA_VERSION;
-			$replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
-			if (self::compare_and_swap($key, $current, $replacement)) {
-				self::write_summary($order, $replacement);
-				return true;
-			}
-		}
+    private static function set_status(WC_Order $order, $operation_id, $status, $stage, array $context, $terminal, array $allowed_from) {
+        $status = sanitize_key($status);
+        $stage = sanitize_key($stage);
+        return self::mutate(
+            $order,
+            $operation_id,
+            static function(array $record) use ($status, $stage, $context, $terminal, $allowed_from) {
+                $current_status = isset($record['status']) ? sanitize_key($record['status']) : '';
+                if (!in_array($current_status, $allowed_from, true)) {
+                    return false;
+                }
+                $record['status'] = $status;
+                $record['completed_at'] = $terminal ? gmdate('c') : null;
+                return self::append_checkpoint($record, $stage, $context);
+            }
+        );
+    }
 
-		return false;
-	}
+    private static function enrich_recovery_context(WC_Order $order, $stage, array $context) {
+        $stage = sanitize_key($stage);
+        $target_ids = isset($context['target_order_ids'])
+            ? array_values(array_unique(array_filter(array_map('absint', (array) $context['target_order_ids']))))
+            : array();
+        if (!empty($target_ids) && class_exists('WCOS_Order_Contract_Snapshot')) {
+            $signatures = array();
+            foreach ($target_ids as $target_id) {
+                $target = wc_get_order($target_id);
+                if ($target instanceof WC_Order) {
+                    $signatures[$target_id] = WCOS_Order_Contract_Snapshot::source_signature($target);
+                }
+            }
+            ksort($signatures, SORT_NUMERIC);
+            $context['target_order_ids'] = $target_ids;
+            $context['child_signatures'] = $signatures;
+        }
 
-	private static function immutable_fields_match(array $current, array $replacement) {
-		foreach (array('source_order_id', 'operation_id', 'type', 'fingerprint') as $field) {
-			if (!array_key_exists($field, $current)
-				|| !array_key_exists($field, $replacement)
-				|| (string) $current[$field] !== (string) $replacement[$field]) {
-				return false;
-			}
-		}
-		return true;
-	}
+        if (in_array($stage, array('source_persisted', 'stock_flags_synchronized', 'source_committed', 'completed'), true)
+            && class_exists('WCOS_Order_Mutation_Snapshot')) {
+            $fresh = wc_get_order($order->get_id());
+            if ($fresh instanceof WC_Order) {
+                $context['source_signature_after'] = WCOS_Order_Contract_Snapshot::source_signature($fresh);
+                $context['source_recovery_signature_after'] = WCOS_Order_Mutation_Snapshot::split_owned_signature($fresh);
+            }
+        }
+        return $context;
+    }
 
-	private static function compare_and_swap($key, array $current, array $replacement) {
-		global $wpdb;
+    private static function append_checkpoint(array $record, $stage, array $context) {
+        $now = gmdate('c');
+        $record['stage'] = sanitize_key($stage);
+        $record['updated_at'] = $now;
+        $record['context'] = array_merge(
+            isset($record['context']) && is_array($record['context']) ? $record['context'] : array(),
+            $context
+        );
+        $checkpoints = isset($record['checkpoints']) && is_array($record['checkpoints']) ? $record['checkpoints'] : array();
+        $checkpoints[] = array(
+            'sequence' => count($checkpoints) + 1,
+            'stage' => sanitize_key($stage),
+            'at' => $now,
+            'context' => $context,
+        );
+        $record['checkpoints'] = $checkpoints;
+        return $record;
+    }
 
-		$updated = $wpdb->query(
-			$wpdb->prepare(
-				"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
-				maybe_serialize($replacement),
-				$key,
-				maybe_serialize($current)
-			)
-		);
+    private static function mutate(WC_Order $order, $operation_id, callable $mutator) {
+        $operation_id = sanitize_key($operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return false;
+        }
 
-		wp_cache_delete($key, 'options');
-		return 1 === $updated;
-	}
+        $key = self::key($order->get_id(), $operation_id);
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $current = get_option($key, null);
+            if (!is_array($current)) {
+                return false;
+            }
 
-	private static function dispatch_recovery(WC_Order $order, $operation_id, array $record) {
-		do_action('wcos_mutation_recovery_required', $order, sanitize_key($operation_id), $record);
-	}
+            $replacement = $mutator($current);
+            if (!is_array($replacement)) {
+                return false;
+            }
+            if (!self::immutable_fields_match($current, $replacement)) {
+                return false;
+            }
 
-	private static function write_summary(WC_Order $order, array $record) {
-		$entries = $order->get_meta(self::SUMMARY_META_KEY, true);
-		$entries = is_array($entries) ? $entries : array();
-		$summary = array(
-			'operation_id' => isset($record['operation_id']) ? $record['operation_id'] : '',
-			'type' => isset($record['type']) ? $record['type'] : '',
-			'fingerprint' => isset($record['fingerprint']) ? $record['fingerprint'] : '',
-			'status' => isset($record['status']) ? $record['status'] : '',
-			'stage' => isset($record['stage']) ? $record['stage'] : '',
-			'revision' => isset($record['revision']) ? (int) $record['revision'] : 0,
-			'started_at' => isset($record['started_at']) ? $record['started_at'] : null,
-			'updated_at' => isset($record['updated_at']) ? $record['updated_at'] : null,
-			'completed_at' => isset($record['completed_at']) ? $record['completed_at'] : null,
-		);
+            $replacement['schema_version'] = self::SCHEMA_VERSION;
+            $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
+            if (self::compare_and_swap($key, $current, $replacement)) {
+                self::write_summary($order, $replacement);
+                return true;
+            }
+        }
 
-		$replaced = false;
-		foreach ($entries as $index => $entry) {
-			if (isset($entry['operation_id']) && $entry['operation_id'] === $summary['operation_id']) {
-				$entries[$index] = $summary;
-				$replaced = true;
-				break;
-			}
-		}
-		if (!$replaced) {
-			$entries[] = $summary;
-		}
+        return false;
+    }
 
-		$order->update_meta_data(self::SUMMARY_META_KEY, array_slice($entries, -self::MAX_SUMMARY_ENTRIES));
-		$order->save_meta_data();
-	}
+    private static function immutable_fields_match(array $current, array $replacement) {
+        foreach (array('source_order_id', 'operation_id', 'type', 'fingerprint') as $field) {
+            if (!array_key_exists($field, $current)
+                || !array_key_exists($field, $replacement)
+                || (string) $current[$field] !== (string) $replacement[$field]) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	private static function key($order_id, $operation_id) {
-		return 'wcos_mutation_op_' . hash('sha256', absint($order_id) . '|' . sanitize_key($operation_id));
-	}
+    private static function compare_and_swap($key, array $current, array $replacement) {
+        global $wpdb;
+
+        $updated = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
+                maybe_serialize($replacement),
+                $key,
+                maybe_serialize($current)
+            )
+        );
+
+        wp_cache_delete($key, 'options');
+        return 1 === $updated;
+    }
+
+    private static function dispatch_recovery(WC_Order $order, $operation_id, array $record) {
+        do_action('wcos_mutation_recovery_required', $order, sanitize_key($operation_id), $record);
+    }
+
+    private static function update_manual_reconciliation_index(WC_Order $order, $operation_id, $add) {
+        $operation_id = sanitize_key($operation_id);
+        if (!$order->get_id() || '' === $operation_id) {
+            return;
+        }
+
+        $fresh = wc_get_order($order->get_id());
+        if (!$fresh instanceof WC_Order) {
+            return;
+        }
+
+        $operation_ids = $fresh->get_meta(self::MANUAL_RECONCILIATION_META_KEY, true);
+        $operation_ids = array_values(array_unique(array_filter(array_map('sanitize_key', (array) $operation_ids))));
+        if ($add) {
+            $operation_ids[] = $operation_id;
+            $operation_ids = array_values(array_unique($operation_ids));
+            sort($operation_ids, SORT_STRING);
+            $fresh->update_meta_data(self::MANUAL_RECONCILIATION_META_KEY, $operation_ids);
+        } else {
+            $operation_ids = array_values(array_filter(
+                $operation_ids,
+                static function($candidate) use ($operation_id) {
+                    return $candidate !== $operation_id;
+                }
+            ));
+            if (empty($operation_ids)) {
+                $fresh->delete_meta_data(self::MANUAL_RECONCILIATION_META_KEY);
+            } else {
+                $fresh->update_meta_data(self::MANUAL_RECONCILIATION_META_KEY, $operation_ids);
+            }
+        }
+        $fresh->save_meta_data();
+    }
+
+    private static function write_summary(WC_Order $order, array $record) {
+        $entries = $order->get_meta(self::SUMMARY_META_KEY, true);
+        $entries = is_array($entries) ? $entries : array();
+        $summary = array(
+            'operation_id' => isset($record['operation_id']) ? $record['operation_id'] : '',
+            'type' => isset($record['type']) ? $record['type'] : '',
+            'fingerprint' => isset($record['fingerprint']) ? $record['fingerprint'] : '',
+            'status' => isset($record['status']) ? $record['status'] : '',
+            'stage' => isset($record['stage']) ? $record['stage'] : '',
+            'revision' => isset($record['revision']) ? (int) $record['revision'] : 0,
+            'started_at' => isset($record['started_at']) ? $record['started_at'] : null,
+            'updated_at' => isset($record['updated_at']) ? $record['updated_at'] : null,
+            'completed_at' => isset($record['completed_at']) ? $record['completed_at'] : null,
+        );
+
+        $replaced = false;
+        foreach ($entries as $index => $entry) {
+            if (isset($entry['operation_id']) && $entry['operation_id'] === $summary['operation_id']) {
+                $entries[$index] = $summary;
+                $replaced = true;
+                break;
+            }
+        }
+        if (!$replaced) {
+            $entries[] = $summary;
+        }
+
+        $order->update_meta_data(self::SUMMARY_META_KEY, array_slice($entries, -self::MAX_SUMMARY_ENTRIES));
+        $order->save_meta_data();
+    }
+
+    private static function key($order_id, $operation_id) {
+        return 'wcos_mutation_op_' . hash('sha256', absint($order_id) . '|' . sanitize_key($operation_id));
+    }
 }

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -242,6 +242,13 @@ final class WCOS_Operation_Journal {
         );
         if ($updated) {
             self::update_manual_reconciliation_index($order, $operation_id, false);
+            if (class_exists('WCOS_Manual_Reconciliation_Blocker')) {
+                $fresh = wc_get_order($order->get_id());
+                if ($fresh instanceof WC_Order
+                    && !WCOS_Manual_Reconciliation_Blocker::resolve_if_reconciled($fresh, $operation_id)) {
+                    do_action('wcos_manual_reconciliation_blocker_clear_error', $fresh, $operation_id);
+                }
+            }
         }
         return $updated;
     }

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -34,6 +34,9 @@ final class WCOS_Operation_Journal {
         if (class_exists('WCOS_Price_Precision_Scope')) {
             $context['price_precision'] = WCOS_Price_Precision_Scope::current_or_store_precision();
         }
+        if ('split' === $type && class_exists('WCOS_Split_Preflight')) {
+            $context['policy_version'] = (int) WCOS_Split_Preflight::POLICY_VERSION;
+        }
 
         $now = gmdate('c');
         $record = array(
@@ -421,10 +424,12 @@ final class WCOS_Operation_Journal {
 
         $current_context = isset($current['context']) && is_array($current['context']) ? $current['context'] : array();
         $replacement_context = isset($replacement['context']) && is_array($replacement['context']) ? $replacement['context'] : array();
-        if (array_key_exists('price_precision', $current_context)) {
-            if (!array_key_exists('price_precision', $replacement_context)
-                || (int) $current_context['price_precision'] !== (int) $replacement_context['price_precision']) {
-                return false;
+        foreach (array('price_precision', 'policy_version') as $field) {
+            if (array_key_exists($field, $current_context)) {
+                if (!array_key_exists($field, $replacement_context)
+                    || (int) $current_context[$field] !== (int) $replacement_context[$field]) {
+                    return false;
+                }
             }
         }
 

--- a/inc/domain/class-wcos-price-precision-scope.php
+++ b/inc/domain/class-wcos-price-precision-scope.php
@@ -1,0 +1,111 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Pins WooCommerce price precision to the value captured for one mutation.
+ *
+ * WooCommerce exposes price decimals through the `wc_get_price_decimals` filter.
+ * A request-local scope keeps historical allocation/recovery deterministic
+ * without changing the persistent store setting.
+ */
+final class WCOS_Price_Precision_Scope {
+    const MAX_SUPPORTED_PRECISION = 6;
+
+    private static $bootstrapped = false;
+    private static $scopes = array();
+    private static $stack = array();
+
+    public static function bootstrap() {
+        if (self::$bootstrapped) {
+            return;
+        }
+        self::$bootstrapped = true;
+        add_filter('wc_get_price_decimals', array(__CLASS__, 'filter_precision'), PHP_INT_MAX, 1);
+    }
+
+    public static function validate($precision) {
+        if (!is_numeric($precision)) {
+            throw new InvalidArgumentException(__('Price precision must be numeric.', 'wc-order-splitter'));
+        }
+        $precision = (int) $precision;
+        if ($precision < 0 || $precision > self::MAX_SUPPORTED_PRECISION) {
+            throw new RuntimeException(
+                sprintf(
+                    /* translators: %d: maximum supported price decimal places. */
+                    __('This Split workflow supports price precision from 0 to %d decimal places.', 'wc-order-splitter'),
+                    self::MAX_SUPPORTED_PRECISION
+                )
+            );
+        }
+        return $precision;
+    }
+
+    public static function store_precision() {
+        return self::validate(wc_get_price_decimals());
+    }
+
+    public static function for_operation(WC_Order $source, $operation_id = '') {
+        $operation_id = sanitize_key((string) $operation_id);
+        if ($operation_id !== '' && $source->get_id() && class_exists('WCOS_Operation_Journal')) {
+            $record = WCOS_Operation_Journal::get($source, $operation_id);
+            if (is_array($record)
+                && isset($record['context'])
+                && is_array($record['context'])
+                && array_key_exists('price_precision', $record['context'])) {
+                return self::validate($record['context']['price_precision']);
+            }
+        }
+        return self::store_precision();
+    }
+
+    public static function begin($precision) {
+        $precision = self::validate($precision);
+        self::bootstrap();
+
+        $token = hash('sha256', $precision . '|' . wp_generate_uuid4() . '|' . microtime(true));
+        self::$scopes[$token] = $precision;
+        self::$stack[] = $token;
+        return $token;
+    }
+
+    public static function end($token) {
+        $token = (string) $token;
+        if (!isset(self::$scopes[$token])) {
+            return false;
+        }
+        unset(self::$scopes[$token]);
+        self::$stack = array_values(
+            array_filter(
+                self::$stack,
+                static function($candidate) use ($token) {
+                    return $candidate !== $token;
+                }
+            )
+        );
+        return true;
+    }
+
+    public static function has_active_scope() {
+        return null !== self::current_precision();
+    }
+
+    public static function current_precision() {
+        if (empty(self::$stack)) {
+            return null;
+        }
+        $stack = self::$stack;
+        $token = end($stack);
+        return isset(self::$scopes[$token]) ? (int) self::$scopes[$token] : null;
+    }
+
+    public static function current_or_store_precision() {
+        $precision = self::current_precision();
+        return null === $precision ? self::store_precision() : $precision;
+    }
+
+    public static function filter_precision($precision) {
+        $current = self::current_precision();
+        return null === $current ? $precision : $current;
+    }
+}

--- a/inc/domain/class-wcos-price-precision-scope.php
+++ b/inc/domain/class-wcos-price-precision-scope.php
@@ -45,7 +45,11 @@ final class WCOS_Price_Precision_Scope {
         return self::validate(wc_get_price_decimals());
     }
 
-    public static function for_operation(WC_Order $source, $operation_id = '') {
+    /**
+     * Resolve precision in strict authority order: existing journal, explicitly
+     * confirmed request precision, then the ambient store setting.
+     */
+    public static function for_operation(WC_Order $source, $operation_id = '', $requested_precision = null) {
         $operation_id = sanitize_key((string) $operation_id);
         if ($operation_id !== '' && $source->get_id() && class_exists('WCOS_Operation_Journal')) {
             $record = WCOS_Operation_Journal::get($source, $operation_id);
@@ -55,6 +59,9 @@ final class WCOS_Price_Precision_Scope {
                 && array_key_exists('price_precision', $record['context'])) {
                 return self::validate($record['context']['price_precision']);
             }
+        }
+        if (null !== $requested_precision) {
+            return self::validate($requested_precision);
         }
         return self::store_precision();
     }

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -48,8 +48,8 @@ final class WCOS_Split_Preflight {
         );
     }
 
-    public static function assert_supported(WC_Order $source) {
-        $report = self::report($source);
+    public static function assert_supported(WC_Order $source, $precision = null) {
+        $report = self::report($source, $precision);
         if (empty($report['supported'])) {
             throw new WCOS_Split_Preflight_Exception(
                 isset($report['reason']) ? $report['reason'] : 'unsupported',
@@ -60,7 +60,10 @@ final class WCOS_Split_Preflight {
         return $report;
     }
 
-    public static function report(WC_Order $source) {
+    public static function report(WC_Order $source, $precision = null) {
+        $precision = null === $precision
+            ? WCOS_Price_Precision_Scope::store_precision()
+            : WCOS_Price_Precision_Scope::validate($precision);
         $report = array(
             'supported' => false,
             'reason' => '',
@@ -70,6 +73,7 @@ final class WCOS_Split_Preflight {
             'status' => sanitize_key((string) $source->get_status()),
             'currency' => (string) $source->get_currency(),
             'prices_include_tax' => (bool) $source->get_prices_include_tax(),
+            'price_precision' => $precision,
             'is_paid' => (bool) $source->is_paid(),
             'line_count' => count($source->get_items('line_item')),
             'shipping_count' => count($source->get_items('shipping')),
@@ -91,7 +95,7 @@ final class WCOS_Split_Preflight {
         );
 
         foreach ($source->get_items('fee') as $fee) {
-            if (WCOS_Decimal::to_units($fee->get_total(), wc_get_price_decimals()) < 0) {
+            if (WCOS_Decimal::to_units($fee->get_total(), $precision) < 0) {
                 $report['negative_fee_count']++;
             }
         }
@@ -210,7 +214,7 @@ final class WCOS_Split_Preflight {
         }
 
         try {
-            WCOS_Order_Totals_Rebuilder::assert_consistent($source, wc_get_price_decimals());
+            WCOS_Order_Totals_Rebuilder::assert_consistent($source, $precision);
         } catch (Throwable $throwable) {
             return self::reject($report, 'inconsistent_totals', __('The source order totals are internally inconsistent and cannot be split safely.', 'wc-order-splitter'));
         }

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -26,7 +26,7 @@ final class WCOS_Split_Preflight_Exception extends RuntimeException {
  * Reports intentionally contain no customer/address/payment plaintext.
  */
 final class WCOS_Split_Preflight {
-    const POLICY_VERSION = 5;
+    const POLICY_VERSION = 6;
 
     public static function policy() {
         return array(
@@ -45,7 +45,16 @@ final class WCOS_Split_Preflight {
             'manual_reconciliation' => 'reject',
             'unknown_private_line_meta' => 'reject',
             'context_inconsistent_private_meta' => 'reject',
+            'fractional_quantity' => self::fractional_quantities_supported() ? 'supported_by_integration' : 'integer_only',
         );
+    }
+
+    public static function fractional_quantities_supported() {
+        try {
+            return 1500000 === WCOS_Decimal::to_units(apply_filters('woocommerce_stock_amount', '1.500000'), 6);
+        } catch (Throwable $throwable) {
+            return false;
+        }
     }
 
     public static function assert_supported(WC_Order $source, $precision = null) {
@@ -64,6 +73,7 @@ final class WCOS_Split_Preflight {
         $precision = null === $precision
             ? WCOS_Price_Precision_Scope::store_precision()
             : WCOS_Price_Precision_Scope::validate($precision);
+        $fractional_supported = self::fractional_quantities_supported();
         $report = array(
             'supported' => false,
             'reason' => '',
@@ -74,6 +84,7 @@ final class WCOS_Split_Preflight {
             'currency' => (string) $source->get_currency(),
             'prices_include_tax' => (bool) $source->get_prices_include_tax(),
             'price_precision' => $precision,
+            'fractional_quantity_supported' => $fractional_supported,
             'is_paid' => (bool) $source->is_paid(),
             'line_count' => count($source->get_items('line_item')),
             'shipping_count' => count($source->get_items('shipping')),
@@ -154,6 +165,9 @@ final class WCOS_Split_Preflight {
             }
             if (0 !== ($quantity_units % 1000000)) {
                 $report['fractional_quantity_lines']++;
+                if (!$fractional_supported) {
+                    return self::reject($report, 'fractional_quantity_unsupported', __('This order contains fractional quantities but the current WooCommerce quantity integration only supports integers.', 'wc-order-splitter'));
+                }
             }
 
             $unknown_private_meta = array_merge(

--- a/inc/domain/class-wcos-split-preflight.php
+++ b/inc/domain/class-wcos-split-preflight.php
@@ -3,22 +3,22 @@
 defined('ABSPATH') || exit;
 
 final class WCOS_Split_Preflight_Exception extends RuntimeException {
-	private $reason;
-	private $report;
+    private $reason;
+    private $report;
 
-	public function __construct($reason, $message, array $report = array()) {
-		$this->reason = sanitize_key((string) $reason);
-		$this->report = $report;
-		parent::__construct((string) $message);
-	}
+    public function __construct($reason, $message, array $report = array()) {
+        $this->reason = sanitize_key((string) $reason);
+        $this->report = $report;
+        parent::__construct((string) $message);
+    }
 
-	public function get_reason() {
-		return $this->reason;
-	}
+    public function get_reason() {
+        return $this->reason;
+    }
 
-	public function get_report() {
-		return $this->report;
-	}
+    public function get_report() {
+        return $this->report;
+    }
 }
 
 /**
@@ -26,190 +26,205 @@ final class WCOS_Split_Preflight_Exception extends RuntimeException {
  * Reports intentionally contain no customer/address/payment plaintext.
  */
 final class WCOS_Split_Preflight {
-	const POLICY_VERSION = 4;
+    const POLICY_VERSION = 5;
 
-	public static function policy() {
-		return array(
-			'policy_version' => self::POLICY_VERSION,
-			'shipping' => 'keep_on_source',
-			'fees' => 'keep_on_source',
-			'negative_fees' => 'reject',
-			'coupons' => 'reject',
-			'refunds' => 'reject',
-			'payment' => 'source_only',
-			'payment_transaction' => 'keep_on_source',
-			'child_status' => 'pending',
-			'tax' => 'preserve_historical',
-			'physical_stock' => 'no_write',
-			'nested_split' => 'reject',
-			'unknown_private_line_meta' => 'reject',
-			'context_inconsistent_private_meta' => 'reject',
-		);
-	}
+    public static function policy() {
+        return array(
+            'policy_version' => self::POLICY_VERSION,
+            'shipping' => 'keep_on_source',
+            'fees' => 'keep_on_source',
+            'negative_fees' => 'reject',
+            'coupons' => 'reject',
+            'refunds' => 'reject',
+            'payment' => 'source_only',
+            'payment_transaction' => 'keep_on_source',
+            'child_status' => 'pending',
+            'tax' => 'preserve_historical',
+            'physical_stock' => 'no_write',
+            'nested_split' => 'reject',
+            'manual_reconciliation' => 'reject',
+            'unknown_private_line_meta' => 'reject',
+            'context_inconsistent_private_meta' => 'reject',
+        );
+    }
 
-	public static function assert_supported(WC_Order $source) {
-		$report = self::report($source);
-		if (empty($report['supported'])) {
-			throw new WCOS_Split_Preflight_Exception(
-				isset($report['reason']) ? $report['reason'] : 'unsupported',
-				isset($report['message']) ? $report['message'] : __('This order is not supported by the quantity-split adapter.', 'wc-order-splitter'),
-				$report
-			);
-		}
-		return $report;
-	}
+    public static function assert_supported(WC_Order $source) {
+        $report = self::report($source);
+        if (empty($report['supported'])) {
+            throw new WCOS_Split_Preflight_Exception(
+                isset($report['reason']) ? $report['reason'] : 'unsupported',
+                isset($report['message']) ? $report['message'] : __('This order is not supported by the quantity-split adapter.', 'wc-order-splitter'),
+                $report
+            );
+        }
+        return $report;
+    }
 
-	public static function report(WC_Order $source) {
-		$report = array(
-			'supported' => false,
-			'reason' => '',
-			'message' => '',
-			'order_id' => absint($source->get_id()),
-			'order_type' => sanitize_key((string) $source->get_type()),
-			'status' => sanitize_key((string) $source->get_status()),
-			'currency' => (string) $source->get_currency(),
-			'prices_include_tax' => (bool) $source->get_prices_include_tax(),
-			'is_paid' => (bool) $source->is_paid(),
-			'line_count' => count($source->get_items('line_item')),
-			'shipping_count' => count($source->get_items('shipping')),
-			'fee_count' => count($source->get_items('fee')),
-			'negative_fee_count' => 0,
-			'coupon_count' => count($source->get_items('coupon')),
-			'refund_count' => count($source->get_refunds()),
-			'has_transaction' => '' !== (string) $source->get_transaction_id(),
-			'deleted_product_lines' => 0,
-			'fractional_quantity_lines' => 0,
-			'managed_stock_lines' => 0,
-			'unmanaged_stock_lines' => 0,
-			'backorder_lines' => 0,
-			'unknown_private_meta_keys' => array(),
-			'inconsistent_private_meta_keys' => array(),
-			'policy' => self::policy(),
-		);
+    public static function report(WC_Order $source) {
+        $report = array(
+            'supported' => false,
+            'reason' => '',
+            'message' => '',
+            'order_id' => absint($source->get_id()),
+            'order_type' => sanitize_key((string) $source->get_type()),
+            'status' => sanitize_key((string) $source->get_status()),
+            'currency' => (string) $source->get_currency(),
+            'prices_include_tax' => (bool) $source->get_prices_include_tax(),
+            'is_paid' => (bool) $source->is_paid(),
+            'line_count' => count($source->get_items('line_item')),
+            'shipping_count' => count($source->get_items('shipping')),
+            'fee_count' => count($source->get_items('fee')),
+            'negative_fee_count' => 0,
+            'coupon_count' => count($source->get_items('coupon')),
+            'refund_count' => count($source->get_refunds()),
+            'has_transaction' => '' !== (string) $source->get_transaction_id(),
+            'deleted_product_lines' => 0,
+            'fractional_quantity_lines' => 0,
+            'managed_stock_lines' => 0,
+            'unmanaged_stock_lines' => 0,
+            'backorder_lines' => 0,
+            'manual_reconciliation_count' => 0,
+            'manual_reconciliation_operation_ids' => array(),
+            'unknown_private_meta_keys' => array(),
+            'inconsistent_private_meta_keys' => array(),
+            'policy' => self::policy(),
+        );
 
-		foreach ($source->get_items('fee') as $fee) {
-			if (WCOS_Decimal::to_units($fee->get_total(), wc_get_price_decimals()) < 0) {
-				$report['negative_fee_count']++;
-			}
-		}
+        foreach ($source->get_items('fee') as $fee) {
+            if (WCOS_Decimal::to_units($fee->get_total(), wc_get_price_decimals()) < 0) {
+                $report['negative_fee_count']++;
+            }
+        }
 
-		if (!$source->get_id()) {
-			return self::reject($report, 'unpersisted_order', __('The source order must be persisted before it can be split.', 'wc-order-splitter'));
-		}
-		if ('shop_order' !== $source->get_type()) {
-			return self::reject($report, 'unsupported_order_type', __('Only WooCommerce shop orders can be split.', 'wc-order-splitter'));
-		}
-		if (!in_array($source->get_status(), array('pending', 'on-hold', 'processing'), true)) {
-			return self::reject($report, 'unsupported_status', __('This order status is not supported by the quantity-split policy.', 'wc-order-splitter'));
-		}
-		if ('' === (string) $source->get_currency()) {
-			return self::reject($report, 'missing_currency', __('The source order does not have a currency.', 'wc-order-splitter'));
-		}
-		if ($report['negative_fee_count'] > 0) {
-			return self::reject($report, 'negative_fee_policy_missing', __('Orders containing negative fee rows are not supported until an explicit discount-like fee policy is implemented.', 'wc-order-splitter'));
-		}
-		if ($report['coupon_count'] > 0) {
-			return self::reject($report, 'coupon_policy_missing', __('Orders containing coupon rows are not supported until a coupon allocation policy is implemented.', 'wc-order-splitter'));
-		}
-		if ($source->get_total_refunded() != 0 || $report['refund_count'] > 0) {
-			return self::reject($report, 'refund_policy_missing', __('Refunded or partially refunded orders are not supported until a refund allocation policy is implemented.', 'wc-order-splitter'));
-		}
-		if (!empty($source->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true)) || !empty($source->get_meta('yoos_original_order', true))) {
-			return self::reject($report, 'nested_split', __('Nested splitting of an existing split child is not supported.', 'wc-order-splitter'));
-		}
-		if (0 === $report['line_count']) {
-			return self::reject($report, 'no_line_items', __('An order without product line items cannot be split.', 'wc-order-splitter'));
-		}
+        if (!$source->get_id()) {
+            return self::reject($report, 'unpersisted_order', __('The source order must be persisted before it can be split.', 'wc-order-splitter'));
+        }
+        if ('shop_order' !== $source->get_type()) {
+            return self::reject($report, 'unsupported_order_type', __('Only WooCommerce shop orders can be split.', 'wc-order-splitter'));
+        }
 
-		$order_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source->get_id());
-		$unknown_private_meta = array();
-		$inconsistent_private_meta = array();
-		foreach ($source->get_items('line_item') as $item) {
-			try {
-				$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
-			} catch (Throwable $throwable) {
-				return self::reject($report, 'invalid_line_quantity', __('A source line contains an invalid quantity.', 'wc-order-splitter'));
-			}
-			if ($quantity_units <= 0) {
-				return self::reject($report, 'invalid_line_quantity', __('Every source line must have a positive quantity.', 'wc-order-splitter'));
-			}
-			if (0 !== ($quantity_units % 1000000)) {
-				$report['fractional_quantity_lines']++;
-			}
+        $manual_records = WCOS_Operation_Journal::manual_reconciliation_records($source);
+        if (!empty($manual_records)) {
+            $report['manual_reconciliation_count'] = count($manual_records);
+            $report['manual_reconciliation_operation_ids'] = array_keys($manual_records);
+            return self::reject(
+                $report,
+                'manual_reconciliation_required',
+                __('This order has an unresolved mutation incident that requires manual stock reconciliation before another split can run.', 'wc-order-splitter')
+            );
+        }
 
-			$unknown_private_meta = array_merge(
-				$unknown_private_meta,
-				WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT)
-			);
-			$inconsistent_private_meta = array_merge(
-				$inconsistent_private_meta,
-				WCOS_Order_Item_Meta_Policy::inconsistent_private_keys($item)
-			);
+        if (!in_array($source->get_status(), array('pending', 'on-hold', 'processing'), true)) {
+            return self::reject($report, 'unsupported_status', __('This order status is not supported by the quantity-split policy.', 'wc-order-splitter'));
+        }
+        if ('' === (string) $source->get_currency()) {
+            return self::reject($report, 'missing_currency', __('The source order does not have a currency.', 'wc-order-splitter'));
+        }
+        if ($report['negative_fee_count'] > 0) {
+            return self::reject($report, 'negative_fee_policy_missing', __('Orders containing negative fee rows are not supported until an explicit discount-like fee policy is implemented.', 'wc-order-splitter'));
+        }
+        if ($report['coupon_count'] > 0) {
+            return self::reject($report, 'coupon_policy_missing', __('Orders containing coupon rows are not supported until a coupon allocation policy is implemented.', 'wc-order-splitter'));
+        }
+        if ($source->get_total_refunded() != 0 || $report['refund_count'] > 0) {
+            return self::reject($report, 'refund_policy_missing', __('Refunded or partially refunded orders are not supported until a refund allocation policy is implemented.', 'wc-order-splitter'));
+        }
+        if (!empty($source->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true)) || !empty($source->get_meta('yoos_original_order', true))) {
+            return self::reject($report, 'nested_split', __('Nested splitting of an existing split child is not supported.', 'wc-order-splitter'));
+        }
+        if (0 === $report['line_count']) {
+            return self::reject($report, 'no_line_items', __('An order without product line items cannot be split.', 'wc-order-splitter'));
+        }
 
-			$product = $item->get_product();
-			if (!$product) {
-				$report['deleted_product_lines']++;
-			} elseif ($product->managing_stock()) {
-				$report['managed_stock_lines']++;
-				if ($product->is_on_backorder($item->get_quantity())) {
-					$report['backorder_lines']++;
-				}
-			} else {
-				$report['unmanaged_stock_lines']++;
-			}
+        $order_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source->get_id());
+        $unknown_private_meta = array();
+        $inconsistent_private_meta = array();
+        foreach ($source->get_items('line_item') as $item) {
+            try {
+                $quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
+            } catch (Throwable $throwable) {
+                return self::reject($report, 'invalid_line_quantity', __('A source line contains an invalid quantity.', 'wc-order-splitter'));
+            }
+            if ($quantity_units <= 0) {
+                return self::reject($report, 'invalid_line_quantity', __('Every source line must have a positive quantity.', 'wc-order-splitter'));
+            }
+            if (0 !== ($quantity_units % 1000000)) {
+                $report['fractional_quantity_lines']++;
+            }
 
-			$reduced = $item->get_meta('_reduced_stock', true);
-			if ('' === $reduced) {
-				continue;
-			}
-			try {
-				$reduced_units = WCOS_Decimal::to_units($reduced, 6);
-			} catch (Throwable $throwable) {
-				return self::reject($report, 'invalid_stock_marker', __('A source line contains a non-numeric reduced-stock marker.', 'wc-order-splitter'));
-			}
-			if (!$order_stock_reduced || $reduced_units < 0 || $reduced_units > $quantity_units) {
-				return self::reject($report, 'invalid_stock_marker', __('The source order contains inconsistent reduced-stock markers.', 'wc-order-splitter'));
-			}
-		}
+            $unknown_private_meta = array_merge(
+                $unknown_private_meta,
+                WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT)
+            );
+            $inconsistent_private_meta = array_merge(
+                $inconsistent_private_meta,
+                WCOS_Order_Item_Meta_Policy::inconsistent_private_keys($item)
+            );
 
-		$unknown_private_meta = array_values(array_unique(array_map('strval', $unknown_private_meta)));
-		sort($unknown_private_meta, SORT_STRING);
-		$inconsistent_private_meta = array_values(array_unique(array_map('strval', $inconsistent_private_meta)));
-		sort($inconsistent_private_meta, SORT_STRING);
-		$report['unknown_private_meta_keys'] = $unknown_private_meta;
-		$report['inconsistent_private_meta_keys'] = $inconsistent_private_meta;
+            $product = $item->get_product();
+            if (!$product) {
+                $report['deleted_product_lines']++;
+            } elseif ($product->managing_stock()) {
+                $report['managed_stock_lines']++;
+                if ($product->is_on_backorder($item->get_quantity())) {
+                    $report['backorder_lines']++;
+                }
+            } else {
+                $report['unmanaged_stock_lines']++;
+            }
 
-		if (!empty($inconsistent_private_meta)) {
-			return self::reject(
-				$report,
-				'inconsistent_private_metadata_classification',
-				__('A private line-item metadata adapter classifies the same key differently for Split copying and canonical line identity.', 'wc-order-splitter')
-			);
-		}
-		if (!empty($unknown_private_meta)) {
-			return self::reject(
-				$report,
-				'unclassified_private_metadata',
-				__('The source order contains private line-item metadata that has not been classified by a compatibility adapter.', 'wc-order-splitter')
-			);
-		}
+            $reduced = $item->get_meta('_reduced_stock', true);
+            if ('' === $reduced) {
+                continue;
+            }
+            try {
+                $reduced_units = WCOS_Decimal::to_units($reduced, 6);
+            } catch (Throwable $throwable) {
+                return self::reject($report, 'invalid_stock_marker', __('A source line contains a non-numeric reduced-stock marker.', 'wc-order-splitter'));
+            }
+            if (!$order_stock_reduced || $reduced_units < 0 || $reduced_units > $quantity_units) {
+                return self::reject($report, 'invalid_stock_marker', __('The source order contains inconsistent reduced-stock markers.', 'wc-order-splitter'));
+            }
+        }
 
-		try {
-			WCOS_Order_Totals_Rebuilder::assert_consistent($source, wc_get_price_decimals());
-		} catch (Throwable $throwable) {
-			return self::reject($report, 'inconsistent_totals', __('The source order totals are internally inconsistent and cannot be split safely.', 'wc-order-splitter'));
-		}
+        $unknown_private_meta = array_values(array_unique(array_map('strval', $unknown_private_meta)));
+        sort($unknown_private_meta, SORT_STRING);
+        $inconsistent_private_meta = array_values(array_unique(array_map('strval', $inconsistent_private_meta)));
+        sort($inconsistent_private_meta, SORT_STRING);
+        $report['unknown_private_meta_keys'] = $unknown_private_meta;
+        $report['inconsistent_private_meta_keys'] = $inconsistent_private_meta;
 
-		$report['supported'] = true;
-		$report['reason'] = 'supported';
-		$report['message'] = __('This order is compatible with the current quantity-split policy.', 'wc-order-splitter');
-		return $report;
-	}
+        if (!empty($inconsistent_private_meta)) {
+            return self::reject(
+                $report,
+                'inconsistent_private_metadata_classification',
+                __('A private line-item metadata adapter classifies the same key differently for Split copying and canonical line identity.', 'wc-order-splitter')
+            );
+        }
+        if (!empty($unknown_private_meta)) {
+            return self::reject(
+                $report,
+                'unclassified_private_metadata',
+                __('The source order contains private line-item metadata that has not been classified by a compatibility adapter.', 'wc-order-splitter')
+            );
+        }
 
-	private static function reject(array $report, $reason, $message) {
-		$report['supported'] = false;
-		$report['reason'] = sanitize_key((string) $reason);
-		$report['message'] = (string) $message;
-		return $report;
-	}
+        try {
+            WCOS_Order_Totals_Rebuilder::assert_consistent($source, wc_get_price_decimals());
+        } catch (Throwable $throwable) {
+            return self::reject($report, 'inconsistent_totals', __('The source order totals are internally inconsistent and cannot be split safely.', 'wc-order-splitter'));
+        }
+
+        $report['supported'] = true;
+        $report['reason'] = 'supported';
+        $report['message'] = __('This order is compatible with the current quantity-split policy.', 'wc-order-splitter');
+        return $report;
+    }
+
+    private static function reject(array $report, $reason, $message) {
+        $report['supported'] = false;
+        $report['reason'] = sanitize_key((string) $reason);
+        $report['message'] = (string) $message;
+        return $report;
+    }
 }

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -18,10 +18,23 @@ final class WCOS_Split_WooCommerce_Adapter {
             throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
         }
 
+        $source_id = $source->get_id();
         $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
 
         try {
+            /*
+             * WooCommerce derives line subtotal/total-tax props while hydrating
+             * order items and that path calls wc_round_tax_total(). Reload only
+             * after the operation precision is pinned so a retry cannot be
+             * rounded by a changed ambient store precision before mutation code
+             * even sees the source.
+             */
+            $source = wc_get_order($source_id);
+            if (!$source instanceof WC_Order) {
+                throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
+
             WCOS_Split_Preflight::assert_supported($source, $precision);
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
@@ -32,7 +45,7 @@ final class WCOS_Split_WooCommerce_Adapter {
             } catch (Throwable $throwable) {
                 $events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
                 if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
-                    $this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
+                    $this->mark_manual_stock_reconciliation($source_id, $operation_id, $events, $throwable);
                 }
                 if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
                     throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
@@ -47,9 +60,14 @@ final class WCOS_Split_WooCommerce_Adapter {
     }
 
     public function preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+        $source_id = $source->get_id();
         $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
         try {
+            $source = $source_id ? wc_get_order($source_id) : $source;
+            if (!$source instanceof WC_Order) {
+                throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
             return WCOS_Split_Preflight::report($source, $precision);
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -91,10 +91,17 @@ final class WCOS_Split_WooCommerce_Adapter {
             if (!$source instanceof WC_Order) {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
-            return $this->apply_reconciliation_blocker(
+            $report = $this->apply_reconciliation_blocker(
                 $source,
                 WCOS_Split_Preflight::report($source, $precision)
             );
+            /*
+             * PII-free hash of the exact source state the server reviewed. The
+             * confirmation store must compare this against its own scoped reload
+             * before creating a token, closing Review -> confirmation TOCTOU.
+             */
+            $report['source_signature'] = WCOS_Order_Contract_Snapshot::source_signature($source);
+            return $report;
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);
         }

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -38,6 +38,27 @@ final class WCOS_Split_WooCommerce_Adapter {
             WCOS_Split_Preflight::assert_supported($source, $precision);
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
+            /*
+             * Persist confirmed after-write evidence while the Split service's
+             * order lease is still held. This closes the narrow gap between a
+             * late third-party side effect and the adapter's outer postcondition
+             * check after the service returns/releases its lease.
+             */
+            $boundary_guard = function() use ($source_id, $operation_id, $stock_token) {
+                $events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+                if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+                    $this->mark_manual_stock_reconciliation(
+                        $source_id,
+                        $operation_id,
+                        $events,
+                        new RuntimeException(__('Unexpected physical-stock evidence was observed before the Split request boundary completed.', 'wc-order-splitter'))
+                    );
+                }
+                WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+            };
+            add_action('wcos_split_mutation_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
+            add_action('woocommerce_order_note_added', $boundary_guard, PHP_INT_MAX, 2);
+
             try {
                 $children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
                 WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
@@ -52,6 +73,8 @@ final class WCOS_Split_WooCommerce_Adapter {
                 }
                 throw $throwable;
             } finally {
+                remove_action('wcos_split_mutation_checkpoint', $boundary_guard, PHP_INT_MAX);
+                remove_action('woocommerce_order_note_added', $boundary_guard, PHP_INT_MAX);
                 WCOS_Stock_Side_Effect_Guard::end($stock_token);
             }
         } finally {

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -35,7 +35,7 @@ final class WCOS_Split_WooCommerce_Adapter {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
 
-            WCOS_Split_Preflight::assert_supported($source, $precision);
+            $this->assert_supported($source, $precision);
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
             /*
@@ -91,10 +91,52 @@ final class WCOS_Split_WooCommerce_Adapter {
             if (!$source instanceof WC_Order) {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
-            return WCOS_Split_Preflight::report($source, $precision);
+            return $this->apply_reconciliation_blocker(
+                $source,
+                WCOS_Split_Preflight::report($source, $precision)
+            );
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);
         }
+    }
+
+    private function assert_supported(WC_Order $source, $precision) {
+        $report = $this->apply_reconciliation_blocker(
+            $source,
+            WCOS_Split_Preflight::report($source, $precision)
+        );
+        if (empty($report['supported'])) {
+            throw new WCOS_Split_Preflight_Exception(
+                isset($report['reason']) ? $report['reason'] : 'unsupported',
+                isset($report['message']) ? $report['message'] : __('This order is not supported by the quantity-split adapter.', 'wc-order-splitter'),
+                $report
+            );
+        }
+        return $report;
+    }
+
+    private function apply_reconciliation_blocker(WC_Order $source, array $report) {
+        if (!class_exists('WCOS_Manual_Reconciliation_Blocker')) {
+            return $report;
+        }
+
+        $operation_ids = WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source);
+        if (empty($operation_ids)) {
+            return $report;
+        }
+
+        $existing = isset($report['manual_reconciliation_operation_ids'])
+            ? array_values(array_filter(array_map('sanitize_key', (array) $report['manual_reconciliation_operation_ids'])))
+            : array();
+        $operation_ids = array_values(array_unique(array_merge($existing, $operation_ids)));
+        sort($operation_ids, SORT_STRING);
+
+        $report['supported'] = false;
+        $report['reason'] = 'manual_reconciliation_required';
+        $report['message'] = __('This order has an unresolved mutation incident that requires manual stock reconciliation before another split can run.', 'wc-order-splitter');
+        $report['manual_reconciliation_count'] = count($operation_ids);
+        $report['manual_reconciliation_operation_ids'] = $operation_ids;
+        return $report;
     }
 
     private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {
@@ -104,6 +146,23 @@ final class WCOS_Split_WooCommerce_Adapter {
         }
         $record = WCOS_Operation_Journal::get($fresh, $operation_id);
         if (!is_array($record)) {
+            return false;
+        }
+
+        /*
+         * Persist the source-level blocker first. If the process dies before the
+         * journal transition, the next preflight remains fail-closed rather than
+         * missing a physical-stock incident because the secondary index was never
+         * written.
+         */
+        if (!WCOS_Manual_Reconciliation_Blocker::block($fresh, $operation_id)) {
+            do_action(
+                'wcos_manual_reconciliation_record_error',
+                $fresh,
+                $operation_id,
+                $events,
+                $throwable
+            );
             return false;
         }
 
@@ -119,6 +178,7 @@ final class WCOS_Split_WooCommerce_Adapter {
         );
 
         if (!$updated) {
+            /* Keep the first-phase blocker in place deliberately. */
             do_action(
                 'wcos_manual_reconciliation_record_error',
                 $fresh,

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -133,7 +133,11 @@ final class WCOS_Split_WooCommerce_Adapter {
 
         $report['supported'] = false;
         $report['reason'] = 'manual_reconciliation_required';
-        $report['message'] = __('This order has an unresolved mutation incident that requires manual stock reconciliation before another split can run.', 'wc-order-splitter');
+        $report['message'] = sprintf(
+            /* translators: %s: comma-separated mutation operation IDs requiring manual stock reconciliation. */
+            __('This order has an unresolved mutation incident that requires manual stock reconciliation before another split can run. Operation ID(s): %s.', 'wc-order-splitter'),
+            implode(', ', $operation_ids)
+        );
         $report['manual_reconciliation_count'] = count($operation_ids);
         $report['manual_reconciliation_operation_ids'] = $operation_ids;
         return $report;

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -18,29 +18,42 @@ final class WCOS_Split_WooCommerce_Adapter {
             throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
         }
 
-        WCOS_Split_Preflight::assert_supported($source);
-        $token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
 
         try {
-            $children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
-            WCOS_Stock_Side_Effect_Guard::assert_clean($token);
-            return $children;
-        } catch (Throwable $throwable) {
-            $events = WCOS_Stock_Side_Effect_Guard::events($token);
-            if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
-                $this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
+            WCOS_Split_Preflight::assert_supported($source, $precision);
+            $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+
+            try {
+                $children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
+                WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+                return $children;
+            } catch (Throwable $throwable) {
+                $events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+                if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+                    $this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
+                }
+                if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+                    throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
+                }
+                throw $throwable;
+            } finally {
+                WCOS_Stock_Side_Effect_Guard::end($stock_token);
             }
-            if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
-                throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
-            }
-            throw $throwable;
         } finally {
-            WCOS_Stock_Side_Effect_Guard::end($token);
+            WCOS_Price_Precision_Scope::end($precision_token);
         }
     }
 
-    public function preflight(WC_Order $source) {
-        return WCOS_Split_Preflight::report($source);
+    public function preflight(WC_Order $source, $operation_id = '') {
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            return WCOS_Split_Preflight::report($source, $precision);
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
     }
 
     private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -12,59 +12,67 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Split_WooCommerce_Adapter {
 
-	public function split(WC_Order $source, array $plan, $operation_id) {
-		$operation_id = sanitize_key((string) $operation_id);
-		if ('' === $operation_id) {
-			throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
-		}
+    public function split(WC_Order $source, array $plan, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if ('' === $operation_id) {
+            throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
+        }
 
-		WCOS_Split_Preflight::assert_supported($source);
-		$token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+        WCOS_Split_Preflight::assert_supported($source);
+        $token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
-		try {
-			$children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
-			WCOS_Stock_Side_Effect_Guard::assert_clean($token);
-			return $children;
-		} catch (Throwable $throwable) {
-			$events = WCOS_Stock_Side_Effect_Guard::events($token);
-			if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
-				$this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
-			}
-			if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
-				throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
-			}
-			throw $throwable;
-		} finally {
-			WCOS_Stock_Side_Effect_Guard::end($token);
-		}
-	}
+        try {
+            $children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
+            WCOS_Stock_Side_Effect_Guard::assert_clean($token);
+            return $children;
+        } catch (Throwable $throwable) {
+            $events = WCOS_Stock_Side_Effect_Guard::events($token);
+            if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+                $this->mark_manual_stock_reconciliation($source->get_id(), $operation_id, $events, $throwable);
+            }
+            if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+                throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
+            }
+            throw $throwable;
+        } finally {
+            WCOS_Stock_Side_Effect_Guard::end($token);
+        }
+    }
 
-	public function preflight(WC_Order $source) {
-		return WCOS_Split_Preflight::report($source);
-	}
+    public function preflight(WC_Order $source) {
+        return WCOS_Split_Preflight::report($source);
+    }
 
-	private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {
-		$fresh = wc_get_order(absint($source_id));
-		if (!$fresh instanceof WC_Order) {
-			return;
-		}
-		$record = WCOS_Operation_Journal::get($fresh, $operation_id);
-		if (!is_array($record)) {
-			return;
-		}
-		$status = isset($record['status']) ? sanitize_key((string) $record['status']) : '';
-		if (in_array($status, array('completed', 'compensated'), true)) {
-			return;
-		}
-		WCOS_Operation_Journal::require_recovery(
-			$fresh,
-			$operation_id,
-			array(
-				'reason' => 'unexpected_physical_stock_write',
-				'automatic_compensation_allowed' => false,
-				'stock_side_effects' => array_values($events),
-				'error' => $throwable->getMessage(),
-			)
-		);
-	}
+    private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {
+        $fresh = wc_get_order(absint($source_id));
+        if (!$fresh instanceof WC_Order) {
+            return false;
+        }
+        $record = WCOS_Operation_Journal::get($fresh, $operation_id);
+        if (!is_array($record)) {
+            return false;
+        }
+
+        $updated = WCOS_Operation_Journal::mark_manual_reconciliation(
+            $fresh,
+            $operation_id,
+            array(
+                'reason' => 'unexpected_physical_stock_write',
+                'automatic_compensation_allowed' => false,
+                'stock_side_effects' => array_values($events),
+                'error' => $throwable->getMessage(),
+            )
+        );
+
+        if (!$updated) {
+            do_action(
+                'wcos_manual_reconciliation_record_error',
+                $fresh,
+                $operation_id,
+                $events,
+                $throwable
+            );
+        }
+        return $updated;
+    }
 }

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -12,13 +12,13 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Split_WooCommerce_Adapter {
 
-    public function split(WC_Order $source, array $plan, $operation_id) {
+    public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null) {
         $operation_id = sanitize_key((string) $operation_id);
         if ('' === $operation_id) {
             throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
         }
 
-        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id);
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
 
         try {
@@ -46,8 +46,8 @@ final class WCOS_Split_WooCommerce_Adapter {
         }
     }
 
-    public function preflight(WC_Order $source, $operation_id = '') {
-        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id);
+    public function preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
         try {
             return WCOS_Split_Preflight::report($source, $precision);

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -189,6 +189,9 @@
     function setBusy(nextBusy) {
         busy = !!nextBusy;
         form.setAttribute('aria-busy', busy ? 'true' : 'false');
+        Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-split-quantity'), function (field) {
+            field.disabled = busy || completed;
+        });
         reviewButton.disabled = busy || completed;
         confirmCheckbox.disabled = busy || completed;
         executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -108,32 +108,44 @@
         Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
             var itemId = row.getAttribute('data-item-id');
             var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
-            var quantityInput = row.querySelector('.wcos-split-quantity');
-            var targetSelect = row.querySelector('.wcos-split-target');
-            var quantity = quantityInput ? quantityInput.value.trim() : '';
+            var movedForLine = 0;
 
-            if (quantity === '' || Number(quantity) === 0) {
-                return;
-            }
-            if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
-                invalid = true;
-                return;
-            }
+            Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (quantityInput) {
+                var quantity = quantityInput.value.trim();
+                if (quantity === '' || Number(quantity) === 0) {
+                    return;
+                }
+                if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
+                    invalid = true;
+                    return;
+                }
 
-            var childKey = targetSelect ? targetSelect.value : '';
-            if (!/^child-(?:[1-9]|10)$/.test(childKey)) {
+                var childKey = quantityInput.getAttribute('data-child-key') || '';
+                if (!/^child-(?:[1-9]|10)$/.test(childKey)) {
+                    invalid = true;
+                    return;
+                }
+                if (!plan[childKey]) {
+                    plan[childKey] = {};
+                }
+                plan[childKey][itemId] = quantity;
+                movedForLine += Number(quantity);
+                hasQuantity = true;
+            });
+
+            if (movedForLine >= Number(sourceQuantity)) {
                 invalid = true;
-                return;
             }
-            if (!plan[childKey]) {
-                plan[childKey] = {};
+        });
+
+        Object.keys(plan).forEach(function (childKey) {
+            if (!Object.keys(plan[childKey]).length) {
+                delete plan[childKey];
             }
-            plan[childKey][itemId] = quantity;
-            hasQuantity = true;
         });
 
         if (invalid || !hasQuantity) {
-            throw new Error(text('invalidPlan', 'Enter at least one quantity smaller than its source line quantity.'));
+            throw new Error(text('invalidPlan', 'Enter at least one quantity and keep a positive residual quantity on every affected source line.'));
         }
         return plan;
     }
@@ -258,7 +270,6 @@
         if (!state || !confirmCheckbox.checked) {
             return;
         }
-
         clearError();
         clearResult();
         setBusy(true);
@@ -303,14 +314,6 @@
             setStatus('');
         }
     });
-    form.addEventListener('change', function (event) {
-        if (event.target.classList.contains('wcos-split-target')) {
-            invalidateReview();
-            clearError();
-            setStatus('');
-        }
-    });
-
     dialog.addEventListener('keydown', function (event) {
         if (event.key === 'Escape') {
             event.preventDefault();

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -1,0 +1,339 @@
+(function () {
+    'use strict';
+
+    var strings = window.wcosSplitAdminStrings || {};
+    var launcher = document.querySelector('.wcos-split-launcher');
+    if (!launcher) {
+        return;
+    }
+
+    var dialogId = launcher.getAttribute('aria-controls');
+    var dialog = dialogId ? document.getElementById(dialogId) : null;
+    if (!dialog) {
+        return;
+    }
+
+    var panel = dialog.querySelector('.wcos-split-dialog__panel');
+    var form = dialog.querySelector('.wcos-split-form');
+    var closeButton = dialog.querySelector('.wcos-split-close');
+    var cancelButton = dialog.querySelector('.wcos-split-cancel');
+    var reviewButton = dialog.querySelector('.wcos-split-review-button');
+    var executeButton = dialog.querySelector('.wcos-split-execute-button');
+    var confirmCheckbox = dialog.querySelector('.wcos-split-confirm-checkbox');
+    var reviewBox = dialog.querySelector('.wcos-split-review');
+    var reviewSummary = dialog.querySelector('.wcos-split-review-summary');
+    var statusBox = dialog.querySelector('.wcos-split-status');
+    var errorBox = dialog.querySelector('.wcos-split-error');
+    var resultBox = dialog.querySelector('.wcos-split-result');
+    var state = null;
+    var returnFocus = null;
+    var busy = false;
+
+    function text(key, fallback) {
+        return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
+    }
+
+    function focusableElements() {
+        return Array.prototype.slice.call(dialog.querySelectorAll(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter(function (element) {
+            return !element.hidden && element.offsetParent !== null;
+        });
+    }
+
+    function openDialog() {
+        returnFocus = document.activeElement;
+        dialog.hidden = false;
+        document.body.classList.add('wcos-split-modal-open');
+        window.setTimeout(function () {
+            var firstQuantity = dialog.querySelector('.wcos-split-quantity');
+            (firstQuantity || panel).focus();
+        }, 0);
+    }
+
+    function closeDialog() {
+        if (busy) {
+            return;
+        }
+        dialog.hidden = true;
+        document.body.classList.remove('wcos-split-modal-open');
+        if (returnFocus && typeof returnFocus.focus === 'function') {
+            returnFocus.focus();
+        }
+    }
+
+    function clearError() {
+        errorBox.hidden = true;
+        errorBox.textContent = '';
+    }
+
+    function showError(message) {
+        errorBox.textContent = message || text('requestFailed', 'The Split request could not be completed.');
+        errorBox.hidden = false;
+        errorBox.focus();
+    }
+
+    function setStatus(message) {
+        statusBox.textContent = message || '';
+    }
+
+    function clearResult() {
+        resultBox.hidden = true;
+        resultBox.textContent = '';
+    }
+
+    function invalidateReview() {
+        state = null;
+        reviewBox.hidden = true;
+        reviewSummary.textContent = '';
+        confirmCheckbox.checked = false;
+        executeButton.disabled = true;
+        clearResult();
+    }
+
+    function decimalIsPositiveAndLessThan(value, sourceValue) {
+        if (!/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,6})?$/.test(value)) {
+            return false;
+        }
+        var valueNumber = Number(value);
+        var sourceNumber = Number(sourceValue);
+        return Number.isFinite(valueNumber) && Number.isFinite(sourceNumber) && valueNumber > 0 && valueNumber < sourceNumber;
+    }
+
+    function buildPlan() {
+        var plan = {};
+        var hasQuantity = false;
+        var invalid = false;
+
+        Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+            var itemId = row.getAttribute('data-item-id');
+            var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
+            var quantityInput = row.querySelector('.wcos-split-quantity');
+            var targetSelect = row.querySelector('.wcos-split-target');
+            var quantity = quantityInput ? quantityInput.value.trim() : '';
+
+            if (quantity === '' || Number(quantity) === 0) {
+                return;
+            }
+            if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
+                invalid = true;
+                return;
+            }
+
+            var childKey = targetSelect ? targetSelect.value : '';
+            if (!/^child-(?:[1-9]|10)$/.test(childKey)) {
+                invalid = true;
+                return;
+            }
+            if (!plan[childKey]) {
+                plan[childKey] = {};
+            }
+            plan[childKey][itemId] = quantity;
+            hasQuantity = true;
+        });
+
+        if (invalid || !hasQuantity) {
+            throw new Error(text('invalidPlan', 'Enter at least one quantity smaller than its source line quantity.'));
+        }
+        return plan;
+    }
+
+    function request(action, data) {
+        var body = new URLSearchParams();
+        body.set('action', action);
+        Object.keys(data).forEach(function (key) {
+            body.set(key, String(data[key]));
+        });
+
+        return window.fetch(dialog.getAttribute('data-ajax-url'), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            body: body.toString()
+        }).then(function (response) {
+            return response.json().catch(function () {
+                throw new Error(text('requestFailed', 'The Split request could not be completed.'));
+            });
+        }).then(function (payload) {
+            if (!payload || payload.success !== true) {
+                var failure = payload && payload.data ? payload.data : {};
+                var error = new Error(failure.message || text('requestFailed', 'The Split request could not be completed.'));
+                error.code = failure.code || 'request_failed';
+                error.retryable = !!failure.retryable;
+                throw error;
+            }
+            return payload.data || {};
+        });
+    }
+
+    function setBusy(nextBusy) {
+        busy = !!nextBusy;
+        form.setAttribute('aria-busy', busy ? 'true' : 'false');
+        reviewButton.disabled = busy;
+        confirmCheckbox.disabled = busy;
+        executeButton.disabled = busy || !state || !confirmCheckbox.checked;
+        cancelButton.disabled = busy;
+        closeButton.disabled = busy;
+    }
+
+    function reviewPlan() {
+        clearError();
+        clearResult();
+        var plan;
+        try {
+            plan = buildPlan();
+        } catch (error) {
+            showError(error.message);
+            return;
+        }
+
+        setBusy(true);
+        setStatus(text('reviewing', 'Reviewing Split plan…'));
+        request('wcos_split_review', {
+            order_id: dialog.getAttribute('data-order-id'),
+            nonce: dialog.getAttribute('data-nonce'),
+            plan: JSON.stringify(plan)
+        }).then(function (data) {
+            state = {
+                operationId: data.operation_id,
+                token: data.confirmation_token
+            };
+            var summary = data.summary || {};
+            reviewSummary.textContent = text('reviewSummary', 'Reviewed children / affected lines / moved quantity:') + ' ' +
+                String(summary.child_count || 0) + ' / ' +
+                String(summary.affected_line_count || 0) + ' / ' +
+                String(summary.moved_quantity || '0');
+            reviewBox.hidden = false;
+            confirmCheckbox.checked = false;
+            setStatus(text('reviewReady', 'The plan passed server review. Confirm the acknowledgement to execute it.'));
+            confirmCheckbox.focus();
+        }).catch(function (error) {
+            invalidateReview();
+            setStatus('');
+            showError(error.message);
+        }).finally(function () {
+            setBusy(false);
+        });
+    }
+
+    function renderSuccess(data) {
+        resultBox.textContent = '';
+        var message = document.createElement('p');
+        message.textContent = text('completed', 'Split completed successfully.');
+        resultBox.appendChild(message);
+
+        var children = Array.isArray(data.children) ? data.children : [];
+        if (children.length) {
+            var list = document.createElement('ul');
+            children.forEach(function (child) {
+                var item = document.createElement('li');
+                if (child.edit_url) {
+                    var link = document.createElement('a');
+                    link.href = child.edit_url;
+                    link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                    item.appendChild(link);
+                } else {
+                    item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                }
+                list.appendChild(item);
+            });
+            resultBox.appendChild(list);
+        }
+
+        var reload = document.createElement('button');
+        reload.type = 'button';
+        reload.className = 'button';
+        reload.textContent = text('reloadOrder', 'Reload source order');
+        reload.addEventListener('click', function () {
+            window.location.reload();
+        });
+        resultBox.appendChild(reload);
+        resultBox.hidden = false;
+        resultBox.focus();
+    }
+
+    function executePlan() {
+        if (!state || !confirmCheckbox.checked) {
+            return;
+        }
+
+        clearError();
+        clearResult();
+        setBusy(true);
+        setStatus(text('executing', 'Executing Split…'));
+        request('wcos_split_execute', {
+            order_id: dialog.getAttribute('data-order-id'),
+            nonce: dialog.getAttribute('data-nonce'),
+            operation_id: state.operationId,
+            confirmation_token: state.token
+        }).then(function (data) {
+            setStatus(text('completed', 'Split completed successfully.'));
+            Array.prototype.forEach.call(dialog.querySelectorAll('input, select'), function (field) {
+                field.disabled = true;
+            });
+            reviewButton.disabled = true;
+            executeButton.disabled = true;
+            renderSuccess(data);
+        }).catch(function (error) {
+            if (error.code === 'confirmation_source_changed' || error.code === 'confirmation_expired') {
+                invalidateReview();
+            }
+            setStatus('');
+            showError(error.message);
+        }).finally(function () {
+            setBusy(false);
+        });
+    }
+
+    launcher.addEventListener('click', openDialog);
+    closeButton.addEventListener('click', closeDialog);
+    cancelButton.addEventListener('click', closeDialog);
+    reviewButton.addEventListener('click', reviewPlan);
+    executeButton.addEventListener('click', executePlan);
+    confirmCheckbox.addEventListener('change', function () {
+        executeButton.disabled = busy || !state || !confirmCheckbox.checked;
+    });
+
+    form.addEventListener('input', function (event) {
+        if (event.target.classList.contains('wcos-split-quantity')) {
+            invalidateReview();
+            clearError();
+            setStatus('');
+        }
+    });
+    form.addEventListener('change', function (event) {
+        if (event.target.classList.contains('wcos-split-target')) {
+            invalidateReview();
+            clearError();
+            setStatus('');
+        }
+    });
+
+    dialog.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeDialog();
+            return;
+        }
+        if (event.key !== 'Tab') {
+            return;
+        }
+        var focusable = focusableElements();
+        if (!focusable.length) {
+            event.preventDefault();
+            panel.focus();
+            return;
+        }
+        var first = focusable[0];
+        var last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    });
+})();

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -28,6 +28,7 @@
     var state = null;
     var returnFocus = null;
     var busy = false;
+    var completed = false;
 
     function text(key, fallback) {
         return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
@@ -46,8 +47,10 @@
         dialog.hidden = false;
         document.body.classList.add('wcos-split-modal-open');
         window.setTimeout(function () {
-            var firstQuantity = dialog.querySelector('.wcos-split-quantity');
-            (firstQuantity || panel).focus();
+            var preferred = completed && !resultBox.hidden
+                ? resultBox
+                : dialog.querySelector('.wcos-split-quantity:not([disabled])');
+            (preferred || panel).focus();
         }, 0);
     }
 
@@ -83,6 +86,9 @@
     }
 
     function invalidateReview() {
+        if (completed) {
+            return;
+        }
         state = null;
         reviewBox.hidden = true;
         reviewSummary.textContent = '';
@@ -183,14 +189,17 @@
     function setBusy(nextBusy) {
         busy = !!nextBusy;
         form.setAttribute('aria-busy', busy ? 'true' : 'false');
-        reviewButton.disabled = busy;
-        confirmCheckbox.disabled = busy;
-        executeButton.disabled = busy || !state || !confirmCheckbox.checked;
+        reviewButton.disabled = busy || completed;
+        confirmCheckbox.disabled = busy || completed;
+        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
         cancelButton.disabled = busy;
         closeButton.disabled = busy;
     }
 
     function reviewPlan() {
+        if (busy || completed) {
+            return;
+        }
         clearError();
         clearResult();
         var plan;
@@ -267,7 +276,7 @@
     }
 
     function executePlan() {
-        if (!state || !confirmCheckbox.checked) {
+        if (busy || completed || !state || !confirmCheckbox.checked) {
             return;
         }
         clearError();
@@ -280,15 +289,14 @@
             operation_id: state.operationId,
             confirmation_token: state.token
         }).then(function (data) {
+            completed = true;
             setStatus(text('completed', 'Split completed successfully.'));
             Array.prototype.forEach.call(dialog.querySelectorAll('input, select'), function (field) {
                 field.disabled = true;
             });
-            reviewButton.disabled = true;
-            executeButton.disabled = true;
             renderSuccess(data);
         }).catch(function (error) {
-            if (error.code === 'confirmation_source_changed' || error.code === 'confirmation_expired') {
+            if (!error.retryable) {
                 invalidateReview();
             }
             setStatus('');
@@ -304,10 +312,13 @@
     reviewButton.addEventListener('click', reviewPlan);
     executeButton.addEventListener('click', executePlan);
     confirmCheckbox.addEventListener('change', function () {
-        executeButton.disabled = busy || !state || !confirmCheckbox.checked;
+        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
     });
 
     form.addEventListener('input', function (event) {
+        if (completed) {
+            return;
+        }
         if (event.target.classList.contains('wcos-split-quantity')) {
             invalidateReview();
             clearError();

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -85,6 +85,7 @@ $order->delete(true);
 
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-manual-reconciliation-smoke.php';
+require __DIR__ . '/p2-price-precision-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -95,6 +95,7 @@ require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 require __DIR__ . '/p2-journal-retention-smoke.php';
 require __DIR__ . '/p2-admin-transport-smoke.php';
 require __DIR__ . '/p2-admin-client-state-smoke.php';
+require __DIR__ . '/p2-review-confirmation-toctou-smoke.php';
 require __DIR__ . '/p2-policy-replay-smoke.php';
 require __DIR__ . '/p2-durable-replay-smoke.php';
 

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -92,5 +92,6 @@ require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';
 require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 require __DIR__ . '/p2-journal-retention-smoke.php';
+require __DIR__ . '/p2-admin-transport-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -93,6 +93,7 @@ require __DIR__ . '/p2-production-side-effect-smoke.php';
 require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 require __DIR__ . '/p2-journal-retention-smoke.php';
 require __DIR__ . '/p2-admin-transport-smoke.php';
+require __DIR__ . '/p2-admin-client-state-smoke.php';
 require __DIR__ . '/p2-durable-replay-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -93,5 +93,6 @@ require __DIR__ . '/p2-production-side-effect-smoke.php';
 require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 require __DIR__ . '/p2-journal-retention-smoke.php';
 require __DIR__ . '/p2-admin-transport-smoke.php';
+require __DIR__ . '/p2-durable-replay-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -87,6 +87,7 @@ require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-manual-reconciliation-smoke.php';
 require __DIR__ . '/p2-price-precision-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
+require __DIR__ . '/p2-stock-cancellation-lifecycle-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';
 require __DIR__ . '/p2-metadata-compatibility-smoke.php';

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -84,6 +84,7 @@ wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 
 $order->delete(true);
 
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
+require __DIR__ . '/p2-manual-reconciliation-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
 require __DIR__ . '/p2-production-side-effect-smoke.php';

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -85,6 +85,7 @@ $order->delete(true);
 
 require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
 require __DIR__ . '/p2-manual-reconciliation-smoke.php';
+require __DIR__ . '/p2-manual-reconciliation-crash-window-smoke.php';
 require __DIR__ . '/p2-price-precision-smoke.php';
 require __DIR__ . '/p2-stock-matrix-smoke.php';
 require __DIR__ . '/p2-stock-cancellation-lifecycle-smoke.php';

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -95,6 +95,7 @@ require __DIR__ . '/p2-metadata-compatibility-smoke.php';
 require __DIR__ . '/p2-journal-retention-smoke.php';
 require __DIR__ . '/p2-admin-transport-smoke.php';
 require __DIR__ . '/p2-admin-client-state-smoke.php';
+require __DIR__ . '/p2-policy-replay-smoke.php';
 require __DIR__ . '/p2-durable-replay-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -10,6 +10,8 @@ wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split a
 
 foreach (array(
     'var completed = false;',
+    "dialog.querySelectorAll('.wcos-split-quantity')",
+    'field.disabled = busy || completed;',
     'reviewButton.disabled = busy || completed;',
     'confirmCheckbox.disabled = busy || completed;',
     'executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;',
@@ -19,7 +21,7 @@ foreach (array(
 ) as $needle) {
     wcos_p2_adapter_assert(
         false !== strpos($js, $needle),
-        'Split admin client is missing terminal-success protection: ' . $needle
+        'Split admin client is missing terminal/async-boundary protection: ' . $needle
     );
 }
 

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -1,0 +1,31 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$js_path = dirname(__DIR__, 2) . '/js/p2-split-admin.js';
+$js = file_get_contents($js_path);
+wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split admin client script for terminal-state verification.');
+
+foreach (array(
+    'var completed = false;',
+    'reviewButton.disabled = busy || completed;',
+    'confirmCheckbox.disabled = busy || completed;',
+    'executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;',
+    'if (busy || completed) {',
+    'completed = true;',
+    'completed && !resultBox.hidden',
+) as $needle) {
+    wcos_p2_adapter_assert(
+        false !== strpos($js, $needle),
+        'Split admin client is missing terminal-success protection: ' . $needle
+    );
+}
+
+wcos_p2_adapter_assert(
+    false !== strpos($js, 'if (!error.retryable) {'),
+    'Non-retryable execute failures do not invalidate the reviewed confirmation state.'
+);
+
+echo "p2-admin-client-terminal-state-ok\n";

--- a/tests/integration/p2-admin-transport-smoke.php
+++ b/tests/integration/p2-admin-transport-smoke.php
@@ -89,13 +89,54 @@ try {
     );
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array(
+                'child-1' => array($transport_item_id => '2.000000'),
+                'child-2' => array($transport_item_id => '2.000000'),
+            )), $transport_source);
+        },
+        'Parser allowed aggregate multi-child allocation to consume the entire source line.'
+    );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
             WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '1e0'))), $transport_source);
         },
         'Parser accepted scientific-notation quantity input.'
     );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '999999999999999999999999999999999999'))), $transport_source);
+        },
+        'Parser allowed numeric overflow to escape validation.'
+    );
+
+    /* WooCommerce integer mode rejects fractional transport input. */
+    wcos_p2_adapter_assert(!WCOS_Split_Preflight::fractional_quantities_supported(), 'Default WooCommerce fixture unexpectedly supports fractional stock amounts.');
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))), $transport_source);
+        },
+        'Parser accepted fractional transport input under integer-only WooCommerce stock amounts.'
+    );
+
+    remove_filter('woocommerce_stock_amount', 'intval');
+    add_filter('woocommerce_stock_amount', 'floatval');
+    try {
+        wcos_p2_adapter_assert(WCOS_Split_Preflight::fractional_quantities_supported(), 'Explicit fractional integration was not detected.');
+        $fractional_plan = WCOS_Split_Request_Parser::parse_json(
+            wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))),
+            $transport_source
+        );
+        wcos_p2_adapter_assert('0.500000' === $fractional_plan['child-1'][$transport_item_id], 'Fractional transport input was not preserved exactly.');
+    } finally {
+        remove_filter('woocommerce_stock_amount', 'floatval');
+        add_filter('woocommerce_stock_amount', 'intval');
+    }
 
     $nonce = wp_create_nonce('wcos_split_order_' . $source_id);
-    $plan_json = wp_json_encode(array('child-1' => array((string) $transport_item_id => '1.000000')));
+    $plan_json = wp_json_encode(array(
+        'child-1' => array((string) $transport_item_id => '1.000000'),
+        'child-2' => array((string) $transport_item_id => '1.000000'),
+    ));
     $review = $controller->review_request(array(
         'order_id' => $source_id,
         'nonce' => $nonce,
@@ -105,9 +146,9 @@ try {
     wcos_p2_adapter_assert(1 === preg_match('/^[0-9a-f-]{36}$/D', $review['operation_id']), 'Review did not return a server-generated operation UUID.');
     wcos_p2_adapter_assert(is_string($review['confirmation_token']) && strlen($review['confirmation_token']) >= 32, 'Review did not return a strong confirmation token.');
     wcos_p2_adapter_assert(!empty($review['preflight']['supported']), 'Review did not return a supported preflight.');
-    wcos_p2_adapter_assert(1 === (int) $review['summary']['child_count'], 'Review summary child count is wrong.');
+    wcos_p2_adapter_assert(2 === (int) $review['summary']['child_count'], 'Review summary did not preserve multi-child allocation.');
     wcos_p2_adapter_assert(1 === (int) $review['summary']['affected_line_count'], 'Review summary affected-line count is wrong.');
-    wcos_p2_adapter_assert('1.000000' === $review['summary']['moved_quantity'], 'Review summary moved quantity is wrong.');
+    wcos_p2_adapter_assert('2.000000' === $review['summary']['moved_quantity'], 'Review summary moved quantity is wrong.');
     wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($source_id), $review['operation_id']), 'Read-only review created a mutation journal.');
     wcos_p2_adapter_assert($source_signature_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source_id)), 'Read-only review changed the source order.');
     wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($source_id, $review['operation_id'])), 'Read-only review created a child order.');
@@ -135,7 +176,7 @@ try {
     wcos_p2_adapter_assert($source_signature_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source_id)), 'Hard-off execute changed the source.');
 
     /* Token binding rejects a different token before workflow gate evaluation. */
-    wcos_p2_transport_expect(
+    $invalid_token = wcos_p2_transport_expect(
         'confirmation_invalid_token',
         static function() use ($controller, $source_id, $nonce, $review) {
             $controller->execute_request(array(
@@ -147,6 +188,7 @@ try {
         },
         'Execute accepted a mismatched confirmation token.'
     );
+    wcos_p2_adapter_assert(403 === $invalid_token->get_http_status(), 'Invalid confirmation token used the wrong HTTP status.');
 
     /* A source change invalidates review before any mutation begins. */
     $review_changed = $controller->review_request(array(
@@ -158,7 +200,7 @@ try {
     $changed_source = wc_get_order($source_id);
     $changed_source->set_customer_note('changed-after-review');
     $changed_source->save();
-    wcos_p2_transport_expect(
+    $source_changed = wcos_p2_transport_expect(
         'confirmation_source_changed',
         static function() use ($controller, $source_id, $nonce, $review_changed) {
             $controller->execute_request(array(
@@ -170,6 +212,7 @@ try {
         },
         'Execute accepted a source changed after review.'
     );
+    wcos_p2_adapter_assert(409 === $source_changed->get_http_status(), 'Changed source used the wrong HTTP status.');
     $changed_source = wc_get_order($source_id);
     $changed_source->set_customer_note('');
     $changed_source->save();
@@ -205,7 +248,7 @@ try {
     );
     update_option('order_splitter_status_allowed', array('wc-pending'));
 
-    /* Server-rendered dialog carries semantic labels and no address/customer PII. */
+    /* Server-rendered matrix carries semantic labels and no customer/address PII. */
     $fresh_source = wc_get_order($source_id);
     $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($fresh_source);
     $html = $controller->dialog_html($fresh_source, $preflight);
@@ -220,14 +263,27 @@ try {
         'wcos-split-review-button',
         'wcos-split-execute-button',
         'for="wcos-split-quantity-',
-        'for="wcos-split-target-',
+        'data-child-key="child-10"',
         '>Child 10<',
+        'scope="row"',
         'change stock directly in the database',
+        'only supports integer Split quantities',
     ) as $needle) {
         wcos_p2_adapter_assert(false !== strpos($html, $needle), 'Accessible Split dialog is missing required markup: ' . $needle);
     }
+    wcos_p2_adapter_assert(false === strpos($html, 'wcos-split-target'), 'Legacy single-destination selector remained in the multi-child dialog.');
     wcos_p2_adapter_assert(false === strpos($html, 'PrivateFirstNameProbe'), 'Billing first name leaked into the Split dialog.');
     wcos_p2_adapter_assert(false === strpos($html, 'private-probe@example.test'), 'Billing email leaked into the Split dialog.');
+
+    /* Client script keeps user-visible values in text nodes and preserves keyboard focus semantics. */
+    $js_path = dirname(__DIR__, 2) . '/js/p2-split-admin.js';
+    $js = file_get_contents($js_path);
+    wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split admin client script.');
+    wcos_p2_adapter_assert(false === strpos($js, 'innerHTML'), 'Split admin client uses innerHTML for mutation result/UI content.');
+    wcos_p2_adapter_assert(false === strpos($js, 'alert('), 'Split admin client uses blocking alert() UI.');
+    foreach (array('textContent', "event.key === 'Escape'", "event.key !== 'Tab'", 'data-child-key', 'returnFocus.focus()') as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Split admin client is missing accessibility/security behavior: ' . $needle);
+    }
 
     ob_start();
     $controller->render_launcher($fresh_source);

--- a/tests/integration/p2-admin-transport-smoke.php
+++ b/tests/integration/p2-admin-transport-smoke.php
@@ -1,0 +1,259 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_transport_expect($code, callable $callback, $message) {
+    try {
+        $callback();
+    } catch (WCOS_Split_Transport_Exception $exception) {
+        wcos_p2_adapter_assert($code === $exception->get_error_code(), $message . ' Wrong code: ' . $exception->get_error_code());
+        return $exception;
+    }
+    throw new RuntimeException($message);
+}
+
+function wcos_p2_transport_expect_invalid_plan(callable $callback, $message) {
+    try {
+        $callback();
+    } catch (InvalidArgumentException $exception) {
+        return $exception;
+    }
+    throw new RuntimeException($message);
+}
+
+$original_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$original_manager_permission = get_option('order_splitter_shop_manager_permission', 'no');
+$previous_user_id = get_current_user_id();
+
+$admin_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_transport_admin_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-transport-admin-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+$subscriber_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_transport_subscriber_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-transport-subscriber-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'subscriber',
+));
+wcos_p2_adapter_assert(!is_wp_error($admin_id) && !is_wp_error($subscriber_id), 'Unable to create Split transport test users.');
+
+$transport_product = wcos_p2_adapter_product('WCOS P2 transport product', '12.00');
+list($transport_source, $transport_item_id) = wcos_p2_adapter_order($transport_product, 4);
+$transport_source->set_billing_first_name('PrivateFirstNameProbe');
+$transport_source->set_billing_email('private-probe@example.test');
+$transport_source->save();
+$transport_source = wc_get_order($transport_source->get_id());
+$source_id = $transport_source->get_id();
+$source_signature_before = WCOS_Order_Contract_Snapshot::source_signature($transport_source);
+
+$controller = new WCOS_Split_Admin_Controller();
+$review_operations = array();
+
+try {
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    update_option('order_splitter_shop_manager_permission', 'no');
+    wp_set_current_user($admin_id);
+
+    wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Admin_Controller::REVIEW_ACTION), 'Split review AJAX transport was not bootstrapped.');
+    wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Admin_Controller::EXECUTE_ACTION), 'Split execute AJAX transport was not bootstrapped.');
+    wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Transport acceptance test unexpectedly found Split enabled.');
+
+    /* Strict parser rejects ambiguous or unsafe request shapes. */
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('new-order' => array($transport_item_id => '1.000000'))), $transport_source);
+        },
+        'Parser accepted a non-canonical child key.'
+    );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => 1))), $transport_source);
+        },
+        'Parser accepted a JSON numeric quantity instead of a decimal string.'
+    );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array('99999999' => '1.000000'))), $transport_source);
+        },
+        'Parser accepted an order item outside the source.'
+    );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '4.000000'))), $transport_source);
+        },
+        'Parser allowed a Split plan to consume the entire source line.'
+    );
+    wcos_p2_transport_expect_invalid_plan(
+        static function() use ($transport_source, $transport_item_id) {
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '1e0'))), $transport_source);
+        },
+        'Parser accepted scientific-notation quantity input.'
+    );
+
+    $nonce = wp_create_nonce('wcos_split_order_' . $source_id);
+    $plan_json = wp_json_encode(array('child-1' => array((string) $transport_item_id => '1.000000')));
+    $review = $controller->review_request(array(
+        'order_id' => $source_id,
+        'nonce' => $nonce,
+        'plan' => $plan_json,
+    ));
+    $review_operations[] = $review['operation_id'];
+    wcos_p2_adapter_assert(1 === preg_match('/^[0-9a-f-]{36}$/D', $review['operation_id']), 'Review did not return a server-generated operation UUID.');
+    wcos_p2_adapter_assert(is_string($review['confirmation_token']) && strlen($review['confirmation_token']) >= 32, 'Review did not return a strong confirmation token.');
+    wcos_p2_adapter_assert(!empty($review['preflight']['supported']), 'Review did not return a supported preflight.');
+    wcos_p2_adapter_assert(1 === (int) $review['summary']['child_count'], 'Review summary child count is wrong.');
+    wcos_p2_adapter_assert(1 === (int) $review['summary']['affected_line_count'], 'Review summary affected-line count is wrong.');
+    wcos_p2_adapter_assert('1.000000' === $review['summary']['moved_quantity'], 'Review summary moved quantity is wrong.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($source_id), $review['operation_id']), 'Read-only review created a mutation journal.');
+    wcos_p2_adapter_assert($source_signature_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source_id)), 'Read-only review changed the source order.');
+    wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($source_id, $review['operation_id'])), 'Read-only review created a child order.');
+
+    $review_json = wp_json_encode($review);
+    wcos_p2_adapter_assert(false === strpos($review_json, 'PrivateFirstNameProbe'), 'PII leaked into the review response.');
+    wcos_p2_adapter_assert(false === strpos($review_json, 'private-probe@example.test'), 'Billing email leaked into the review response.');
+
+    /* Execute endpoint is fully wired but must remain non-runnable while SPLIT=false. */
+    $disabled = wcos_p2_transport_expect(
+        'workflow_disabled',
+        static function() use ($controller, $source_id, $nonce, $review) {
+            $controller->execute_request(array(
+                'order_id' => $source_id,
+                'nonce' => $nonce,
+                'operation_id' => $review['operation_id'],
+                'confirmation_token' => $review['confirmation_token'],
+            ));
+        },
+        'Hard-off execute transport reached mutation runtime.'
+    );
+    wcos_p2_adapter_assert(503 === $disabled->get_http_status() && !$disabled->is_retryable(), 'Hard-off execute response semantics are incorrect.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($source_id), $review['operation_id']), 'Hard-off execute created a journal.');
+    wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($source_id, $review['operation_id'])), 'Hard-off execute created a child order.');
+    wcos_p2_adapter_assert($source_signature_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source_id)), 'Hard-off execute changed the source.');
+
+    /* Token binding rejects a different token before workflow gate evaluation. */
+    wcos_p2_transport_expect(
+        'confirmation_invalid_token',
+        static function() use ($controller, $source_id, $nonce, $review) {
+            $controller->execute_request(array(
+                'order_id' => $source_id,
+                'nonce' => $nonce,
+                'operation_id' => $review['operation_id'],
+                'confirmation_token' => 'different-confirmation-token',
+            ));
+        },
+        'Execute accepted a mismatched confirmation token.'
+    );
+
+    /* A source change invalidates review before any mutation begins. */
+    $review_changed = $controller->review_request(array(
+        'order_id' => $source_id,
+        'nonce' => $nonce,
+        'plan' => $plan_json,
+    ));
+    $review_operations[] = $review_changed['operation_id'];
+    $changed_source = wc_get_order($source_id);
+    $changed_source->set_customer_note('changed-after-review');
+    $changed_source->save();
+    wcos_p2_transport_expect(
+        'confirmation_source_changed',
+        static function() use ($controller, $source_id, $nonce, $review_changed) {
+            $controller->execute_request(array(
+                'order_id' => $source_id,
+                'nonce' => $nonce,
+                'operation_id' => $review_changed['operation_id'],
+                'confirmation_token' => $review_changed['confirmation_token'],
+            ));
+        },
+        'Execute accepted a source changed after review.'
+    );
+    $changed_source = wc_get_order($source_id);
+    $changed_source->set_customer_note('');
+    $changed_source->save();
+
+    /* Nonce, authorization, and configured order-status policy are independent gates. */
+    wcos_p2_transport_expect(
+        'invalid_nonce',
+        static function() use ($controller, $source_id, $plan_json) {
+            $controller->review_request(array('order_id' => $source_id, 'nonce' => 'invalid', 'plan' => $plan_json));
+        },
+        'Review accepted an invalid nonce.'
+    );
+
+    wp_set_current_user($subscriber_id);
+    $subscriber_nonce = wp_create_nonce('wcos_split_order_' . $source_id);
+    wcos_p2_transport_expect(
+        'authorization_failed',
+        static function() use ($controller, $source_id, $subscriber_nonce, $plan_json) {
+            $controller->review_request(array('order_id' => $source_id, 'nonce' => $subscriber_nonce, 'plan' => $plan_json));
+        },
+        'Subscriber was allowed to review a Split operation.'
+    );
+
+    wp_set_current_user($admin_id);
+    update_option('order_splitter_status_allowed', array('wc-processing'));
+    $status_nonce = wp_create_nonce('wcos_split_order_' . $source_id);
+    wcos_p2_transport_expect(
+        'status_disabled',
+        static function() use ($controller, $source_id, $status_nonce, $plan_json) {
+            $controller->review_request(array('order_id' => $source_id, 'nonce' => $status_nonce, 'plan' => $plan_json));
+        },
+        'Transport ignored the configured allowed-status policy.'
+    );
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+
+    /* Server-rendered dialog carries semantic labels and no address/customer PII. */
+    $fresh_source = wc_get_order($source_id);
+    $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($fresh_source);
+    $html = $controller->dialog_html($fresh_source, $preflight);
+    foreach (array(
+        'role="dialog"',
+        'aria-modal="true"',
+        'aria-labelledby=',
+        'role="status"',
+        'aria-live="polite"',
+        'role="alert"',
+        'wcos-split-confirm-checkbox',
+        'wcos-split-review-button',
+        'wcos-split-execute-button',
+        'for="wcos-split-quantity-',
+        'for="wcos-split-target-',
+        '>Child 10<',
+        'change stock directly in the database',
+    ) as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($html, $needle), 'Accessible Split dialog is missing required markup: ' . $needle);
+    }
+    wcos_p2_adapter_assert(false === strpos($html, 'PrivateFirstNameProbe'), 'Billing first name leaked into the Split dialog.');
+    wcos_p2_adapter_assert(false === strpos($html, 'private-probe@example.test'), 'Billing email leaked into the Split dialog.');
+
+    ob_start();
+    $controller->render_launcher($fresh_source);
+    $launcher_html = ob_get_clean();
+    wcos_p2_adapter_assert('' === $launcher_html, 'Production Split launcher rendered while the feature gate is hard-off.');
+} finally {
+    foreach ($review_operations as $operation_id) {
+        WCOS_Split_Confirmation_Store::delete($operation_id);
+    }
+    update_option('order_splitter_status_allowed', $original_allowed_statuses);
+    update_option('order_splitter_shop_manager_permission', $original_manager_permission);
+    wp_set_current_user($previous_user_id);
+    $transport_source = wc_get_order($source_id);
+    if ($transport_source instanceof WC_Order) {
+        $transport_source->delete(true);
+    }
+    wp_delete_post($transport_product->get_id(), true);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    if (!is_wp_error($admin_id)) {
+        wp_delete_user($admin_id);
+    }
+    if (!is_wp_error($subscriber_id)) {
+        wp_delete_user($subscriber_id);
+    }
+}
+
+echo "p2-admin-transport-accessibility-ok\n";

--- a/tests/integration/p2-confirmation-precision-smoke.php
+++ b/tests/integration/p2-confirmation-precision-smoke.php
@@ -1,0 +1,61 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$confirmation_precision_original = get_option('woocommerce_price_num_decimals', 2);
+$confirmation_precision_operation = '';
+$confirmation_precision_product_id = 0;
+$confirmation_precision_source_id = 0;
+
+try {
+    update_option('woocommerce_price_num_decimals', '3');
+    list($confirmation_precision_source, $confirmation_precision_product_id, $confirmation_precision_item_id) = wcos_p2_precision_build_order(
+        3,
+        'BHD',
+        '10.001',
+        '1.001'
+    );
+    $confirmation_precision_source_id = $confirmation_precision_source->get_id();
+    $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($confirmation_precision_source);
+    wcos_p2_adapter_assert(3 === (int) $preflight['price_precision'], 'Confirmation precision fixture was not reviewed at three decimals.');
+
+    $confirmation = WCOS_Split_Confirmation_Store::create(
+        $confirmation_precision_source,
+        array('child-1' => array($confirmation_precision_item_id => '1.000000')),
+        $preflight,
+        1
+    );
+    $confirmation_precision_operation = $confirmation['operation_id'];
+
+    update_option('woocommerce_price_num_decimals', '0');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Confirmation precision fixture did not change the ambient store precision.');
+
+    $verified = WCOS_Split_Confirmation_Store::verify(
+        wc_get_order($confirmation_precision_source_id),
+        $confirmation_precision_operation,
+        $confirmation['confirmation_token'],
+        1
+    );
+    wcos_p2_adapter_assert('confirmation' === $verified['replay_authority'], 'Pre-mutation confirmation unexpectedly used durable journal authority.');
+    wcos_p2_adapter_assert(3 === (int) $verified['price_precision'], 'Confirmation verification lost the reviewed three-decimal precision.');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Confirmation verification leaked its reviewed precision into ambient request state.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($confirmation_precision_source_id), $confirmation_precision_operation), 'Confirmation verification created a mutation journal.');
+} finally {
+    if ($confirmation_precision_operation) {
+        WCOS_Split_Confirmation_Store::delete($confirmation_precision_operation);
+    }
+    if ($confirmation_precision_source_id) {
+        $confirmation_precision_source = wc_get_order($confirmation_precision_source_id);
+        if ($confirmation_precision_source instanceof WC_Order) {
+            $confirmation_precision_source->delete(true);
+        }
+    }
+    if ($confirmation_precision_product_id) {
+        wp_delete_post($confirmation_precision_product_id, true);
+    }
+    update_option('woocommerce_price_num_decimals', $confirmation_precision_original);
+}
+
+echo "p2-confirmation-precision-ok\n";

--- a/tests/integration/p2-durable-replay-smoke.php
+++ b/tests/integration/p2-durable-replay-smoke.php
@@ -1,0 +1,181 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_replay_expect_transport($code, $http_status, callable $callback, $message) {
+    try {
+        $callback();
+    } catch (WCOS_Split_Transport_Exception $exception) {
+        wcos_p2_adapter_assert($code === $exception->get_error_code(), $message . ' Wrong code: ' . $exception->get_error_code());
+        wcos_p2_adapter_assert($http_status === $exception->get_http_status(), $message . ' Wrong HTTP status.');
+        return $exception;
+    }
+    throw new RuntimeException($message);
+}
+
+$replay_previous_user = get_current_user_id();
+$replay_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$replay_user_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_replay_admin_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-replay-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($replay_user_id), 'Unable to create durable replay test user.');
+
+$replay_product = wcos_p2_adapter_product('WCOS P2 durable replay', '11.00');
+list($replay_source, $replay_item_id) = wcos_p2_adapter_order($replay_product, 4);
+$replay_source_id = $replay_source->get_id();
+$replay_controller = new WCOS_Split_Admin_Controller();
+$replay_operation = '';
+
+try {
+    wp_set_current_user($replay_user_id);
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    $replay_nonce = wp_create_nonce('wcos_split_order_' . $replay_source_id);
+    $replay_plan = array('child-1' => array($replay_item_id => '1.000000'));
+
+    $review = $replay_controller->review_request(array(
+        'order_id' => $replay_source_id,
+        'nonce' => $replay_nonce,
+        'plan' => wp_json_encode(array('child-1' => array((string) $replay_item_id => '1.000000'))),
+    ));
+    $replay_operation = $review['operation_id'];
+
+    $fail_once = true;
+    $crash = static function($stage) use (&$fail_once) {
+        if ($fail_once && 'after_child_save' === $stage) {
+            $fail_once = false;
+            throw new RuntimeException('Injected durable replay crash.');
+        }
+    };
+    add_action('wcos_split_mutation_checkpoint', $crash, 10, 4);
+    $crashed = false;
+    try {
+        (new WCOS_Split_WooCommerce_Adapter())->split(
+            wc_get_order($replay_source_id),
+            $replay_plan,
+            $replay_operation,
+            $review['preflight']['price_precision']
+        );
+    } catch (RuntimeException $exception) {
+        $crashed = false !== strpos($exception->getMessage(), 'Injected durable replay crash.');
+    }
+    remove_action('wcos_split_mutation_checkpoint', $crash, 10);
+    wcos_p2_adapter_assert($crashed, 'Durable replay fixture did not crash at the intended boundary.');
+
+    $replay_source = wc_get_order($replay_source_id);
+    $journal = WCOS_Operation_Journal::get($replay_source, $replay_operation);
+    wcos_p2_adapter_assert(is_array($journal), 'Interrupted Split did not create a durable journal.');
+    wcos_p2_adapter_assert(!empty($journal['context']['plan']) && array_key_exists('price_precision', $journal['context']), 'Durable journal is missing replay plan or precision.');
+    $persisted_children = wcos_p2_adapter_children($replay_source_id, $replay_operation);
+    wcos_p2_adapter_assert(1 === count($persisted_children), 'Interrupted Split did not persist exactly one reusable child.');
+
+    /* Simulate confirmation TTL expiry: replay must now come from the journal. */
+    WCOS_Split_Confirmation_Store::delete($replay_operation);
+    $durable = WCOS_Split_Confirmation_Store::verify(
+        wc_get_order($replay_source_id),
+        $replay_operation,
+        '',
+        $replay_user_id
+    );
+    wcos_p2_adapter_assert('journal' === $durable['replay_authority'], 'Expired confirmation did not fall back to durable journal replay authority.');
+    wcos_p2_adapter_assert($replay_operation === $durable['operation_id'], 'Durable replay returned the wrong operation ID.');
+    wcos_p2_adapter_assert($journal['context']['plan'] === $durable['plan'], 'Durable replay did not return the journal plan exactly.');
+    wcos_p2_adapter_assert((int) $journal['context']['price_precision'] === (int) $durable['price_precision'], 'Durable replay did not return journal price precision.');
+
+    $hard_off = wcos_p2_replay_expect_transport(
+        'workflow_disabled',
+        503,
+        static function() use ($replay_controller, $replay_source_id, $replay_nonce, $replay_operation) {
+            $replay_controller->execute_request(array(
+                'order_id' => $replay_source_id,
+                'nonce' => $replay_nonce,
+                'operation_id' => $replay_operation,
+                'confirmation_token' => '',
+            ));
+        },
+        'Controller treated an expired confirmation as fatal even though a durable journal existed.'
+    );
+    wcos_p2_adapter_assert(!$hard_off->is_retryable(), 'Hard-off durable replay response became retryable.');
+
+    /* Direct adapter completion proves durable replay points to the reusable target set. */
+    $replayed_children = (new WCOS_Split_WooCommerce_Adapter())->split(
+        wc_get_order($replay_source_id),
+        $durable['plan'],
+        $replay_operation,
+        $durable['price_precision']
+    );
+    wcos_p2_adapter_assert(1 === count($replayed_children), 'Durable replay did not complete with one child.');
+    wcos_p2_adapter_assert($persisted_children[0]->get_id() === $replayed_children[0]->get_id(), 'Durable replay created a duplicate child.');
+    $journal = WCOS_Operation_Journal::get(wc_get_order($replay_source_id), $replay_operation);
+    wcos_p2_adapter_assert('completed' === $journal['status'], 'Durable replay did not complete the original journal.');
+
+    /* Manual reconciliation must override durable replay and receive HTTP 409. */
+    wcos_p2_adapter_assert(
+        WCOS_Operation_Journal::mark_manual_reconciliation(
+            wc_get_order($replay_source_id),
+            $replay_operation,
+            array('reason' => 'transport-replay-regression', 'automatic_compensation_allowed' => false)
+        ),
+        'Unable to place completed replay fixture into manual reconciliation.'
+    );
+    wcos_p2_replay_expect_transport(
+        'confirmation_manual_reconciliation',
+        409,
+        static function() use ($replay_controller, $replay_source_id, $replay_nonce, $replay_operation) {
+            $replay_controller->execute_request(array(
+                'order_id' => $replay_source_id,
+                'nonce' => $replay_nonce,
+                'operation_id' => $replay_operation,
+                'confirmation_token' => '',
+            ));
+        },
+        'Controller did not expose unresolved manual reconciliation as a conflict.'
+    );
+
+    wcos_p2_adapter_assert(
+        WCOS_Operation_Journal::mark_manual_reconciled(
+            wc_get_order($replay_source_id),
+            $replay_operation,
+            array('reconciliation_note' => 'durable-replay-test-resolved')
+        ),
+        'Unable to resolve durable replay manual reconciliation fixture.'
+    );
+    wcos_p2_replay_expect_transport(
+        'confirmation_operation_closed',
+        409,
+        static function() use ($replay_controller, $replay_source_id, $replay_nonce, $replay_operation) {
+            $replay_controller->execute_request(array(
+                'order_id' => $replay_source_id,
+                'nonce' => $replay_nonce,
+                'operation_id' => $replay_operation,
+                'confirmation_token' => '',
+            ));
+        },
+        'Controller allowed replay of a manually closed operation.'
+    );
+} finally {
+    if ($replay_operation) {
+        WCOS_Split_Confirmation_Store::delete($replay_operation);
+        wcos_p2_adapter_cleanup($replay_source_id, $replay_operation);
+    } else {
+        $source = wc_get_order($replay_source_id);
+        if ($source instanceof WC_Order) {
+            $source->delete(true);
+        }
+    }
+    wp_delete_post($replay_product->get_id(), true);
+    update_option('order_splitter_status_allowed', $replay_allowed_statuses);
+    wp_set_current_user($replay_previous_user);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    if (!is_wp_error($replay_user_id)) {
+        wp_delete_user($replay_user_id);
+    }
+}
+
+echo "p2-durable-replay-ok\n";

--- a/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
@@ -1,0 +1,75 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$crash_window_product = wcos_p2_adapter_product('WCOS P2 reconciliation crash window', '8.00', 30);
+list($crash_window_source, $crash_window_item_id) = wcos_p2_adapter_order($crash_window_product, 4);
+$crash_window_source_id = $crash_window_source->get_id();
+$crash_window_operation = 'p2-reconciliation-window-' . wp_generate_uuid4();
+$crash_window_adapter = new WCOS_Split_WooCommerce_Adapter();
+
+$crash_window_children = $crash_window_adapter->split(
+    $crash_window_source,
+    array('child-one' => array($crash_window_item_id => '1.000000')),
+    $crash_window_operation
+);
+wcos_p2_adapter_assert(1 === count($crash_window_children), 'Crash-window fixture did not create one Split child.');
+
+$crash_window_source = wc_get_order($crash_window_source_id);
+$crash_window_journal = WCOS_Operation_Journal::get($crash_window_source, $crash_window_operation);
+wcos_p2_adapter_assert(is_array($crash_window_journal) && 'completed' === $crash_window_journal['status'], 'Crash-window fixture did not reach completed before blocker injection.');
+
+/*
+ * Simulate the exact durability window: the fail-closed blocker is persisted,
+ * then the process dies before the journal can transition to
+ * manual_reconciliation. The older order-meta index is therefore still absent.
+ */
+wcos_p2_adapter_assert(
+    WCOS_Manual_Reconciliation_Blocker::block($crash_window_source, $crash_window_operation),
+    'Unable to persist the first-phase reconciliation blocker.'
+);
+$crash_window_source = wc_get_order($crash_window_source_id);
+wcos_p2_adapter_assert(
+    empty($crash_window_source->get_meta(WCOS_Operation_Journal::MANUAL_RECONCILIATION_META_KEY, true)),
+    'Crash-window fixture unexpectedly wrote the secondary journal index.'
+);
+$crash_window_journal = WCOS_Operation_Journal::get($crash_window_source, $crash_window_operation);
+wcos_p2_adapter_assert('completed' === $crash_window_journal['status'], 'First-phase blocker unexpectedly mutated the journal.');
+
+$blocked_report = $crash_window_adapter->preflight($crash_window_source);
+wcos_p2_adapter_assert(empty($blocked_report['supported']), 'Preflight missed a first-phase reconciliation blocker.');
+wcos_p2_adapter_assert('manual_reconciliation_required' === $blocked_report['reason'], 'Crash-window blocker used the wrong rejection reason.');
+wcos_p2_adapter_assert(
+    in_array($crash_window_operation, $blocked_report['manual_reconciliation_operation_ids'], true),
+    'Crash-window blocker did not expose its PII-free operation ID.'
+);
+
+/* Finish the interrupted transition and prove a later explicit resolution clears it. */
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal::mark_manual_reconciliation(
+        $crash_window_source,
+        $crash_window_operation,
+        array('reason' => 'two-phase-crash-window-test', 'automatic_compensation_allowed' => false)
+    ),
+    'Unable to finish the interrupted manual-reconciliation journal transition.'
+);
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal::mark_manual_reconciled(
+        wc_get_order($crash_window_source_id),
+        $crash_window_operation,
+        array('reconciliation_note' => 'two-phase-crash-window-resolved')
+    ),
+    'Unable to resolve the crash-window reconciliation fixture.'
+);
+
+$crash_window_source = wc_get_order($crash_window_source_id);
+$resolved_report = $crash_window_adapter->preflight($crash_window_source);
+wcos_p2_adapter_assert('manual_reconciliation_required' !== $resolved_report['reason'], 'Resolved crash-window blocker remained active.');
+wcos_p2_adapter_assert(!WCOS_Manual_Reconciliation_Blocker::has_active($crash_window_source), 'Resolved crash-window blocker was not lazily cleared by journal revision.');
+
+wcos_p2_adapter_cleanup($crash_window_source_id, $crash_window_operation);
+wp_delete_post($crash_window_product->get_id(), true);
+
+echo "p2-manual-reconciliation-crash-window-ok\n";

--- a/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
@@ -50,6 +50,18 @@ wcos_p2_adapter_assert(
     'Operator-facing reconciliation feedback omitted the blocking operation ID.'
 );
 
+/*
+ * If eager blocker cleanup ever fails after resolution, retention must not erase
+ * the only authoritative journal proof needed to clear that blocker later.
+ */
+$retention_guard_record = $crash_window_journal;
+$retention_guard_record['status'] = 'manual_reconciled';
+$retention_guard_record['completed_at'] = gmdate('c', time() - (100 * DAY_IN_SECONDS));
+wcos_p2_adapter_assert(
+    !WCOS_Operation_Journal_Retention::is_expired_terminal_record($retention_guard_record, time()),
+    'Retention considered a reconciled journal purgeable while its source blocker still existed.'
+);
+
 /* Finish the interrupted transition and prove a later explicit resolution clears it. */
 wcos_p2_adapter_assert(
     WCOS_Operation_Journal::mark_manual_reconciliation(

--- a/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
@@ -69,9 +69,21 @@ wcos_p2_adapter_assert(
 );
 
 $crash_window_source = wc_get_order($crash_window_source_id);
+wcos_p2_adapter_assert(
+    !WCOS_Manual_Reconciliation_Blocker::contains_operation($crash_window_source_id, $crash_window_operation),
+    'Explicit manual reconciliation did not eagerly clear its source-level blocker.'
+);
+$resolved_journal = WCOS_Operation_Journal::get($crash_window_source, $crash_window_operation);
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal_Retention::is_expired_terminal_record(
+        array_merge($resolved_journal, array('completed_at' => gmdate('c', time() - (100 * DAY_IN_SECONDS)))),
+        time()
+    ),
+    'Resolved reconciliation journal remained retention-blocked after its source blocker cleared.'
+);
 $resolved_report = $crash_window_adapter->preflight($crash_window_source);
 wcos_p2_adapter_assert('manual_reconciliation_required' !== $resolved_report['reason'], 'Resolved crash-window blocker remained active.');
-wcos_p2_adapter_assert(!WCOS_Manual_Reconciliation_Blocker::has_active($crash_window_source), 'Resolved crash-window blocker was not lazily cleared by journal revision.');
+wcos_p2_adapter_assert(!WCOS_Manual_Reconciliation_Blocker::has_active($crash_window_source), 'Resolved crash-window blocker remained active after eager clear.');
 
 wcos_p2_adapter_cleanup($crash_window_source_id, $crash_window_operation);
 wp_delete_post($crash_window_product->get_id(), true);

--- a/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-crash-window-smoke.php
@@ -45,6 +45,10 @@ wcos_p2_adapter_assert(
     in_array($crash_window_operation, $blocked_report['manual_reconciliation_operation_ids'], true),
     'Crash-window blocker did not expose its PII-free operation ID.'
 );
+wcos_p2_adapter_assert(
+    false !== strpos((string) $blocked_report['message'], $crash_window_operation),
+    'Operator-facing reconciliation feedback omitted the blocking operation ID.'
+);
 
 /* Finish the interrupted transition and prove a later explicit resolution clears it. */
 wcos_p2_adapter_assert(

--- a/tests/integration/p2-manual-reconciliation-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-smoke.php
@@ -6,38 +6,43 @@ if (!defined('ABSPATH')) {
 
 /*
  * Extreme fallback: an integration reports that physical stock was already
- * written after the hardened Split has passed persisted verification. The
- * adapter must convert even a completed journal into a durable
- * manual_reconciliation incident and block every later Split on the source.
+ * written after the hardened Split journal has completed but while the service
+ * still owns its source-order lease during best-effort order notes. The adapter
+ * must persist manual_reconciliation before that lease is released.
  */
 $manual_product = wcos_p2_adapter_product('WCOS P2 manual reconciliation', '8.00', 30);
 list($manual_source, $manual_item_id) = wcos_p2_adapter_order($manual_product, 4);
+$manual_source_id = $manual_source->get_id();
 $manual_operation = 'p2-manual-reconciliation-' . wp_generate_uuid4();
 $manual_injected = false;
+$lease_owned_during_injection = false;
 
-$manual_callback = static function($stage) use (&$manual_injected, $manual_product) {
-    if (!$manual_injected && 'after_persisted_verify' === $stage) {
-        $manual_injected = true;
-        WCOS_Stock_Side_Effect_Guard::record_product_stock_write($manual_product);
+$manual_callback = static function($note_id, $note_order) use (&$manual_injected, &$lease_owned_during_injection, $manual_product, $manual_source_id, $manual_operation) {
+    if ($manual_injected || !$note_order instanceof WC_Order) {
+        return;
     }
+    $manual_injected = true;
+    $lease_owned_during_injection = WCOS_Operation_Lock::is_current_owned_for($manual_source_id, $manual_operation);
+    WCOS_Stock_Side_Effect_Guard::record_product_stock_write($manual_product);
 };
-add_action('wcos_split_mutation_checkpoint', $manual_callback, 10, 4);
+add_action('woocommerce_order_note_added', $manual_callback, 10, 2);
 
 $manual_exception = false;
 try {
     (new WCOS_Split_WooCommerce_Adapter())->split(
-        wc_get_order($manual_source->get_id()),
+        wc_get_order($manual_source_id),
         array('child-one' => array($manual_item_id => '1.000000')),
         $manual_operation
     );
 } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
     $manual_exception = WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($exception->get_events());
 }
-remove_action('wcos_split_mutation_checkpoint', $manual_callback, 10);
+remove_action('woocommerce_order_note_added', $manual_callback, 10);
 
 wcos_p2_adapter_assert($manual_injected && $manual_exception, 'After-write fallback did not surface a manual-reconciliation exception.');
+wcos_p2_adapter_assert($lease_owned_during_injection, 'After-write evidence was injected after the Split service had already released its source lease.');
 
-$manual_source = wc_get_order($manual_source->get_id());
+$manual_source = wc_get_order($manual_source_id);
 $manual_record = WCOS_Operation_Journal::get($manual_source, $manual_operation);
 wcos_p2_adapter_assert(is_array($manual_record), 'Manual-reconciliation journal disappeared.');
 wcos_p2_adapter_assert('manual_reconciliation' === $manual_record['status'], 'Completed Split was not converted to manual_reconciliation.');

--- a/tests/integration/p2-manual-reconciliation-smoke.php
+++ b/tests/integration/p2-manual-reconciliation-smoke.php
@@ -1,0 +1,124 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+/*
+ * Extreme fallback: an integration reports that physical stock was already
+ * written after the hardened Split has passed persisted verification. The
+ * adapter must convert even a completed journal into a durable
+ * manual_reconciliation incident and block every later Split on the source.
+ */
+$manual_product = wcos_p2_adapter_product('WCOS P2 manual reconciliation', '8.00', 30);
+list($manual_source, $manual_item_id) = wcos_p2_adapter_order($manual_product, 4);
+$manual_operation = 'p2-manual-reconciliation-' . wp_generate_uuid4();
+$manual_injected = false;
+
+$manual_callback = static function($stage) use (&$manual_injected, $manual_product) {
+    if (!$manual_injected && 'after_persisted_verify' === $stage) {
+        $manual_injected = true;
+        WCOS_Stock_Side_Effect_Guard::record_product_stock_write($manual_product);
+    }
+};
+add_action('wcos_split_mutation_checkpoint', $manual_callback, 10, 4);
+
+$manual_exception = false;
+try {
+    (new WCOS_Split_WooCommerce_Adapter())->split(
+        wc_get_order($manual_source->get_id()),
+        array('child-one' => array($manual_item_id => '1.000000')),
+        $manual_operation
+    );
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+    $manual_exception = WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($exception->get_events());
+}
+remove_action('wcos_split_mutation_checkpoint', $manual_callback, 10);
+
+wcos_p2_adapter_assert($manual_injected && $manual_exception, 'After-write fallback did not surface a manual-reconciliation exception.');
+
+$manual_source = wc_get_order($manual_source->get_id());
+$manual_record = WCOS_Operation_Journal::get($manual_source, $manual_operation);
+wcos_p2_adapter_assert(is_array($manual_record), 'Manual-reconciliation journal disappeared.');
+wcos_p2_adapter_assert('manual_reconciliation' === $manual_record['status'], 'Completed Split was not converted to manual_reconciliation.');
+wcos_p2_adapter_assert(null === $manual_record['completed_at'], 'Manual-reconciliation state remained retention-terminal.');
+wcos_p2_adapter_assert(false === $manual_record['context']['automatic_compensation_allowed'], 'Manual reconciliation accidentally allowed automatic compensation.');
+wcos_p2_adapter_assert(
+    'completed' === $manual_record['context']['previous_status'],
+    'Manual-reconciliation journal did not preserve that the Split had already completed.'
+);
+wcos_p2_adapter_assert(WCOS_Operation_Journal::has_manual_reconciliation($manual_source), 'Order-level manual-reconciliation index was not persisted.');
+
+$manual_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($manual_source);
+wcos_p2_adapter_assert(empty($manual_report['supported']), 'Preflight allowed a source with unresolved manual reconciliation.');
+wcos_p2_adapter_assert('manual_reconciliation_required' === $manual_report['reason'], 'Manual-reconciliation preflight used the wrong rejection reason.');
+wcos_p2_adapter_assert(1 === (int) $manual_report['manual_reconciliation_count'], 'Preflight did not report the unresolved incident count.');
+wcos_p2_adapter_assert(
+    array($manual_operation) === $manual_report['manual_reconciliation_operation_ids'],
+    'Preflight did not expose the PII-free operation ID requiring reconciliation.'
+);
+
+$retry_rejected = false;
+try {
+    (new WCOS_Split_WooCommerce_Adapter())->split(
+        wc_get_order($manual_source->get_id()),
+        array('child-one' => array($manual_item_id => '1.000000')),
+        $manual_operation
+    );
+} catch (WCOS_Split_Preflight_Exception $exception) {
+    $retry_rejected = 'manual_reconciliation_required' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($retry_rejected, 'Retry auto-finalized an operation requiring manual reconciliation.');
+
+$new_operation_rejected = false;
+try {
+    (new WCOS_Split_WooCommerce_Adapter())->split(
+        wc_get_order($manual_source->get_id()),
+        array('child-two' => array($manual_item_id => '1.000000')),
+        'p2-manual-block-new-' . wp_generate_uuid4()
+    );
+} catch (WCOS_Split_Preflight_Exception $exception) {
+    $new_operation_rejected = 'manual_reconciliation_required' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($new_operation_rejected, 'A new Split bypassed an unresolved manual-reconciliation incident.');
+
+$now = time();
+wcos_p2_adapter_assert(
+    !WCOS_Operation_Journal_Retention::is_expired_terminal_record(
+        array('status' => 'manual_reconciliation', 'completed_at' => gmdate('c', $now - (400 * DAY_IN_SECONDS))),
+        $now
+    ),
+    'Manual-reconciliation journal became retention-purgeable.'
+);
+
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal::mark_manual_reconciled(
+        $manual_source,
+        $manual_operation,
+        array(
+            'reconciled_by_user_id' => 1,
+            'reconciliation_note' => 'integration-test-explicit-human-resolution',
+        )
+    ),
+    'Explicit manual-reconciled transition failed.'
+);
+$manual_source = wc_get_order($manual_source->get_id());
+$resolved = WCOS_Operation_Journal::get($manual_source, $manual_operation);
+wcos_p2_adapter_assert('manual_reconciled' === $resolved['status'], 'Manual reconciliation did not reach its resolved terminal state.');
+wcos_p2_adapter_assert(!empty($resolved['completed_at']), 'Resolved manual reconciliation has no terminal timestamp.');
+wcos_p2_adapter_assert(!WCOS_Operation_Journal::has_manual_reconciliation($manual_source), 'Resolved incident remained in the order-level blocking index.');
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal_Retention::is_expired_terminal_record(
+        array('status' => 'manual_reconciled', 'completed_at' => gmdate('c', $now - (100 * DAY_IN_SECONDS))),
+        $now
+    ),
+    'Resolved manual-reconciliation state is not eligible for normal terminal retention.'
+);
+
+$resolved_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($manual_source);
+wcos_p2_adapter_assert('manual_reconciliation_required' !== $resolved_report['reason'], 'Resolved incident still blocked preflight as unresolved.');
+
+wcos_p2_adapter_cleanup($manual_source->get_id(), $manual_operation);
+wp_delete_post($manual_product->get_id(), true);
+
+echo "p2-manual-reconciliation-state-ok\n";

--- a/tests/integration/p2-policy-replay-smoke.php
+++ b/tests/integration/p2-policy-replay-smoke.php
@@ -1,0 +1,107 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$policy_user_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_policy_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-policy-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($policy_user_id), 'Unable to create durable-policy test user.');
+
+$policy_product = wcos_p2_adapter_product('WCOS P2 durable policy authority', '5.00');
+list($policy_source, $policy_item_id) = wcos_p2_adapter_order($policy_product, 3);
+$policy_source_id = $policy_source->get_id();
+$policy_operation = wp_generate_uuid4();
+$policy_plan = array('child-1' => array($policy_item_id => '1.000000'));
+$policy_fingerprint = WCOS_Mutation_Fingerprint::create(
+    'split',
+    $policy_source_id,
+    array('plan' => $policy_plan, 'policy-test' => true)
+);
+
+wcos_p2_adapter_assert(
+    WCOS_Operation_Journal::start(
+        $policy_source,
+        $policy_operation,
+        'split',
+        array('plan' => $policy_plan),
+        $policy_fingerprint
+    ),
+    'Unable to start durable-policy journal fixture.'
+);
+
+$policy_source = wc_get_order($policy_source_id);
+$policy_record = WCOS_Operation_Journal::get($policy_source, $policy_operation);
+wcos_p2_adapter_assert(
+    isset($policy_record['context']['policy_version'])
+        && (int) $policy_record['context']['policy_version'] === (int) WCOS_Split_Preflight::POLICY_VERSION,
+    'Split journal did not capture the current preflight policy version.'
+);
+wcos_p2_adapter_assert(
+    array_key_exists('price_precision', $policy_record['context']),
+    'Split journal did not retain price precision alongside policy authority.'
+);
+
+$policy_replay = WCOS_Split_Confirmation_Store::verify(
+    $policy_source,
+    $policy_operation,
+    '',
+    $policy_user_id
+);
+wcos_p2_adapter_assert('journal' === $policy_replay['replay_authority'], 'Durable policy fixture did not replay from journal authority.');
+wcos_p2_adapter_assert(
+    (int) WCOS_Split_Preflight::POLICY_VERSION === (int) $policy_replay['policy_version'],
+    'Durable replay did not return its bound policy version.'
+);
+
+/* Journal mutation APIs must not be able to rewrite the captured safety policy. */
+wcos_p2_adapter_assert(
+    false === WCOS_Operation_Journal::checkpoint(
+        $policy_source,
+        $policy_operation,
+        'policy_tamper_attempt',
+        array('policy_version' => WCOS_Split_Preflight::POLICY_VERSION + 1)
+    ),
+    'Journal checkpoint rewrote immutable Split policy authority.'
+);
+$policy_record = WCOS_Operation_Journal::get(wc_get_order($policy_source_id), $policy_operation);
+wcos_p2_adapter_assert(
+    (int) WCOS_Split_Preflight::POLICY_VERSION === (int) $policy_record['context']['policy_version'],
+    'Immutable Split policy version changed after rejected checkpoint.'
+);
+
+/* Simulate a corrupted/legacy durable record whose policy no longer matches current code. */
+$journal_key = 'wcos_mutation_op_' . hash('sha256', absint($policy_source_id) . '|' . sanitize_key($policy_operation));
+$corrupt_record = $policy_record;
+$corrupt_record['context']['policy_version'] = WCOS_Split_Preflight::POLICY_VERSION + 1;
+update_option($journal_key, $corrupt_record, false);
+wp_cache_delete($journal_key, 'options');
+
+$policy_changed = false;
+try {
+    WCOS_Split_Confirmation_Store::verify(
+        wc_get_order($policy_source_id),
+        $policy_operation,
+        '',
+        $policy_user_id
+    );
+} catch (WCOS_Split_Confirmation_Exception $exception) {
+    $policy_changed = 'policy_changed' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($policy_changed, 'Durable replay crossed a changed Split safety policy.');
+
+update_option($journal_key, $policy_record, false);
+wp_cache_delete($journal_key, 'options');
+WCOS_Operation_Journal::delete(wc_get_order($policy_source_id), $policy_operation);
+$policy_source = wc_get_order($policy_source_id);
+if ($policy_source) {
+    $policy_source->delete(true);
+}
+wp_delete_post($policy_product->get_id(), true);
+wp_delete_user($policy_user_id);
+
+echo "p2-durable-policy-binding-ok\n";

--- a/tests/integration/p2-price-precision-smoke.php
+++ b/tests/integration/p2-price-precision-smoke.php
@@ -176,10 +176,19 @@ try {
     wcos_p2_adapter_assert($persisted_children[0]->get_id() === $retry_children[0]->get_id(), 'Precision retry created a duplicate child.');
     wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Mutation precision scope leaked after retry completion.');
 
-    $retry_source = wc_get_order($retry_source->get_id());
-    $retry_child = wc_get_order($retry_children[0]->get_id());
-    wcos_p2_precision_assert_conserved($retry_source, array($retry_child), $retry_before, 3);
-    $retry_record = WCOS_Operation_Journal::get($retry_source, $retry_operation);
+    /* Persisted-state verification must hydrate historical items under the captured precision. */
+    $verify_token = WCOS_Price_Precision_Scope::begin(3);
+    try {
+        $retry_source = wc_get_order($retry_source->get_id());
+        $retry_child = wc_get_order($retry_children[0]->get_id());
+        wcos_p2_precision_assert_conserved($retry_source, array($retry_child), $retry_before, 3);
+        WCOS_Order_Totals_Rebuilder::assert_consistent($retry_source, 3);
+        WCOS_Order_Totals_Rebuilder::assert_consistent($retry_child, 3);
+        $retry_record = WCOS_Operation_Journal::get($retry_source, $retry_operation);
+    } finally {
+        WCOS_Price_Precision_Scope::end($verify_token);
+    }
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Persisted-state verification leaked the mutation precision scope.');
     wcos_p2_adapter_assert('completed' === $retry_record['status'], 'Precision retry did not complete the original journal.');
     wcos_p2_adapter_assert(3 === (int) $retry_record['context']['price_precision'], 'Retry mutated the journal precision contract.');
 

--- a/tests/integration/p2-price-precision-smoke.php
+++ b/tests/integration/p2-price-precision-smoke.php
@@ -1,0 +1,192 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_precision_build_order($precision, $currency, $line_amount, $tax_amount) {
+    $precision = WCOS_Price_Precision_Scope::validate($precision);
+    $product = new WC_Product_Simple();
+    $product->set_name('WCOS P2 precision ' . $precision);
+    $product->set_regular_price($line_amount);
+    $product_id = $product->save();
+
+    $order = wc_create_order();
+    $order->set_status('pending');
+    $order->set_currency($currency);
+    $order->set_prices_include_tax(false);
+
+    $line = new WC_Order_Item_Product();
+    $line_result = $line->set_props(array(
+        'name' => 'Precision line',
+        'product_id' => $product_id,
+        'quantity' => '3.000000',
+        'tax_class' => '',
+        'subtotal' => $line_amount,
+        'total' => $line_amount,
+        'taxes' => array(
+            'subtotal' => array(700 + $precision => $tax_amount),
+            'total' => array(700 + $precision => $tax_amount),
+        ),
+        'subtotal_tax' => $tax_amount,
+        'total_tax' => $tax_amount,
+    ));
+    wcos_p2_adapter_assert(!is_wp_error($line_result), 'Unable to build the precision line item.');
+    $order->add_item($line);
+
+    $tax = new WC_Order_Item_Tax();
+    $tax_result = $tax->set_props(array(
+        'rate_id' => 700 + $precision,
+        'label' => 'Precision historical rate',
+        'compound' => false,
+        'tax_total' => $tax_amount,
+        'shipping_tax_total' => WCOS_Decimal::from_units(0, $precision),
+        'rate_percent' => 10,
+    ));
+    wcos_p2_adapter_assert(!is_wp_error($tax_result), 'Unable to build the precision tax row.');
+    $order->add_item($tax);
+
+    $grand_units = WCOS_Decimal::to_units($line_amount, $precision) + WCOS_Decimal::to_units($tax_amount, $precision);
+    $order_result = $order->set_props(array(
+        'discount_total' => WCOS_Decimal::from_units(0, $precision),
+        'discount_tax' => WCOS_Decimal::from_units(0, $precision),
+        'shipping_total' => WCOS_Decimal::from_units(0, $precision),
+        'shipping_tax' => WCOS_Decimal::from_units(0, $precision),
+        'cart_tax' => $tax_amount,
+        'total_tax' => $tax_amount,
+        'total' => WCOS_Decimal::from_units($grand_units, $precision),
+    ));
+    wcos_p2_adapter_assert(!is_wp_error($order_result), 'Unable to set precision order totals.');
+    $order->save();
+    return array(wc_get_order($order->get_id()), $product_id, $line->get_id());
+}
+
+function wcos_p2_precision_assert_conserved(WC_Order $source, array $children, array $before, $precision) {
+    $orders = array_merge(array($source), $children);
+    $after = WCOS_Order_Contract_Snapshot::aggregate($orders, $precision);
+    WCOS_Mutation_Contract::assert_conserved($before, $after, $precision);
+}
+
+$original_precision_option = get_option('woocommerce_price_num_decimals', 2);
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+
+try {
+    foreach (array(
+        array('precision' => 0, 'currency' => 'JPY', 'line' => '10', 'tax' => '1'),
+        array('precision' => 3, 'currency' => 'BHD', 'line' => '10.001', 'tax' => '1.001'),
+    ) as $case) {
+        update_option('woocommerce_price_num_decimals', (string) $case['precision']);
+        wcos_p2_adapter_assert($case['precision'] === wc_get_price_decimals(), 'WooCommerce did not expose the requested precision fixture.');
+
+        list($source, $product_id, $item_id) = wcos_p2_precision_build_order(
+            $case['precision'],
+            $case['currency'],
+            $case['line'],
+            $case['tax']
+        );
+        WCOS_Order_Totals_Rebuilder::assert_consistent($source, $case['precision']);
+        $before = WCOS_Order_Contract_Snapshot::aggregate(array($source), $case['precision']);
+        $operation = 'p2-price-precision-' . $case['precision'] . '-' . wp_generate_uuid4();
+        $report = $adapter->preflight($source, $operation);
+        wcos_p2_adapter_assert($case['precision'] === (int) $report['price_precision'], 'Preflight reported the wrong price precision.');
+
+        $children = $adapter->split(
+            $source,
+            array('child-one' => array($item_id => '1.000000')),
+            $operation
+        );
+        wcos_p2_adapter_assert(1 === count($children), 'Precision Split did not create exactly one child.');
+
+        $source = wc_get_order($source->get_id());
+        $child = wc_get_order($children[0]->get_id());
+        wcos_p2_precision_assert_conserved($source, array($child), $before, $case['precision']);
+        WCOS_Order_Totals_Rebuilder::assert_consistent($source, $case['precision']);
+        WCOS_Order_Totals_Rebuilder::assert_consistent($child, $case['precision']);
+
+        $record = WCOS_Operation_Journal::get($source, $operation);
+        wcos_p2_adapter_assert(
+            is_array($record) && $case['precision'] === (int) $record['context']['price_precision'],
+            'Durable journal did not capture the mutation price precision.'
+        );
+
+        if (0 === $case['precision']) {
+            foreach (array($source, $child) as $order) {
+                foreach ($order->get_items('line_item') as $line) {
+                    wcos_p2_adapter_assert(false === strpos((string) $line->get_total(), '.'), 'Zero-decimal Split persisted a fractional line total.');
+                }
+            }
+        } else {
+            $source_lines = $source->get_items('line_item');
+            $child_lines = $child->get_items('line_item');
+            $source_line = reset($source_lines);
+            $child_line = reset($child_lines);
+            wcos_p2_adapter_assert('6.667' === WCOS_Decimal::normalize($source_line->get_total(), 3), 'Three-decimal source allocation drifted.');
+            wcos_p2_adapter_assert('3.334' === WCOS_Decimal::normalize($child_line->get_total(), 3), 'Three-decimal child allocation drifted.');
+            wcos_p2_adapter_assert('0.667' === WCOS_Decimal::normalize($source_line->get_total_tax(), 3), 'Three-decimal source tax allocation drifted.');
+            wcos_p2_adapter_assert('0.334' === WCOS_Decimal::normalize($child_line->get_total_tax(), 3), 'Three-decimal child tax allocation drifted.');
+        }
+
+        wcos_p2_adapter_cleanup($source->get_id(), $operation);
+        wp_delete_post($product_id, true);
+    }
+
+    /* Retry must use the journal-captured precision, not the store setting at retry time. */
+    update_option('woocommerce_price_num_decimals', '3');
+    list($retry_source, $retry_product_id, $retry_item_id) = wcos_p2_precision_build_order(3, 'BHD', '10.001', '1.001');
+    $retry_before = WCOS_Order_Contract_Snapshot::aggregate(array($retry_source), 3);
+    $retry_operation = 'p2-price-precision-retry-' . wp_generate_uuid4();
+    $fail_once = true;
+    $crash = static function($stage) use (&$fail_once) {
+        if ($fail_once && 'after_child_save' === $stage) {
+            $fail_once = false;
+            throw new RuntimeException('Injected precision retry crash.');
+        }
+    };
+    add_action('wcos_split_mutation_checkpoint', $crash, 10, 4);
+    $crashed = false;
+    try {
+        $adapter->split(
+            $retry_source,
+            array('child-one' => array($retry_item_id => '1.000000')),
+            $retry_operation
+        );
+    } catch (RuntimeException $exception) {
+        $crashed = false !== strpos($exception->getMessage(), 'Injected precision retry crash');
+    }
+    remove_action('wcos_split_mutation_checkpoint', $crash, 10);
+    wcos_p2_adapter_assert($crashed, 'Precision retry fixture did not crash at the intended boundary.');
+
+    $retry_record = WCOS_Operation_Journal::get(wc_get_order($retry_source->get_id()), $retry_operation);
+    wcos_p2_adapter_assert(is_array($retry_record) && 3 === (int) $retry_record['context']['price_precision'], 'Interrupted operation did not capture three-decimal precision.');
+    $persisted_children = wcos_p2_adapter_children($retry_source->get_id(), $retry_operation);
+    wcos_p2_adapter_assert(1 === count($persisted_children), 'Precision crash did not preserve exactly one reusable child.');
+
+    update_option('woocommerce_price_num_decimals', '0');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Retry fixture did not change the ambient store precision.');
+    $retry_report = $adapter->preflight(wc_get_order($retry_source->get_id()), $retry_operation);
+    wcos_p2_adapter_assert(3 === (int) $retry_report['price_precision'], 'Retry preflight did not pin the journal-captured precision.');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Preflight precision scope leaked into the ambient request state.');
+
+    $retry_children = $adapter->split(
+        wc_get_order($retry_source->get_id()),
+        array('child-one' => array($retry_item_id => '1.000000')),
+        $retry_operation
+    );
+    wcos_p2_adapter_assert(1 === count($retry_children), 'Precision retry did not return one child.');
+    wcos_p2_adapter_assert($persisted_children[0]->get_id() === $retry_children[0]->get_id(), 'Precision retry created a duplicate child.');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Mutation precision scope leaked after retry completion.');
+
+    $retry_source = wc_get_order($retry_source->get_id());
+    $retry_child = wc_get_order($retry_children[0]->get_id());
+    wcos_p2_precision_assert_conserved($retry_source, array($retry_child), $retry_before, 3);
+    $retry_record = WCOS_Operation_Journal::get($retry_source, $retry_operation);
+    wcos_p2_adapter_assert('completed' === $retry_record['status'], 'Precision retry did not complete the original journal.');
+    wcos_p2_adapter_assert(3 === (int) $retry_record['context']['price_precision'], 'Retry mutated the journal precision contract.');
+
+    wcos_p2_adapter_cleanup($retry_source->get_id(), $retry_operation);
+    wp_delete_post($retry_product_id, true);
+} finally {
+    update_option('woocommerce_price_num_decimals', $original_precision_option);
+}
+
+echo "p2-price-precision-ok\n";

--- a/tests/integration/p2-review-confirmation-toctou-smoke.php
+++ b/tests/integration/p2-review-confirmation-toctou-smoke.php
@@ -34,7 +34,7 @@ $concurrent_item = $concurrent_source->get_item($review_item_id);
 $concurrent_item->set_quantity(6);
 $concurrent_item->save();
 
-$race_rejected = false;
+$after_preflight_rejected = false;
 try {
     WCOS_Split_Confirmation_Store::create(
         $review_source,
@@ -43,11 +43,39 @@ try {
         $review_user_id
     );
 } catch (WCOS_Split_Confirmation_Exception $exception) {
-    $race_rejected = 'source_changed' === $exception->get_reason();
+    $after_preflight_rejected = 'source_changed' === $exception->get_reason();
 }
 wcos_p2_adapter_assert(
-    $race_rejected,
-    'Confirmation token was issued after the source changed behind the reviewed plan.'
+    $after_preflight_rejected,
+    'Confirmation token was issued after the source changed behind a completed preflight.'
+);
+
+/*
+ * Now model the opposite intra-request ordering: strict parser used stale source
+ * A, a concurrent editor writes B, then fresh preflight observes B. A
+ * confirmation must still be rejected because the parser source does not equal
+ * the source that preflight reviewed.
+ */
+$fresh_preflight = $review_adapter->preflight(wc_get_order($review_source_id));
+wcos_p2_adapter_assert(!empty($fresh_preflight['supported']), 'Fresh concurrent source was not preflight-compatible for parser-race test.');
+wcos_p2_adapter_assert(
+    !hash_equals($review_preflight['source_signature'], $fresh_preflight['source_signature']),
+    'Concurrent order edit did not alter the PII-free source signature.'
+);
+$parser_race_rejected = false;
+try {
+    WCOS_Split_Confirmation_Store::create(
+        $review_source,
+        $review_plan,
+        $fresh_preflight,
+        $review_user_id
+    );
+} catch (WCOS_Split_Confirmation_Exception $exception) {
+    $parser_race_rejected = 'source_changed' === $exception->get_reason();
+}
+wcos_p2_adapter_assert(
+    $parser_race_rejected,
+    'Confirmation token was issued when strict parser and fresh preflight validated different source states.'
 );
 
 $review_source = wc_get_order($review_source_id);

--- a/tests/integration/p2-review-confirmation-toctou-smoke.php
+++ b/tests/integration/p2-review-confirmation-toctou-smoke.php
@@ -1,0 +1,58 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$review_user_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_review_race_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-review-race-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($review_user_id), 'Unable to create review-race test user.');
+
+$review_product = wcos_p2_adapter_product('WCOS P2 review confirmation race', '10.00');
+list($review_source, $review_item_id) = wcos_p2_adapter_order($review_product, 5);
+$review_source_id = $review_source->get_id();
+$review_adapter = new WCOS_Split_WooCommerce_Adapter();
+$review_preflight = $review_adapter->preflight($review_source);
+wcos_p2_adapter_assert(!empty($review_preflight['supported']), 'Review-race fixture failed initial preflight.');
+wcos_p2_adapter_assert(
+    !empty($review_preflight['source_signature']),
+    'PII-free reviewed source signature was not returned by preflight.'
+);
+$review_plan = array('child-1' => array($review_item_id => '1.000000'));
+
+/*
+ * Simulate a concurrent editor after server preflight/parser but before the
+ * confirmation store creates its operation identity. Keep the original order
+ * object stale exactly as the review controller would during this window.
+ */
+$concurrent_source = wc_get_order($review_source_id);
+$concurrent_item = $concurrent_source->get_item($review_item_id);
+$concurrent_item->set_quantity(6);
+$concurrent_item->save();
+
+$race_rejected = false;
+try {
+    WCOS_Split_Confirmation_Store::create(
+        $review_source,
+        $review_plan,
+        $review_preflight,
+        $review_user_id
+    );
+} catch (WCOS_Split_Confirmation_Exception $exception) {
+    $race_rejected = 'source_changed' === $exception->get_reason();
+}
+wcos_p2_adapter_assert(
+    $race_rejected,
+    'Confirmation token was issued after the source changed behind the reviewed plan.'
+);
+
+$review_source = wc_get_order($review_source_id);
+$review_source->delete(true);
+wp_delete_post($review_product->get_id(), true);
+wp_delete_user($review_user_id);
+
+echo "p2-review-confirmation-toctou-ok\n";

--- a/tests/integration/p2-stock-cancellation-lifecycle-smoke.php
+++ b/tests/integration/p2-stock-cancellation-lifecycle-smoke.php
@@ -1,0 +1,124 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_stock_lifecycle_assert_marker(WC_Order_Item_Product $item, $expected, $message) {
+    wcos_p2_adapter_assert(
+        WCOS_Decimal::to_units($expected, 6) === WCOS_Decimal::to_units($item->get_meta('_reduced_stock', true), 6),
+        $message
+    );
+}
+
+function wcos_p2_stock_lifecycle_quantity($product) {
+    $product = $product instanceof WC_Product ? wc_get_product($product->get_id()) : wc_get_product($product);
+    return $product ? WCOS_Decimal::normalize($product->get_stock_quantity(), 6) : null;
+}
+
+$adapter = new WCOS_Split_WooCommerce_Adapter();
+$manage_stock_before_lifecycle = get_option('woocommerce_manage_stock', 'yes');
+update_option('woocommerce_manage_stock', 'yes');
+
+try {
+    /* Variation-owned stock: cancellation restores each allocated share exactly once. */
+    list($variation_parent, $variation) = wcos_p2_stock_variable_pair('WCOS P2 variation cancellation', false, true, 0, 18);
+    list($variation_source, $variation_item_id) = wcos_p2_adapter_order($variation, 4);
+    $variation_source->update_status('processing');
+    $variation_source = wc_get_order($variation_source->get_id());
+    wcos_p2_adapter_assert('14.000000' === wcos_p2_stock_lifecycle_quantity($variation), 'Processing did not reduce variation-owned stock by four units.');
+    wcos_p2_stock_lifecycle_assert_marker($variation_source->get_item($variation_item_id), '4', 'Variation-owned processing order lacks the full reduced-stock marker.');
+
+    $variation_operation = 'p2-variation-cancel-' . wp_generate_uuid4();
+    $variation_children = $adapter->split(
+        $variation_source,
+        array('child-one' => array($variation_item_id => '1.000000')),
+        $variation_operation
+    );
+    $variation_source = wc_get_order($variation_source->get_id());
+    $variation_child = wc_get_order($variation_children[0]->get_id());
+    $variation_child_items = array_values($variation_child->get_items('line_item'));
+    wcos_p2_stock_lifecycle_assert_marker($variation_source->get_item($variation_item_id), '3', 'Variation-owned source marker was not reduced to three.');
+    wcos_p2_stock_lifecycle_assert_marker($variation_child_items[0], '1', 'Variation-owned child marker was not allocated one unit.');
+    wcos_p2_adapter_assert('14.000000' === wcos_p2_stock_lifecycle_quantity($variation), 'Split changed variation-owned physical stock.');
+
+    $variation_child->update_status('cancelled');
+    wcos_p2_adapter_assert('15.000000' === wcos_p2_stock_lifecycle_quantity($variation), 'Cancelling variation child did not restore exactly one unit.');
+    $variation_source->update_status('cancelled');
+    wcos_p2_adapter_assert('18.000000' === wcos_p2_stock_lifecycle_quantity($variation), 'Cancelling variation source did not restore exactly the residual three units.');
+    wcos_p2_adapter_cleanup($variation_source->get_id(), $variation_operation);
+    wcos_p2_stock_delete_product($variation);
+    wcos_p2_stock_delete_product($variation_parent);
+
+    /* Parent-managed variation: every restore must target the parent stock owner. */
+    list($parent_product, $parent_variation) = wcos_p2_stock_variable_pair('WCOS P2 parent cancellation', true, false, 25, 0);
+    wcos_p2_adapter_assert($parent_product->get_id() === $parent_variation->get_stock_managed_by_id(), 'Parent-managed lifecycle fixture has the wrong stock owner.');
+    list($parent_source, $parent_item_id) = wcos_p2_adapter_order($parent_variation, 4);
+    $parent_source->update_status('processing');
+    $parent_source = wc_get_order($parent_source->get_id());
+    wcos_p2_adapter_assert('21.000000' === wcos_p2_stock_lifecycle_quantity($parent_product), 'Processing did not reduce parent-owned stock by four units.');
+    wcos_p2_stock_lifecycle_assert_marker($parent_source->get_item($parent_item_id), '4', 'Parent-managed processing order lacks the full reduced-stock marker.');
+
+    $parent_operation = 'p2-parent-cancel-' . wp_generate_uuid4();
+    $parent_children = $adapter->split(
+        $parent_source,
+        array('child-one' => array($parent_item_id => '1.000000')),
+        $parent_operation
+    );
+    $parent_source = wc_get_order($parent_source->get_id());
+    $parent_child = wc_get_order($parent_children[0]->get_id());
+    $parent_child_items = array_values($parent_child->get_items('line_item'));
+    wcos_p2_stock_lifecycle_assert_marker($parent_source->get_item($parent_item_id), '3', 'Parent-managed source marker was not reduced to three.');
+    wcos_p2_stock_lifecycle_assert_marker($parent_child_items[0], '1', 'Parent-managed child marker was not allocated one unit.');
+    wcos_p2_adapter_assert('21.000000' === wcos_p2_stock_lifecycle_quantity($parent_product), 'Split changed parent-managed physical stock.');
+
+    $parent_child->update_status('cancelled');
+    wcos_p2_adapter_assert('22.000000' === wcos_p2_stock_lifecycle_quantity($parent_product), 'Cancelling parent-managed child did not restore one parent-owned unit.');
+    $parent_source->update_status('cancelled');
+    wcos_p2_adapter_assert('25.000000' === wcos_p2_stock_lifecycle_quantity($parent_product), 'Cancelling parent-managed source did not restore the residual parent-owned units.');
+    wcos_p2_adapter_cleanup($parent_source->get_id(), $parent_operation);
+    wcos_p2_stock_delete_product($parent_variation);
+    wcos_p2_stock_delete_product($parent_product);
+
+    /* Fractional managed stock under an explicit fractional-quantity integration contract. */
+    remove_filter('woocommerce_stock_amount', 'intval');
+    add_filter('woocommerce_stock_amount', 'floatval');
+
+    $fractional = wcos_p2_adapter_product('WCOS P2 fractional cancellation', '4.00', '10.500000');
+    list($fractional_source, $fractional_item_id) = wcos_p2_adapter_order($fractional, '3.500000');
+    $fractional_source->update_status('processing');
+    $fractional_source = wc_get_order($fractional_source->get_id());
+    wcos_p2_adapter_assert('7.000000' === wcos_p2_stock_lifecycle_quantity($fractional), 'Processing did not reduce fractional stock by 3.5 units.');
+    wcos_p2_stock_lifecycle_assert_marker($fractional_source->get_item($fractional_item_id), '3.500000', 'Fractional processing order lacks the 3.5 reduced-stock marker.');
+
+    $fractional_operation = 'p2-fractional-cancel-' . wp_generate_uuid4();
+    $fractional_children = $adapter->split(
+        $fractional_source,
+        array('child-one' => array($fractional_item_id => '1.250000')),
+        $fractional_operation
+    );
+    $fractional_source = wc_get_order($fractional_source->get_id());
+    $fractional_child = wc_get_order($fractional_children[0]->get_id());
+    $fractional_child_items = array_values($fractional_child->get_items('line_item'));
+    wcos_p2_stock_lifecycle_assert_marker($fractional_source->get_item($fractional_item_id), '2.250000', 'Fractional source marker was not reduced to 2.25.');
+    wcos_p2_stock_lifecycle_assert_marker($fractional_child_items[0], '1.250000', 'Fractional child marker was not allocated 1.25.');
+    wcos_p2_adapter_assert('7.000000' === wcos_p2_stock_lifecycle_quantity($fractional), 'Split changed fractional managed physical stock.');
+
+    $fractional_child->update_status('cancelled');
+    wcos_p2_adapter_assert('8.250000' === wcos_p2_stock_lifecycle_quantity($fractional), 'Cancelling fractional child did not restore exactly 1.25 units.');
+    $fractional_source->update_status('cancelled');
+    wcos_p2_adapter_assert('10.500000' === wcos_p2_stock_lifecycle_quantity($fractional), 'Cancelling fractional source did not restore the residual 2.25 units.');
+    wcos_p2_adapter_cleanup($fractional_source->get_id(), $fractional_operation);
+    wcos_p2_stock_delete_product($fractional);
+
+    remove_filter('woocommerce_stock_amount', 'floatval');
+    add_filter('woocommerce_stock_amount', 'intval');
+} finally {
+    if (has_filter('woocommerce_stock_amount', 'floatval')) {
+        remove_filter('woocommerce_stock_amount', 'floatval');
+        add_filter('woocommerce_stock_amount', 'intval');
+    }
+    update_option('woocommerce_manage_stock', $manage_stock_before_lifecycle);
+}
+
+echo "p2-stock-cancellation-lifecycle-ok\n";


### PR DESCRIPTION
## Classification

`P2_PRODUCTION_ENABLEMENT`

## Mission

Complete the production-readiness gates for the first reintroduced workflow: manual quantity Split, while keeping `WCOS_Feature_Gates::SPLIT` hard-off until a separate explicit Human Gate.

## Final reviewed architecture

Production write path:

`WCOS_Split_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`

The controller never instantiates the mutation service directly. `split_preflight()` is read-only and authorized; `split()` still asserts the production feature gate before entering the adapter/service.

## Completed production-readiness gates

### Persistent manual reconciliation

- authoritative `manual_reconciliation` and explicit `manual_reconciled` journal states;
- PII-free source-order blocker written before the journal transition, closing the blocker/journal crash window fail-closed;
- blocker bound to the journal revision observed when the incident occurred;
- stale reconciliation cannot clear a newer incident on the same operation;
- preflight blocks every later Split and exposes the unresolved operation ID(s) without customer PII;
- `manual_reconciled` eagerly clears the source blocker only after a newer authoritative journal revision proves resolution;
- retention preserves a resolved journal if blocker cleanup ever fails, so the resolution proof cannot disappear and leave a permanent orphan blocker;
- no automatic stock correction and no one-click resolve action; manual stock evidence review is required before resolution.

### Price precision and durable authority

- request-local `WCOS_Price_Precision_Scope`;
- durable operation-level `price_precision` capture and immutability;
- retry remains pinned to captured precision even if the ambient WooCommerce setting changes;
- zero-decimal, two-decimal, and three-decimal financial/tax conservation evidence;
- confirmation and journal precision must agree before replay.

### Safety-policy replay binding

- review confirmation is bound to `WCOS_Split_Preflight::POLICY_VERSION`;
- Split journal captures `policy_version` when the durable operation starts;
- `price_precision` and `policy_version` are immutable journal context;
- live confirmation must match durable journal policy once a journal exists;
- durable replay after transient expiry requires the recorded policy version;
- a changed safety policy fails closed with `policy_changed` rather than resuming under new semantics.

### Stock lifecycle

Acceptance covers:

- simple managed stock;
- unmanaged stock;
- variation-owned stock;
- parent-managed variation stock;
- backorders;
- explicitly enabled fractional managed stock;
- processing -> Split -> child cancellation -> residual source cancellation with exact `_reduced_stock` redistribution/restoration to the correct stock owner;
- Split itself performs no physical-stock write.

Direct database/raw-meta stock mutation that bypasses WooCommerce stock hooks remains unsupported unless a compatibility adapter supplies equivalent fail-closed evidence.

### Production transport

`WCOS_Split_Admin_Controller` implements review and execute AJAX transport with:

- order-specific nonce/CSRF protection;
- centralized mutation authorization;
- configured order-status boundary;
- strict server-side plan parser;
- server-generated operation UUID;
- HMAC-backed confirmation token;
- source/order/user/plan/precision/policy binding;
- durable journal replay after confirmation TTL once a mutation has started;
- structured HTTP/error/retry semantics;
- execute remains `workflow_disabled` while `SPLIT=false`.

Strict plan grammar includes child-1..child-10, <=10 children, <=500 assignments, <=64 KiB, item IDs belonging to the source order, decimal-string quantities only, <=6 decimals, no scientific notation, overflow rejection, fractional integration policy, and positive residual quantity on every affected source line.

### Review/confirmation concurrency safety

The final review closes both intra-request TOCTOU windows:

1. strict-parser source must equal fresh preflight `source_signature`;
2. confirmation store reload must still equal that same PII-free signature before operation UUID/token issuance.

Any later source edit is caught again by execute confirmation verification before mutation.

### Accessible confirmation UI

Server-rendered admin UI includes:

- semantic allocation table and labels;
- `role="dialog"`, `aria-modal`, labelled/described dialog;
- review-before-execute flow and explicit acknowledgement;
- live status and alert regions;
- focus trap, Escape close, focus return;
- DOM/text rendering without `innerHTML` or blocking `alert()`;
- result/audit links;
- disclosed fail-closed unsupported policies.

Client state hardening additionally proves:

- quantity matrix is frozen during async Review/Execute requests;
- editing quantities invalidates a prior confirmation;
- successful execution enters a terminal client state;
- `finally`/busy cleanup cannot re-enable Review, acknowledgement, Execute, or quantity inputs after success;
- reopening after success focuses the result region;
- non-retryable execute failures invalidate reviewed state.

## Independent review blockers found and fixed in this PR

The final review found and closed the following issues that were not exposed by the earlier green CI alone:

1. post-success `.finally(setBusy(false))` could re-enable completed UI controls;
2. quantity inputs remained editable during asynchronous Review, allowing visible quantities to diverge from the reviewed plan;
3. manual-reconciliation journal/index writes had a crash window that could create a false-negative preflight;
4. reconciliation blocker cleanup could lose authoritative proof after journal retention;
5. stale reconciliation could race with and clear a newer stock incident;
6. durable replay was not bound to the safety-policy version used when the operation started;
7. Review -> confirmation creation could issue a token after a concurrent source change;
8. strict parser and fresh preflight could validate different source states inside the same Review request.

Each finding now has a regression contract in the canonical WooCommerce integration matrix.

## Final acceptance evidence

Final reviewed head:

`3e713c99a1505cc788c5a7a72519271ad2e7c61c`

Canonical `CI` run **#543** completed successfully, including:

- PHP 7.4 / 8.1 / 8.3;
- architecture and hard-off contract;
- package safety;
- legacy order storage;
- HPOS-only;
- HPOS compatibility/sync;
- P1 recovery/failure/concurrency regressions;
- P2 adapter/stock/tax/payment/side-effect/metadata/retention suites;
- manual-reconciliation state, two-phase crash window, eager-clear/retention safeguards;
- 0/3-decimal precision and stock cancellation lifecycle;
- production admin transport and strict parser;
- client terminal-state / async quantity-freeze regression;
- durable policy replay binding;
- parser -> preflight -> confirmation TOCTOU regressions;
- `Required CI`.

## Production boundary / Human Gate

This PR is **technically accepted but intentionally remains draft** pending explicit Human Gate approval to merge.

It does **not** change `inc/domain/class-wcos-feature-gates.php`; all production mutation gates remain false, including `SPLIT`.

Merging this PR and enabling Split are two separate decisions. Even after this PR is approved for merge, `WCOS_Feature_Gates::SPLIT` must remain false until a separate final enablement diff is independently reviewed, passes CI, and receives explicit Human Gate approval.

Duplicate, category Split, stock-status Split, Merge, Return, and Bulk Return remain outside this production-enable milestone and stay hard-off.