### PR TITLE
P2: harden Duplicate production readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,11 @@ jobs:
 
           grep -Fq 'WCOS_Feature_Gates::assert_enabled' inc/domain/class-wcos-mutation-gateway.php
           grep -Fq 'WCOS_Order_Mutation_Authorizer::assert_workflow' inc/domain/class-wcos-mutation-gateway.php
+          grep -Fq 'new WCOS_Duplicate_WooCommerce_Adapter' inc/domain/class-wcos-mutation-gateway.php
+          grep -Fq 'class-wcos-duplicate-preflight.php' inc/cores/script.php
+          grep -Fq 'class-wcos-duplicate-woocommerce-adapter.php' inc/cores/script.php
+          grep -Fq 'class-wcos-duplicate-confirmation-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-duplicate-admin-controller.php' inc/cores/script.php
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -202,9 +207,16 @@ jobs:
             'inc/domain/class-wcos-split-woocommerce-adapter.php' \
             'inc/domain/class-wcos-split-order-service.php' \
             'css/p2-split-admin.css' \
-            'js/p2-split-admin.js'; do
+            'js/p2-split-admin.js' \
+            'inc/backend/class-wcos-duplicate-admin-controller.php' \
+            'inc/backend/class-wcos-duplicate-confirmation-store.php' \
+            'inc/domain/class-wcos-duplicate-preflight.php' \
+            'inc/domain/class-wcos-duplicate-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-duplicate-order-service.php' \
+            'css/p2-duplicate-admin.css' \
+            'js/p2-duplicate-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
-              echo "Required production Split path is missing from package: $required_path" >&2
+              echo "Required hardened mutation path is missing from package: $required_path" >&2
               exit 1
             fi
           done
@@ -240,6 +252,10 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-duplicate-admin-controller.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-duplicate-woocommerce-adapter.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-duplicate-admin.js'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-duplicate-admin.css'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
             echo 'Development-only content entered the ZIP.' >&2
             exit 1
@@ -348,6 +364,8 @@ jobs:
             }
             if (false === has_action("wp_ajax_" . WCOS_Split_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false === has_action("wp_ajax_" . WCOS_Split_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Duplicate_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Duplicate_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
             $legacy_hooks = array(
               "wp_ajax_split_order",
               "wp_ajax_split_order_by_category",

--- a/css/p2-duplicate-admin.css
+++ b/css/p2-duplicate-admin.css
@@ -1,0 +1,116 @@
+body.wcos-duplicate-modal-open {
+    overflow: hidden;
+}
+
+.wcos-duplicate-launcher-description {
+    margin-left: 8px;
+}
+
+.wcos-duplicate-dialog[hidden] {
+    display: none;
+}
+
+.wcos-duplicate-dialog {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.wcos-duplicate-dialog__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.wcos-duplicate-dialog__panel {
+    position: relative;
+    width: min(760px, 100%);
+    max-height: calc(100vh - 48px);
+    overflow: auto;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    padding: 24px;
+}
+
+.wcos-duplicate-dialog__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.wcos-duplicate-dialog__header h2 {
+    margin-top: 0;
+}
+
+.wcos-duplicate-close {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 28px;
+    line-height: 1;
+}
+
+.wcos-duplicate-policy {
+    margin-top: 20px;
+    padding: 12px 16px;
+    border-left: 4px solid #646970;
+    background: #f6f7f7;
+}
+
+.wcos-duplicate-policy h3,
+.wcos-duplicate-review h3 {
+    margin-top: 0;
+}
+
+.wcos-duplicate-confirm-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-weight: 600;
+}
+
+.wcos-duplicate-status,
+.wcos-duplicate-error,
+.wcos-duplicate-result,
+.wcos-duplicate-review {
+    margin-top: 16px;
+}
+
+.wcos-duplicate-error,
+.wcos-duplicate-result {
+    padding: 10px 12px;
+}
+
+.wcos-duplicate-dialog__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #dcdcde;
+}
+
+@media (max-width: 782px) {
+    .wcos-duplicate-dialog {
+        padding: 12px;
+    }
+
+    .wcos-duplicate-dialog__panel {
+        max-height: calc(100vh - 24px);
+        padding: 16px;
+    }
+
+    .wcos-duplicate-dialog__actions {
+        flex-direction: column-reverse;
+    }
+
+    .wcos-duplicate-dialog__actions .button {
+        width: 100%;
+        min-height: 44px;
+    }
+}

--- a/docs/p2-duplicate-production-readiness.md
+++ b/docs/p2-duplicate-production-readiness.md
@@ -42,7 +42,7 @@ The first hardened Duplicate rejects before mutation when it cannot prove compat
 - unsupported fractional quantities when the active WooCommerce quantity integration no longer preserves fractional stock amounts;
 - internally inconsistent historical totals/taxes.
 
-Deleted catalog products remain supported because persisted historical order-item state is authoritative.
+Deleted catalog products remain supported because persisted historical order-item state is authoritative. Paid source orders are supported, but their Duplicate target remains pending and never inherits the source transaction ID, `date_paid`, or stock-reduced state.
 
 ## Historical item integrity
 
@@ -54,7 +54,7 @@ Aggregate monetary equality is not sufficient for Duplicate. The service verifie
 - tax rate ID/label/compound/rate percent/cart/shipping tax totals and business metadata;
 - coupon code/discount/discount-tax and business metadata.
 
-Persisted item IDs must be fresh and may never be re-parented from the source order.
+Persisted item IDs must be fresh and may never be re-parented from the source order. Configured lines sharing a product ID remain distinct when an explicit metadata adapter classifies their private business metadata consistently for Duplicate and canonical identity.
 
 ## Review -> confirmation -> execute
 
@@ -67,9 +67,21 @@ The read-only Review endpoint requires:
 
 The server creates the operation UUID and short-lived confirmation token. The stored record contains only the token HMAC plus source/user/signature/price-precision/policy authority.
 
-Execute re-verifies the same nonce, authorization, source signature, user, token, price precision and Duplicate policy before any mutation. Once a durable journal exists, it becomes replay authority after confirmation expiry.
+Source authority is checked across every pre-mutation boundary:
+
+1. the source object used by Review must match the fresh preflight `source_signature`;
+2. confirmation creation reloads the source under the reviewed price precision and requires the same signature;
+3. Execute confirmation verification reloads and rechecks the source before mutation;
+4. for a new operation without a durable journal, confirmation verification publishes only the verified PII-free source hash into request-local authority;
+5. the WooCommerce adapter reloads the source again immediately before preflight/service and must still match that verified hash.
+
+The last check closes the narrow confirmation-verify -> adapter/service TOCTOU window. Once a durable journal exists, the journal becomes replay authority and the request-local transient signature is deliberately not used.
+
+Execute also re-verifies the same nonce, authorization, user, token, price precision and Duplicate policy before any mutation. Once a durable journal exists, it becomes replay authority after confirmation expiry.
 
 `DUPLICATE=false` means Execute returns `workflow_disabled` and does not create a journal or target order in this readiness milestone.
+
+The same request-local post-verification source authority was applied to the already production-enabled manual quantity Split path after independent review found the shared boundary issue; the canonical integration matrix protects both workflows.
 
 ## Stock / side-effect contract
 
@@ -88,6 +100,8 @@ Acceptance requires:
 ## Precision and durable replay
 
 Duplicate executes under request-local `WCOS_Price_Precision_Scope`. The durable journal captures immutable `price_precision` and Duplicate preflight `policy_version`.
+
+`WCOS_Duplicate_Order_Service::POLICY_VERSION` and `WCOS_Duplicate_Preflight::POLICY_VERSION` are one production authority and are locked together by a unit contract so service fingerprint semantics cannot drift from review/confirmation semantics.
 
 Acceptance covers 0-, 2- and 3-decimal historical order values. An interrupted operation must replay using journal precision/policy even if the ambient store precision changes. A changed durable policy fails closed instead of replaying under new semantics.
 

--- a/docs/p2-duplicate-production-readiness.md
+++ b/docs/p2-duplicate-production-readiness.md
@@ -1,0 +1,104 @@
+# P2 Hardened Duplicate — Production Readiness Contract
+
+## Status
+
+This milestone prepares hardened single-order Duplicate for production while `WCOS_Feature_Gates::DUPLICATE` remains `false`.
+
+Manual quantity Split remains the only production-enabled mutation workflow. Duplicate requires a separate final gate-changing PR and Human Gate after this readiness foundation is accepted.
+
+## Production path
+
+All future production Duplicate writes must use only:
+
+`WCOS_Duplicate_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Duplicate_WooCommerce_Adapter -> WCOS_Duplicate_Order_Service`
+
+Legacy `order-duplicate-option.php` and `actions/duplicate-order.php` remain unbootstrapped and excluded from the release package.
+
+## First hardened Duplicate policy
+
+The target order:
+
+- is a fresh WooCommerce order in `pending` status;
+- copies core customer, address, currency, payment-method and customer-note context;
+- copies historical line, shipping, fee, tax and coupon rows exactly through fresh `WC_Order_Item` objects;
+- does not copy the source transaction ID;
+- does not copy the source paid state;
+- does not copy order-level stock-reduced state;
+- does not copy line `_reduced_stock` state;
+- does not copy arbitrary custom order-level metadata outside the explicitly copied core fields;
+- records only internal Duplicate source/operation relation metadata.
+
+The request itself must not write physical product stock.
+
+## Fail-closed compatibility boundary
+
+The first hardened Duplicate rejects before mutation when it cannot prove compatibility, including:
+
+- refunds or partial refunds;
+- unresolved manual-reconciliation stock evidence on the source;
+- unclassified private order-item metadata;
+- inconsistent private line-item business/identity metadata classification;
+- non-canonical business metadata values;
+- unsupported fractional quantities when the active WooCommerce quantity integration no longer preserves fractional stock amounts;
+- internally inconsistent historical totals/taxes.
+
+Deleted catalog products remain supported because persisted historical order-item state is authoritative.
+
+## Historical item integrity
+
+Aggregate monetary equality is not sufficient for Duplicate. The service verifies exact multisets of cloned item semantics for:
+
+- product/variation identity, quantity, tax class, historical subtotal/total/tax arrays and business metadata;
+- shipping method ID, instance ID, title, totals, taxes and business metadata;
+- fee amount, tax class/status, totals, taxes and business metadata;
+- tax rate ID/label/compound/rate percent/cart/shipping tax totals and business metadata;
+- coupon code/discount/discount-tax and business metadata.
+
+Persisted item IDs must be fresh and may never be re-parented from the source order.
+
+## Review -> confirmation -> execute
+
+The read-only Review endpoint requires:
+
+- order-specific nonce;
+- centralized mutation authorization;
+- configured allowed order status;
+- PII-free Duplicate preflight.
+
+The server creates the operation UUID and short-lived confirmation token. The stored record contains only the token HMAC plus source/user/signature/price-precision/policy authority.
+
+Execute re-verifies the same nonce, authorization, source signature, user, token, price precision and Duplicate policy before any mutation. Once a durable journal exists, it becomes replay authority after confirmation expiry.
+
+`DUPLICATE=false` means Execute returns `workflow_disabled` and does not create a journal or target order in this readiness milestone.
+
+## Stock / side-effect contract
+
+Acceptance requires:
+
+- no physical-stock write for a normal Duplicate;
+- WooCommerce pre-write stock attempts inside the Duplicate request are blocked before persistence;
+- confirmed after-write stock evidence enters persistent `manual_reconciliation` and blocks later mutations;
+- exactly one WooCommerce new-order event for the target;
+- at most one active `order.created` webhook scheduling for the target;
+- no implicit target status transition;
+- no implicit email;
+- exactly one best-effort operation note on source and target for a successful first execution;
+- completed retry reuses the same target and does not repeat new-order/webhook/email/note/stock side effects.
+
+## Precision and durable replay
+
+Duplicate executes under request-local `WCOS_Price_Precision_Scope`. The durable journal captures immutable `price_precision` and Duplicate preflight `policy_version`.
+
+Acceptance covers 0-, 2- and 3-decimal historical order values. An interrupted operation must replay using journal precision/policy even if the ambient store precision changes. A changed durable policy fails closed instead of replaying under new semantics.
+
+## Enablement gate
+
+This readiness PR does not authorize `WCOS_Feature_Gates::DUPLICATE = true`.
+
+A later exact gate-changing diff requires:
+
+1. this readiness foundation merged with `DUPLICATE=false`;
+2. canonical CI green on legacy / HPOS / HPOS-sync;
+3. independent technical/security/accessibility review;
+4. production-enabled Duplicate end-to-end acceptance under the real gate state;
+5. explicit Human Gate approval.

--- a/inc/backend/class-wcos-duplicate-admin-controller.php
+++ b/inc/backend/class-wcos-duplicate-admin-controller.php
@@ -1,0 +1,362 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Duplicate_Transport_Exception extends RuntimeException {
+    private $error_code;
+    private $http_status;
+    private $retryable;
+    private $context;
+
+    public function __construct($error_code, $message, $http_status = 400, $retryable = false, array $context = array()) {
+        $this->error_code = sanitize_key((string) $error_code);
+        $this->http_status = max(400, min(599, (int) $http_status));
+        $this->retryable = (bool) $retryable;
+        $this->context = $context;
+        parent::__construct((string) $message);
+    }
+
+    public function get_error_code() { return $this->error_code; }
+    public function get_http_status() { return $this->http_status; }
+    public function is_retryable() { return $this->retryable; }
+    public function get_context() { return $this->context; }
+}
+
+/**
+ * Production admin transport for hardened single-order Duplicate.
+ * Safe to bootstrap while DUPLICATE remains hard-off.
+ */
+final class WCOS_Duplicate_Admin_Controller {
+    const REVIEW_ACTION = 'wcos_duplicate_review';
+    const EXECUTE_ACTION = 'wcos_duplicate_execute';
+
+    private $current_order = null;
+    private $current_preflight = null;
+    private $current_surface_supported = false;
+
+    public function __construct() {
+        add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+        add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+        add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 21, 1);
+        add_action('admin_footer', array($this, 'render_dialog'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+    }
+
+    public function review_request(array $request) {
+        $order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+        $order = $this->authorized_order($request, $order_id);
+        $preflight = (new WCOS_Mutation_Gateway())->duplicate_preflight($order);
+        if (empty($preflight['supported'])) {
+            throw new WCOS_Duplicate_Transport_Exception(
+                'preflight_' . (isset($preflight['reason']) ? $preflight['reason'] : 'unsupported'),
+                isset($preflight['message']) ? $preflight['message'] : __('This order is not supported by the current Duplicate policy.', 'wc-order-splitter'),
+                409,
+                false,
+                array('preflight' => $preflight)
+            );
+        }
+
+        try {
+            $confirmation = WCOS_Duplicate_Confirmation_Store::create($order, $preflight, get_current_user_id());
+        } catch (WCOS_Duplicate_Confirmation_Exception $exception) {
+            if ('source_changed' === $exception->get_reason()) {
+                throw new WCOS_Duplicate_Transport_Exception('review_source_changed', $exception->getMessage(), 409, true);
+            }
+            throw $exception;
+        }
+
+        return array(
+            'operation_id' => $confirmation['operation_id'],
+            'confirmation_token' => $confirmation['confirmation_token'],
+            'expires_at' => $confirmation['expires_at'],
+            'preflight' => $preflight,
+            'summary' => array(
+                'line_count' => (int) $preflight['line_count'],
+                'shipping_count' => (int) $preflight['shipping_count'],
+                'fee_count' => (int) $preflight['fee_count'],
+                'coupon_count' => (int) $preflight['coupon_count'],
+                'currency' => (string) $preflight['currency'],
+            ),
+        );
+    }
+
+    public function execute_request(array $request) {
+        $order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+        $order = $this->authorized_order($request, $order_id);
+        $operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
+        $confirmation_token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
+
+        try {
+            $confirmation = WCOS_Duplicate_Confirmation_Store::verify(
+                $order,
+                $operation_id,
+                $confirmation_token,
+                get_current_user_id()
+            );
+        } catch (WCOS_Duplicate_Confirmation_Exception $exception) {
+            $http_statuses = array(
+                'invalid_identity' => 400,
+                'invalid_token' => 403,
+                'owner_mismatch' => 403,
+                'expired' => 410,
+                'source_changed' => 409,
+                'source_missing' => 404,
+                'policy_changed' => 409,
+                'precision_mismatch' => 409,
+                'journal_mismatch' => 409,
+                'manual_reconciliation' => 409,
+                'operation_closed' => 409,
+                'journal_incomplete' => 409,
+            );
+            $reason = $exception->get_reason();
+            throw new WCOS_Duplicate_Transport_Exception(
+                'confirmation_' . $reason,
+                $exception->getMessage(),
+                isset($http_statuses[$reason]) ? $http_statuses[$reason] : 403,
+                false
+            );
+        }
+
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE)) {
+            throw new WCOS_Duplicate_Transport_Exception(
+                'workflow_disabled',
+                __('Hardened Duplicate is not enabled for production use yet.', 'wc-order-splitter'),
+                503,
+                false
+            );
+        }
+
+        try {
+            $target = (new WCOS_Mutation_Gateway())->duplicate(
+                $order,
+                $operation_id,
+                $confirmation['price_precision']
+            );
+        } catch (WCOS_Duplicate_Preflight_Exception $exception) {
+            throw new WCOS_Duplicate_Transport_Exception(
+                'preflight_' . $exception->get_reason(),
+                $exception->getMessage(),
+                409,
+                false,
+                array('preflight' => $exception->get_report())
+            );
+        } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+            throw new WCOS_Duplicate_Transport_Exception(
+                'manual_reconciliation_required',
+                __('Duplicate detected an unexpected physical-stock side effect and now requires manual reconciliation.', 'wc-order-splitter'),
+                409,
+                false
+            );
+        } catch (RuntimeException $exception) {
+            $message = $exception->getMessage();
+            if (false !== strpos($message, 'Another order mutation is already in progress')) {
+                throw new WCOS_Duplicate_Transport_Exception('operation_busy', $message, 409, true);
+            }
+            if (false !== strpos($message, 'different mutation request')) {
+                throw new WCOS_Duplicate_Transport_Exception('operation_conflict', $message, 409, false);
+            }
+            throw new WCOS_Duplicate_Transport_Exception('duplicate_failed', $message, 409, true);
+        }
+
+        return array(
+            'operation_id' => $operation_id,
+            'status' => 'completed',
+            'source_order_id' => $order->get_id(),
+            'target' => array(
+                'id' => $target->get_id(),
+                'number' => (string) $target->get_order_number(),
+                'status' => (string) $target->get_status(),
+                'edit_url' => method_exists($target, 'get_edit_order_url') ? esc_url_raw((string) $target->get_edit_order_url()) : '',
+            ),
+        );
+    }
+
+    public function ajax_review() {
+        try {
+            wp_send_json_success($this->review_request(wp_unslash($_POST)));
+        } catch (WCOS_Duplicate_Transport_Exception $exception) {
+            $this->send_transport_error($exception);
+        } catch (Throwable $throwable) {
+            $this->send_transport_error(new WCOS_Duplicate_Transport_Exception('review_failed', __('Unable to review Duplicate.', 'wc-order-splitter'), 500, true));
+        }
+    }
+
+    public function ajax_execute() {
+        try {
+            wp_send_json_success($this->execute_request(wp_unslash($_POST)));
+        } catch (WCOS_Duplicate_Transport_Exception $exception) {
+            $this->send_transport_error($exception);
+        } catch (Throwable $throwable) {
+            $this->send_transport_error(new WCOS_Duplicate_Transport_Exception('execute_failed', __('Unable to execute Duplicate.', 'wc-order-splitter'), 500, true));
+        }
+    }
+
+    public function render_launcher($order) {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE) || !$order instanceof WC_Order) {
+            return;
+        }
+
+        try {
+            WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $order);
+            $this->assert_status_enabled($order);
+            $preflight = (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($order);
+        } catch (Throwable $throwable) {
+            return;
+        }
+
+        $this->current_order = $order;
+        $this->current_preflight = $preflight;
+        $this->current_surface_supported = !empty($preflight['supported']);
+        $dialog_id = 'wcos-duplicate-dialog-' . $order->get_id();
+        $description_id = 'wcos-duplicate-launcher-description-' . $order->get_id();
+        $disabled = !$this->current_surface_supported;
+
+        echo '<button type="button" class="button wcos-duplicate-launcher" aria-haspopup="dialog"' . ($disabled ? '' : ' aria-controls="' . esc_attr($dialog_id) . '"') . ' aria-describedby="' . esc_attr($description_id) . '"' . disabled($disabled, true, false) . '>';
+        echo esc_html__('Duplicate order', 'wc-order-splitter');
+        echo '</button>';
+        echo '<span id="' . esc_attr($description_id) . '" class="description wcos-duplicate-launcher-description">';
+        echo esc_html($disabled ? $preflight['message'] : __('Review the Duplicate safety policy before creating a new pending order.', 'wc-order-splitter'));
+        echo '</span>';
+    }
+
+    public function enqueue_assets() {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE) || !$this->is_order_edit_screen()) {
+            return;
+        }
+        $plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+        wp_enqueue_style('wcos-duplicate-admin', plugins_url('css/p2-duplicate-admin.css', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION);
+        wp_enqueue_script('wcos-duplicate-admin', plugins_url('js/p2-duplicate-admin.js', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION, true);
+        wp_localize_script(
+            'wcos-duplicate-admin',
+            'wcosDuplicateAdminStrings',
+            array(
+                'reviewing' => __('Reviewing Duplicate…', 'wc-order-splitter'),
+                'reviewReady' => __('The order passed server review. Confirm the acknowledgement to duplicate it.', 'wc-order-splitter'),
+                'executing' => __('Duplicating order…', 'wc-order-splitter'),
+                'completed' => __('Order duplicated successfully.', 'wc-order-splitter'),
+                'requestFailed' => __('The Duplicate request could not be completed.', 'wc-order-splitter'),
+                'targetOrder' => __('Duplicated order', 'wc-order-splitter'),
+                'reviewSummary' => __('Reviewed lines / shipping / fees / coupons:', 'wc-order-splitter'),
+            )
+        );
+    }
+
+    public function render_dialog() {
+        if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE)
+            || !$this->current_surface_supported
+            || !$this->current_order instanceof WC_Order) {
+            return;
+        }
+        echo $this->dialog_html($this->current_order, $this->current_preflight); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    public function dialog_html(WC_Order $order, array $preflight = array()) {
+        if (empty($preflight)) {
+            $preflight = (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($order);
+        }
+        $dialog_id = 'wcos-duplicate-dialog-' . $order->get_id();
+        $title_id = $dialog_id . '-title';
+        $description_id = $dialog_id . '-description';
+        $nonce = wp_create_nonce('wcos_duplicate_order_' . $order->get_id());
+
+        ob_start();
+        ?>
+        <div id="<?php echo esc_attr($dialog_id); ?>" class="wcos-duplicate-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($title_id); ?>" aria-describedby="<?php echo esc_attr($description_id); ?>" data-order-id="<?php echo esc_attr($order->get_id()); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" hidden>
+            <div class="wcos-duplicate-dialog__backdrop" aria-hidden="true"></div>
+            <div class="wcos-duplicate-dialog__panel" tabindex="-1">
+                <div class="wcos-duplicate-dialog__header">
+                    <div>
+                        <h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Review order duplicate', 'wc-order-splitter'); ?></h2>
+                        <p id="<?php echo esc_attr($description_id); ?>"><?php esc_html_e('Duplicate creates one new Pending payment order from the reviewed historical order state.', 'wc-order-splitter'); ?></p>
+                    </div>
+                    <button type="button" class="button-link wcos-duplicate-close" aria-label="<?php esc_attr_e('Close Duplicate dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
+                </div>
+
+                <div class="wcos-duplicate-policy" aria-labelledby="<?php echo esc_attr($dialog_id . '-policy-title'); ?>">
+                    <h3 id="<?php echo esc_attr($dialog_id . '-policy-title'); ?>"><?php esc_html_e('Current safety policy', 'wc-order-splitter'); ?></h3>
+                    <ul>
+                        <li><?php esc_html_e('The target is created as Pending payment.', 'wc-order-splitter'); ?></li>
+                        <li><?php esc_html_e('Historical line, shipping, fee, coupon, and tax rows are copied exactly; current catalog prices and tax rates are not recalculated.', 'wc-order-splitter'); ?></li>
+                        <li><?php esc_html_e('Payment method context is copied, but the source transaction ID, paid state, and stock-reduction state are not copied.', 'wc-order-splitter'); ?></li>
+                        <li><?php esc_html_e('The Duplicate request must not write physical product stock.', 'wc-order-splitter'); ?></li>
+                        <li><?php esc_html_e('Refunded orders and unclassified private order-item metadata are rejected before mutation.', 'wc-order-splitter'); ?></li>
+                        <li><?php esc_html_e('Custom order-level metadata outside the copied WooCommerce core fields is not copied by the first hardened Duplicate workflow.', 'wc-order-splitter'); ?></li>
+                    </ul>
+                </div>
+
+                <div class="wcos-duplicate-review" hidden>
+                    <h3><?php esc_html_e('Reviewed order', 'wc-order-splitter'); ?></h3>
+                    <p class="wcos-duplicate-review-summary"></p>
+                    <label class="wcos-duplicate-confirm-label">
+                        <input type="checkbox" class="wcos-duplicate-confirm-checkbox" />
+                        <span><?php esc_html_e('I reviewed the policy and understand that this will create a new pending order without copying payment transaction or stock-reduction state.', 'wc-order-splitter'); ?></span>
+                    </label>
+                </div>
+
+                <div class="wcos-duplicate-status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
+                <div class="wcos-duplicate-error notice notice-error inline" role="alert" tabindex="-1" hidden></div>
+                <div class="wcos-duplicate-result notice notice-success inline" tabindex="-1" hidden></div>
+
+                <div class="wcos-duplicate-dialog__actions">
+                    <button type="button" class="button wcos-duplicate-cancel"><?php esc_html_e('Cancel', 'wc-order-splitter'); ?></button>
+                    <button type="button" class="button button-secondary wcos-duplicate-review-button"><?php esc_html_e('Review duplicate', 'wc-order-splitter'); ?></button>
+                    <button type="button" class="button button-primary wcos-duplicate-execute-button" disabled><?php esc_html_e('Confirm and duplicate', 'wc-order-splitter'); ?></button>
+                </div>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    private function authorized_order(array $request, $order_id) {
+        if (!$order_id) {
+            throw new WCOS_Duplicate_Transport_Exception('invalid_order', __('A valid order ID is required.', 'wc-order-splitter'), 400, false);
+        }
+        $nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
+        if (!wp_verify_nonce($nonce, 'wcos_duplicate_order_' . $order_id)) {
+            throw new WCOS_Duplicate_Transport_Exception('invalid_nonce', __('The Duplicate request failed nonce verification.', 'wc-order-splitter'), 403, false);
+        }
+
+        $order = wc_get_order($order_id);
+        if (!$order instanceof WC_Order) {
+            throw new WCOS_Duplicate_Transport_Exception('order_not_found', __('The source order could not be found.', 'wc-order-splitter'), 404, false);
+        }
+        try {
+            WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $order);
+        } catch (Throwable $throwable) {
+            throw new WCOS_Duplicate_Transport_Exception('authorization_failed', __('You are not allowed to duplicate this order.', 'wc-order-splitter'), 403, false);
+        }
+        $this->assert_status_enabled($order);
+        return $order;
+    }
+
+    private function assert_status_enabled(WC_Order $order) {
+        $allowed = (array) get_option('order_splitter_status_allowed', array('wc-processing'));
+        $status = 'wc-' . $order->get_status();
+        if (!in_array($status, $allowed, true)) {
+            throw new WCOS_Duplicate_Transport_Exception('status_disabled', __('This order status is disabled in the Order Splitter settings.', 'wc-order-splitter'), 409, false);
+        }
+    }
+
+    private function send_transport_error(WCOS_Duplicate_Transport_Exception $exception) {
+        wp_send_json_error(
+            array(
+                'code' => $exception->get_error_code(),
+                'message' => $exception->getMessage(),
+                'retryable' => $exception->is_retryable(),
+                'context' => $exception->get_context(),
+            ),
+            $exception->get_http_status()
+        );
+    }
+
+    private function is_order_edit_screen() {
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if (!$screen) {
+            return false;
+        }
+        $hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+        $hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+        return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
+    }
+}

