### PR TITLE
P2: enable manual quantity Split in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: php tests/unit/run.php
 
   foundation-contract:
-    name: Architecture and hard-off contract
+    name: Architecture and approved production gate contract
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -66,7 +66,7 @@ jobs:
             exit 1
           fi
 
-      - name: Verify mutation runtime remains internally hard off
+      - name: Verify approved production gate state
         shell: bash
         run: |
           set -euo pipefail
@@ -77,8 +77,12 @@ jobs:
           test "$plugin_version" = "$stable_tag"
           grep -Fq 'Requires at least: 6.5' wc-order-splitter.php
           grep -Fq 'Requires at least: 6.5' readme.txt
-          grep -A2 -F 'public static function mutations_enabled()' inc/cores/safety.php | grep -Fq 'return false;'
-          grep -Fq 'private static $states = array(' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
+          grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::DUPLICATE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'Legacy mutation handlers are deliberately never loaded here.' inc/cores/script.php
 
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
@@ -123,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Validate release metadata and hard-off runtime
+      - name: Validate release metadata and production gate contract
         shell: bash
         run: |
           set -euo pipefail
@@ -133,8 +137,12 @@ jobs:
           test -n "$plugin_version"
           test -n "$stable_tag"
           test "$plugin_version" = "$stable_tag"
-          grep -A2 -F 'public static function mutations_enabled()' inc/cores/safety.php | grep -Fq 'return false;'
-          grep -Fq 'private static $states = array(' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
+          grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::DUPLICATE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           test ! -d inc/mutation-v2
 
           telemetry_host='yoexpress''.''top'
@@ -185,6 +193,22 @@ jobs:
             fi
           done
 
+          for required_path in \
+            'inc/backend/class-wcos-split-admin-controller.php' \
+            'inc/backend/class-wcos-split-confirmation-store.php' \
+            'inc/backend/class-wcos-split-request-parser.php' \
+            'inc/domain/class-wcos-feature-gates.php' \
+            'inc/domain/class-wcos-mutation-gateway.php' \
+            'inc/domain/class-wcos-split-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-split-order-service.php' \
+            'css/p2-split-admin.css' \
+            'js/p2-split-admin.js'; do
+            if test ! -e "$package_root/$required_path"; then
+              echo "Required production Split path is missing from package: $required_path" >&2
+              exit 1
+            fi
+          done
+
           if find "$package_root" -type l | grep -q .; then
             echo 'Release package must not contain symbolic links.' >&2
             exit 1
@@ -211,6 +235,11 @@ jobs:
           archive_stable_tag=$(unzip -p wc-order-splitter.zip wc-order-splitter/readme.txt | sed -n 's/^Stable tag: //p' | head -n 1)
           test -n "$archive_version"
           test "$archive_version" = "$archive_stable_tag"
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::SPLIT => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::DUPLICATE => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
             echo 'Development-only content entered the ZIP.' >&2
             exit 1
@@ -286,7 +315,7 @@ jobs:
           npx wp-env run cli wp option update woocommerce_custom_orders_table_enabled yes
           npx wp-env run cli wp option update woocommerce_custom_orders_table_data_sync_enabled yes
 
-      - name: Verify plugin, storage mode, and fail-closed runtime
+      - name: Verify plugin, storage mode, and Split-only production state
         shell: bash
         run: |
           set -euo pipefail
@@ -296,8 +325,17 @@ jobs:
             $expected = "${{ matrix.storage }}";
             $hpos = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
             if (("legacy" === $expected && $hpos) || ("legacy" !== $expected && !$hpos)) { exit(1); }
