### PR TITLE
P2: add whole-line Split transfer foundation

### DIFF
--- a/.github/workflows/diagnostic-whole-line-lint.yml
+++ b/.github/workflows/diagnostic-whole-line-lint.yml
@@ -1,0 +1,29 @@
+name: Diagnostic whole-line lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint ${{ matrix.file }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        file:
+          - inc/domain/class-wcos-split-execution-policy.php
+          - inc/domain/class-wcos-split-plan.php
+          - inc/domain/class-wcos-split-order-service.php
+          - inc/cores/script.php
+    steps:
+      - uses: actions/checkout@v7
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+      - run: php -l "${{ matrix.file }}"

--- a/docs/p2-whole-line-transfer-foundation.md
+++ b/docs/p2-whole-line-transfer-foundation.md
@@ -1,0 +1,69 @@
+# P2 Whole-Line Transfer Foundation
+
+## Purpose
+
+This milestone adds one internal capability required by future server-built Category and Stock-status Split strategies: moving an entire persisted source line to one or more child orders while continuing to use the hardened Split saga.
+
+It does **not** add or enable a Category or Stock-status controller, endpoint, button, strategy gate, or legacy handler.
+
+## Execution policies
+
+`WCOS_Split_Execution_Policy` defines two internal policies:
+
+- `partial_lines_only` — the existing manual quantity Split behavior. Every affected source line must retain a positive quantity.
+- `allow_whole_line_transfer` — an explicit internal strategy policy. A fully allocated source line may be removed, but at least one product line must remain on the source order.
+
+The default remains `partial_lines_only`. Existing production manual Split calls therefore retain their previous semantics.
+
+## Durable operation authority
+
+New Split journals record:
+
+- `execution_policy`;
+- `fully_moved_item_ids`.
+
+The execution policy also participates in the mutation fingerprint. A durable operation cannot be retried under a different policy. Legacy journals that predate this field may only resume under `partial_lines_only`.
+
+## Whole-line mutation semantics
+
+For a fully allocated line:
+
+1. the historical source line is allocated across child destinations using the same exact amount/tax/reduced-stock allocator as a partial Split;
+2. fresh child `WC_Order_Item_Product` objects are created;
+3. no source remainder is synthesized;
+4. the persisted source item is staged for deletion with WooCommerce CRUD `WC_Order::remove_item()` and deleted on the later source save;
+5. source + children must still conserve quantity, subtotal, discount, shipping, fees, historical tax, grand total and `_reduced_stock`;
+6. the Split request itself must not write physical product stock.
+
+Shipping and positive fees remain on the source under the existing manual Split financial policy.
+
+## Stock lifecycle
+
+When the source had already reduced stock, the full `_reduced_stock` marker for a moved line follows the child allocation and the child receives the source order-level stock-reduced flag.
+
+Acceptance proves:
+
+- Split itself does not change physical stock;
+- cancelling the child restores only the fully moved product stock;
+- cancelling the residual source restores only the residual source product stock;
+- aggregate restoration happens exactly once.
+
+## Crash and recovery boundary
+
+Before the destructive source-line deletion is persisted, existing compensation/retry behavior remains available.
+
+After a fully moved source line has been deleted from persisted source state:
+
+- if persisted source + operation-owned children form a valid conserved commit, retry may finalize that exact persisted state;
+- if the persisted state is ambiguous or fails conservation, the engine must not guess/recreate the deleted line from current catalog data;
+- instead the operation enters persistent `manual_reconciliation`, automatic compensation is disabled, and the source is blocked from later mutations until a human proves and records the correct state.
+
+This converts an irreversible/ambiguous crash window into a fail-closed operational incident rather than silent data reconstruction.
+
+## Future strategy boundary
+
+Future Category and Stock-status planners may only produce an explicit, reviewed quantity plan. They must never restore the old mutation handlers.
+
+Execution must still enter the shared hardened Split path and pass `allow_whole_line_transfer` as the immutable operation policy.
+
+No future strategy may recompute volatile classification during Execute. Classification evidence and the resulting plan must be frozen at Review/confirmation time.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -36,6 +36,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-mutation-authorizer.php';
 		include_once $root . 'domain/class-wcos-order-item-meta-policy.php';
 		include_once $root . 'domain/class-wcos-order-item-cloner.php';
+		include_once $root . 'domain/class-wcos-split-execution-policy.php';
 		include_once $root . 'domain/class-wcos-split-plan.php';
 		include_once $root . 'domain/class-wcos-order-totals-rebuilder.php';
 		include_once $root . 'domain/class-wcos-tax-item-synchronizer.php';
@@ -71,8 +72,8 @@ class WC_Order_Splitter_Script {
 
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Production
-		 * Split transport is isolated behind WCOS_Mutation_Gateway and remains
-		 * non-runnable while WCOS_Feature_Gates::SPLIT is hard-off.
+		 * Split transport is isolated behind WCOS_Mutation_Gateway; future server-
+		 * built strategies must still enter the same gateway/adapter/service path.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-split-execution-policy.php
+++ b/inc/domain/class-wcos-split-execution-policy.php
@@ -1,0 +1,30 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Immutable policy selector for one Split operation.
+ *
+ * Manual quantity Split keeps its existing positive-residual behavior. Future
+ * server-built strategies may opt into whole-line transfer only through the
+ * explicit strategy policy; external configuration cannot change this value.
+ */
+final class WCOS_Split_Execution_Policy {
+    const PARTIAL_LINES_ONLY = 'partial_lines_only';
+    const ALLOW_WHOLE_LINE_TRANSFER = 'allow_whole_line_transfer';
+
+    public static function normalize($policy) {
+        $policy = sanitize_key((string) $policy);
+        if ('' === $policy) {
+            $policy = self::PARTIAL_LINES_ONLY;
+        }
+        if (!in_array($policy, array(self::PARTIAL_LINES_ONLY, self::ALLOW_WHOLE_LINE_TRANSFER), true)) {
+            throw new InvalidArgumentException(__('Unknown Split execution policy.', 'wc-order-splitter'));
+        }
+        return $policy;
+    }
+
+    public static function allows_whole_line_transfer($policy) {
+        return self::ALLOW_WHOLE_LINE_TRANSFER === self::normalize($policy);
+    }
+}

--- a/inc/domain/class-wcos-split-order-service.php
+++ b/inc/domain/class-wcos-split-order-service.php
@@ -7,7 +7,8 @@ defined('ABSPATH') || exit;
  *
  * Safety policy:
  * - shipping, fees, and coupons are never duplicated;
- * - every source product line must retain a positive quantity;
+ * - manual quantity Split keeps a positive residual on every affected line;
+ * - explicit server-built strategy policy may transfer a whole line;
  * - child orders are persisted as pending review;
  * - historical amounts/tax arrays are allocated at currency precision;
  * - reduced-stock markers are redistributed without touching physical stock;
@@ -22,8 +23,9 @@ final class WCOS_Split_Order_Service {
 	const OPERATION_META = '_wcos_operation_id';
 	const CHILD_KEY_META = '_wcos_split_child_key';
 
-	public function split(WC_Order $source, array $plan, $operation_id) {
+	public function split(WC_Order $source, array $plan, $operation_id, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY) {
 		$operation_id = sanitize_key($operation_id);
+		$execution_policy = WCOS_Split_Execution_Policy::normalize($execution_policy);
 		if ('' === $operation_id) {
 			throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
 		}
@@ -32,22 +34,35 @@ final class WCOS_Split_Order_Service {
 		}
 
 		$canonical_plan = WCOS_Split_Plan::canonicalize_request($plan);
-		$fingerprint = WCOS_Mutation_Fingerprint::create(
-			self::TYPE,
-			$source->get_id(),
-			array(
-				'policy_version' => self::POLICY_VERSION,
-				'plan' => $canonical_plan,
-				'shipping_policy' => 'keep_on_source',
-				'fee_policy' => 'keep_on_source',
-				'child_status' => 'pending',
-			)
-		);
-
 		$existing = WCOS_Operation_Journal::get($source, $operation_id);
+		$legacy_journal = is_array($existing)
+			&& (!isset($existing['context']) || !is_array($existing['context']) || !array_key_exists('execution_policy', $existing['context']));
+		if ($legacy_journal && WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY !== $execution_policy) {
+			throw new RuntimeException(__('A legacy Split journal cannot be resumed under the whole-line transfer policy.', 'wc-order-splitter'));
+		}
+
+		$fingerprint_context = array(
+			'policy_version' => self::POLICY_VERSION,
+			'plan' => $canonical_plan,
+			'shipping_policy' => 'keep_on_source',
+			'fee_policy' => 'keep_on_source',
+			'child_status' => 'pending',
+		);
+		if (!$legacy_journal) {
+			$fingerprint_context['execution_policy'] = $execution_policy;
+		}
+		$fingerprint = WCOS_Mutation_Fingerprint::create(self::TYPE, $source->get_id(), $fingerprint_context);
+
 		if (is_array($existing)) {
 			WCOS_Operation_Journal::assert_fingerprint($existing, $fingerprint);
-			if (isset($existing['status']) && 'completed' === $existing['status']) {
+			$status = isset($existing['status']) ? sanitize_key((string) $existing['status']) : '';
+			if ('manual_reconciliation' === $status) {
+				throw new RuntimeException(__('This Split operation requires manual reconciliation before it can continue.', 'wc-order-splitter'));
+			}
+			if ('manual_reconciled' === $status) {
+				throw new RuntimeException(__('This Split operation was manually reconciled and is closed.', 'wc-order-splitter'));
+			}
+			if ('completed' === $status) {
 				return $this->load_completed_children($source, $operation_id, $canonical_plan, $existing);
 			}
 		}
@@ -67,6 +82,12 @@ final class WCOS_Split_Order_Service {
 			$record = WCOS_Operation_Journal::get($source, $operation_id);
 			if (is_array($record)) {
 				WCOS_Operation_Journal::assert_fingerprint($record, $fingerprint);
+				$record_policy = isset($record['context']['execution_policy'])
+					? WCOS_Split_Execution_Policy::normalize($record['context']['execution_policy'])
+					: WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+				if ($record_policy !== $execution_policy) {
+					throw new RuntimeException(__('The requested Split execution policy does not match the durable operation journal.', 'wc-order-splitter'));
+				}
 				$recovered = $this->try_finalize_persisted($source, $operation_id, $canonical_plan, $record);
 				if (is_array($recovered)) {
 					return $recovered;
@@ -75,11 +96,15 @@ final class WCOS_Split_Order_Service {
 				$expected_signature = isset($record['context']['source_signature']) ? (string) $record['context']['source_signature'] : '';
 				$current_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
 				if ('' === $expected_signature || !hash_equals($expected_signature, $current_signature)) {
-					WCOS_Operation_Journal::require_recovery(
-						$source,
-						$operation_id,
-						array('reason' => 'source_changed_without_conserved_commit')
-					);
+					if ($this->whole_line_source_deletion_persisted($source, $record)) {
+						$this->mark_whole_line_manual_reconciliation($source, $operation_id, $record, 'source_changed_without_conserved_commit');
+					} else {
+						WCOS_Operation_Journal::require_recovery(
+							$source,
+							$operation_id,
+							array('reason' => 'source_changed_without_conserved_commit')
+						);
+					}
 					throw new RuntimeException(__('The source order changed after splitting started and the persisted state is not a conserved commit.', 'wc-order-splitter'));
 				}
 
@@ -88,19 +113,25 @@ final class WCOS_Split_Order_Service {
 				}
 				$normalized_plan = isset($record['context']['plan']) && is_array($record['context']['plan'])
 					? $record['context']['plan']
-					: WCOS_Split_Plan::normalize($source, $canonical_plan);
+					: WCOS_Split_Plan::normalize($source, $canonical_plan, $execution_policy);
 				$before_contract = isset($record['context']['before_contract']) && is_array($record['context']['before_contract'])
 					? $record['context']['before_contract']
 					: WCOS_Order_Contract_Snapshot::aggregate(array($source));
 				$source_stock_reduced = !empty($record['context']['source_stock_reduced']);
+				$fully_moved_item_ids = isset($record['context']['fully_moved_item_ids'])
+					? array_values(array_unique(array_filter(array_map('absint', (array) $record['context']['fully_moved_item_ids']))))
+					: array();
 			} else {
 				$this->assert_supported_source($source);
-				$normalized_plan = WCOS_Split_Plan::normalize($source, $canonical_plan);
+				$normalized_plan = WCOS_Split_Plan::normalize($source, $canonical_plan, $execution_policy);
+				$fully_moved_item_ids = WCOS_Split_Plan::fully_moved_item_ids($source, $normalized_plan, $execution_policy);
 				$before_contract = WCOS_Order_Contract_Snapshot::aggregate(array($source));
 				$source_stock_reduced = (bool) $source->get_data_store()->get_stock_reduced($source_id);
 				$context = array(
 					'plan' => $normalized_plan,
 					'child_keys' => WCOS_Split_Plan::child_keys($normalized_plan),
+					'execution_policy' => $execution_policy,
+					'fully_moved_item_ids' => $fully_moved_item_ids,
 					'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
 					'before_contract' => $before_contract,
 					'source_stock_reduced' => $source_stock_reduced,
@@ -117,7 +148,7 @@ final class WCOS_Split_Order_Service {
 			$this->assert_supported_source($source);
 			$execution_stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
 			$tax_templates = WCOS_Tax_Item_Synchronizer::templates($source);
-			$expected_children = $this->build_mutation($source, $normalized_plan, $operation_id, $tax_templates);
+			$expected_children = $this->build_mutation($source, $normalized_plan, $operation_id, $tax_templates, $execution_policy);
 			$existing_children = $this->discover_children($source, $operation_id);
 			$children = $this->persist_or_reuse_children(
 				$source,
@@ -161,7 +192,7 @@ final class WCOS_Split_Order_Service {
 
 			$source = wc_get_order($source_id);
 			$children = $this->reload_children($children);
-			$this->verify_persisted_split($source, $children, $normalized_plan, $operation_id, $before_contract, $source_stock_reduced);
+			$this->verify_persisted_split($source, $children, $normalized_plan, $operation_id, $before_contract, $source_stock_reduced, $fully_moved_item_ids);
 			WCOS_Order_Contract_Snapshot::assert_product_stock_equal(
 				$execution_stock_before,
 				WCOS_Order_Contract_Snapshot::product_stock($source)
@@ -187,14 +218,18 @@ final class WCOS_Split_Order_Service {
 						return $recovered;
 					}
 				} catch (Throwable $recovery_error) {
-					WCOS_Operation_Journal::require_recovery(
-						$fresh_source,
-						$operation_id,
-						array(
-							'error' => $throwable->getMessage(),
-							'recovery_error' => $recovery_error->getMessage(),
-						)
-					);
+					if ($this->whole_line_source_deletion_persisted($fresh_source, $record)) {
+						$this->mark_whole_line_manual_reconciliation($fresh_source, $operation_id, $record, 'whole_line_recovery_verification_failed', $recovery_error);
+					} else {
+						WCOS_Operation_Journal::require_recovery(
+							$fresh_source,
+							$operation_id,
+							array(
+								'error' => $throwable->getMessage(),
+								'recovery_error' => $recovery_error->getMessage(),
+							)
+						);
+					}
 					throw $recovery_error;
 				}
 
@@ -208,6 +243,8 @@ final class WCOS_Split_Order_Service {
 							'target_order_ids' => $this->child_ids($this->discover_children($fresh_source, $operation_id)),
 						)
 					);
+				} elseif ($this->whole_line_source_deletion_persisted($fresh_source, $record)) {
+					$this->mark_whole_line_manual_reconciliation($fresh_source, $operation_id, $record, 'whole_line_source_state_ambiguous', $throwable);
 				} else {
 					WCOS_Operation_Journal::require_recovery($fresh_source, $operation_id, array('error' => $throwable->getMessage()));
 				}
@@ -257,7 +294,7 @@ final class WCOS_Split_Order_Service {
 		}
 	}
 
-	private function build_mutation(WC_Order $source, array $plan, $operation_id, array $tax_templates) {
+	private function build_mutation(WC_Order $source, array $plan, $operation_id, array $tax_templates, $execution_policy) {
 		$precision = wc_get_price_decimals();
 		$children = array();
 		foreach (WCOS_Split_Plan::child_keys($plan) as $child_key) {
@@ -265,7 +302,11 @@ final class WCOS_Split_Order_Service {
 		}
 
 		foreach ($source->get_items('line_item') as $item_id => $source_item) {
-			$this->allocate_line($source_item, (int) $item_id, $plan, $children, $precision);
+			$this->allocate_line($source, $source_item, (int) $item_id, $plan, $children, $precision, $execution_policy);
+		}
+
+		if (empty($source->get_items('line_item'))) {
+			throw new RuntimeException(__('Whole-line Split may not remove every product line from the source order.', 'wc-order-splitter'));
 		}
 
 		WCOS_Tax_Item_Synchronizer::synchronize($source, $tax_templates, $precision, true);
@@ -302,7 +343,7 @@ final class WCOS_Split_Order_Service {
 		return $child;
 	}
 
-	private function allocate_line(WC_Order_Item_Product $source_item, $item_id, array $plan, array $children, $precision) {
+	private function allocate_line(WC_Order $source, WC_Order_Item_Product $source_item, $item_id, array $plan, array $children, $precision, $execution_policy) {
 		$source_quantity_units = WCOS_Decimal::to_units($source_item->get_quantity(), 6);
 		$weights = array();
 		$split_units = 0;
@@ -319,10 +360,15 @@ final class WCOS_Split_Order_Service {
 		}
 
 		$remaining_units = $source_quantity_units - $split_units;
-		if ($remaining_units <= 0) {
-			throw new RuntimeException(__('A source line would be removed by the split plan.', 'wc-order-splitter'));
+		if ($remaining_units < 0) {
+			throw new RuntimeException(__('A Split plan allocated more than the source line quantity.', 'wc-order-splitter'));
 		}
-		$weights = array_merge(array('source' => WCOS_Decimal::from_units($remaining_units, 6)), $weights);
+		if (0 === $remaining_units && !WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy)) {
+			throw new RuntimeException(__('The active Split policy does not allow a source line to be removed.', 'wc-order-splitter'));
+		}
+		if ($remaining_units > 0) {
+			$weights = array_merge(array('source' => WCOS_Decimal::from_units($remaining_units, 6)), $weights);
+		}
 
 		$subtotals = WCOS_Amount_Allocator::allocate($source_item->get_subtotal(), $weights, $precision);
 		$totals = WCOS_Amount_Allocator::allocate($source_item->get_total(), $weights, $precision);
@@ -332,20 +378,6 @@ final class WCOS_Split_Order_Service {
 		if ('' !== $reduced_stock) {
 			$reduced_allocations = WCOS_Amount_Allocator::allocate($reduced_stock, $weights, 6);
 		}
-
-		$source_taxes = $tax_allocations['source'];
-		$source_result = $source_item->set_props(array(
-			'quantity' => WCOS_Decimal::from_units($remaining_units, 6),
-			'subtotal' => $subtotals['source'],
-			'total' => $totals['source'],
-			'taxes' => $source_taxes,
-			'subtotal_tax' => $this->sum_tax_bucket($source_taxes['subtotal'], $precision),
-			'total_tax' => $this->sum_tax_bucket($source_taxes['total'], $precision),
-		));
-		if (is_wp_error($source_result)) {
-			throw new RuntimeException($source_result->get_error_message());
-		}
-		$this->replace_reduced_stock($source_item, isset($reduced_allocations['source']) ? $reduced_allocations['source'] : null);
 
 		foreach ($weights as $destination => $quantity) {
 			if ('source' === $destination) {
@@ -368,6 +400,32 @@ final class WCOS_Split_Order_Service {
 			$child_item->add_meta_data('_wcos_source_item_id', $item_id, true);
 			$this->replace_reduced_stock($child_item, isset($reduced_allocations[$destination]) ? $reduced_allocations[$destination] : null);
 			$children[$destination]->add_item($child_item);
+		}
+
+		if ($remaining_units > 0) {
+			$source_taxes = $tax_allocations['source'];
+			$source_result = $source_item->set_props(array(
+				'quantity' => WCOS_Decimal::from_units($remaining_units, 6),
+				'subtotal' => $subtotals['source'],
+				'total' => $totals['source'],
+				'taxes' => $source_taxes,
+				'subtotal_tax' => $this->sum_tax_bucket($source_taxes['subtotal'], $precision),
+				'total_tax' => $this->sum_tax_bucket($source_taxes['total'], $precision),
+			));
+			if (is_wp_error($source_result)) {
+				throw new RuntimeException($source_result->get_error_message());
+			}
+			$this->replace_reduced_stock($source_item, isset($reduced_allocations['source']) ? $reduced_allocations['source'] : null);
+			return;
+		}
+
+		/*
+		 * WC_Order::remove_item() only marks this persisted item for deletion on
+		 * the later source save. The product-stock lifecycle is deliberately not
+		 * invoked here; the request-local stock guard remains the safety proof.
+		 */
+		if (false === $source->remove_item($item_id)) {
+			throw new RuntimeException(__('The fully allocated source line could not be staged for removal.', 'wc-order-splitter'));
 		}
 	}
 
@@ -475,7 +533,7 @@ final class WCOS_Split_Order_Service {
 		$source->update_meta_data(self::RELATION_CHILDREN_META, array_values(array_unique(array_merge($current, $child_ids))));
 
 		$legacy = array_filter(array_map('absint', explode(',', (string) $source->get_meta('yoos_splitted_order', true))));
-		$source->update_meta_data('yoos_splitted_order', implode(',', array_values(array_unique(array_merge($legacy, $child_ids)))));
+		$source->update_meta_data('yoos_splitted_order', implode(',', array_values(array_unique(array_merge($legacy, $child_ids))));
 	}
 
 	private function synchronize_child_stock_flags(array $children, $source_stock_reduced) {
@@ -507,10 +565,13 @@ final class WCOS_Split_Order_Service {
 		}
 
 		$source_stock_reduced = !empty($record['context']['source_stock_reduced']);
+		$fully_moved_item_ids = isset($record['context']['fully_moved_item_ids'])
+			? array_values(array_unique(array_filter(array_map('absint', (array) $record['context']['fully_moved_item_ids']))))
+			: array();
 		$this->apply_relations($source, $children);
 		$source->save_meta_data();
 		$this->synchronize_child_stock_flags($children, $source_stock_reduced);
-		$this->verify_persisted_split($source, $children, $canonical_plan, $operation_id, $before_contract, $source_stock_reduced);
+		$this->verify_persisted_split($source, $children, $canonical_plan, $operation_id, $before_contract, $source_stock_reduced, $fully_moved_item_ids);
 
 		if (!WCOS_Operation_Journal::mark_committed($source, $operation_id, array('target_order_ids' => $this->child_ids($children), 'recovered' => true))) {
 			throw new RuntimeException(__('Unable to record the recovered split commit point.', 'wc-order-splitter'));
@@ -522,12 +583,20 @@ final class WCOS_Split_Order_Service {
 		return array_values($children);
 	}
 
-	private function verify_persisted_split(WC_Order $source, array $children, array $plan, $operation_id, array $before_contract, $source_stock_reduced) {
+	private function verify_persisted_split(WC_Order $source, array $children, array $plan, $operation_id, array $before_contract, $source_stock_reduced, array $fully_moved_item_ids = array()) {
 		if (!$source) {
 			throw new RuntimeException(__('The source order could not be reloaded after split persistence.', 'wc-order-splitter'));
 		}
 		if (array_keys($children) !== WCOS_Split_Plan::child_keys($plan)) {
 			throw new RuntimeException(__('The persisted split child set does not match the normalized plan.', 'wc-order-splitter'));
+		}
+		if (empty($source->get_items('line_item'))) {
+			throw new RuntimeException(__('The persisted source order no longer contains a product line.', 'wc-order-splitter'));
+		}
+		foreach ($fully_moved_item_ids as $source_item_id) {
+			if ($source->get_item(absint($source_item_id)) instanceof WC_Order_Item_Product) {
+				throw new RuntimeException(__('A whole-line Split source item remained persisted after full transfer.', 'wc-order-splitter'));
+			}
 		}
 		$this->assert_conserved($before_contract, array_merge(array($source), array_values($children)));
 
@@ -603,6 +672,44 @@ final class WCOS_Split_Order_Service {
 			}
 		}
 		return array_values(array_unique(array_map('absint', $ids)));
+	}
+
+	private function whole_line_source_deletion_persisted(WC_Order $source, array $record) {
+		$policy = isset($record['context']['execution_policy'])
+			? WCOS_Split_Execution_Policy::normalize($record['context']['execution_policy'])
+			: WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+		if (!WCOS_Split_Execution_Policy::allows_whole_line_transfer($policy)) {
+			return false;
+		}
+		$item_ids = isset($record['context']['fully_moved_item_ids'])
+			? array_values(array_unique(array_filter(array_map('absint', (array) $record['context']['fully_moved_item_ids']))))
+			: array();
+		if (empty($item_ids)) {
+			return false;
+		}
+		foreach ($item_ids as $item_id) {
+			if (!$source->get_item($item_id)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function mark_whole_line_manual_reconciliation(WC_Order $source, $operation_id, array $record, $reason, Throwable $throwable = null) {
+		if (!class_exists('WCOS_Manual_Reconciliation_Blocker') || !WCOS_Manual_Reconciliation_Blocker::block($source, $operation_id)) {
+			return false;
+		}
+		$context = array(
+			'reason' => sanitize_key((string) $reason),
+			'workflow' => 'split',
+			'execution_policy' => isset($record['context']['execution_policy']) ? $record['context']['execution_policy'] : '',
+			'fully_moved_item_ids' => isset($record['context']['fully_moved_item_ids']) ? $record['context']['fully_moved_item_ids'] : array(),
+			'automatic_compensation_allowed' => false,
+		);
+		if ($throwable) {
+			$context['error'] = $throwable->getMessage();
+		}
+		return WCOS_Operation_Journal::mark_manual_reconciliation($source, $operation_id, $context);
 	}
 
 	private function add_notes_best_effort(WC_Order $source, array $children) {

--- a/inc/domain/class-wcos-split-plan.php
+++ b/inc/domain/class-wcos-split-plan.php
@@ -44,11 +44,17 @@ final class WCOS_Split_Plan {
 		return $canonical;
 	}
 
-	public static function normalize(WC_Order $source, array $plan) {
+	public static function normalize(WC_Order $source, array $plan, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY) {
+		$execution_policy = WCOS_Split_Execution_Policy::normalize($execution_policy);
+		$whole_line_allowed = WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy);
 		$normalized = self::canonicalize_request($plan);
 		$source_quantities = array();
 		foreach ($source->get_items('line_item') as $item_id => $item) {
-			$source_quantities[(int) $item_id] = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			if ($quantity_units <= 0) {
+				throw new InvalidArgumentException(__('Every source line must have a positive quantity before Split.', 'wc-order-splitter'));
+			}
+			$source_quantities[(int) $item_id] = $quantity_units;
 		}
 
 		$totals_by_item = array();
@@ -64,13 +70,56 @@ final class WCOS_Split_Plan {
 			}
 		}
 
+		$fully_moved_items = array();
 		foreach ($totals_by_item as $item_id => $split_units) {
-			if ($split_units >= $source_quantities[$item_id]) {
-				throw new InvalidArgumentException(__('The hardened split engine requires every affected source line to retain a positive quantity.', 'wc-order-splitter'));
+			if ($split_units > $source_quantities[$item_id]) {
+				throw new InvalidArgumentException(__('The split plan allocates more than the source line quantity.', 'wc-order-splitter'));
+			}
+			if ($split_units === $source_quantities[$item_id]) {
+				if (!$whole_line_allowed) {
+					throw new InvalidArgumentException(__('The manual quantity Split policy requires every affected source line to retain a positive quantity.', 'wc-order-splitter'));
+				}
+				$fully_moved_items[$item_id] = true;
+			}
+		}
+
+		if ($whole_line_allowed && !empty($fully_moved_items)) {
+			$residual_line_count = count($source_quantities) - count($fully_moved_items);
+			if ($residual_line_count <= 0) {
+				throw new InvalidArgumentException(__('Whole-line Split must leave at least one product line on the source order.', 'wc-order-splitter'));
 			}
 		}
 
 		return $normalized;
+	}
+
+	public static function fully_moved_item_ids(WC_Order $source, array $normalized_plan, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY) {
+		if (!WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy)) {
+			return array();
+		}
+
+		$source_quantities = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			$source_quantities[(int) $item_id] = WCOS_Decimal::to_units($item->get_quantity(), 6);
+		}
+		$allocated = array();
+		foreach ($normalized_plan as $items) {
+			foreach ($items as $item_id => $quantity) {
+				$quantity_units = WCOS_Decimal::to_units($quantity, 6);
+				$allocated[$item_id] = isset($allocated[$item_id])
+					? self::safe_add($allocated[$item_id], $quantity_units)
+					: $quantity_units;
+			}
+		}
+
+		$fully_moved = array();
+		foreach ($allocated as $item_id => $quantity_units) {
+			if (isset($source_quantities[$item_id]) && $quantity_units === $source_quantities[$item_id]) {
+				$fully_moved[] = (int) $item_id;
+			}
+		}
+		sort($fully_moved, SORT_NUMERIC);
+		return $fully_moved;
 	}
 
 	public static function child_keys(array $normalized_plan) {

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -123,5 +123,6 @@ wcos_control_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Rel
 wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not restore the production-enabled state.');
 
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
+require __DIR__ . '/p2-whole-line-transfer-smoke.php';
 
 echo "operation-lock-and-journal-ok\n";

--- a/tests/integration/p2-whole-line-transfer-smoke.php
+++ b/tests/integration/p2-whole-line-transfer-smoke.php
@@ -1,0 +1,205 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit(1);
+}
+
+function wcos_whole_line_order(WC_Product $first, $first_qty, WC_Product $second, $second_qty, $status = 'processing') {
+    $order = wc_create_order();
+    $order->set_status($status);
+    $order->set_currency('USD');
+    $first_item_id = $order->add_product($first, $first_qty);
+    $second_item_id = $order->add_product($second, $second_qty);
+    $order->calculate_totals(false);
+    $order->save();
+    return array($order, (int) $first_item_id, (int) $second_item_id);
+}
+
+wcos_p2_adapter_assert(
+    WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === WCOS_Split_Execution_Policy::normalize(''),
+    'Empty Split execution policy did not resolve to the production manual default.'
+);
+wcos_p2_adapter_assert(
+    WCOS_Split_Execution_Policy::allows_whole_line_transfer(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER),
+    'Whole-line execution policy was not recognized.'
+);
+
+/* Manual quantity policy must still reject residual=0. */
+$manual_a = wcos_p2_adapter_product('WCOS whole-line manual A', '10.00');
+$manual_b = wcos_p2_adapter_product('WCOS whole-line manual B', '5.00');
+list($manual_source, $manual_a_item, $manual_b_item) = wcos_whole_line_order($manual_a, 2, $manual_b, 1, 'pending');
+$manual_rejected = false;
+try {
+    WCOS_Split_Plan::normalize(
+        $manual_source,
+        array('child-1' => array($manual_a_item => '2.000000')),
+        WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY
+    );
+} catch (InvalidArgumentException $exception) {
+    $manual_rejected = false !== strpos($exception->getMessage(), 'positive quantity');
+}
+wcos_p2_adapter_assert($manual_rejected, 'Manual quantity Split policy accepted a full-line transfer.');
+
+$all_lines_rejected = false;
+try {
+    WCOS_Split_Plan::normalize(
+        $manual_source,
+        array(
+            'child-1' => array(
+                $manual_a_item => '2.000000',
+                $manual_b_item => '1.000000',
+            ),
+        ),
+        WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+    );
+} catch (InvalidArgumentException $exception) {
+    $all_lines_rejected = false !== strpos($exception->getMessage(), 'at least one product line');
+}
+wcos_p2_adapter_assert($all_lines_rejected, 'Whole-line policy allowed every product line to leave the source order.');
+$manual_source->delete(true);
+wp_delete_post($manual_a->get_id(), true);
+wp_delete_post($manual_b->get_id(), true);
+
+/* Normal whole-line transfer conserves money/tax/quantity/_reduced_stock and physical stock. */
+$product_a = wcos_p2_adapter_product('WCOS whole-line stock A', '12.00', 30);
+$product_b = wcos_p2_adapter_product('WCOS whole-line stock B', '7.00', 40);
+list($source, $a_item_id, $b_item_id) = wcos_whole_line_order($product_a, 2, $product_b, 3, 'processing');
+$source_id = $source->get_id();
+wc_reduce_stock_levels($source);
+$source->get_data_store()->set_stock_reduced($source_id, true);
+$source = wc_get_order($source_id);
+$stock_after_sale_a = wc_get_product($product_a->get_id())->get_stock_quantity();
+$stock_after_sale_b = wc_get_product($product_b->get_id())->get_stock_quantity();
+$contract_before = WCOS_Order_Contract_Snapshot::aggregate(array($source));
+$operation = 'p2-whole-line-' . wp_generate_uuid4();
+$children = (new WCOS_Split_Order_Service())->split(
+    $source,
+    array('child-1' => array($a_item_id => '2.000000')),
+    $operation,
+    WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+);
+wcos_p2_adapter_assert(1 === count($children), 'Whole-line Split did not create exactly one child.');
+$child = wc_get_order($children[0]->get_id());
+$source = wc_get_order($source_id);
+wcos_p2_adapter_assert(!$source->get_item($a_item_id), 'Fully transferred source item remained persisted.');
+wcos_p2_adapter_assert($source->get_item($b_item_id) instanceof WC_Order_Item_Product, 'Unmoved source item disappeared.');
+wcos_p2_adapter_assert(1 === count($source->get_items('line_item')), 'Whole-line Split left an unexpected source line count.');
+wcos_p2_adapter_assert(1 === count($child->get_items('line_item')), 'Whole-line child has an unexpected line count.');
+$child_line = current($child->get_items('line_item'));
+wcos_p2_adapter_assert(2 === (int) $child_line->get_quantity(), 'Whole-line child did not receive the full source line quantity.');
+wcos_p2_adapter_assert('2.000000' === WCOS_Decimal::normalize($child_line->get_meta('_reduced_stock', true), 6), 'Whole-line child did not receive the full reduced-stock marker.');
+wcos_p2_adapter_assert((bool) $source->get_data_store()->get_stock_reduced($source_id), 'Whole-line source lost its order-level stock-reduced flag.');
+wcos_p2_adapter_assert((bool) $child->get_data_store()->get_stock_reduced($child->get_id()), 'Whole-line child did not receive the order-level stock-reduced flag.');
+WCOS_Mutation_Contract::assert_conserved(
+    $contract_before,
+    WCOS_Order_Contract_Snapshot::aggregate(array($source, $child)),
+    wc_get_price_decimals()
+);
+wcos_p2_adapter_assert($stock_after_sale_a == wc_get_product($product_a->get_id())->get_stock_quantity(), 'Whole-line Split changed physical stock for the moved line.');
+wcos_p2_adapter_assert($stock_after_sale_b == wc_get_product($product_b->get_id())->get_stock_quantity(), 'Whole-line Split changed physical stock for the residual line.');
+$record = WCOS_Operation_Journal::get($source, $operation);
+wcos_p2_adapter_assert(is_array($record) && 'completed' === $record['status'], 'Whole-line Split journal did not complete.');
+wcos_p2_adapter_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $record['context']['execution_policy'], 'Whole-line execution policy was not durably journaled.');
+wcos_p2_adapter_assert(array($a_item_id) === array_values($record['context']['fully_moved_item_ids']), 'Whole-line journal did not preserve the destructive source-item set.');
+
+/* WooCommerce cancellation/restock must restore each stock owner exactly once. */
+$child->update_status('cancelled');
+wcos_p2_adapter_assert(30 == wc_get_product($product_a->get_id())->get_stock_quantity(), 'Cancelling the whole-line child did not restore the moved product exactly once.');
+wcos_p2_adapter_assert($stock_after_sale_b == wc_get_product($product_b->get_id())->get_stock_quantity(), 'Cancelling the whole-line child changed residual source stock.');
+$source->update_status('cancelled');
+wcos_p2_adapter_assert(40 == wc_get_product($product_b->get_id())->get_stock_quantity(), 'Cancelling the residual source did not restore its product exactly once.');
+WCOS_Operation_Journal::delete(wc_get_order($source_id), $operation);
+$child->delete(true);
+wc_get_order($source_id)->delete(true);
+wp_delete_post($product_a->get_id(), true);
+wp_delete_post($product_b->get_id(), true);
+
+/* Crash after source persistence but before the normal checkpoint must finalize from conserved persisted evidence. */
+$crash_a = wcos_p2_adapter_product('WCOS whole-line crash A', '9.00');
+$crash_b = wcos_p2_adapter_product('WCOS whole-line crash B', '4.00');
+list($crash_source, $crash_a_item, $crash_b_item) = wcos_whole_line_order($crash_a, 2, $crash_b, 2, 'pending');
+$crash_source_id = $crash_source->get_id();
+$crash_operation = 'p2-whole-line-source-crash-' . wp_generate_uuid4();
+$crash_injected = false;
+$crash_callback = static function($stage, $mutating_source) use (&$crash_injected) {
+    if (!$crash_injected && 'before_source_save' === $stage && $mutating_source instanceof WC_Order) {
+        $crash_injected = true;
+        $mutating_source->save();
+        throw new RuntimeException('Injected whole-line post-source-persist crash.');
+    }
+};
+add_action('wcos_split_mutation_checkpoint', $crash_callback, 10, 4);
+$crash_children = (new WCOS_Split_Order_Service())->split(
+    $crash_source,
+    array('child-1' => array($crash_a_item => '2.000000')),
+    $crash_operation,
+    WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+);
+remove_action('wcos_split_mutation_checkpoint', $crash_callback, 10);
+wcos_p2_adapter_assert($crash_injected, 'Whole-line source-persist crash fixture did not fire.');
+wcos_p2_adapter_assert(1 === count($crash_children), 'Whole-line source-persist crash did not recover its child set.');
+$crash_source = wc_get_order($crash_source_id);
+wcos_p2_adapter_assert(!$crash_source->get_item($crash_a_item), 'Recovered whole-line source retained the fully moved item.');
+$crash_record = WCOS_Operation_Journal::get($crash_source, $crash_operation);
+wcos_p2_adapter_assert(is_array($crash_record) && 'completed' === $crash_record['status'], 'Whole-line source-persist crash did not finalize the durable journal.');
+wcos_p2_adapter_assert(!WCOS_Manual_Reconciliation_Blocker::has_active($crash_source), 'Conserved whole-line crash recovery incorrectly entered manual reconciliation.');
+foreach ($crash_children as $crash_child) {
+    $crash_child->delete(true);
+}
+WCOS_Operation_Journal::delete($crash_source, $crash_operation);
+$crash_source->delete(true);
+wp_delete_post($crash_a->get_id(), true);
+wp_delete_post($crash_b->get_id(), true);
+
+/* If a fully moved source line is already deleted but persisted children no longer conserve state, auto-compensation is forbidden. */
+$bad_a = wcos_p2_adapter_product('WCOS whole-line ambiguous A', '8.00');
+$bad_b = wcos_p2_adapter_product('WCOS whole-line ambiguous B', '3.00');
+list($bad_source, $bad_a_item, $bad_b_item) = wcos_whole_line_order($bad_a, 2, $bad_b, 2, 'pending');
+$bad_source_id = $bad_source->get_id();
+$bad_operation = 'p2-whole-line-ambiguous-' . wp_generate_uuid4();
+$bad_injected = false;
+$bad_callback = static function($stage, $mutating_source, $children) use (&$bad_injected) {
+    if (!$bad_injected && 'before_source_save' === $stage && $mutating_source instanceof WC_Order) {
+        $bad_injected = true;
+        $mutating_source->save();
+        $child = reset($children);
+        if ($child instanceof WC_Order) {
+            $line = current($child->get_items('line_item'));
+            $line->set_quantity(((float) $line->get_quantity()) + 1);
+            $line->save();
+        }
+        throw new RuntimeException('Injected corrupted whole-line persisted state.');
+    }
+};
+add_action('wcos_split_mutation_checkpoint', $bad_callback, 10, 4);
+$bad_failed = false;
+try {
+    (new WCOS_Split_Order_Service())->split(
+        $bad_source,
+        array('child-1' => array($bad_a_item => '2.000000')),
+        $bad_operation,
+        WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+    );
+} catch (RuntimeException $exception) {
+    $bad_failed = true;
+}
+remove_action('wcos_split_mutation_checkpoint', $bad_callback, 10);
+wcos_p2_adapter_assert($bad_injected && $bad_failed, 'Corrupted whole-line persisted state did not fail closed.');
+$bad_source = wc_get_order($bad_source_id);
+wcos_p2_adapter_assert(!$bad_source->get_item($bad_a_item), 'Ambiguous whole-line fixture did not persist the destructive source deletion.');
+$bad_record = WCOS_Operation_Journal::get($bad_source, $bad_operation);
+wcos_p2_adapter_assert(is_array($bad_record) && 'manual_reconciliation' === $bad_record['status'], 'Ambiguous whole-line persisted state did not enter manual reconciliation.');
+wcos_p2_adapter_assert(WCOS_Manual_Reconciliation_Blocker::has_active($bad_source), 'Ambiguous whole-line persisted state did not block later mutations.');
+$blocked_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($bad_source);
+wcos_p2_adapter_assert(empty($blocked_report['supported']) && 'manual_reconciliation_required' === $blocked_report['reason'], 'Split preflight did not block the ambiguous whole-line source.');
+
+WCOS_Operation_Journal::mark_manual_reconciled($bad_source, $bad_operation, array('reconciliation_note' => 'whole-line-ambiguity-test-cleanup'));
+foreach (wcos_p2_adapter_children($bad_source_id, $bad_operation) as $bad_child) {
+    $bad_child->delete(true);
+}
+WCOS_Operation_Journal::delete(wc_get_order($bad_source_id), $bad_operation);
+wc_get_order($bad_source_id)->delete(true);
+wp_delete_post($bad_a->get_id(), true);
+wp_delete_post($bad_b->get_id(), true);
+
+echo "p2-whole-line-transfer-ok\n";


### PR DESCRIPTION
## Superseded

This draft is superseded by the staged whole-line v2 work.

The original PR mixed plan-policy and mutation-service changes, then failed before integration. A temporary diagnostic workflow was also added while isolating that compile failure. Rather than keep layering fixes onto a noisy authority branch, the work was restarted cleanly from `main` in two explicit stages:

1. prove execution-policy + plan validation first;
2. add mutation/recovery only after the plan layer is green.

Do not merge or reopen this PR. No code from this failed draft reached `main`.