--- a/inc/backend/class-wcos-duplicate-confirmation-store.php
+++ b/inc/backend/class-wcos-duplicate-confirmation-store.php
@@ -23,6 +23,8 @@ final class WCOS_Duplicate_Confirmation_Store {
     const SCHEMA_VERSION = 1;
     const TTL = 1800;
 
+    private static $verified_source_signatures = array();
+
     public static function create(WC_Order $source, array $preflight, $user_id) {
         $user_id = absint($user_id);
         if (!$source->get_id() || !$user_id) {
@@ -88,6 +90,7 @@ final class WCOS_Duplicate_Confirmation_Store {
         $operation_id = sanitize_key((string) $operation_id);
         $token = (string) $token;
         $user_id = absint($user_id);
+        unset(self::$verified_source_signatures[$operation_id]);
         if (!self::is_uuid($operation_id) || !$user_id) {
             throw new WCOS_Duplicate_Confirmation_Exception('invalid_identity', __('The Duplicate confirmation identity is invalid.', 'wc-order-splitter'));
         }
@@ -125,6 +128,7 @@ final class WCOS_Duplicate_Confirmation_Store {
                 if ('' === $expected || !hash_equals($expected, $actual)) {
                     throw new WCOS_Duplicate_Confirmation_Exception('source_changed', __('The source order changed after Duplicate review. Review it again before executing.', 'wc-order-splitter'));
                 }
+                self::$verified_source_signatures[$operation_id] = $expected;
             } else {
                 self::assert_journal_identity($scoped_source, $operation_id, $journal);
                 $context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
@@ -145,12 +149,21 @@ final class WCOS_Duplicate_Confirmation_Store {
         }
     }
 
+    public static function verified_source_signature($operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        return isset(self::$verified_source_signatures[$operation_id])
+            ? (string) self::$verified_source_signatures[$operation_id]
+            : '';
+    }
+
     public static function delete($operation_id) {
         $operation_id = sanitize_key((string) $operation_id);
+        unset(self::$verified_source_signatures[$operation_id]);
         return self::is_uuid($operation_id) ? delete_transient(self::key($operation_id)) : false;
     }
 
     private static function durable_replay(WC_Order $source, $operation_id) {
+        unset(self::$verified_source_signatures[$operation_id]);
         $journal = WCOS_Operation_Journal::get($source, $operation_id);
         if (!is_array($journal)) {
             throw new WCOS_Duplicate_Confirmation_Exception('expired', __('The Duplicate confirmation expired. Review the order again before executing.', 'wc-order-splitter'));

--- a/inc/backend/class-wcos-duplicate-confirmation-store.php
+++ b/inc/backend/class-wcos-duplicate-confirmation-store.php
@@ -1,0 +1,205 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Duplicate_Confirmation_Exception extends RuntimeException {
+    private $reason;
+
+    public function __construct($reason, $message) {
+        $this->reason = sanitize_key((string) $reason);
+        parent::__construct((string) $message);
+    }
+
+    public function get_reason() {
+        return $this->reason;
+    }
+}
+
+/**
+ * Short-lived non-PII confirmation record for Duplicate review -> execute.
+ * A durable duplicate journal becomes replay authority once mutation starts.
+ */
+final class WCOS_Duplicate_Confirmation_Store {
+    const SCHEMA_VERSION = 1;
+    const TTL = 1800;
+
+    public static function create(WC_Order $source, array $preflight, $user_id) {
+        $user_id = absint($user_id);
+        if (!$source->get_id() || !$user_id) {
+            throw new InvalidArgumentException(__('A persisted order and signed-in user are required to confirm Duplicate.', 'wc-order-splitter'));
+        }
+
+        $operation_id = wp_generate_uuid4();
+        $token = wp_generate_password(48, false, false);
+        $precision = WCOS_Price_Precision_Scope::validate(isset($preflight['price_precision']) ? $preflight['price_precision'] : wc_get_price_decimals());
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            $reviewed_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
+            $parsed_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+            if ('' === $reviewed_signature || !hash_equals($reviewed_signature, $parsed_signature)) {
+                throw new WCOS_Duplicate_Confirmation_Exception(
+                    'source_changed',
+                    __('The order changed while Duplicate was being reviewed. Review the current order state again.', 'wc-order-splitter')
+                );
+            }
+
+            $scoped_source = wc_get_order($source->get_id());
+            if (!$scoped_source instanceof WC_Order) {
+                throw new WCOS_Duplicate_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+            }
+            $current_signature = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+            if (!hash_equals($reviewed_signature, $current_signature)) {
+                throw new WCOS_Duplicate_Confirmation_Exception(
+                    'source_changed',
+                    __('The order changed while the Duplicate confirmation was being created. Review it again.', 'wc-order-splitter')
+                );
+            }
+
+            $now = time();
+            $record = array(
+                'schema_version' => self::SCHEMA_VERSION,
+                'operation_id' => $operation_id,
+                'token_hash' => self::token_hash($token),
+                'source_order_id' => $scoped_source->get_id(),
+                'user_id' => $user_id,
+                'source_signature' => $current_signature,
+                'price_precision' => $precision,
+                'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,
+                'created_at' => $now,
+                'expires_at' => $now + self::TTL,
+            );
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
+
+        if (!set_transient(self::key($operation_id), $record, self::TTL)) {
+            throw new RuntimeException(__('Unable to create the temporary Duplicate confirmation record.', 'wc-order-splitter'));
+        }
+
+        return array(
+            'operation_id' => $operation_id,
+            'confirmation_token' => $token,
+            'expires_at' => $record['expires_at'],
+            'record' => $record,
+        );
+    }
+
+    public static function verify(WC_Order $source, $operation_id, $token, $user_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $token = (string) $token;
+        $user_id = absint($user_id);
+        if (!self::is_uuid($operation_id) || !$user_id) {
+            throw new WCOS_Duplicate_Confirmation_Exception('invalid_identity', __('The Duplicate confirmation identity is invalid.', 'wc-order-splitter'));
+        }
+
+        $record = get_transient(self::key($operation_id));
+        if (!is_array($record)) {
+            return self::durable_replay($source, $operation_id);
+        }
+        if ('' === $token || !isset($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+            throw new WCOS_Duplicate_Confirmation_Exception('invalid_token', __('The Duplicate confirmation token is invalid.', 'wc-order-splitter'));
+        }
+        if (absint($record['source_order_id']) !== $source->get_id() || absint($record['user_id']) !== $user_id) {
+            throw new WCOS_Duplicate_Confirmation_Exception('owner_mismatch', __('The Duplicate confirmation does not belong to this user and order.', 'wc-order-splitter'));
+        }
+        if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+            self::delete($operation_id);
+            return self::durable_replay($source, $operation_id);
+        }
+        if (!isset($record['policy_version']) || (int) $record['policy_version'] !== (int) WCOS_Duplicate_Preflight::POLICY_VERSION) {
+            throw new WCOS_Duplicate_Confirmation_Exception('policy_changed', __('The Duplicate safety policy changed after review. Review the order again.', 'wc-order-splitter'));
+        }
+
+        $precision = WCOS_Price_Precision_Scope::validate(isset($record['price_precision']) ? $record['price_precision'] : null);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            $scoped_source = wc_get_order($source->get_id());
+            if (!$scoped_source instanceof WC_Order) {
+                throw new WCOS_Duplicate_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+            }
+
+            $journal = WCOS_Operation_Journal::get($scoped_source, $operation_id);
+            if (!is_array($journal)) {
+                $expected = isset($record['source_signature']) ? (string) $record['source_signature'] : '';
+                $actual = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+                if ('' === $expected || !hash_equals($expected, $actual)) {
+                    throw new WCOS_Duplicate_Confirmation_Exception('source_changed', __('The source order changed after Duplicate review. Review it again before executing.', 'wc-order-splitter'));
+                }
+            } else {
+                self::assert_journal_identity($scoped_source, $operation_id, $journal);
+                $context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+                if (!array_key_exists('price_precision', $context) || (int) $context['price_precision'] !== $precision) {
+                    throw new WCOS_Duplicate_Confirmation_Exception('precision_mismatch', __('The Duplicate confirmation precision no longer matches the durable operation journal.', 'wc-order-splitter'));
+                }
+                if (!array_key_exists('policy_version', $context) || (int) $context['policy_version'] !== (int) $record['policy_version']) {
+                    throw new WCOS_Duplicate_Confirmation_Exception('policy_changed', __('The durable Duplicate operation no longer matches the policy that was reviewed.', 'wc-order-splitter'));
+                }
+            }
+
+            $record['operation_id'] = $operation_id;
+            $record['price_precision'] = $precision;
+            $record['replay_authority'] = is_array($journal) ? 'journal' : 'confirmation';
+            return $record;
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
+    }
+
+    public static function delete($operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        return self::is_uuid($operation_id) ? delete_transient(self::key($operation_id)) : false;
+    }
+
+    private static function durable_replay(WC_Order $source, $operation_id) {
+        $journal = WCOS_Operation_Journal::get($source, $operation_id);
+        if (!is_array($journal)) {
+            throw new WCOS_Duplicate_Confirmation_Exception('expired', __('The Duplicate confirmation expired. Review the order again before executing.', 'wc-order-splitter'));
+        }
+        self::assert_journal_identity($source, $operation_id, $journal);
+
+        $status = isset($journal['status']) ? sanitize_key((string) $journal['status']) : '';
+        if ('manual_reconciliation' === $status) {
+            throw new WCOS_Duplicate_Confirmation_Exception('manual_reconciliation', __('This Duplicate operation requires manual reconciliation before it can continue.', 'wc-order-splitter'));
+        }
+        if (in_array($status, array('manual_reconciled', 'compensated'), true)) {
+            throw new WCOS_Duplicate_Confirmation_Exception('operation_closed', __('This Duplicate operation has been closed and cannot be replayed.', 'wc-order-splitter'));
+        }
+
+        $context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+        if (!array_key_exists('price_precision', $context) || !array_key_exists('policy_version', $context)) {
+            throw new WCOS_Duplicate_Confirmation_Exception('journal_incomplete', __('The durable Duplicate operation is missing replay authority and requires manual review.', 'wc-order-splitter'));
+        }
+        if ((int) $context['policy_version'] !== (int) WCOS_Duplicate_Preflight::POLICY_VERSION) {
+            throw new WCOS_Duplicate_Confirmation_Exception('policy_changed', __('The Duplicate safety policy changed after this durable operation started.', 'wc-order-splitter'));
+        }
+
+        return array(
+            'schema_version' => self::SCHEMA_VERSION,
+            'operation_id' => $operation_id,
+            'source_order_id' => $source->get_id(),
+            'price_precision' => WCOS_Price_Precision_Scope::validate($context['price_precision']),
+            'policy_version' => (int) $context['policy_version'],
+            'replay_authority' => 'journal',
+        );
+    }
+
+    private static function assert_journal_identity(WC_Order $source, $operation_id, array $journal) {
+        if (!isset($journal['type']) || 'duplicate' !== sanitize_key((string) $journal['type'])
+            || !isset($journal['source_order_id']) || absint($journal['source_order_id']) !== $source->get_id()
+            || !isset($journal['operation_id']) || sanitize_key((string) $journal['operation_id']) !== $operation_id) {
+            throw new WCOS_Duplicate_Confirmation_Exception('journal_mismatch', __('The durable Duplicate operation does not match this source order.', 'wc-order-splitter'));
+        }
+    }
+
+    private static function token_hash($token) {
+        return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+    }
+
+    private static function key($operation_id) {
+        return 'wcos_duplicate_confirm_' . hash('sha256', sanitize_key((string) $operation_id));
+    }
+
+    private static function is_uuid($value) {
+        return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+    }
+}

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -26,6 +26,8 @@ final class WCOS_Split_Confirmation_Store {
     const SCHEMA_VERSION = 1;
     const TTL = 1800;
 
+    private static $verified_source_signatures = array();
+
     public static function create(WC_Order $source, array $plan, array $preflight, $user_id) {
         $user_id = absint($user_id);
         if (!$source->get_id() || !$user_id) {
@@ -103,6 +105,7 @@ final class WCOS_Split_Confirmation_Store {
         $operation_id = sanitize_key((string) $operation_id);
         $token = (string) $token;
         $user_id = absint($user_id);
+        unset(self::$verified_source_signatures[$operation_id]);
         if (!self::is_uuid($operation_id) || !$user_id) {
             throw new WCOS_Split_Confirmation_Exception('invalid_identity', __('The Split confirmation identity is invalid.', 'wc-order-splitter'));
         }
@@ -140,6 +143,7 @@ final class WCOS_Split_Confirmation_Store {
                 if ('' === $expected || !hash_equals($expected, $actual)) {
                     throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
                 }
+                self::$verified_source_signatures[$operation_id] = $expected;
             } else {
                 $journal_context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
                 if (!array_key_exists('price_precision', $journal_context)
@@ -162,8 +166,16 @@ final class WCOS_Split_Confirmation_Store {
         }
     }
 
+    public static function verified_source_signature($operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        return isset(self::$verified_source_signatures[$operation_id])
+            ? (string) self::$verified_source_signatures[$operation_id]
+            : '';
+    }
+
     public static function delete($operation_id) {
         $operation_id = sanitize_key((string) $operation_id);
+        unset(self::$verified_source_signatures[$operation_id]);
         if (!self::is_uuid($operation_id)) {
             return false;
         }
@@ -171,6 +183,7 @@ final class WCOS_Split_Confirmation_Store {
     }
 
     private static function durable_replay(WC_Order $source, $operation_id) {
+        unset(self::$verified_source_signatures[$operation_id]);
         $journal = WCOS_Operation_Journal::get($source, $operation_id);
         if (!is_array($journal)) {
             throw new WCOS_Split_Confirmation_Exception('expired', __('The Split confirmation expired. Review the plan again before executing it.', 'wc-order-splitter'));

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -57,6 +57,8 @@ class WC_Order_Splitter_Script {
 		WCOS_Mutation_Recovery_Coordinator::bootstrap();
 		include_once $root . 'domain/class-wcos-split-preflight.php';
 		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
+		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
+		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 
 		include_once $root . 'backend/class-wcos-split-request-parser.php';
@@ -64,15 +66,19 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'backend/class-wcos-split-admin-controller.php';
 		new WCOS_Split_Admin_Controller();
 
+		include_once $root . 'backend/class-wcos-duplicate-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-duplicate-admin-controller.php';
+		new WCOS_Duplicate_Admin_Controller();
+
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';
 		include_once $root . 'backend/yoohw-woo-settings-tabs-reorder.php';
 		include_once plugin_dir_path(__FILE__) . 'safety.php';
 
 		/*
-		 * Legacy mutation handlers are deliberately never loaded here. Production
-		 * Split transport is isolated behind WCOS_Mutation_Gateway and remains
-		 * non-runnable while WCOS_Feature_Gates::SPLIT is hard-off.
+		 * Legacy mutation handlers are deliberately never loaded here. Hardened
+		 * production transports must enter through WCOS_Mutation_Gateway; their
+		 * individual workflow gates remain the only execution authority.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-duplicate-order-service.php
+++ b/inc/domain/class-wcos-duplicate-order-service.php
@@ -9,7 +9,7 @@ defined('ABSPATH') || exit;
 final class WCOS_Duplicate_Order_Service {
 
 	const TYPE = 'duplicate';
-	const POLICY_VERSION = 3;
+	const POLICY_VERSION = 4;
 
 	public function duplicate(WC_Order $source, $operation_id) {
 		$operation_id = sanitize_key($operation_id);
@@ -89,6 +89,7 @@ final class WCOS_Duplicate_Order_Service {
 					'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
 					'source_copy_context_signature' => WCOS_Order_Copy_Context::signature($source),
 					'source_contract' => $source_contract,
+					'policy_version' => class_exists('WCOS_Duplicate_Preflight') ? (int) WCOS_Duplicate_Preflight::POLICY_VERSION : 0,
 				);
 				if (!WCOS_Operation_Journal::start($source, $operation_id, self::TYPE, $context, $fingerprint)) {
 					throw new RuntimeException(__('Unable to start the duplicate operation journal.', 'wc-order-splitter'));
@@ -101,7 +102,7 @@ final class WCOS_Duplicate_Order_Service {
 			}
 			$this->assert_source_matches_record($source, $record);
 
-			if (!WCOS_Operation_Lock::is_owned($source_id, $lease_token)) {
+			if (!WCOS_Operation_Lock::is_owned($source_id, $lease_token, $operation_id)) {
 				throw new RuntimeException(__('The duplicate operation lease was lost before target creation.', 'wc-order-splitter'));
 			}
 
@@ -114,12 +115,12 @@ final class WCOS_Duplicate_Order_Service {
 				: '';
 
 			$target = $this->build_target($source, $operation_id);
-			$this->assert_target_policy($target, $source_contract, $copy_context_signature);
+			$this->assert_target_policy($source, $target, $source_contract, $copy_context_signature);
 
 			do_action('wcos_duplicate_mutation_checkpoint', 'before_target_save', $source, $target, $operation_id);
-			$this->assert_target_policy($target, $source_contract, $copy_context_signature);
+			$this->assert_target_policy($source, $target, $source_contract, $copy_context_signature);
 			$this->assert_source_snapshot_current($source_id, $record);
-			if (!WCOS_Operation_Lock::refresh($source_id, $lease_token)) {
+			if (!WCOS_Operation_Lock::refresh($source_id, $lease_token, WCOS_Operation_Lock::DEFAULT_TTL, $operation_id)) {
 				throw new RuntimeException(__('The duplicate operation lease could not be refreshed before target commit.', 'wc-order-splitter'));
 			}
 
@@ -282,7 +283,7 @@ final class WCOS_Duplicate_Order_Service {
 		return !empty($orders) ? reset($orders) : false;
 	}
 
-	private function assert_target_policy(WC_Order $target, array $source_contract, $copy_context_signature) {
+	private function assert_target_policy(WC_Order $source, WC_Order $target, array $source_contract, $copy_context_signature) {
 		if ('pending' !== $target->get_status()) {
 			throw new RuntimeException(__('The hardened duplicate target must remain in pending status.', 'wc-order-splitter'));
 		}
@@ -302,6 +303,7 @@ final class WCOS_Duplicate_Order_Service {
 		$target_contract = WCOS_Order_Contract_Snapshot::aggregate(array($target));
 		unset($target_contract['stock_reduced']);
 		WCOS_Mutation_Contract::assert_conserved($source_contract, $target_contract, wc_get_price_decimals());
+		$this->assert_item_clone_equivalence($source, $target);
 	}
 
 	private function verify_target(WC_Order $source, WC_Order $target, array $record) {
@@ -321,7 +323,7 @@ final class WCOS_Duplicate_Order_Service {
 		$copy_context_signature = isset($record['context']['source_copy_context_signature'])
 			? (string) $record['context']['source_copy_context_signature']
 			: '';
-		$this->assert_target_policy($target, $source_contract, $copy_context_signature);
+		$this->assert_target_policy($source, $target, $source_contract, $copy_context_signature);
 
 		$source_item_ids = array();
 		foreach (array('line_item', 'shipping', 'fee', 'tax', 'coupon') as $item_type) {
@@ -332,6 +334,87 @@ final class WCOS_Duplicate_Order_Service {
 				}
 			}
 		}
+	}
+
+	private function assert_item_clone_equivalence(WC_Order $source, WC_Order $target) {
+		foreach (array('line_item', 'shipping', 'fee', 'tax', 'coupon') as $item_type) {
+			$source_signatures = array();
+			foreach ($source->get_items($item_type) as $item) {
+				$source_signatures[] = $this->item_signature($item);
+			}
+			$target_signatures = array();
+			foreach ($target->get_items($item_type) as $item) {
+				$target_signatures[] = $this->item_signature($item);
+			}
+			sort($source_signatures, SORT_STRING);
+			sort($target_signatures, SORT_STRING);
+			if ($source_signatures !== $target_signatures) {
+				throw new RuntimeException(
+					sprintf(
+						/* translators: %s: WooCommerce order item type. */
+						__('Duplicate target did not preserve exact %s item semantics.', 'wc-order-splitter'),
+						$item_type
+					)
+				);
+			}
+		}
+	}
+
+	private function item_signature(WC_Order_Item $item) {
+		$state = array(
+			'type' => $item->get_type(),
+			'name' => $item->get_name(),
+			'meta' => WCOS_Order_Item_Meta_Policy::business_metadata($item),
+		);
+
+		if ($item instanceof WC_Order_Item_Product) {
+			$state += array(
+				'product_id' => $item->get_product_id(),
+				'variation_id' => $item->get_variation_id(),
+				'quantity' => WCOS_Decimal::normalize($item->get_quantity(), 6),
+				'tax_class' => $item->get_tax_class(),
+				'subtotal' => (string) $item->get_subtotal(),
+				'total' => (string) $item->get_total(),
+				'subtotal_tax' => (string) $item->get_subtotal_tax(),
+				'total_tax' => (string) $item->get_total_tax(),
+				'taxes' => $item->get_taxes(),
+			);
+		} elseif ($item instanceof WC_Order_Item_Shipping) {
+			$state += array(
+				'method_title' => $item->get_method_title(),
+				'method_id' => $item->get_method_id(),
+				'instance_id' => $item->get_instance_id(),
+				'total' => (string) $item->get_total(),
+				'total_tax' => (string) $item->get_total_tax(),
+				'taxes' => $item->get_taxes(),
+			);
+		} elseif ($item instanceof WC_Order_Item_Fee) {
+			$state += array(
+				'tax_class' => $item->get_tax_class(),
+				'tax_status' => $item->get_tax_status(),
+				'amount' => (string) $item->get_amount(),
+				'total' => (string) $item->get_total(),
+				'total_tax' => (string) $item->get_total_tax(),
+				'taxes' => $item->get_taxes(),
+			);
+		} elseif ($item instanceof WC_Order_Item_Tax) {
+			$state += array(
+				'rate_id' => $item->get_rate_id(),
+				'label' => $item->get_label(),
+				'compound' => (bool) $item->get_compound(),
+				'tax_total' => (string) $item->get_tax_total(),
+				'shipping_tax_total' => (string) $item->get_shipping_tax_total(),
+				'rate_percent' => (string) $item->get_rate_percent(),
+			);
+		} elseif ($item instanceof WC_Order_Item_Coupon) {
+			$state += array(
+				'code' => $item->get_code(),
+				'discount' => (string) $item->get_discount(),
+				'discount_tax' => (string) $item->get_discount_tax(),
+			);
+		}
+
+		return WCOS_Mutation_Fingerprint::create('duplicate_item', 0, $state);
 	}
 
 	private function add_notes_best_effort(WC_Order $source, WC_Order $target) {

--- a/inc/domain/class-wcos-duplicate-preflight.php
+++ b/inc/domain/class-wcos-duplicate-preflight.php
@@ -27,7 +27,7 @@ final class WCOS_Duplicate_Preflight_Exception extends RuntimeException {
  * Reports intentionally contain no customer/address/payment plaintext.
  */
 final class WCOS_Duplicate_Preflight {
-    const POLICY_VERSION = 1;
+    const POLICY_VERSION = 4;
 
     public static function policy() {
         return array(

--- a/inc/domain/class-wcos-duplicate-preflight.php
+++ b/inc/domain/class-wcos-duplicate-preflight.php
@@ -1,0 +1,236 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Duplicate_Preflight_Exception extends RuntimeException {
+    private $reason;
+    private $report;
+
+    public function __construct($reason, $message, array $report = array()) {
+        $this->reason = sanitize_key((string) $reason);
+        $this->report = $report;
+        parent::__construct((string) $message);
+    }
+
+    public function get_reason() {
+        return $this->reason;
+    }
+
+    public function get_report() {
+        return $this->report;
+    }
+}
+
+/**
+ * Read-only production preflight for hardened single-order Duplicate.
+ *
+ * Reports intentionally contain no customer/address/payment plaintext.
+ */
+final class WCOS_Duplicate_Preflight {
+    const POLICY_VERSION = 1;
+
+    public static function policy() {
+        return array(
+            'policy_version' => self::POLICY_VERSION,
+            'target_status' => 'pending',
+            'payment_method' => 'copy',
+            'payment_transaction' => 'do_not_copy',
+            'stock_reduced' => 'do_not_copy',
+            'physical_stock' => 'no_write',
+            'historical_totals' => 'copy_exact',
+            'historical_tax' => 'copy_exact',
+            'shipping' => 'copy_exact',
+            'fees' => 'copy_exact',
+            'coupons' => 'copy_exact',
+            'refunds' => 'reject',
+            'order_custom_meta' => 'do_not_copy',
+            'unknown_private_item_meta' => 'reject',
+            'manual_reconciliation' => 'reject',
+        );
+    }
+
+    public static function assert_supported(WC_Order $source, $precision = null) {
+        $report = self::report($source, $precision);
+        if (empty($report['supported'])) {
+            throw new WCOS_Duplicate_Preflight_Exception(
+                isset($report['reason']) ? $report['reason'] : 'unsupported',
+                isset($report['message']) ? $report['message'] : __('This order is not supported by the hardened Duplicate workflow.', 'wc-order-splitter'),
+                $report
+            );
+        }
+        return $report;
+    }
+
+    public static function report(WC_Order $source, $precision = null) {
+        $precision = null === $precision
+            ? WCOS_Price_Precision_Scope::store_precision()
+            : WCOS_Price_Precision_Scope::validate($precision);
+
+        $report = array(
+            'supported' => false,
+            'reason' => '',
+            'message' => '',
+            'order_id' => absint($source->get_id()),
+            'order_type' => sanitize_key((string) $source->get_type()),
+            'status' => sanitize_key((string) $source->get_status()),
+            'currency' => (string) $source->get_currency(),
+            'price_precision' => $precision,
+            'is_paid' => (bool) $source->is_paid(),
+            'has_transaction' => '' !== (string) $source->get_transaction_id(),
+            'line_count' => count($source->get_items('line_item')),
+            'shipping_count' => count($source->get_items('shipping')),
+            'fee_count' => count($source->get_items('fee')),
+            'coupon_count' => count($source->get_items('coupon')),
+            'refund_count' => count($source->get_refunds()),
+            'deleted_product_lines' => 0,
+            'fractional_quantity_lines' => 0,
+            'manual_reconciliation_count' => 0,
+            'manual_reconciliation_operation_ids' => array(),
+            'unknown_private_meta_keys' => array(),
+            'inconsistent_private_meta_keys' => array(),
+            'source_signature' => '',
+            'policy' => self::policy(),
+        );
+
+        if (!$source->get_id()) {
+            return self::reject($report, 'unpersisted_order', __('The source order must be persisted before it can be duplicated.', 'wc-order-splitter'));
+        }
+        if ('shop_order' !== $source->get_type()) {
+            return self::reject($report, 'unsupported_order_type', __('Only WooCommerce shop orders can be duplicated.', 'wc-order-splitter'));
+        }
+        if ('trash' === $source->get_status()) {
+            return self::reject($report, 'trashed_order', __('Trashed orders cannot be duplicated.', 'wc-order-splitter'));
+        }
+        if ('' === (string) $source->get_currency()) {
+            return self::reject($report, 'missing_currency', __('The source order does not have a currency.', 'wc-order-splitter'));
+        }
+        if (0 === $report['line_count']) {
+            return self::reject($report, 'no_line_items', __('An order without product line items cannot be duplicated.', 'wc-order-splitter'));
+        }
+        if ($source->get_total_refunded() != 0 || $report['refund_count'] > 0) {
+            return self::reject($report, 'refund_policy_missing', __('Refunded or partially refunded orders are not supported by the first hardened Duplicate workflow.', 'wc-order-splitter'));
+        }
+
+        if (class_exists('WCOS_Manual_Reconciliation_Blocker')) {
+            $operation_ids = WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source);
+            if (!empty($operation_ids)) {
+                $report['manual_reconciliation_count'] = count($operation_ids);
+                $report['manual_reconciliation_operation_ids'] = $operation_ids;
+                return self::reject(
+                    $report,
+                    'manual_reconciliation_required',
+                    sprintf(
+                        /* translators: %s: comma-separated mutation operation IDs. */
+                        __('This order has unresolved stock-reconciliation evidence for operation(s): %s. Resolve it before duplicating the order.', 'wc-order-splitter'),
+                        implode(', ', $operation_ids)
+                    )
+                );
+            }
+        }
+
+        $unknown_private = array();
+        $inconsistent_private = array();
+        foreach (array('line_item', 'shipping', 'fee', 'tax', 'coupon') as $item_type) {
+            foreach ($source->get_items($item_type) as $item) {
+                try {
+                    /* Validate every copied business-meta value before mutation. */
+                    WCOS_Order_Item_Meta_Policy::business_metadata($item);
+                } catch (Throwable $throwable) {
+                    return self::reject($report, 'noncanonical_business_metadata', $throwable->getMessage());
+                }
+
+                $unknown_private = array_merge(
+                    $unknown_private,
+                    WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_DUPLICATE)
+                );
+
+                if ($item instanceof WC_Order_Item_Product) {
+                    foreach ($item->get_meta_data() as $meta) {
+                        $key = (string) $meta->key;
+                        if (0 !== strpos($key, '_') || WCOS_Order_Item_Meta_Policy::is_protected($key)) {
+                            continue;
+                        }
+                        $duplicate_class = WCOS_Order_Item_Meta_Policy::classify(
+                            $key,
+                            $meta->value,
+                            WCOS_Order_Item_Meta_Policy::CONTEXT_DUPLICATE,
+                            $item
+                        );
+                        $identity_class = WCOS_Order_Item_Meta_Policy::classify(
+                            $key,
+                            $meta->value,
+                            WCOS_Order_Item_Meta_Policy::CONTEXT_IDENTITY,
+                            $item
+                        );
+                        if ($duplicate_class !== $identity_class) {
+                            $inconsistent_private[] = $key;
+                        }
+                    }
+
+                    try {
+                        $quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
+                    } catch (Throwable $throwable) {
+                        return self::reject($report, 'invalid_line_quantity', __('A source line contains an invalid quantity.', 'wc-order-splitter'));
+                    }
+                    if ($quantity_units <= 0) {
+                        return self::reject($report, 'invalid_line_quantity', __('Every source line must have a positive quantity.', 'wc-order-splitter'));
+                    }
+                    if (0 !== ($quantity_units % 1000000)) {
+                        $report['fractional_quantity_lines']++;
+                        if (!WCOS_Split_Preflight::fractional_quantities_supported()) {
+                            return self::reject(
+                                $report,
+                                'fractional_quantity_unsupported',
+                                __('This order contains fractional quantities but the active WooCommerce quantity integration no longer preserves fractional stock amounts.', 'wc-order-splitter')
+                            );
+                        }
+                    }
+                    if (!$item->get_product()) {
+                        $report['deleted_product_lines']++;
+                    }
+                }
+            }
+        }
+
+        $unknown_private = array_values(array_unique(array_map('strval', $unknown_private)));
+        sort($unknown_private, SORT_STRING);
+        $inconsistent_private = array_values(array_unique(array_map('strval', $inconsistent_private)));
+        sort($inconsistent_private, SORT_STRING);
+        $report['unknown_private_meta_keys'] = $unknown_private;
+        $report['inconsistent_private_meta_keys'] = $inconsistent_private;
+
+        if (!empty($inconsistent_private)) {
+            return self::reject(
+                $report,
+                'inconsistent_private_metadata_classification',
+                __('A private line-item metadata adapter classifies the same key differently for Duplicate copying and canonical line identity.', 'wc-order-splitter')
+            );
+        }
+        if (!empty($unknown_private)) {
+            return self::reject(
+                $report,
+                'unclassified_private_metadata',
+                __('The source order contains private order-item metadata that has not been classified by a compatibility adapter.', 'wc-order-splitter')
+            );
+        }
+
+        try {
+            WCOS_Order_Totals_Rebuilder::assert_consistent($source, $precision);
+            $report['source_signature'] = WCOS_Order_Contract_Snapshot::source_signature($source);
+        } catch (Throwable $throwable) {
+            return self::reject($report, 'inconsistent_source', __('The source order cannot be proven internally consistent for Duplicate.', 'wc-order-splitter'));
+        }
+
+        $report['supported'] = true;
+        $report['reason'] = 'supported';
+        $report['message'] = __('This order is compatible with the current hardened Duplicate policy.', 'wc-order-splitter');
+        return $report;
+    }
+
+    private static function reject(array $report, $reason, $message) {
+        $report['supported'] = false;
+        $report['reason'] = sanitize_key((string) $reason);
+        $report['message'] = (string) $message;
+        return $report;
+    }
+}

--- a/inc/domain/class-wcos-duplicate-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-duplicate-woocommerce-adapter.php
@@ -26,6 +26,7 @@ final class WCOS_Duplicate_WooCommerce_Adapter {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
 
+            $this->assert_verified_confirmation_source($source, $operation_id);
             WCOS_Duplicate_Preflight::assert_supported($source, $precision);
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
@@ -79,6 +80,28 @@ final class WCOS_Duplicate_WooCommerce_Adapter {
             return WCOS_Duplicate_Preflight::report($source, $precision);
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);
+        }
+    }
+
+    private function assert_verified_confirmation_source(WC_Order $source, $operation_id) {
+        if (!class_exists('WCOS_Duplicate_Confirmation_Store')) {
+            return;
+        }
+        $expected = WCOS_Duplicate_Confirmation_Store::verified_source_signature($operation_id);
+        if ('' === $expected) {
+            return;
+        }
+        $actual = WCOS_Order_Contract_Snapshot::source_signature($source);
+        if (!hash_equals($expected, $actual)) {
+            throw new WCOS_Duplicate_Preflight_Exception(
+                'source_changed_after_confirmation',
+                __('The source order changed after Duplicate confirmation verification but before mutation began. Review the order again.', 'wc-order-splitter'),
+                array(
+                    'supported' => false,
+                    'reason' => 'source_changed_after_confirmation',
+                    'order_id' => $source->get_id(),
+                )
+            );
         }
     }
 

--- a/inc/domain/class-wcos-duplicate-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-duplicate-woocommerce-adapter.php
@@ -1,0 +1,116 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * WooCommerce-facing adapter for hardened single-order Duplicate.
+ *
+ * The production gateway owns feature gating/authorization. This adapter owns
+ * compatibility preflight, precision scope, and request-local stock evidence.
+ */
+final class WCOS_Duplicate_WooCommerce_Adapter {
+
+    public function duplicate(WC_Order $source, $operation_id, $confirmed_precision = null) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if ('' === $operation_id) {
+            throw new InvalidArgumentException(__('A duplicate operation ID is required.', 'wc-order-splitter'));
+        }
+
+        $source_id = $source->get_id();
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+
+        try {
+            $source = $source_id ? wc_get_order($source_id) : $source;
+            if (!$source instanceof WC_Order) {
+                throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
+
+            WCOS_Duplicate_Preflight::assert_supported($source, $precision);
+            $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+
+            $boundary_guard = function() use ($source_id, $operation_id, $stock_token) {
+                $events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+                if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+                    $this->mark_manual_stock_reconciliation(
+                        $source_id,
+                        $operation_id,
+                        $events,
+                        new RuntimeException(__('Unexpected physical-stock evidence was observed before the Duplicate request boundary completed.', 'wc-order-splitter'))
+                    );
+                }
+                WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+            };
+            add_action('wcos_duplicate_mutation_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
+            add_action('woocommerce_order_note_added', $boundary_guard, PHP_INT_MAX, 2);
+
+            try {
+                $target = (new WCOS_Duplicate_Order_Service())->duplicate($source, $operation_id);
+                WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+                return $target;
+            } catch (Throwable $throwable) {
+                $events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+                if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+                    $this->mark_manual_stock_reconciliation($source_id, $operation_id, $events, $throwable);
+                }
+                if (!empty($events) && !$throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+                    throw new WCOS_Unexpected_Stock_Mutation_Exception($events, $throwable);
+                }
+                throw $throwable;
+            } finally {
+                remove_action('wcos_duplicate_mutation_checkpoint', $boundary_guard, PHP_INT_MAX);
+                remove_action('woocommerce_order_note_added', $boundary_guard, PHP_INT_MAX);
+                WCOS_Stock_Side_Effect_Guard::end($stock_token);
+            }
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
+    }
+
+    public function preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+        $source_id = $source->get_id();
+        $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
+        $precision_token = WCOS_Price_Precision_Scope::begin($precision);
+        try {
+            $source = $source_id ? wc_get_order($source_id) : $source;
+            if (!$source instanceof WC_Order) {
+                throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+            }
+            return WCOS_Duplicate_Preflight::report($source, $precision);
+        } finally {
+            WCOS_Price_Precision_Scope::end($precision_token);
+        }
+    }
+
+    private function mark_manual_stock_reconciliation($source_id, $operation_id, array $events, Throwable $throwable) {
+        $fresh = wc_get_order(absint($source_id));
+        if (!$fresh instanceof WC_Order) {
+            return false;
+        }
+        $record = WCOS_Operation_Journal::get($fresh, $operation_id);
+        if (!is_array($record)) {
+            return false;
+        }
+
+        if (!WCOS_Manual_Reconciliation_Blocker::block($fresh, $operation_id)) {
+            do_action('wcos_manual_reconciliation_record_error', $fresh, $operation_id, $events, $throwable);
+            return false;
+        }
+
+        $updated = WCOS_Operation_Journal::mark_manual_reconciliation(
+            $fresh,
+            $operation_id,
+            array(
+                'reason' => 'unexpected_physical_stock_write',
+                'workflow' => 'duplicate',
+                'automatic_compensation_allowed' => false,
+                'stock_side_effects' => array_values($events),
+                'error' => $throwable->getMessage(),
+            )
+        );
+        if (!$updated) {
+            do_action('wcos_manual_reconciliation_record_error', $fresh, $operation_id, $events, $throwable);
+        }
+        return $updated;
+    }
+}

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -22,10 +22,15 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
-	public function duplicate(WC_Order $source, $operation_id) {
+	public function duplicate(WC_Order $source, $operation_id, $confirmed_precision = null) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::DUPLICATE);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $source);
-		return (new WCOS_Duplicate_Order_Service())->duplicate($source, $operation_id);
+		return (new WCOS_Duplicate_WooCommerce_Adapter())->duplicate($source, $operation_id, $confirmed_precision);
+	}
+
+	public function duplicate_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $source);
+		return (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
 	public function merge(WC_Order $source, WC_Order $target, $operation_id) {

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -35,6 +35,7 @@ final class WCOS_Split_WooCommerce_Adapter {
                 throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
             }
 
+            $this->assert_verified_confirmation_source($source, $operation_id);
             $this->assert_supported($source, $precision);
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
@@ -104,6 +105,28 @@ final class WCOS_Split_WooCommerce_Adapter {
             return $report;
         } finally {
             WCOS_Price_Precision_Scope::end($precision_token);
+        }
+    }
+
+    private function assert_verified_confirmation_source(WC_Order $source, $operation_id) {
+        if (!class_exists('WCOS_Split_Confirmation_Store')) {
+            return;
+        }
+        $expected = WCOS_Split_Confirmation_Store::verified_source_signature($operation_id);
+        if ('' === $expected) {
+            return;
+        }
+        $actual = WCOS_Order_Contract_Snapshot::source_signature($source);
+        if (!hash_equals($expected, $actual)) {
+            throw new WCOS_Split_Preflight_Exception(
+                'source_changed_after_confirmation',
+                __('The source order changed after Split confirmation verification but before mutation began. Review the order again.', 'wc-order-splitter'),
+                array(
+                    'supported' => false,
+                    'reason' => 'source_changed_after_confirmation',
+                    'order_id' => $source->get_id(),
+                )
+            );
         }
     }
 

--- a/js/p2-duplicate-admin.js
+++ b/js/p2-duplicate-admin.js
@@ -1,0 +1,261 @@
+(function () {
+    'use strict';
+
+    var strings = window.wcosDuplicateAdminStrings || {};
+    var launcher = document.querySelector('.wcos-duplicate-launcher');
+    if (!launcher) {
+        return;
+    }
+
+    var dialogId = launcher.getAttribute('aria-controls');
+    var dialog = dialogId ? document.getElementById(dialogId) : null;
+    if (!dialog) {
+        return;
+    }
+
+    var panel = dialog.querySelector('.wcos-duplicate-dialog__panel');
+    var closeButton = dialog.querySelector('.wcos-duplicate-close');
+    var cancelButton = dialog.querySelector('.wcos-duplicate-cancel');
+    var reviewButton = dialog.querySelector('.wcos-duplicate-review-button');
+    var executeButton = dialog.querySelector('.wcos-duplicate-execute-button');
+    var confirmCheckbox = dialog.querySelector('.wcos-duplicate-confirm-checkbox');
+    var reviewBox = dialog.querySelector('.wcos-duplicate-review');
+    var reviewSummary = dialog.querySelector('.wcos-duplicate-review-summary');
+    var statusBox = dialog.querySelector('.wcos-duplicate-status');
+    var errorBox = dialog.querySelector('.wcos-duplicate-error');
+    var resultBox = dialog.querySelector('.wcos-duplicate-result');
+    var state = null;
+    var returnFocus = null;
+    var busy = false;
+    var completed = false;
+
+    function text(key, fallback) {
+        return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
+    }
+
+    function focusableElements() {
+        return Array.prototype.slice.call(dialog.querySelectorAll(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter(function (element) {
+            return !element.hidden && element.offsetParent !== null;
+        });
+    }
+
+    function openDialog() {
+        returnFocus = document.activeElement;
+        dialog.hidden = false;
+        document.body.classList.add('wcos-duplicate-modal-open');
+        window.setTimeout(function () {
+            var preferred = completed && !resultBox.hidden ? resultBox : reviewButton;
+            (preferred || panel).focus();
+        }, 0);
+    }
+
+    function closeDialog() {
+        if (busy) {
+            return;
+        }
+        dialog.hidden = true;
+        document.body.classList.remove('wcos-duplicate-modal-open');
+        if (returnFocus && typeof returnFocus.focus === 'function') {
+            returnFocus.focus();
+        }
+    }
+
+    function clearError() {
+        errorBox.hidden = true;
+        errorBox.textContent = '';
+    }
+
+    function showError(message) {
+        errorBox.textContent = message || text('requestFailed', 'The Duplicate request could not be completed.');
+        errorBox.hidden = false;
+        errorBox.focus();
+    }
+
+    function setStatus(message) {
+        statusBox.textContent = message || '';
+    }
+
+    function clearResult() {
+        resultBox.hidden = true;
+        resultBox.textContent = '';
+    }
+
+    function invalidateReview() {
+        if (completed) {
+            return;
+        }
+        state = null;
+        reviewBox.hidden = true;
+        reviewSummary.textContent = '';
+        confirmCheckbox.checked = false;
+        executeButton.disabled = true;
+        clearResult();
+    }
+
+    function request(action, data) {
+        var body = new URLSearchParams();
+        body.set('action', action);
+        Object.keys(data).forEach(function (key) {
+            body.set(key, String(data[key]));
+        });
+
+        return window.fetch(dialog.getAttribute('data-ajax-url'), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            body: body.toString()
+        }).then(function (response) {
+            return response.json().catch(function () {
+                throw new Error(text('requestFailed', 'The Duplicate request could not be completed.'));
+            });
+        }).then(function (payload) {
+            if (!payload || payload.success !== true) {
+                var failure = payload && payload.data ? payload.data : {};
+                var error = new Error(failure.message || text('requestFailed', 'The Duplicate request could not be completed.'));
+                error.code = failure.code || 'request_failed';
+                error.retryable = !!failure.retryable;
+                throw error;
+            }
+            return payload.data || {};
+        });
+    }
+
+    function setBusy(nextBusy) {
+        busy = !!nextBusy;
+        dialog.setAttribute('aria-busy', busy ? 'true' : 'false');
+        reviewButton.disabled = busy || completed;
+        confirmCheckbox.disabled = busy || completed;
+        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+        cancelButton.disabled = busy;
+        closeButton.disabled = busy;
+    }
+
+    function reviewDuplicate() {
+        if (busy || completed) {
+            return;
+        }
+        clearError();
+        clearResult();
+        invalidateReview();
+        setBusy(true);
+        setStatus(text('reviewing', 'Reviewing Duplicate…'));
+
+        request('wcos_duplicate_review', {
+            order_id: dialog.getAttribute('data-order-id'),
+            nonce: dialog.getAttribute('data-nonce')
+        }).then(function (data) {
+            state = {
+                operationId: data.operation_id,
+                token: data.confirmation_token
+            };
+            var summary = data.summary || {};
+            reviewSummary.textContent = text('reviewSummary', 'Reviewed lines / shipping / fees / coupons:') + ' ' +
+                String(summary.line_count || 0) + ' / ' +
+                String(summary.shipping_count || 0) + ' / ' +
+                String(summary.fee_count || 0) + ' / ' +
+                String(summary.coupon_count || 0);
+            reviewBox.hidden = false;
+            confirmCheckbox.checked = false;
+            setStatus(text('reviewReady', 'The order passed server review. Confirm the acknowledgement to duplicate it.'));
+            confirmCheckbox.focus();
+        }).catch(function (error) {
+            invalidateReview();
+            setStatus('');
+            showError(error.message);
+        }).finally(function () {
+            setBusy(false);
+        });
+    }
+
+    function renderSuccess(data) {
+        resultBox.textContent = '';
+        var message = document.createElement('p');
+        message.textContent = text('completed', 'Order duplicated successfully.');
+        resultBox.appendChild(message);
+
+        var target = data && data.target ? data.target : null;
+        if (target) {
+            var detail = document.createElement('p');
+            if (target.edit_url) {
+                var link = document.createElement('a');
+                link.href = target.edit_url;
+                link.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
+                detail.appendChild(link);
+            } else {
+                detail.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
+            }
+            resultBox.appendChild(detail);
+        }
+        resultBox.hidden = false;
+        resultBox.focus();
+    }
+
+    function executeDuplicate() {
+        if (busy || completed || !state || !confirmCheckbox.checked) {
+            return;
+        }
+        clearError();
+        clearResult();
+        setBusy(true);
+        setStatus(text('executing', 'Duplicating order…'));
+
+        request('wcos_duplicate_execute', {
+            order_id: dialog.getAttribute('data-order-id'),
+            nonce: dialog.getAttribute('data-nonce'),
+            operation_id: state.operationId,
+            confirmation_token: state.token
+        }).then(function (data) {
+            completed = true;
+            setStatus(text('completed', 'Order duplicated successfully.'));
+            confirmCheckbox.disabled = true;
+            renderSuccess(data);
+        }).catch(function (error) {
+            if (!error.retryable) {
+                invalidateReview();
+            }
+            setStatus('');
+            showError(error.message);
+        }).finally(function () {
+            setBusy(false);
+        });
+    }
+
+    launcher.addEventListener('click', openDialog);
+    closeButton.addEventListener('click', closeDialog);
+    cancelButton.addEventListener('click', closeDialog);
+    reviewButton.addEventListener('click', reviewDuplicate);
+    executeButton.addEventListener('click', executeDuplicate);
+    confirmCheckbox.addEventListener('change', function () {
+        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+    });
+
+    dialog.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeDialog();
+            return;
+        }
+        if (event.key !== 'Tab') {
+            return;
+        }
+        var focusable = focusableElements();
+        if (!focusable.length) {
+            event.preventDefault();
+            panel.focus();
+            return;
+        }
+        var first = focusable[0];
+        var last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    });
+})();

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -135,5 +135,6 @@ wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
 require __DIR__ . '/p2-duplicate-readiness-smoke.php';
 require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
+require __DIR__ . '/p2-duplicate-precision-replay-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -10,6 +10,16 @@ function wcos_control_assert($condition, $message) {
 	}
 }
 
+function wcos_duplicate_targets($source_id, $operation_id) {
+	return WCOS_Order_Relation_Repository::find(
+		array(
+			array('key' => '_wcos_operation_id', 'value' => sanitize_key($operation_id)),
+			array('key' => '_wcos_duplicate_source_order', 'value' => absint($source_id), 'type' => 'NUMERIC'),
+		),
+		-1
+	);
+}
+
 $order = wc_create_order();
 $order->set_status('pending');
 $order->save();
@@ -123,5 +133,6 @@ wcos_control_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Rel
 wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not restore the production-enabled state.');
 
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
+require __DIR__ . '/p2-duplicate-readiness-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -89,7 +89,7 @@ foreach ($summary as $entry) {
 	}
 }
 wcos_control_assert(is_array($summary_entry) && 'completed' === $summary_entry['status'], 'Bounded order-meta audit summary was not updated.');
-wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is missing the terminal timestamp.');
+wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is missing its terminal timestamp.');
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
@@ -136,5 +136,7 @@ require __DIR__ . '/p2-production-split-enabled-smoke.php';
 require __DIR__ . '/p2-duplicate-readiness-smoke.php';
 require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
 require __DIR__ . '/p2-duplicate-precision-replay-smoke.php';
+require __DIR__ . '/p2-duplicate-compatibility-smoke.php';
+require __DIR__ . '/p2-duplicate-confirmation-race-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -134,5 +134,6 @@ wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety
 
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
 require __DIR__ . '/p2-duplicate-readiness-smoke.php';
+require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -89,7 +89,7 @@ foreach ($summary as $entry) {
 	}
 }
 wcos_control_assert(is_array($summary_entry) && 'completed' === $summary_entry['status'], 'Bounded order-meta audit summary was not updated.');
-wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is missing its terminal timestamp.');
+wcos_control_assert(!empty($summary_entry['completed_at']), 'Audit summary is missing the terminal timestamp.');
 wcos_control_assert(WCOS_Operation_Journal::delete($order, $journal_operation), 'Durable journal cleanup failed.');
 $order->delete(true);
 
@@ -138,5 +138,6 @@ require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
 require __DIR__ . '/p2-duplicate-precision-replay-smoke.php';
 require __DIR__ . '/p2-duplicate-compatibility-smoke.php';
 require __DIR__ . '/p2-duplicate-confirmation-race-smoke.php';
+require __DIR__ . '/p2-confirmation-mutation-boundary-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/p2-confirmation-mutation-boundary-smoke.php
+++ b/tests/integration/p2-confirmation-mutation-boundary-smoke.php
@@ -1,0 +1,134 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$boundary_previous_user = get_current_user_id();
+$boundary_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$boundary_user_id = wp_insert_user(array(
+    'user_login' => 'wcos_confirmation_boundary_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-confirmation-boundary-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($boundary_user_id), 'Unable to create confirmation-boundary user.');
+
+$split_product = wcos_p2_adapter_product('WCOS Split verify boundary', '10.00');
+list($split_source, $split_item_id) = wcos_p2_adapter_order($split_product, 3, 'pending');
+$split_source_id = $split_source->get_id();
+$split_operation = '';
+
+$duplicate_product = wcos_p2_adapter_product('WCOS Duplicate verify boundary', '11.00');
+list($duplicate_source, $duplicate_item_id) = wcos_p2_adapter_order($duplicate_product, 2, 'pending');
+$duplicate_source_id = $duplicate_source->get_id();
+$duplicate_operation = '';
+
+try {
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    wp_set_current_user($boundary_user_id);
+
+    /* Split: verify succeeds, source changes, adapter must still fail before journal/child persistence. */
+    $split_plan = array('child-1' => array($split_item_id => '1.000000'));
+    $split_preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($split_source);
+    $split_confirmation = WCOS_Split_Confirmation_Store::create(
+        $split_source,
+        $split_plan,
+        $split_preflight,
+        $boundary_user_id
+    );
+    $split_operation = $split_confirmation['operation_id'];
+    $split_verified = WCOS_Split_Confirmation_Store::verify(
+        wc_get_order($split_source_id),
+        $split_operation,
+        $split_confirmation['confirmation_token'],
+        $boundary_user_id
+    );
+    wcos_p2_adapter_assert('confirmation' === $split_verified['replay_authority'], 'Split verify-boundary fixture did not use transient confirmation authority.');
+    wcos_p2_adapter_assert(
+        '' !== WCOS_Split_Confirmation_Store::verified_source_signature($split_operation),
+        'Split verify did not publish request-local source authority.'
+    );
+
+    $changed_split = wc_get_order($split_source_id);
+    $changed_split->set_customer_note('changed-after-split-verify');
+    $changed_split->save();
+
+    $split_rejected = false;
+    try {
+        (new WCOS_Mutation_Gateway())->split(
+            wc_get_order($split_source_id),
+            $split_verified['plan'],
+            $split_operation,
+            $split_verified['price_precision']
+        );
+    } catch (WCOS_Split_Preflight_Exception $exception) {
+        $split_rejected = 'source_changed_after_confirmation' === $exception->get_reason();
+    }
+    wcos_p2_adapter_assert($split_rejected, 'Split crossed a source edit after confirmation verify.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($split_source_id), $split_operation), 'Split verify-boundary rejection created a journal.');
+    wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($split_source_id, $split_operation)), 'Split verify-boundary rejection created a child.');
+
+    /* Duplicate: same request-local authority must block before journal/target persistence. */
+    $duplicate_preflight = (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($duplicate_source);
+    $duplicate_confirmation = WCOS_Duplicate_Confirmation_Store::create(
+        $duplicate_source,
+        $duplicate_preflight,
+        $boundary_user_id
+    );
+    $duplicate_operation = $duplicate_confirmation['operation_id'];
+    $duplicate_verified = WCOS_Duplicate_Confirmation_Store::verify(
+        wc_get_order($duplicate_source_id),
+        $duplicate_operation,
+        $duplicate_confirmation['confirmation_token'],
+        $boundary_user_id
+    );
+    wcos_p2_adapter_assert('confirmation' === $duplicate_verified['replay_authority'], 'Duplicate verify-boundary fixture did not use transient confirmation authority.');
+    wcos_p2_adapter_assert(
+        '' !== WCOS_Duplicate_Confirmation_Store::verified_source_signature($duplicate_operation),
+        'Duplicate verify did not publish request-local source authority.'
+    );
+
+    $changed_duplicate = wc_get_order($duplicate_source_id);
+    $changed_duplicate->set_customer_note('changed-after-duplicate-verify');
+    $changed_duplicate->save();
+
+    $duplicate_rejected = false;
+    try {
+        (new WCOS_Duplicate_WooCommerce_Adapter())->duplicate(
+            wc_get_order($duplicate_source_id),
+            $duplicate_operation,
+            $duplicate_verified['price_precision']
+        );
+    } catch (WCOS_Duplicate_Preflight_Exception $exception) {
+        $duplicate_rejected = 'source_changed_after_confirmation' === $exception->get_reason();
+    }
+    wcos_p2_adapter_assert($duplicate_rejected, 'Duplicate crossed a source edit after confirmation verify.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($duplicate_source_id), $duplicate_operation), 'Duplicate verify-boundary rejection created a journal.');
+    wcos_p2_adapter_assert(empty(wcos_duplicate_targets($duplicate_source_id, $duplicate_operation)), 'Duplicate verify-boundary rejection created a target.');
+} finally {
+    if ($split_operation) {
+        WCOS_Split_Confirmation_Store::delete($split_operation);
+    }
+    if ($duplicate_operation) {
+        WCOS_Duplicate_Confirmation_Store::delete($duplicate_operation);
+    }
+    $split_source = wc_get_order($split_source_id);
+    if ($split_source) {
+        $split_source->delete(true);
+    }
+    $duplicate_source = wc_get_order($duplicate_source_id);
+    if ($duplicate_source) {
+        $duplicate_source->delete(true);
+    }
+    wp_delete_post($split_product->get_id(), true);
+    wp_delete_post($duplicate_product->get_id(), true);
+    update_option('order_splitter_status_allowed', $boundary_allowed_statuses);
+    wp_set_current_user($boundary_previous_user);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    wp_delete_user($boundary_user_id);
+}
+
+echo "p2-confirmation-mutation-boundary-ok\n";

--- a/tests/integration/p2-confirmation-mutation-boundary-smoke.php
+++ b/tests/integration/p2-confirmation-mutation-boundary-smoke.php
@@ -29,6 +29,7 @@ try {
     wp_set_current_user($boundary_user_id);
 
     /* Split: verify succeeds, source changes, adapter must still fail before journal/child persistence. */
+    $split_source = wc_get_order($split_source_id);
     $split_plan = array('child-1' => array($split_item_id => '1.000000'));
     $split_preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($split_source);
     $split_confirmation = WCOS_Split_Confirmation_Store::create(
@@ -70,6 +71,7 @@ try {
     wcos_p2_adapter_assert(empty(wcos_p2_adapter_children($split_source_id, $split_operation)), 'Split verify-boundary rejection created a child.');
 
     /* Duplicate: same request-local authority must block before journal/target persistence. */
+    $duplicate_source = wc_get_order($duplicate_source_id);
     $duplicate_preflight = (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($duplicate_source);
     $duplicate_confirmation = WCOS_Duplicate_Confirmation_Store::create(
         $duplicate_source,

--- a/tests/integration/p2-duplicate-compatibility-smoke.php
+++ b/tests/integration/p2-duplicate-compatibility-smoke.php
@@ -1,0 +1,83 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$compat_product = wcos_p2_adapter_product('WCOS Duplicate configured product', '15.00', 30);
+$compat_order = wc_create_order();
+$compat_order->set_status('processing');
+$compat_order->set_currency('USD');
+$compat_item_a = $compat_order->add_product($compat_product, 1);
+$compat_item_b = $compat_order->add_product($compat_product, 2);
+$compat_order->calculate_totals(false);
+$compat_order->set_payment_method('bacs');
+$compat_order->set_payment_method_title('Direct bank transfer');
+$compat_order->set_transaction_id('paid-source-transaction');
+$compat_order->set_date_paid(time());
+$compat_order->save();
+$compat_order = wc_get_order($compat_order->get_id());
+$compat_order_id = $compat_order->get_id();
+
+$item_a = $compat_order->get_item($compat_item_a);
+$item_a->add_meta_data('_vendor_configuration', 'config-a', true);
+$item_a->save();
+$item_b = $compat_order->get_item($compat_item_b);
+$item_b->add_meta_data('_vendor_configuration', 'config-b', true);
+$item_b->save();
+$compat_order = wc_get_order($compat_order_id);
+
+$compat_adapter = new WCOS_Duplicate_WooCommerce_Adapter();
+$unadapted = $compat_adapter->preflight($compat_order);
+wcos_p2_adapter_assert(empty($unadapted['supported']) && 'unclassified_private_metadata' === $unadapted['reason'], 'Duplicate accepted configured private metadata without an adapter.');
+
+$classification_filter = static function($classification, $key, $value, $context) {
+    if ('_vendor_configuration' === $key
+        && in_array($context, array(WCOS_Order_Item_Meta_Policy::CONTEXT_DUPLICATE, WCOS_Order_Item_Meta_Policy::CONTEXT_IDENTITY), true)) {
+        return WCOS_Order_Item_Meta_Policy::CLASS_BUSINESS;
+    }
+    return $classification;
+};
+add_filter('wcos_order_item_meta_classification', $classification_filter, 10, 4);
+
+$compat_operation = 'p2-duplicate-configured-' . wp_generate_uuid4();
+try {
+    $adapted = $compat_adapter->preflight(wc_get_order($compat_order_id));
+    wcos_p2_adapter_assert(!empty($adapted['supported']), 'Explicit Duplicate metadata adapter did not unlock configured lines.');
+    wcos_p2_adapter_assert(!empty($adapted['is_paid']) && !empty($adapted['has_transaction']), 'Paid-source Duplicate preflight lost payment-state disclosure.');
+
+    /* Historical order items remain authoritative even when the catalog product is gone. */
+    wp_delete_post($compat_product->get_id(), true);
+    $deleted_report = $compat_adapter->preflight(wc_get_order($compat_order_id));
+    wcos_p2_adapter_assert(!empty($deleted_report['supported']), 'Duplicate rejected configured historical lines after catalog product deletion.');
+    wcos_p2_adapter_assert(2 === (int) $deleted_report['deleted_product_lines'], 'Duplicate did not report both deleted-product lines.');
+
+    $target = $compat_adapter->duplicate(wc_get_order($compat_order_id), $compat_operation);
+    $target = wc_get_order($target->get_id());
+    wcos_p2_adapter_assert('pending' === $target->get_status(), 'Paid source did not duplicate to Pending payment.');
+    wcos_p2_adapter_assert(!$target->is_paid(), 'Duplicate target inherited paid state.');
+    wcos_p2_adapter_assert('' === (string) $target->get_transaction_id(), 'Duplicate target inherited paid transaction ID.');
+    wcos_p2_adapter_assert(!$target->get_date_paid(), 'Duplicate target inherited date_paid.');
+    wcos_p2_adapter_assert(2 === count($target->get_items('line_item')), 'Duplicate collapsed configured lines sharing one product ID.');
+
+    $configs = array();
+    foreach ($target->get_items('line_item') as $line) {
+        $configs[] = (string) $line->get_meta('_vendor_configuration', true);
+    }
+    sort($configs, SORT_STRING);
+    wcos_p2_adapter_assert(array('config-a', 'config-b') === $configs, 'Duplicate did not preserve configured-line business metadata exactly.');
+
+    $target->delete(true);
+    WCOS_Operation_Journal::delete(wc_get_order($compat_order_id), $compat_operation);
+} finally {
+    remove_filter('wcos_order_item_meta_classification', $classification_filter, 10);
+    $source = wc_get_order($compat_order_id);
+    if ($source) {
+        $source->delete(true);
+    }
+    if (get_post($compat_product->get_id())) {
+        wp_delete_post($compat_product->get_id(), true);
+    }
+}
+
+echo "p2-duplicate-compatibility-ok\n";

--- a/tests/integration/p2-duplicate-confirmation-race-smoke.php
+++ b/tests/integration/p2-duplicate-confirmation-race-smoke.php
@@ -1,0 +1,91 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$race_previous_user = get_current_user_id();
+$race_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$race_user_id = wp_insert_user(array(
+    'user_login' => 'wcos_duplicate_race_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-duplicate-race-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($race_user_id), 'Unable to create Duplicate source-race test user.');
+
+$race_product = wcos_p2_adapter_product('WCOS Duplicate source race', '9.00');
+list($race_source, $race_item_id) = wcos_p2_adapter_order($race_product, 3, 'pending');
+$race_source_id = $race_source->get_id();
+$race_adapter = new WCOS_Duplicate_WooCommerce_Adapter();
+$race_controller = new WCOS_Duplicate_Admin_Controller();
+$race_operations = array();
+
+try {
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    wp_set_current_user($race_user_id);
+
+    /* Preflight -> confirmation issuance must fail if the persisted source changes. */
+    $preflight = $race_adapter->preflight($race_source);
+    $changed = wc_get_order($race_source_id);
+    $changed_item = $changed->get_item($race_item_id);
+    $changed_item->set_quantity(4);
+    $changed_item->save();
+
+    $create_rejected = false;
+    try {
+        WCOS_Duplicate_Confirmation_Store::create($race_source, $preflight, $race_user_id);
+    } catch (WCOS_Duplicate_Confirmation_Exception $exception) {
+        $create_rejected = 'source_changed' === $exception->get_reason();
+    }
+    wcos_p2_adapter_assert($create_rejected, 'Duplicate confirmation was issued after the source changed behind preflight.');
+
+    /* Restore a clean fixture, review through transport, then edit before Execute. */
+    $restored = wc_get_order($race_source_id);
+    $restored_item = $restored->get_item($race_item_id);
+    $restored_item->set_quantity(3);
+    $restored_item->save();
+    $restored = wc_get_order($race_source_id);
+    $restored->calculate_totals(false);
+    $restored->save();
+
+    $nonce = wp_create_nonce('wcos_duplicate_order_' . $race_source_id);
+    $review = $race_controller->review_request(array('order_id' => $race_source_id, 'nonce' => $nonce));
+    $race_operations[] = $review['operation_id'];
+    $after_review = wc_get_order($race_source_id);
+    $after_review->set_customer_note('changed-after-duplicate-review');
+    $after_review->save();
+
+    $execute_rejected = false;
+    try {
+        $race_controller->execute_request(array(
+            'order_id' => $race_source_id,
+            'nonce' => $nonce,
+            'operation_id' => $review['operation_id'],
+            'confirmation_token' => $review['confirmation_token'],
+        ));
+    } catch (WCOS_Duplicate_Transport_Exception $exception) {
+        $execute_rejected = 'confirmation_source_changed' === $exception->get_error_code()
+            && 409 === $exception->get_http_status();
+    }
+    wcos_p2_adapter_assert($execute_rejected, 'Duplicate Execute accepted a source changed after Review.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($race_source_id), $review['operation_id']), 'Source-changed Duplicate Execute created a mutation journal.');
+    wcos_p2_adapter_assert(empty(wcos_duplicate_targets($race_source_id, $review['operation_id'])), 'Source-changed Duplicate Execute created a target.');
+} finally {
+    foreach ($race_operations as $operation_id) {
+        WCOS_Duplicate_Confirmation_Store::delete($operation_id);
+    }
+    update_option('order_splitter_status_allowed', $race_allowed_statuses);
+    wp_set_current_user($race_previous_user);
+    $source = wc_get_order($race_source_id);
+    if ($source) {
+        $source->delete(true);
+    }
+    wp_delete_post($race_product->get_id(), true);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    wp_delete_user($race_user_id);
+}
+
+echo "p2-duplicate-confirmation-race-ok\n";

--- a/tests/integration/p2-duplicate-precision-replay-smoke.php
+++ b/tests/integration/p2-duplicate-precision-replay-smoke.php
@@ -1,0 +1,151 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+$duplicate_precision_original = get_option('woocommerce_price_num_decimals', 2);
+$duplicate_precision_adapter = new WCOS_Duplicate_WooCommerce_Adapter();
+
+try {
+    foreach (array(
+        array('precision' => 0, 'currency' => 'JPY', 'line' => '10', 'tax' => '1'),
+        array('precision' => 3, 'currency' => 'BHD', 'line' => '10.001', 'tax' => '1.001'),
+    ) as $case) {
+        update_option('woocommerce_price_num_decimals', (string) $case['precision']);
+        list($source, $product_id, $item_id) = wcos_p2_precision_build_order(
+            $case['precision'],
+            $case['currency'],
+            $case['line'],
+            $case['tax']
+        );
+        $source_id = $source->get_id();
+        $source_contract = WCOS_Order_Contract_Snapshot::aggregate(array($source), $case['precision']);
+        unset($source_contract['stock_reduced']);
+        $operation = 'p2-duplicate-precision-' . $case['precision'] . '-' . wp_generate_uuid4();
+
+        $report = $duplicate_precision_adapter->preflight($source, $operation);
+        wcos_p2_adapter_assert($case['precision'] === (int) $report['price_precision'], 'Duplicate preflight reported the wrong price precision.');
+        $target = $duplicate_precision_adapter->duplicate($source, $operation);
+        $target = wc_get_order($target->get_id());
+        $target_contract = WCOS_Order_Contract_Snapshot::aggregate(array($target), $case['precision']);
+        unset($target_contract['stock_reduced']);
+        WCOS_Mutation_Contract::assert_conserved($source_contract, $target_contract, $case['precision']);
+        WCOS_Order_Totals_Rebuilder::assert_consistent($target, $case['precision']);
+
+        $record = WCOS_Operation_Journal::get(wc_get_order($source_id), $operation);
+        wcos_p2_adapter_assert(is_array($record) && $case['precision'] === (int) $record['context']['price_precision'], 'Duplicate journal did not capture the reviewed price precision.');
+        wcos_p2_adapter_assert((int) WCOS_Duplicate_Preflight::POLICY_VERSION === (int) $record['context']['policy_version'], 'Duplicate journal did not capture the reviewed policy version.');
+
+        WCOS_Operation_Journal::delete(wc_get_order($source_id), $operation);
+        $target->delete(true);
+        wc_get_order($source_id)->delete(true);
+        wp_delete_post($product_id, true);
+    }
+
+    /* Interrupted Duplicate must retain journal precision/policy authority after confirmation expiry. */
+    $previous_user = get_current_user_id();
+    $allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+    $user_id = wp_insert_user(array(
+        'user_login' => 'wcos_duplicate_replay_' . wp_generate_password(8, false),
+        'user_pass' => wp_generate_password(24, true),
+        'user_email' => 'wcos-duplicate-replay-' . wp_generate_uuid4() . '@example.test',
+        'role' => 'administrator',
+    ));
+    wcos_p2_adapter_assert(!is_wp_error($user_id), 'Unable to create Duplicate replay user.');
+
+    update_option('woocommerce_price_num_decimals', '3');
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    wp_set_current_user($user_id);
+    list($replay_source, $replay_product_id, $replay_item_id) = wcos_p2_precision_build_order(3, 'BHD', '10.001', '1.001');
+    $replay_source_id = $replay_source->get_id();
+    $controller = new WCOS_Duplicate_Admin_Controller();
+    $nonce = wp_create_nonce('wcos_duplicate_order_' . $replay_source_id);
+    $review = $controller->review_request(array('order_id' => $replay_source_id, 'nonce' => $nonce));
+    $operation = $review['operation_id'];
+    wcos_p2_adapter_assert(3 === (int) $review['preflight']['price_precision'], 'Duplicate replay review did not capture three-decimal precision.');
+
+    $fail_once = true;
+    $crash = static function($stage) use (&$fail_once) {
+        if ($fail_once && 'after_target_save' === $stage) {
+            $fail_once = false;
+            throw new RuntimeException('Injected Duplicate durable replay crash.');
+        }
+    };
+    add_action('wcos_duplicate_mutation_checkpoint', $crash, 10, 4);
+    $crashed = false;
+    try {
+        $duplicate_precision_adapter->duplicate(
+            wc_get_order($replay_source_id),
+            $operation,
+            $review['preflight']['price_precision']
+        );
+    } catch (RuntimeException $exception) {
+        $crashed = false !== strpos($exception->getMessage(), 'Injected Duplicate durable replay crash.');
+    }
+    remove_action('wcos_duplicate_mutation_checkpoint', $crash, 10);
+    wcos_p2_adapter_assert($crashed, 'Duplicate durable replay fixture did not crash at the intended persistence boundary.');
+
+    $record = WCOS_Operation_Journal::get(wc_get_order($replay_source_id), $operation);
+    wcos_p2_adapter_assert(is_array($record), 'Interrupted Duplicate did not create a durable journal.');
+    wcos_p2_adapter_assert(3 === (int) $record['context']['price_precision'], 'Interrupted Duplicate lost its three-decimal precision.');
+    wcos_p2_adapter_assert((int) WCOS_Duplicate_Preflight::POLICY_VERSION === (int) $record['context']['policy_version'], 'Interrupted Duplicate lost its policy authority.');
+    $persisted_targets = wcos_duplicate_targets($replay_source_id, $operation);
+    wcos_p2_adapter_assert(1 === count($persisted_targets), 'Interrupted Duplicate did not preserve exactly one reusable target.');
+
+    WCOS_Duplicate_Confirmation_Store::delete($operation);
+    update_option('woocommerce_price_num_decimals', '0');
+    $durable = WCOS_Duplicate_Confirmation_Store::verify(
+        wc_get_order($replay_source_id),
+        $operation,
+        '',
+        $user_id
+    );
+    wcos_p2_adapter_assert('journal' === $durable['replay_authority'], 'Expired Duplicate confirmation did not fall back to journal authority.');
+    wcos_p2_adapter_assert(3 === (int) $durable['price_precision'], 'Durable Duplicate replay did not preserve journal price precision.');
+    wcos_p2_adapter_assert((int) WCOS_Duplicate_Preflight::POLICY_VERSION === (int) $durable['policy_version'], 'Durable Duplicate replay did not preserve journal policy version.');
+    wcos_p2_adapter_assert(0 === wc_get_price_decimals(), 'Duplicate confirmation replay leaked precision scope into ambient state.');
+
+    $completed = $duplicate_precision_adapter->duplicate(
+        wc_get_order($replay_source_id),
+        $operation,
+        $durable['price_precision']
+    );
+    wcos_p2_adapter_assert($persisted_targets[0]->get_id() === $completed->get_id(), 'Duplicate durable replay created another target.');
+    $record = WCOS_Operation_Journal::get(wc_get_order($replay_source_id), $operation);
+    wcos_p2_adapter_assert('completed' === $record['status'], 'Duplicate durable replay did not complete the original journal.');
+
+    /* A changed durable policy fails closed rather than replaying under new semantics. */
+    $journal_key = 'wcos_mutation_op_' . hash('sha256', absint($replay_source_id) . '|' . sanitize_key($operation));
+    $original_record = $record;
+    $tampered = $record;
+    $tampered['context']['policy_version'] = WCOS_Duplicate_Preflight::POLICY_VERSION + 1;
+    update_option($journal_key, $tampered, false);
+    wp_cache_delete($journal_key, 'options');
+    $policy_changed = false;
+    try {
+        WCOS_Duplicate_Confirmation_Store::verify(wc_get_order($replay_source_id), $operation, '', $user_id);
+    } catch (WCOS_Duplicate_Confirmation_Exception $exception) {
+        $policy_changed = 'policy_changed' === $exception->get_reason();
+    }
+    wcos_p2_adapter_assert($policy_changed, 'Duplicate durable replay crossed a changed safety policy.');
+    update_option($journal_key, $original_record, false);
+    wp_cache_delete($journal_key, 'options');
+
+    WCOS_Operation_Journal::delete(wc_get_order($replay_source_id), $operation);
+    foreach (wcos_duplicate_targets($replay_source_id, $operation) as $target) {
+        $target->delete(true);
+    }
+    wc_get_order($replay_source_id)->delete(true);
+    wp_delete_post($replay_product_id, true);
+    update_option('order_splitter_status_allowed', $allowed_statuses);
+    wp_set_current_user($previous_user);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    wp_delete_user($user_id);
+} finally {
+    update_option('woocommerce_price_num_decimals', $duplicate_precision_original);
+}
+
+echo "p2-duplicate-precision-replay-ok\n";

--- a/tests/integration/p2-duplicate-readiness-smoke.php
+++ b/tests/integration/p2-duplicate-readiness-smoke.php
@@ -1,0 +1,272 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_duplicate_expect_transport($code, $http_status, callable $callback, $message) {
+    try {
+        $callback();
+    } catch (WCOS_Duplicate_Transport_Exception $exception) {
+        wcos_p2_adapter_assert($code === $exception->get_error_code(), $message . ' Wrong code: ' . $exception->get_error_code());
+        wcos_p2_adapter_assert($http_status === $exception->get_http_status(), $message . ' Wrong HTTP status.');
+        return $exception;
+    }
+    throw new RuntimeException($message);
+}
+
+wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Duplicate readiness test unexpectedly found the production gate enabled.');
+
+$duplicate_previous_user = get_current_user_id();
+$duplicate_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$duplicate_manager_permission = get_option('order_splitter_shop_manager_permission', 'no');
+$duplicate_admin_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_duplicate_admin_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-duplicate-admin-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'administrator',
+));
+$duplicate_subscriber_id = wp_insert_user(array(
+    'user_login' => 'wcos_p2_duplicate_subscriber_' . wp_generate_password(8, false),
+    'user_pass' => wp_generate_password(24, true),
+    'user_email' => 'wcos-p2-duplicate-subscriber-' . wp_generate_uuid4() . '@example.test',
+    'role' => 'subscriber',
+));
+wcos_p2_adapter_assert(!is_wp_error($duplicate_admin_id) && !is_wp_error($duplicate_subscriber_id), 'Unable to create Duplicate readiness test users.');
+
+$duplicate_product = wcos_p2_adapter_product('WCOS P2 hardened Duplicate', '12.34', 40);
+list($duplicate_source, $duplicate_item_id) = wcos_p2_adapter_order($duplicate_product, 4, 'pending');
+$duplicate_source_id = $duplicate_source->get_id();
+$duplicate_line = $duplicate_source->get_item($duplicate_item_id);
+$duplicate_line->add_meta_data('engraving', 'Duplicate-A', true);
+$duplicate_line->save();
+
+$duplicate_shipping = new WC_Order_Item_Shipping();
+$duplicate_shipping->set_method_title('Duplicate historical shipping');
+$duplicate_shipping->set_method_id('flat_rate');
+$duplicate_shipping->set_instance_id(42);
+$duplicate_shipping->set_total('3.21');
+$duplicate_source->add_item($duplicate_shipping);
+
+$duplicate_fee = new WC_Order_Item_Fee();
+$duplicate_fee->set_name('Duplicate historical fee');
+$duplicate_fee->set_amount('1.11');
+$duplicate_fee->set_total('1.11');
+$duplicate_source->add_item($duplicate_fee);
+
+$duplicate_coupon = new WC_Order_Item_Coupon();
+$duplicate_coupon->set_code('historic-duplicate-coupon');
+$duplicate_coupon->set_discount('0.44');
+$duplicate_coupon->set_discount_tax('0');
+$duplicate_source->add_item($duplicate_coupon);
+$duplicate_source->calculate_totals(false);
+$duplicate_source->set_payment_method('cod');
+$duplicate_source->set_payment_method_title('Cash on delivery');
+$duplicate_source->set_transaction_id('source-duplicate-transaction');
+$duplicate_source->set_billing_first_name('DuplicatePrivateProbe');
+$duplicate_source->set_billing_email('duplicate-private@example.test');
+$duplicate_source->update_meta_data('_third_party_order_state', 'must-not-copy');
+$duplicate_source->save();
+
+wc_reduce_stock_levels($duplicate_source);
+$duplicate_source->get_data_store()->set_stock_reduced($duplicate_source_id, true);
+$duplicate_source = wc_get_order($duplicate_source_id);
+$duplicate_stock_before = wc_get_product($duplicate_product->get_id())->get_stock_quantity();
+$duplicate_source_signature = WCOS_Order_Contract_Snapshot::source_signature($duplicate_source);
+$duplicate_adapter = new WCOS_Duplicate_WooCommerce_Adapter();
+$duplicate_controller = new WCOS_Duplicate_Admin_Controller();
+$duplicate_operation = '';
+$duplicate_direct_operation = '';
+
+try {
+    update_option('order_splitter_status_allowed', array('wc-pending'));
+    update_option('order_splitter_shop_manager_permission', 'no');
+    wp_set_current_user($duplicate_admin_id);
+
+    $preflight = $duplicate_adapter->preflight($duplicate_source);
+    wcos_p2_adapter_assert(!empty($preflight['supported']), 'Valid source failed Duplicate preflight.');
+    wcos_p2_adapter_assert('copy_exact' === $preflight['policy']['coupons'], 'Duplicate coupon policy was not explicit.');
+    wcos_p2_adapter_assert('do_not_copy' === $preflight['policy']['payment_transaction'], 'Duplicate transaction policy was not explicit.');
+    wcos_p2_adapter_assert(!empty($preflight['source_signature']), 'Duplicate preflight omitted the PII-free source signature.');
+    $preflight_json = wp_json_encode($preflight);
+    wcos_p2_adapter_assert(false === strpos($preflight_json, 'DuplicatePrivateProbe'), 'Duplicate preflight leaked billing PII.');
+    wcos_p2_adapter_assert(false === strpos($preflight_json, 'duplicate-private@example.test'), 'Duplicate preflight leaked billing email.');
+
+    /* Custom order-level meta is deliberately not copied by the service. */
+    $duplicate_direct_operation = 'p2-duplicate-adapter-' . wp_generate_uuid4();
+    $target = $duplicate_adapter->duplicate($duplicate_source, $duplicate_direct_operation);
+    $target = wc_get_order($target->get_id());
+    wcos_p2_adapter_assert($target instanceof WC_Order, 'Duplicate adapter did not create a target.');
+    wcos_p2_adapter_assert('pending' === $target->get_status(), 'Duplicate target did not remain Pending payment.');
+    wcos_p2_adapter_assert('' === (string) $target->get_transaction_id(), 'Duplicate target copied the transaction ID.');
+    wcos_p2_adapter_assert(false === (bool) $target->get_data_store()->get_stock_reduced($target->get_id()), 'Duplicate target inherited order-level stock-reduced state.');
+    wcos_p2_adapter_assert('' === (string) $target->get_meta('_third_party_order_state', true), 'Duplicate target copied unsupported custom order-level metadata.');
+    wcos_p2_adapter_assert($duplicate_stock_before == wc_get_product($duplicate_product->get_id())->get_stock_quantity(), 'Duplicate adapter changed physical stock.');
+    wcos_p2_adapter_assert($duplicate_source_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($duplicate_source_id)), 'Duplicate adapter changed the source commercial state.');
+
+    $target_line = current($target->get_items('line_item'));
+    wcos_p2_adapter_assert('Duplicate-A' === (string) $target_line->get_meta('engraving', true), 'Duplicate target lost public business metadata.');
+    wcos_p2_adapter_assert('' === (string) $target_line->get_meta('_reduced_stock', true), 'Duplicate target inherited _reduced_stock.');
+    $target_shipping = current($target->get_items('shipping'));
+    wcos_p2_adapter_assert('flat_rate' === $target_shipping->get_method_id() && 42 === (int) $target_shipping->get_instance_id(), 'Duplicate target lost shipping method identity.');
+    $target_coupon = current($target->get_items('coupon'));
+    wcos_p2_adapter_assert('historic-duplicate-coupon' === $target_coupon->get_code(), 'Duplicate target lost historical coupon row.');
+
+    $direct_retry = $duplicate_adapter->duplicate(wc_get_order($duplicate_source_id), $duplicate_direct_operation);
+    wcos_p2_adapter_assert($direct_retry->get_id() === $target->get_id(), 'Duplicate adapter retry created a different target.');
+    wcos_p2_adapter_assert(1 === count(wcos_duplicate_targets($duplicate_source_id, $duplicate_direct_operation)), 'Duplicate adapter retry produced more than one target.');
+    wcos_p2_adapter_assert($duplicate_stock_before == wc_get_product($duplicate_product->get_id())->get_stock_quantity(), 'Duplicate adapter retry changed physical stock.');
+
+    $journal = WCOS_Operation_Journal::get(wc_get_order($duplicate_source_id), $duplicate_direct_operation);
+    wcos_p2_adapter_assert(is_array($journal) && 'completed' === $journal['status'], 'Duplicate adapter journal did not complete.');
+    wcos_p2_adapter_assert((int) WCOS_Duplicate_Preflight::POLICY_VERSION === (int) $journal['context']['policy_version'], 'Duplicate journal lost policy-version authority.');
+    wcos_p2_adapter_assert(array_key_exists('price_precision', $journal['context']), 'Duplicate journal lost price precision.');
+
+    /* Unknown private line metadata fails before a mutation journal/target exists. */
+    $unknown_product = wcos_p2_adapter_product('WCOS Duplicate unknown meta', '5.00');
+    list($unknown_source, $unknown_item_id) = wcos_p2_adapter_order($unknown_product, 2);
+    $unknown_item = $unknown_source->get_item($unknown_item_id);
+    $unknown_item->add_meta_data('_bundle_private_config', 'opaque', true);
+    $unknown_item->save();
+    $unknown_source = wc_get_order($unknown_source->get_id());
+    $unknown_report = $duplicate_adapter->preflight($unknown_source);
+    wcos_p2_adapter_assert(empty($unknown_report['supported']) && 'unclassified_private_metadata' === $unknown_report['reason'], 'Duplicate preflight accepted unknown private metadata.');
+    $unknown_operation = 'p2-duplicate-unknown-' . wp_generate_uuid4();
+    $unknown_rejected = false;
+    try {
+        $duplicate_adapter->duplicate($unknown_source, $unknown_operation);
+    } catch (WCOS_Duplicate_Preflight_Exception $exception) {
+        $unknown_rejected = 'unclassified_private_metadata' === $exception->get_reason();
+    }
+    wcos_p2_adapter_assert($unknown_rejected, 'Duplicate adapter did not fail closed on unknown private metadata.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($unknown_source, $unknown_operation), 'Unknown private metadata rejection created a journal.');
+    wcos_p2_adapter_assert(empty(wcos_duplicate_targets($unknown_source->get_id(), $unknown_operation)), 'Unknown private metadata rejection created a target.');
+    $unknown_source->delete(true);
+    wp_delete_post($unknown_product->get_id(), true);
+
+    /* Refunded orders fail closed before mutation. */
+    $refund_product = wcos_p2_adapter_product('WCOS Duplicate refund reject', '7.00');
+    list($refund_source, $refund_item_id) = wcos_p2_adapter_order($refund_product, 2);
+    $refund = wc_create_refund(array(
+        'order_id' => $refund_source->get_id(),
+        'amount' => '1.00',
+        'reason' => 'duplicate-readiness-test',
+    ));
+    wcos_p2_adapter_assert(!is_wp_error($refund), 'Unable to create Duplicate refund fixture.');
+    $refund_report = $duplicate_adapter->preflight(wc_get_order($refund_source->get_id()));
+    wcos_p2_adapter_assert(empty($refund_report['supported']) && 'refund_policy_missing' === $refund_report['reason'], 'Duplicate preflight accepted a refunded order.');
+    wc_get_order($refund_source->get_id())->delete(true);
+    wp_delete_post($refund_product->get_id(), true);
+
+    /* Production transport is fully wired but remains hard-off. */
+    wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Duplicate_Admin_Controller::REVIEW_ACTION), 'Duplicate review AJAX route was not bootstrapped.');
+    wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Duplicate_Admin_Controller::EXECUTE_ACTION), 'Duplicate execute AJAX route was not bootstrapped.');
+    $nonce = wp_create_nonce('wcos_duplicate_order_' . $duplicate_source_id);
+    $review = $duplicate_controller->review_request(array(
+        'order_id' => $duplicate_source_id,
+        'nonce' => $nonce,
+    ));
+    $duplicate_operation = $review['operation_id'];
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($duplicate_source_id), $duplicate_operation), 'Read-only Duplicate review created a journal.');
+    wcos_p2_adapter_assert($duplicate_source_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($duplicate_source_id)), 'Read-only Duplicate review changed the source.');
+
+    $invalid_token = wcos_p2_duplicate_expect_transport(
+        'confirmation_invalid_token',
+        403,
+        static function() use ($duplicate_controller, $duplicate_source_id, $nonce, $review) {
+            $duplicate_controller->execute_request(array(
+                'order_id' => $duplicate_source_id,
+                'nonce' => $nonce,
+                'operation_id' => $review['operation_id'],
+                'confirmation_token' => 'wrong-duplicate-token',
+            ));
+        },
+        'Duplicate execute accepted an invalid token.'
+    );
+    wcos_p2_adapter_assert(!$invalid_token->is_retryable(), 'Invalid Duplicate token became retryable.');
+
+    $disabled = wcos_p2_duplicate_expect_transport(
+        'workflow_disabled',
+        503,
+        static function() use ($duplicate_controller, $duplicate_source_id, $nonce, $review) {
+            $duplicate_controller->execute_request(array(
+                'order_id' => $duplicate_source_id,
+                'nonce' => $nonce,
+                'operation_id' => $review['operation_id'],
+                'confirmation_token' => $review['confirmation_token'],
+            ));
+        },
+        'Duplicate hard-off execute reached mutation runtime.'
+    );
+    wcos_p2_adapter_assert(!$disabled->is_retryable(), 'Hard-off Duplicate response became retryable.');
+    wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($duplicate_source_id), $duplicate_operation), 'Hard-off Duplicate execute created a journal.');
+
+    wcos_p2_duplicate_expect_transport(
+        'invalid_nonce',
+        403,
+        static function() use ($duplicate_controller, $duplicate_source_id) {
+            $duplicate_controller->review_request(array('order_id' => $duplicate_source_id, 'nonce' => 'invalid'));
+        },
+        'Duplicate review accepted an invalid nonce.'
+    );
+    wp_set_current_user($duplicate_subscriber_id);
+    $subscriber_nonce = wp_create_nonce('wcos_duplicate_order_' . $duplicate_source_id);
+    wcos_p2_duplicate_expect_transport(
+        'authorization_failed',
+        403,
+        static function() use ($duplicate_controller, $duplicate_source_id, $subscriber_nonce) {
+            $duplicate_controller->review_request(array('order_id' => $duplicate_source_id, 'nonce' => $subscriber_nonce));
+        },
+        'Subscriber was allowed to review Duplicate.'
+    );
+    wp_set_current_user($duplicate_admin_id);
+
+    ob_start();
+    $duplicate_controller->render_launcher(wc_get_order($duplicate_source_id));
+    $launcher_html = ob_get_clean();
+    wcos_p2_adapter_assert('' === $launcher_html, 'Duplicate launcher rendered while its feature gate is hard-off.');
+
+    $dialog_html = $duplicate_controller->dialog_html(wc_get_order($duplicate_source_id), $preflight);
+    foreach (array('role="dialog"', 'aria-modal="true"', 'role="status"', 'role="alert"', 'wcos-duplicate-confirm-checkbox', 'Confirm and duplicate', 'Custom order-level metadata') as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($dialog_html, $needle), 'Duplicate dialog is missing required markup/policy: ' . $needle);
+    }
+    wcos_p2_adapter_assert(false === strpos($dialog_html, 'DuplicatePrivateProbe'), 'Duplicate dialog leaked billing PII.');
+    wcos_p2_adapter_assert(false === strpos($dialog_html, 'duplicate-private@example.test'), 'Duplicate dialog leaked billing email.');
+
+    $js = file_get_contents(dirname(__DIR__, 2) . '/js/p2-duplicate-admin.js');
+    wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read Duplicate admin client.');
+    wcos_p2_adapter_assert(false === strpos($js, 'innerHTML'), 'Duplicate admin client uses innerHTML.');
+    wcos_p2_adapter_assert(false === strpos($js, 'alert('), 'Duplicate admin client uses blocking alert().');
+    foreach (array("event.key === 'Escape'", "event.key !== 'Tab'", 'returnFocus.focus()', 'var completed = false;', 'reviewButton.disabled = busy || completed;', 'executeButton.disabled = busy || completed') as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Duplicate admin client is missing terminal/accessibility behavior: ' . $needle);
+    }
+} finally {
+    if ($duplicate_operation) {
+        WCOS_Duplicate_Confirmation_Store::delete($duplicate_operation);
+    }
+    if ($duplicate_direct_operation) {
+        WCOS_Operation_Journal::delete(wc_get_order($duplicate_source_id), $duplicate_direct_operation);
+        foreach (wcos_duplicate_targets($duplicate_source_id, $duplicate_direct_operation) as $target) {
+            $target->delete(true);
+        }
+    }
+    $source = wc_get_order($duplicate_source_id);
+    if ($source instanceof WC_Order) {
+        $source->delete(true);
+    }
+    wp_delete_post($duplicate_product->get_id(), true);
+    update_option('order_splitter_status_allowed', $duplicate_allowed_statuses);
+    update_option('order_splitter_shop_manager_permission', $duplicate_manager_permission);
+    wp_set_current_user($duplicate_previous_user);
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    if (!is_wp_error($duplicate_admin_id)) {
+        wp_delete_user($duplicate_admin_id);
+    }
+    if (!is_wp_error($duplicate_subscriber_id)) {
+        wp_delete_user($duplicate_subscriber_id);
+    }
+}
+
+echo "p2-duplicate-readiness-ok\n";

--- a/tests/integration/p2-duplicate-side-effects-smoke.php
+++ b/tests/integration/p2-duplicate-side-effects-smoke.php
@@ -1,0 +1,221 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_p2_duplicate_note_count($order_id) {
+    return count(wc_get_order_notes(array('order_id' => absint($order_id), 'limit' => -1)));
+}
+
+$side_product = wcos_p2_adapter_product('WCOS Duplicate side-effect product', '10.00', 20);
+list($side_source, $side_item_id) = wcos_p2_adapter_order($side_product, 3, 'pending');
+$side_source_id = $side_source->get_id();
+$side_stock_before = wc_get_product($side_product->get_id())->get_stock_quantity();
+$side_note_before = wcos_p2_duplicate_note_count($side_source_id);
+
+$webhook = new WC_Webhook();
+$webhook->set_name('WCOS Duplicate order-created contract');
+$webhook->set_status('active');
+$webhook->set_topic('order.created');
+$webhook->set_delivery_url('https://example.invalid/wcos-duplicate-webhook');
+$webhook->set_secret('wcos-duplicate-test-secret');
+$webhook->set_user_id(1);
+$webhook->save();
+$webhook->enqueue();
+
+$core_scheduler = false !== has_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery');
+if ($core_scheduler) {
+    remove_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10);
+}
+
+$new_orders = array();
+$status_events = array();
+$webhook_args = array();
+$mail_calls = array();
+$stock_before_writes = array();
+$stock_after_writes = array();
+
+$new_order_callback = static function($order_id, $order = null) use (&$new_orders) {
+    if (!$order instanceof WC_Order) {
+        $order = wc_get_order($order_id);
+    }
+    if ($order instanceof WC_Order && 'wc-order-splitter-duplicate' === $order->get_created_via()) {
+        $new_orders[] = absint($order_id);
+    }
+};
+$status_callback = static function($order_id, $from, $to, $order) use (&$status_events) {
+    if ($order instanceof WC_Order && 'wc-order-splitter-duplicate' === $order->get_created_via()) {
+        $status_events[] = array(absint($order_id), (string) $from, (string) $to);
+    }
+};
+$webhook_callback = static function($active_webhook, $arg) use (&$webhook_args, $webhook) {
+    if ($active_webhook instanceof WC_Webhook && $active_webhook->get_id() === $webhook->get_id()) {
+        $webhook_args[] = absint($arg);
+    }
+};
+$mail_callback = static function($return, $atts) use (&$mail_calls) {
+    $mail_calls[] = is_array($atts) ? $atts : array();
+    return true;
+};
+$stock_before_callback = static function($stock_product) use (&$stock_before_writes) {
+    if ($stock_product instanceof WC_Product) {
+        $stock_before_writes[] = $stock_product->get_id();
+    }
+};
+$stock_after_callback = static function($stock_product) use (&$stock_after_writes) {
+    if ($stock_product instanceof WC_Product) {
+        $stock_after_writes[] = $stock_product->get_id();
+    }
+};
+
+add_action('woocommerce_new_order', $new_order_callback, PHP_INT_MAX, 2);
+add_action('woocommerce_order_status_changed', $status_callback, PHP_INT_MAX, 4);
+add_action('woocommerce_webhook_process_delivery', $webhook_callback, PHP_INT_MAX, 2);
+add_filter('pre_wp_mail', $mail_callback, PHP_INT_MAX, 2);
+add_action('woocommerce_product_before_set_stock', $stock_before_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_variation_before_set_stock', $stock_before_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_product_set_stock', $stock_after_callback, PHP_INT_MAX, 1);
+add_action('woocommerce_variation_set_stock', $stock_after_callback, PHP_INT_MAX, 1);
+
+$side_operation = 'p2-duplicate-side-' . wp_generate_uuid4();
+$side_adapter = new WCOS_Duplicate_WooCommerce_Adapter();
+$side_target = $side_adapter->duplicate(wc_get_order($side_source_id), $side_operation);
+$side_target_id = $side_target->get_id();
+
+wcos_p2_adapter_assert(array($side_target_id) === array_values($new_orders), 'Duplicate did not emit exactly one new-order event for its target.');
+wcos_p2_adapter_assert(array($side_target_id) === array_values($webhook_args), 'Duplicate did not schedule exactly one active order.created webhook for its target.');
+wcos_p2_adapter_assert(empty($status_events), 'Duplicate emitted an implicit target status transition.');
+wcos_p2_adapter_assert(empty($mail_calls), 'Duplicate attempted to send an implicit email.');
+wcos_p2_adapter_assert(empty($stock_before_writes) && empty($stock_after_writes), 'Safe Duplicate invoked a physical stock-write hook.');
+wcos_p2_adapter_assert($side_note_before + 1 === wcos_p2_duplicate_note_count($side_source_id), 'Duplicate did not add exactly one source operation note.');
+wcos_p2_adapter_assert(1 === wcos_p2_duplicate_note_count($side_target_id), 'Duplicate did not add exactly one target operation note.');
+wcos_p2_adapter_assert($side_stock_before == wc_get_product($side_product->get_id())->get_stock_quantity(), 'Duplicate side-effect contract changed physical stock.');
+
+$side_counts = array(
+    'new_order' => count($new_orders),
+    'webhook' => count($webhook_args),
+    'status' => count($status_events),
+    'mail' => count($mail_calls),
+    'source_notes' => wcos_p2_duplicate_note_count($side_source_id),
+    'target_notes' => wcos_p2_duplicate_note_count($side_target_id),
+);
+$side_retry = $side_adapter->duplicate(wc_get_order($side_source_id), $side_operation);
+wcos_p2_adapter_assert($side_target_id === $side_retry->get_id(), 'Duplicate retry returned a different target.');
+wcos_p2_adapter_assert($side_counts['new_order'] === count($new_orders), 'Duplicate retry emitted another new-order event.');
+wcos_p2_adapter_assert($side_counts['webhook'] === count($webhook_args), 'Duplicate retry scheduled another webhook.');
+wcos_p2_adapter_assert($side_counts['status'] === count($status_events), 'Duplicate retry emitted a status transition.');
+wcos_p2_adapter_assert($side_counts['mail'] === count($mail_calls), 'Duplicate retry attempted to send email.');
+wcos_p2_adapter_assert($side_counts['source_notes'] === wcos_p2_duplicate_note_count($side_source_id), 'Duplicate retry duplicated the source note.');
+wcos_p2_adapter_assert($side_counts['target_notes'] === wcos_p2_duplicate_note_count($side_target_id), 'Duplicate retry duplicated the target note.');
+
+remove_action('woocommerce_new_order', $new_order_callback, PHP_INT_MAX);
+remove_action('woocommerce_order_status_changed', $status_callback, PHP_INT_MAX);
+remove_action('woocommerce_webhook_process_delivery', $webhook_callback, PHP_INT_MAX);
+remove_filter('pre_wp_mail', $mail_callback, PHP_INT_MAX);
+remove_action('woocommerce_product_before_set_stock', $stock_before_callback, PHP_INT_MAX);
+remove_action('woocommerce_variation_before_set_stock', $stock_before_callback, PHP_INT_MAX);
+remove_action('woocommerce_product_set_stock', $stock_after_callback, PHP_INT_MAX);
+remove_action('woocommerce_variation_set_stock', $stock_after_callback, PHP_INT_MAX);
+if ($core_scheduler) {
+    add_action('woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10, 2);
+}
+foreach ((array) $webhook->get_hooks() as $hook) {
+    remove_action($hook, array($webhook, 'process'));
+}
+$webhook->delete(true);
+
+/* A stock-write attempt inside Duplicate is blocked before the data store changes. */
+$dirty_product = wcos_p2_adapter_product('WCOS Duplicate blocked stock', '8.00', 12);
+list($dirty_source, $dirty_item_id) = wcos_p2_adapter_order($dirty_product, 2, 'pending');
+$dirty_source_id = $dirty_source->get_id();
+$dirty_stock_before = wc_get_product($dirty_product->get_id())->get_stock_quantity();
+$dirty_operation = 'p2-duplicate-dirty-' . wp_generate_uuid4();
+$dirty_injected = false;
+$dirty_callback = static function($stage) use (&$dirty_injected, $dirty_product) {
+    if (!$dirty_injected && 'before_target_save' === $stage) {
+        $dirty_injected = true;
+        wc_update_product_stock($dirty_product->get_id(), 1, 'decrease');
+    }
+};
+add_action('wcos_duplicate_mutation_checkpoint', $dirty_callback, 10, 4);
+$dirty_blocked = false;
+try {
+    $side_adapter->duplicate(wc_get_order($dirty_source_id), $dirty_operation);
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+    $events = $exception->get_events();
+    $dirty_blocked = !empty($events) && !WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events);
+}
+remove_action('wcos_duplicate_mutation_checkpoint', $dirty_callback, 10);
+wcos_p2_adapter_assert($dirty_injected && $dirty_blocked, 'Duplicate did not block an in-request physical-stock attempt.');
+wcos_p2_adapter_assert($dirty_stock_before == wc_get_product($dirty_product->get_id())->get_stock_quantity(), 'Blocked Duplicate stock attempt changed physical stock.');
+wcos_p2_adapter_assert(empty(wcos_duplicate_targets($dirty_source_id, $dirty_operation)), 'Blocked pre-persistence Duplicate created a target.');
+$dirty_record = WCOS_Operation_Journal::get(wc_get_order($dirty_source_id), $dirty_operation);
+wcos_p2_adapter_assert(is_array($dirty_record) && 'failed' === $dirty_record['status'], 'Blocked Duplicate stock attempt did not leave a retriable failed journal.');
+$dirty_target = $side_adapter->duplicate(wc_get_order($dirty_source_id), $dirty_operation);
+wcos_p2_adapter_assert($dirty_target instanceof WC_Order, 'Duplicate retry did not recover after a blocked pre-write stock attempt.');
+wcos_p2_adapter_assert(1 === count(wcos_duplicate_targets($dirty_source_id, $dirty_operation)), 'Duplicate retry created an unexpected target count.');
+wcos_p2_adapter_assert($dirty_stock_before == wc_get_product($dirty_product->get_id())->get_stock_quantity(), 'Duplicate retry changed physical stock.');
+
+/* Confirmed after-write evidence must persist manual reconciliation and block future mutations. */
+$manual_product = wcos_p2_adapter_product('WCOS Duplicate manual reconciliation', '9.00', 14);
+list($manual_source, $manual_item_id) = wcos_p2_adapter_order($manual_product, 2, 'pending');
+$manual_source_id = $manual_source->get_id();
+$manual_operation = 'p2-duplicate-manual-' . wp_generate_uuid4();
+$manual_injected = false;
+$manual_callback = static function($note_id, $note_order) use (&$manual_injected, $manual_product) {
+    if ($manual_injected || !$note_order instanceof WC_Order) {
+        return;
+    }
+    $manual_injected = true;
+    WCOS_Stock_Side_Effect_Guard::record_product_stock_write($manual_product);
+};
+add_action('woocommerce_order_note_added', $manual_callback, 10, 2);
+$manual_blocked = false;
+try {
+    $side_adapter->duplicate(wc_get_order($manual_source_id), $manual_operation);
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+    $manual_blocked = WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($exception->get_events());
+}
+remove_action('woocommerce_order_note_added', $manual_callback, 10);
+wcos_p2_adapter_assert($manual_injected && $manual_blocked, 'Duplicate after-write evidence did not surface manual reconciliation.');
+$manual_source = wc_get_order($manual_source_id);
+$manual_record = WCOS_Operation_Journal::get($manual_source, $manual_operation);
+wcos_p2_adapter_assert(is_array($manual_record) && 'manual_reconciliation' === $manual_record['status'], 'Duplicate after-write evidence did not persist manual_reconciliation.');
+wcos_p2_adapter_assert(WCOS_Manual_Reconciliation_Blocker::has_active($manual_source), 'Duplicate manual-reconciliation blocker was not persisted.');
+$manual_report = $side_adapter->preflight($manual_source);
+wcos_p2_adapter_assert(empty($manual_report['supported']) && 'manual_reconciliation_required' === $manual_report['reason'], 'Duplicate preflight did not block unresolved manual reconciliation.');
+
+$side_source = wc_get_order($side_source_id);
+WCOS_Operation_Journal::delete($side_source, $side_operation);
+$side_target = wc_get_order($side_target_id);
+if ($side_target) {
+    $side_target->delete(true);
+}
+if ($side_source) {
+    $side_source->delete(true);
+}
+wp_delete_post($side_product->get_id(), true);
+
+$dirty_source = wc_get_order($dirty_source_id);
+WCOS_Operation_Journal::delete($dirty_source, $dirty_operation);
+foreach (wcos_duplicate_targets($dirty_source_id, $dirty_operation) as $target) {
+    $target->delete(true);
+}
+if ($dirty_source) {
+    $dirty_source->delete(true);
+}
+wp_delete_post($dirty_product->get_id(), true);
+
+$manual_source = wc_get_order($manual_source_id);
+WCOS_Operation_Journal::mark_manual_reconciled($manual_source, $manual_operation, array('reconciliation_note' => 'duplicate-side-effect-test-resolved'));
+WCOS_Operation_Journal::delete($manual_source, $manual_operation);
+foreach (wcos_duplicate_targets($manual_source_id, $manual_operation) as $target) {
+    $target->delete(true);
+}
+if ($manual_source) {
+    $manual_source->delete(true);
+}
+wp_delete_post($manual_product->get_id(), true);
+
+echo "p2-duplicate-side-effect-contract-ok\n";

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -210,6 +210,17 @@ $tests['mutation contract rejects currency drift'] = static function() {
 	}, RuntimeException::class);
 };
 