-            if (WCOS_Feature_Gates::any_enabled()) { exit(1); }
-            if (WC_Order_Splitter_Safety_Guard::mutations_enabled()) { exit(1); }
+            if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) { exit(1); }
+            if (!WCOS_Feature_Gates::any_enabled()) { exit(1); }
+            if (!WC_Order_Splitter_Safety_Guard::mutations_enabled()) { exit(1); }
+            foreach (array(
+              WCOS_Feature_Gates::DUPLICATE,
+              WCOS_Feature_Gates::MERGE,
+              WCOS_Feature_Gates::RETURN_ORDER,
+              WCOS_Feature_Gates::BULK_RETURN
+            ) as $disabled_workflow) {
+              if (WCOS_Feature_Gates::enabled($disabled_workflow)) { exit(1); }
+            }
             foreach (array(
               "WC_ORDER_SPLITTER_MUTATIONS_ENABLED",
               "WC_ORDER_SPLITTER_SPLIT_ENABLED",
@@ -308,6 +346,8 @@ jobs:
             ) as $legacy_gate) {
               if (defined($legacy_gate)) { exit(1); }
             }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
             $legacy_hooks = array(
               "wp_ajax_split_order",
               "wp_ajax_split_order_by_category",
@@ -319,7 +359,7 @@ jobs:
             foreach ($legacy_hooks as $hook) {
               if (false !== has_action($hook)) { exit(1); }
             }
-            echo "storage-and-safety-mode-ok\n";
+            echo "storage-and-split-production-state-ok\n";
           '
 
       - name: Verify mutation lease and durable journal controls

--- a/docs/p2-split-production-enablement.md
+++ b/docs/p2-split-production-enablement.md
@@ -1,0 +1,67 @@
+# P2 Manual Quantity Split — Final Production Enablement
+
+## Scope
+
+This change is the final gate-changing diff for the first production-enabled order mutation workflow.
+
+Approved state:
+
+- `WCOS_Feature_Gates::SPLIT = true`
+- `WCOS_Feature_Gates::DUPLICATE = false`
+- `WCOS_Feature_Gates::MERGE = false`
+- `WCOS_Feature_Gates::RETURN_ORDER = false`
+- `WCOS_Feature_Gates::BULK_RETURN = false`
+
+No legacy mutation handler may be loaded or restored.
+
+## Runtime authority
+
+Production Split writes must continue to use only:
+
+`WCOS_Split_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`
+
+The production gate remains internal code. Constants, options, filters, mu-plugins, or `wp-config.php` must not be able to enable another mutation workflow.
+
+`WC_Order_Splitter_Safety_Guard::mutations_enabled()` reflects the internal feature-gate set. It is not a second independently configurable gate.
+
+## Compatibility boundary
+
+The first enabled manual quantity Split intentionally remains fail-closed for unsupported cases already defined by P2 preflight, including:
+
+- coupons;
+- refunds / partial refunds;
+- negative fees;
+- nested Split;
+- unclassified or inconsistently classified private line metadata;
+- direct database/raw-meta stock mutation integrations without an explicit compatibility adapter.
+
+Fractional quantities are accepted only when the active WooCommerce quantity integration preserves fractional stock amounts.
+
+## CI transition
+
+The canonical CI contract changes from "all workflows hard-off" to "Split-only approved production state".
+
+CI must prove:
+
+- PHP 7.4 / 8.1 / 8.3 syntax and unit contracts;
+- `SPLIT=true` and every other mutation gate remains `false`;
+- no externally overrideable mutation gate exists;
+- legacy mutation handlers/hooks remain absent;
+- the package includes the hardened Split controller, confirmation store, parser, gateway, adapter, service, JS and CSS;
+- legacy / HPOS / HPOS-sync all report the Split-only gate state;
+- the complete prior hard-off P2 regression suite still passes inside a test-only simulated hard-off scope;
+- after restoring the real release gate map, production Review -> Confirm -> Gateway -> Adapter -> Service succeeds end-to-end;
+- production retry returns the original child set and does not change physical stock;
+- Duplicate, Merge, Return and Bulk Return remain blocked.
+
+## Human Gate
+
+This branch changes production behavior and must not be merged merely because the readiness foundation was previously accepted.
+
+Merge requires, on the exact final head:
+
+1. canonical `Required CI` green;
+2. independent review of the gate, safety-guard, CI/package and production transport diff;
+3. explicit Human Gate approval to enable manual quantity Split in production.
+
+Version and changelog are intentionally unchanged in this enablement milestone. Release/version bookkeeping remains a later release step.

--- a/inc/cores/safety.php
+++ b/inc/cores/safety.php
@@ -3,10 +3,12 @@
 defined('ABSPATH') || exit;
 
 /**
- * Emergency safety guard for order mutation workflows.
+ * Safety guard for production mutation workflows and unavailable settings.
  *
- * Version 1.4.12 deliberately fails closed while the mutation engine is rebuilt
- * around stock, monetary, line-identity, idempotency, and recovery invariants.
+ * The canonical workflow state lives in WCOS_Feature_Gates. This guard keeps
+ * the emergency fail-closed notice for builds where no production workflow is
+ * enabled and continues to protect settings routes that require unavailable
+ * Premium classes.
  */
 class WC_Order_Splitter_Safety_Guard {
 
@@ -16,7 +18,11 @@ class WC_Order_Splitter_Safety_Guard {
 	}
 
 	public static function mutations_enabled() {
-		return false;
+		if (!class_exists('WCOS_Feature_Gates')) {
+			return false;
+		}
+
+		return WCOS_Feature_Gates::any_enabled();
 	}
 
 	public function guard_unavailable_settings_sections() {
@@ -69,7 +75,7 @@ class WC_Order_Splitter_Safety_Guard {
 		<div class="notice notice-warning">
 			<p>
 				<strong><?php esc_html_e('Order Splitter safety mode is active.', 'wc-order-splitter'); ?></strong>
-				<?php esc_html_e('Order mutation actions are temporarily disabled in this release while their stock, totals, tax, and rollback guarantees are being hardened. Existing orders and split-order relationship metadata are not changed by this safety mode.', 'wc-order-splitter'); ?>
+				<?php esc_html_e('No order mutation workflow is currently enabled for production use. Existing orders and split-order relationship metadata are not changed by this safety mode.', 'wc-order-splitter'); ?>
 			</p>
 		</div>
 		<?php

--- a/inc/domain/class-wcos-feature-gates.php
+++ b/inc/domain/class-wcos-feature-gates.php
@@ -3,11 +3,12 @@
 defined('ABSPATH') || exit;
 
 /**
- * Central fail-closed workflow gates for the foundation release.
+ * Central fail-closed workflow gates.
  *
- * P1 is intentionally non-runnable from production controllers. Gate state is
- * internal code, not constants/options/filters, so another plugin, mu-plugin,
- * or wp-config.php cannot opt an unfinished workflow into production.
+ * Manual quantity Split is the first production-enabled mutation workflow.
+ * Every other mutation path remains internally hard-off. Gate state is code,
+ * not constants/options/filters, so another plugin, mu-plugin, or wp-config.php
+ * cannot opt an unfinished workflow into production.
  */
 final class WCOS_Feature_Gates {
 
@@ -18,7 +19,7 @@ final class WCOS_Feature_Gates {
 	const BULK_RETURN = 'bulk_return';
 
 	private static $states = array(
-		self::SPLIT => false,
+		self::SPLIT => true,
 		self::DUPLICATE => false,
 		self::MERGE => false,
 		self::RETURN_ORDER => false,

--- a/tests/integration/governance-smoke.php
+++ b/tests/integration/governance-smoke.php
@@ -19,7 +19,7 @@ function wcos_governance_expect_runtime(callable $callback, $message) {
 	throw new RuntimeException($message);
 }
 
-/* External configuration must never enable the unfinished P1 runtime. */
+/* External configuration must never alter the internally approved gate set. */
 foreach (array(
 	'WC_ORDER_SPLITTER_MUTATIONS_ENABLED',
 	'WC_ORDER_SPLITTER_SPLIT_ENABLED',
@@ -29,8 +29,17 @@ foreach (array(
 		define($constant, true);
 	}
 }
-wcos_governance_assert(!WCOS_Feature_Gates::any_enabled(), 'External constants enabled an unfinished workflow.');
-wcos_governance_assert(!WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety mode was externally overridden.');
+wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Approved manual quantity Split gate is not enabled.');
+wcos_governance_assert(WCOS_Feature_Gates::any_enabled(), 'Approved production workflow set was reported as entirely disabled.');
+wcos_governance_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved production gate set.');
+foreach (array(
+	WCOS_Feature_Gates::DUPLICATE,
+	WCOS_Feature_Gates::MERGE,
+	WCOS_Feature_Gates::RETURN_ORDER,
+	WCOS_Feature_Gates::BULK_RETURN,
+) as $disabled_workflow) {
+	wcos_governance_assert(!WCOS_Feature_Gates::enabled($disabled_workflow), 'An unapproved mutation workflow became production-enabled.');
+}
 
 $order = wc_create_order();
 $order->set_status('pending');
@@ -90,7 +99,7 @@ wcos_governance_expect_runtime(
 	static function() use ($gateway, $order) {
 		$gateway->duplicate($order, 'governance-disabled-' . wp_generate_uuid4());
 	},
-	'The mandatory gateway did not enforce the hard-off feature gate.'
+	'The mandatory gateway did not keep Duplicate hard-off.'
 );
 
 /* Public business metadata is copied; private metadata needs an explicit adapter. */

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -83,20 +83,45 @@ wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is mi
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
-require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
-require __DIR__ . '/p2-manual-reconciliation-smoke.php';
-require __DIR__ . '/p2-manual-reconciliation-crash-window-smoke.php';
-require __DIR__ . '/p2-price-precision-smoke.php';
-require __DIR__ . '/p2-stock-matrix-smoke.php';
-require __DIR__ . '/p2-stock-cancellation-lifecycle-smoke.php';
-require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
-require __DIR__ . '/p2-production-side-effect-smoke.php';
-require __DIR__ . '/p2-metadata-compatibility-smoke.php';
-require __DIR__ . '/p2-journal-retention-smoke.php';
-require __DIR__ . '/p2-admin-transport-smoke.php';
-require __DIR__ . '/p2-admin-client-state-smoke.php';
-require __DIR__ . '/p2-review-confirmation-toctou-smoke.php';
-require __DIR__ . '/p2-policy-replay-smoke.php';
-require __DIR__ . '/p2-durable-replay-smoke.php';
+/*
+ * Preserve the complete hard-off P2 regression suite even after the first
+ * production workflow is enabled. This Reflection scope is test-only: it
+ * temporarily restores the pre-enablement gate map, executes the previously
+ * accepted foundation contracts unchanged, then restores the real release map.
+ */
+$feature_gate_reflection = new ReflectionClass('WCOS_Feature_Gates');
+$feature_gate_states = $feature_gate_reflection->getProperty('states');
+$feature_gate_states->setAccessible(true);
+$release_gate_states = $feature_gate_states->getValue();
+$hard_off_gate_states = $release_gate_states;
+foreach ($hard_off_gate_states as $workflow => $enabled) {
+	$hard_off_gate_states[$workflow] = false;
+}
+$feature_gate_states->setValue(null, $hard_off_gate_states);
+
+try {
+	require __DIR__ . '/p2-quantity-split-adapter-smoke.php';
+	require __DIR__ . '/p2-manual-reconciliation-smoke.php';
+	require __DIR__ . '/p2-manual-reconciliation-crash-window-smoke.php';
+	require __DIR__ . '/p2-price-precision-smoke.php';
+	require __DIR__ . '/p2-stock-matrix-smoke.php';
+	require __DIR__ . '/p2-stock-cancellation-lifecycle-smoke.php';
+	require __DIR__ . '/p2-charge-tax-matrix-smoke.php';
+	require __DIR__ . '/p2-production-side-effect-smoke.php';
+	require __DIR__ . '/p2-metadata-compatibility-smoke.php';
+	require __DIR__ . '/p2-journal-retention-smoke.php';
+	require __DIR__ . '/p2-admin-transport-smoke.php';
+	require __DIR__ . '/p2-admin-client-state-smoke.php';
+	require __DIR__ . '/p2-review-confirmation-toctou-smoke.php';
+	require __DIR__ . '/p2-policy-replay-smoke.php';
+	require __DIR__ . '/p2-durable-replay-smoke.php';
+} finally {
+	$feature_gate_states->setValue(null, $release_gate_states);
+}
+
+wcos_control_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Release Split gate was not restored after hard-off regression scope.');
+wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not restore the production-enabled state.');
+
+require __DIR__ . '/p2-production-split-enabled-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/p2-production-split-enabled-smoke.php
+++ b/tests/integration/p2-production-split-enabled-smoke.php
@@ -1,0 +1,230 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_p2_enabled_expect_transport($code, $http_status, callable $callback, $message) {
+	try {
+		$callback();
+	} catch (WCOS_Split_Transport_Exception $exception) {
+		wcos_p2_adapter_assert($code === $exception->get_error_code(), $message . ' Wrong code: ' . $exception->get_error_code());
+		wcos_p2_adapter_assert($http_status === $exception->get_http_status(), $message . ' Wrong HTTP status.');
+		return $exception;
+	}
+	throw new RuntimeException($message);
+}
+
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Manual quantity Split is not production-enabled in the enablement contract.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::any_enabled(), 'Production gate set was reported as fully disabled.');
+wcos_p2_adapter_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved Split gate.');
+foreach (array(
+	WCOS_Feature_Gates::DUPLICATE,
+	WCOS_Feature_Gates::MERGE,
+	WCOS_Feature_Gates::RETURN_ORDER,
+	WCOS_Feature_Gates::BULK_RETURN,
+) as $disabled_workflow) {
+	wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled($disabled_workflow), 'An unapproved mutation workflow is enabled alongside Split.');
+}
+
+$enabled_previous_user = get_current_user_id();
+$enabled_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$enabled_manager_permission = get_option('order_splitter_shop_manager_permission', 'no');
+$enabled_manage_stock = get_option('woocommerce_manage_stock', 'yes');
+$enabled_operation = '';
+
+$enabled_admin_id = wp_insert_user(array(
+	'user_login' => 'wcos_p2_enabled_admin_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-p2-enabled-admin-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+$enabled_subscriber_id = wp_insert_user(array(
+	'user_login' => 'wcos_p2_enabled_subscriber_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-p2-enabled-subscriber-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'subscriber',
+));
+wcos_p2_adapter_assert(!is_wp_error($enabled_admin_id) && !is_wp_error($enabled_subscriber_id), 'Unable to create production Split transport users.');
+
+$enabled_product = wcos_p2_adapter_product('WCOS P2 production Split enabled', '12.00', 20);
+list($enabled_source, $enabled_item_id) = wcos_p2_adapter_order($enabled_product, 4, 'pending');
+$enabled_source_id = $enabled_source->get_id();
+$enabled_source->set_billing_first_name('ProductionPrivateProbe');
+$enabled_source->set_billing_email('production-private-probe@example.test');
+$enabled_source->save();
+$enabled_stock_before = wc_get_product($enabled_product->get_id())->get_stock_quantity();
+$enabled_controller = new WCOS_Split_Admin_Controller();
+
+try {
+	update_option('woocommerce_manage_stock', 'yes');
+	update_option('order_splitter_status_allowed', array('wc-pending'));
+	update_option('order_splitter_shop_manager_permission', 'no');
+	wp_set_current_user($enabled_admin_id);
+
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Admin_Controller::REVIEW_ACTION), 'Production Split review AJAX route is not registered.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Admin_Controller::EXECUTE_ACTION), 'Production Split execute AJAX route is not registered.');
+
+	$enabled_source = wc_get_order($enabled_source_id);
+	$enabled_nonce = wp_create_nonce('wcos_split_order_' . $enabled_source_id);
+	$enabled_plan_json = wp_json_encode(array(
+		'child-1' => array((string) $enabled_item_id => '1.000000'),
+		'child-2' => array((string) $enabled_item_id => '1.000000'),
+	));
+
+	wcos_p2_enabled_expect_transport(
+		'invalid_nonce',
+		403,
+		static function() use ($enabled_controller, $enabled_source_id, $enabled_plan_json) {
+			$enabled_controller->review_request(array(
+				'order_id' => $enabled_source_id,
+				'nonce' => 'invalid',
+				'plan' => $enabled_plan_json,
+			));
+		},
+		'Production review accepted an invalid nonce.'
+	);
+
+	wp_set_current_user($enabled_subscriber_id);
+	$subscriber_nonce = wp_create_nonce('wcos_split_order_' . $enabled_source_id);
+	wcos_p2_enabled_expect_transport(
+		'authorization_failed',
+		403,
+		static function() use ($enabled_controller, $enabled_source_id, $subscriber_nonce, $enabled_plan_json) {
+			$enabled_controller->review_request(array(
+				'order_id' => $enabled_source_id,
+				'nonce' => $subscriber_nonce,
+				'plan' => $enabled_plan_json,
+			));
+		},
+		'Production review accepted a subscriber.'
+	);
+
+	wp_set_current_user($enabled_admin_id);
+	$enabled_nonce = wp_create_nonce('wcos_split_order_' . $enabled_source_id);
+	$source_signature_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($enabled_source_id));
+
+	ob_start();
+	$enabled_controller->render_launcher(wc_get_order($enabled_source_id));
+	$launcher_html = ob_get_clean();
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'wcos-split-launcher'), 'Production Split launcher did not render after gate enablement.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-split-dialog-'), 'Production Split launcher is not bound to its dialog.');
+
+	$preflight = (new WCOS_Mutation_Gateway())->split_preflight(wc_get_order($enabled_source_id));
+	wcos_p2_adapter_assert(!empty($preflight['supported']), 'Production Gateway preflight rejected the valid source.');
+	$dialog_html = $enabled_controller->dialog_html(wc_get_order($enabled_source_id), $preflight);
+	wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Production Split dialog lost accessible dialog semantics.');
+	wcos_p2_adapter_assert(false === strpos($dialog_html, 'ProductionPrivateProbe'), 'Production Split dialog leaked billing PII.');
+	wcos_p2_adapter_assert(false === strpos($dialog_html, 'production-private-probe@example.test'), 'Production Split dialog leaked billing email PII.');
+
+	$review = $enabled_controller->review_request(array(
+		'order_id' => $enabled_source_id,
+		'nonce' => $enabled_nonce,
+		'plan' => $enabled_plan_json,
+	));
+	$enabled_operation = $review['operation_id'];
+	wcos_p2_adapter_assert(!empty($review['preflight']['supported']), 'Production review did not return a supported preflight.');
+	wcos_p2_adapter_assert(2 === (int) $review['summary']['child_count'], 'Production review lost the two-child plan.');
+	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($enabled_source_id), $enabled_operation), 'Read-only production review created a journal before confirmation.');
+	wcos_p2_adapter_assert($source_signature_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($enabled_source_id)), 'Read-only production review changed the source order.');
+
+	wcos_p2_enabled_expect_transport(
+		'confirmation_invalid_token',
+		403,
+		static function() use ($enabled_controller, $enabled_source_id, $enabled_nonce, $review) {
+			$enabled_controller->execute_request(array(
+				'order_id' => $enabled_source_id,
+				'nonce' => $enabled_nonce,
+				'operation_id' => $review['operation_id'],
+				'confirmation_token' => 'invalid-confirmation-token',
+			));
+		},
+		'Production execute accepted an invalid confirmation token.'
+	);
+
+	$result = $enabled_controller->execute_request(array(
+		'order_id' => $enabled_source_id,
+		'nonce' => $enabled_nonce,
+		'operation_id' => $review['operation_id'],
+		'confirmation_token' => $review['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $result['status'], 'Production controller did not report completed Split.');
+	wcos_p2_adapter_assert(2 === count($result['children']), 'Production controller did not return exactly two children.');
+
+	$enabled_source = wc_get_order($enabled_source_id);
+	$source_item = $enabled_source->get_item($enabled_item_id);
+	wcos_p2_adapter_assert(
+		WCOS_Decimal::to_units('2.000000', 6) === WCOS_Decimal::to_units($source_item->get_quantity(), 6),
+		'Production Split did not leave the expected source residual quantity.'
+	);
+	$children = wcos_p2_adapter_children($enabled_source_id, $enabled_operation);
+	wcos_p2_adapter_assert(2 === count($children), 'Production relation repository did not find exactly two children.');
+	$child_ids = array();
+	foreach ($children as $child) {
+		$child_ids[] = $child->get_id();
+		wcos_p2_adapter_assert('pending' === $child->get_status(), 'Production Split child did not remain pending.');
+		$child_items = array_values($child->get_items('line_item'));
+		wcos_p2_adapter_assert(1 === count($child_items), 'Production Split child has an unexpected line count.');
+		wcos_p2_adapter_assert(
+			WCOS_Decimal::to_units('1.000000', 6) === WCOS_Decimal::to_units($child_items[0]->get_quantity(), 6),
+			'Production Split child quantity is incorrect.'
+		);
+	}
+	sort($child_ids, SORT_NUMERIC);
+	wcos_p2_adapter_assert(2 === count(array_unique($child_ids)), 'Production Split returned duplicate child identities.');
+	wcos_p2_adapter_assert(
+		WCOS_Decimal::to_units($enabled_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($enabled_product->get_id())->get_stock_quantity(), 6),
+		'Production Split changed physical stock.'
+	);
+
+	$journal = WCOS_Operation_Journal::get($enabled_source, $enabled_operation);
+	wcos_p2_adapter_assert(is_array($journal) && 'completed' === $journal['status'], 'Production Split journal did not complete.');
+	wcos_p2_adapter_assert((int) WCOS_Split_Preflight::POLICY_VERSION === (int) $journal['context']['policy_version'], 'Production Split journal lost its policy-version authority.');
+	wcos_p2_adapter_assert(array_key_exists('price_precision', $journal['context']), 'Production Split journal lost its price precision.');
+
+	$retry_result = $enabled_controller->execute_request(array(
+		'order_id' => $enabled_source_id,
+		'nonce' => $enabled_nonce,
+		'operation_id' => $review['operation_id'],
+		'confirmation_token' => $review['confirmation_token'],
+	));
+	$retry_child_ids = array_map('absint', wp_list_pluck($retry_result['children'], 'id'));
+	sort($retry_child_ids, SORT_NUMERIC);
+	wcos_p2_adapter_assert($child_ids === $retry_child_ids, 'Production controller retry did not return the original child set.');
+	wcos_p2_adapter_assert(2 === count(wcos_p2_adapter_children($enabled_source_id, $enabled_operation)), 'Production controller retry created duplicate children.');
+	wcos_p2_adapter_assert(
+		WCOS_Decimal::to_units($enabled_stock_before, 6) === WCOS_Decimal::to_units(wc_get_product($enabled_product->get_id())->get_stock_quantity(), 6),
+		'Production controller retry changed physical stock.'
+	);
+
+	wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);
+	WCOS_Operation_Journal_Retention::maybe_schedule();
+	wcos_p2_adapter_assert(false !== wp_next_scheduled(WCOS_Operation_Journal_Retention::CRON_HOOK), 'Journal retention was not scheduled after a production workflow was enabled.');
+	wp_clear_scheduled_hook(WCOS_Operation_Journal_Retention::CRON_HOOK);
+} finally {
+	if ($enabled_operation) {
+		WCOS_Split_Confirmation_Store::delete($enabled_operation);
+		wcos_p2_adapter_cleanup($enabled_source_id, $enabled_operation);
+	} else {
+		$source = wc_get_order($enabled_source_id);
+		if ($source instanceof WC_Order) {
+			$source->delete(true);
+		}
+	}
+	wp_delete_post($enabled_product->get_id(), true);
+	update_option('order_splitter_status_allowed', $enabled_allowed_statuses);
+	update_option('order_splitter_shop_manager_permission', $enabled_manager_permission);
+	update_option('woocommerce_manage_stock', $enabled_manage_stock);
+	wp_set_current_user($enabled_previous_user);
+	if (!function_exists('wp_delete_user')) {
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+	}
+	if (!is_wp_error($enabled_admin_id)) {
+		wp_delete_user($enabled_admin_id);
+	}
+	if (!is_wp_error($enabled_subscriber_id)) {
+		wp_delete_user($enabled_subscriber_id);
+	}
+}
+
+echo "p2-production-split-enabled-ok\n";


### PR DESCRIPTION
## Classification

`P2_FINAL_SPLIT_ENABLEMENT`

## Mission

Enable only the hardened manual quantity Split workflow after the production-readiness foundation from PR #8 was merged to `main`.

## Exact gate-changing state

Final reviewed branch state:

- `WCOS_Feature_Gates::SPLIT = true`
- `WCOS_Feature_Gates::DUPLICATE = false`
- `WCOS_Feature_Gates::MERGE = false`
- `WCOS_Feature_Gates::RETURN_ORDER = false`
- `WCOS_Feature_Gates::BULK_RETURN = false`

No legacy mutation handler or legacy mutation hook is restored.

## Enablement boundary

Production writes remain exclusively:

`WCOS_Split_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`

The gate remains internal code and cannot be enabled by constants/options/filters. `WC_Order_Splitter_Safety_Guard::mutations_enabled()` now reflects the canonical internal feature-gate set rather than acting as a contradictory second hard-off gate.

## CI/test transition

The canonical contract changes from “all mutation workflows hard-off” to “Split-only approved production state”.

The complete prior hard-off P2 regression suite is preserved unchanged inside a test-only Reflection scope that temporarily restores the pre-enablement all-false gate map. A `finally` block restores the real release map before enabled-production acceptance runs.

After the real release state is restored, `p2-production-split-enabled-smoke.php` proves:

- Split launcher is rendered for an authorized supported order;
- nonce, capability and confirmation-token boundaries remain enforced;
- Review remains read-only;
- confirmed Execute reaches Controller -> Gateway -> Adapter -> Service;
- two requested child orders are created as pending with exact source residual quantities;
- physical stock is unchanged;
- durable journal reaches `completed` with policy-version and price-precision authority;
- retry returns the original child set without duplicate children or stock writes;
- journal retention schedules once a production mutation workflow is enabled;
- Duplicate / Merge / Return / Bulk Return remain hard-off.

Package CI additionally proves that the distributable ZIP contains the hardened Split controller, confirmation store, parser, gateway, adapter, service, JS and CSS, while legacy handlers and development-only files remain excluded.

## Final reviewed diff

The gate-changing PR is intentionally narrow: 7 changed files / 7 commits. It changes only:

- canonical feature-gate state;
- safety-guard semantics;
- CI production-state assertions/package contract;
- governance acceptance;
- test harness for preserving hard-off regressions;
- enabled production end-to-end acceptance;
- final enablement contract documentation.

The accepted mutation engine, adapter, controller and confirmation implementation from PR #8 are not refactored in this PR.

## Final acceptance evidence

Final reviewed head:

`a85d9a1ec620cc8a93778673848fcc14edfd4dbb`

Canonical CI **#545** (`32211535520`) completed successfully on this exact head:

- PHP 7.4 ✅
- PHP 8.1 ✅
- PHP 8.3 ✅
- Architecture and approved production gate contract ✅
- Package safety contract ✅
- WooCommerce 11.0.1 legacy storage ✅
- WooCommerce 11.0.1 HPOS-only ✅
- WooCommerce 11.0.1 HPOS compatibility/sync ✅
- prior P1/P2 failure/recovery/concurrency regressions ✅
- prior hard-off P2 regression suite under test-only gate scope ✅
- enabled production Controller -> Gateway -> Adapter -> Service flow ✅
- production retry/idempotency/stock-no-write proof ✅
- `Required CI` ✅

Independent review of the exact final diff found no remaining blocker requiring a code change. The production engine path remains the already accepted PR #8 implementation; this PR only changes its internal production gate and the contracts needed to prove that state.

## Production boundary / Human Gate

This PR is **technically accepted but intentionally remains draft** because merging it turns on production behavior.

`main` still has `WCOS_Feature_Gates::SPLIT = false` until this PR is merged.

Merge requires a separate explicit Human Gate approval for this exact head. Version and changelog remain intentionally unchanged here; release/version bookkeeping is a later release step.