+$tests['duplicate service and preflight policy versions stay aligned'] = static function() use ($root) {
+	$service = file_get_contents($root . 'class-wcos-duplicate-order-service.php');
+	$preflight = file_get_contents($root . 'class-wcos-duplicate-preflight.php');
+	assert_true(is_string($service) && is_string($preflight), 'Unable to read Duplicate policy sources.');
+	$service_match = array();
+	$preflight_match = array();
+	assert_true(1 === preg_match('/const POLICY_VERSION = ([0-9]+);/', $service, $service_match), 'Duplicate service policy version is missing.');
+	assert_true(1 === preg_match('/const POLICY_VERSION = ([0-9]+);/', $preflight, $preflight_match), 'Duplicate preflight policy version is missing.');
+	assert_same($service_match[1], $preflight_match[1]);
+};
+
 $failures = 0;
 foreach ($tests as $name => $test) {
 	try {


### PR DESCRIPTION
## Classification

`P2_DUPLICATE_PRODUCTION_READINESS`

## Status

**MERGED — readiness foundation only.**

Squash merge commit on `main`:

`9d7bd45734a9436c6d8f7790d69ae51ecd4b21f0`

The reviewed source head was:

`247bcc86a1168c9e20fc9e55d122a0db541e175e`

Canonical **CI #570** (`32215328204`) completed successfully on that exact reviewed head before merge.

## Final architecture

Future production Duplicate writes must use only:

`WCOS_Duplicate_Admin_Controller -> WCOS_Mutation_Gateway -> WCOS_Duplicate_WooCommerce_Adapter -> WCOS_Duplicate_Order_Service`

Legacy `order-duplicate-option.php` / `actions/duplicate-order.php` remain unbootstrapped and excluded from the release package.

## Final reviewed policy

- fresh target in Pending payment;
- copy historical line/shipping/fee/tax/coupon rows exactly through fresh order-item objects;
- copy payment-method context, but never transaction ID, paid/date-paid state, order-level stock-reduced state, or line `_reduced_stock`;
- never write physical product stock;
- reject refunds, unresolved manual reconciliation, unknown/inconsistently classified private item metadata, non-canonical business metadata, unsupported fractional state, and internally inconsistent historical totals/taxes;
- do not copy arbitrary custom order-level metadata in the first hardened workflow;
- deleted catalog products remain supported from persisted historical line state;
- paid sources may be duplicated, but their target remains pending and unpaid.

## Completed readiness gates

Acceptance and independent review covered exact clone integrity, stock/side-effect contracts, precision and durable replay, operation-bound lease ownership, confirmation concurrency safety, accessible transport/UI, legacy/HPOS/HPOS-sync storage modes, and PHP 7.4/8.1/8.3.

The shared confirmation verify -> mutation TOCTOU hardening for the already-enabled manual quantity Split was also merged through this readiness work.

## Production boundary after merge

This merge does **not** enable Duplicate.

Current production mutation gate state remains:

- `SPLIT = true`
- `DUPLICATE = false`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Duplicate production enablement requires a separate exact gate-changing PR, production-enabled end-to-end acceptance, independent review, and explicit Human Gate approval.