### PR TITLE
P2: add Category and Stock-status planner foundation

### DIFF
--- a/docs/p2-split-strategy-planners.md
+++ b/docs/p2-split-strategy-planners.md
@@ -1,0 +1,93 @@
+# P2 Category and Stock-status Split Planner Foundation
+
+## Scope
+
+This milestone introduces deterministic, read-only server planners for two future Split strategies:
+
+- Category Split;
+- Stock-status Split.
+
+It does not register a controller, AJAX action, order button, mutation route, or production strategy. `WCOS_Split_Strategy_Gates::CATEGORY` and `WCOS_Split_Strategy_Gates::STOCK_STATUS` remain hard-off.
+
+Manual quantity Split remains the only production-enabled **Split strategy**. Hardened single-order Duplicate is a separate production mutation workflow and is unchanged by this milestone.
+
+## Planner-only architecture
+
+A future strategy flow must be:
+
+`Review planner -> frozen classification evidence -> explicit quantity plan -> confirmation -> hardened strategy adapter/gateway -> whole-line Split service`
+
+Review is read-only. Execute must consume the frozen plan and must never re-run category or stock-status classification against volatile catalog state.
+
+The whole-line Split plan/runtime/recovery foundations are already merged. That dependency is satisfied, but whole-line execution remains internal-only and requires an active request-local stock side-effect guard. Therefore these planners still cannot be connected directly to the mutation service.
+
+## Source-state coherence
+
+Each planner begins from the hardened Split preflight, then rehydrates the source order and requires its PII-free commercial source signature to match the preflight signature before classification begins.
+
+This prevents planner evidence from being built from a stale caller-owned `WC_Order` object while the report claims authority over a newer source state.
+
+Future confirmation must revalidate the source signature again before token issuance/execution.
+
+## Category planner
+
+Category authority uses stable taxonomy **term IDs** rather than names or slugs.
+
+For each source line:
+
+- historical order item ID and quantity are authoritative for the resulting plan;
+- the current catalog product must still exist to prove current Category classification at Review time;
+- assigned ancestor + descendant categories collapse to the deepest assigned leaf category;
+- multiple unrelated leaf categories are ambiguous and fail closed;
+- no assigned category becomes an explicit `category-uncategorized` bucket and is never silently dropped;
+- deleted catalog products fail closed because current category classification cannot be proven from volatile catalog state.
+
+Bucket reports may contain term slug/name for display, but the classification fingerprint deliberately excludes them. Its category authority is the source signature, planner policy version, stable term ID, and frozen item allocations. Renaming a category or changing its slug therefore does not change classification identity while the term ID and reviewed source remain the same.
+
+The operator must explicitly choose which reviewed bucket remains on the source order. Every other bucket becomes a full-line child allocation plan.
+
+## Stock-status planner
+
+Stock status is explicitly treated as volatile catalog evidence.
+
+Review accepts only WooCommerce statuses:
+
+- `instock`;
+- `outofstock`;
+- `onbackorder`.
+
+Evidence records source item ID, product/variation IDs, current catalog object ID, current stock owner ID, and reviewed status.
+
+After Review, `build_plan()` uses only the frozen report. A product moving from one stock status to another after Review does not rewrite the already reviewed plan; a new Review observes the new catalog state.
+
+Deleted catalog products fail closed because current stock-status classification cannot be proven.
+
+## Execution policy
+
+Both planners bind their reports to:
+
+`WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER`
+
+`build_plan()` rejects a review whose execution-policy authority has been altered. This planner foundation still does not call the mutation service.
+
+## Future confirmation / transport contract
+
+A future strategy confirmation must bind at least:
+
+- source order signature;
+- strategy name and planner policy version;
+- classification fingerprint;
+- explicit source bucket;
+- canonical quantity plan;
+- price precision;
+- `WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER`.
+
+Before mutation, a dedicated hardened strategy adapter must establish `WCOS_Stock_Side_Effect_Guard` scope and preserve the same fail-closed source/confirmation semantics used by the existing production workflows.
+
+Execute must not query Category or stock status again.
+
+## Production gate
+
+Planner classes are safe to package/load while strategy gates remain hard-off because they register no production surface and perform no writes.
+
+Any future Category or Stock-status production enablement requires its own transport/UI, production-enabled integration matrix, independent review, and explicit Human Gate.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -33,6 +33,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-mutation-contract.php';
 		include_once $root . 'domain/class-wcos-operation-lock.php';
 		include_once $root . 'domain/class-wcos-feature-gates.php';
+		include_once $root . 'domain/class-wcos-split-strategy-gates.php';
 		include_once $root . 'domain/class-wcos-order-mutation-authorizer.php';
 		include_once $root . 'domain/class-wcos-order-item-meta-policy.php';
 		include_once $root . 'domain/class-wcos-order-item-cloner.php';
@@ -58,6 +59,8 @@ class WC_Order_Splitter_Script {
 		WCOS_Mutation_Recovery_Coordinator::bootstrap();
 		include_once $root . 'domain/class-wcos-split-preflight.php';
 		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
+		include_once $root . 'domain/class-wcos-category-split-planner.php';
+		include_once $root . 'domain/class-wcos-stock-status-split-planner.php';
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
@@ -78,8 +81,9 @@ class WC_Order_Splitter_Script {
 
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Hardened
-		 * production transports must enter through WCOS_Mutation_Gateway; their
-		 * individual workflow gates remain the only execution authority.
+		 * production transports must enter through WCOS_Mutation_Gateway. Category
+		 * and Stock-status classes loaded above are read-only planners only; their
+		 * strategy gates remain hard-off and no production transport is registered.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-category-split-planner.php
+++ b/inc/domain/class-wcos-category-split-planner.php
@@ -1,0 +1,226 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Read-only planner for a future Category Split strategy.
+ *
+ * Category classification is sampled only during Review. Execute must consume
+ * the frozen quantity plan/evidence and must never re-query catalog categories.
+ */
+final class WCOS_Category_Split_Planner {
+	const STRATEGY = 'category';
+	const POLICY_VERSION = 2;
+	const UNCATEGORIZED_BUCKET = 'category-uncategorized';
+
+	public static function review(WC_Order $source) {
+		$base = (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		$source_id = absint($source->get_id());
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'strategy' => self::STRATEGY,
+			'policy_version' => self::POLICY_VERSION,
+			'order_id' => $source_id,
+			'source_signature' => isset($base['source_signature']) ? (string) $base['source_signature'] : '',
+			'buckets' => array(),
+			'classification_fingerprint' => '',
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+		);
+
+		if (empty($base['supported'])) {
+			return self::reject(
+				$report,
+				'base_' . (isset($base['reason']) ? sanitize_key((string) $base['reason']) : 'unsupported'),
+				isset($base['message']) ? (string) $base['message'] : __('The source order is not compatible with the hardened Split engine.', 'wc-order-splitter')
+			);
+		}
+
+		$source = $source_id ? wc_get_order($source_id) : false;
+		if (!$source instanceof WC_Order) {
+			return self::reject($report, 'source_unavailable', __('The source order is no longer available for Category Split review.', 'wc-order-splitter'));
+		}
+		$current_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+		if ('' === $report['source_signature'] || !hash_equals($report['source_signature'], $current_signature)) {
+			return self::reject(
+				$report,
+				'review_source_changed',
+				__('The source order changed while Category Split review was being prepared. Review the order again.', 'wc-order-splitter')
+			);
+		}
+
+		$buckets = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				continue;
+			}
+			$product = $item->get_product();
+			if (!$product instanceof WC_Product) {
+				return self::reject(
+					$report,
+					'deleted_product_category_unavailable',
+					__('A historical order line no longer has a catalog product, so its current category classification cannot be proven.', 'wc-order-splitter')
+				);
+			}
+
+			$product_id = absint($item->get_product_id());
+			$terms = wp_get_post_terms($product_id, 'product_cat');
+			if (is_wp_error($terms)) {
+				return self::reject($report, 'category_lookup_failed', __('Product categories could not be read safely for this order.', 'wc-order-splitter'));
+			}
+
+			$leaf_terms = self::leaf_assigned_terms((array) $terms);
+			if (count($leaf_terms) > 1) {
+				return self::reject(
+					$report,
+					'ambiguous_multiple_leaf_categories',
+					sprintf(
+						/* translators: %d: source order item ID. */
+						__('Order item %d belongs to multiple unrelated leaf categories. Choose an explicit category assignment before using Category Split.', 'wc-order-splitter'),
+						absint($item_id)
+					)
+				);
+			}
+
+			if (empty($leaf_terms)) {
+				$bucket_key = self::UNCATEGORIZED_BUCKET;
+				$bucket = array(
+					'key' => $bucket_key,
+					'term_id' => 0,
+					'term_slug' => '',
+					'label' => __('Uncategorized', 'wc-order-splitter'),
+					'items' => array(),
+				);
+			} else {
+				$term = reset($leaf_terms);
+				$bucket_key = 'category-' . absint($term->term_id);
+				$bucket = array(
+					'key' => $bucket_key,
+					'term_id' => absint($term->term_id),
+					'term_slug' => sanitize_title((string) $term->slug),
+					'label' => (string) $term->name,
+					'items' => array(),
+				);
+			}
+
+			if (!isset($buckets[$bucket_key])) {
+				$buckets[$bucket_key] = $bucket;
+			}
+			$buckets[$bucket_key]['items'][(int) $item_id] = WCOS_Decimal::normalize($item->get_quantity(), 6);
+		}
+
+		ksort($buckets, SORT_STRING);
+		foreach ($buckets as &$bucket) {
+			ksort($bucket['items'], SORT_NUMERIC);
+		}
+		unset($bucket);
+
+		if (count($buckets) < 2) {
+			return self::reject($report, 'single_category_bucket', __('Category Split requires at least two deterministic category buckets.', 'wc-order-splitter'));
+		}
+
+		$report['buckets'] = $buckets;
+		$report['classification_fingerprint'] = self::classification_fingerprint(
+			$source->get_id(),
+			$report['source_signature'],
+			$buckets
+		);
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('The order has deterministic category buckets that can be reviewed for Category Split.', 'wc-order-splitter');
+		return $report;
+	}
+
+	public static function build_plan(array $review, $source_bucket_key) {
+		if (empty($review['supported']) || self::STRATEGY !== sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '')) {
+			throw new InvalidArgumentException(__('A supported Category Split review is required to build a plan.', 'wc-order-splitter'));
+		}
+		if (!isset($review['policy_version']) || self::POLICY_VERSION !== (int) $review['policy_version']) {
+			throw new RuntimeException(__('The Category Split review policy no longer matches the current planner.', 'wc-order-splitter'));
+		}
+		if (!isset($review['execution_policy']) || WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $review['execution_policy']) {
+			throw new RuntimeException(__('The Category Split review does not carry the required whole-line execution policy.', 'wc-order-splitter'));
+		}
+		if (empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
+			throw new RuntimeException(__('The Category Split review is missing frozen classification authority.', 'wc-order-splitter'));
+		}
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
+		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
+			throw new InvalidArgumentException(__('Choose one reviewed category bucket to remain on the source order.', 'wc-order-splitter'));
+		}
+
+		$plan = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			if ($bucket_key === $source_bucket_key) {
+				continue;
+			}
+			$items = isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array();
+			if (!empty($items)) {
+				$plan[sanitize_key((string) $bucket_key)] = $items;
+			}
+		}
+		if (empty($plan)) {
+			throw new InvalidArgumentException(__('Category Split must create at least one child bucket.', 'wc-order-splitter'));
+		}
+
+		ksort($plan, SORT_STRING);
+		return WCOS_Split_Plan::canonicalize_request($plan);
+	}
+
+	private static function leaf_assigned_terms(array $terms) {
+		$by_id = array();
+		foreach ($terms as $term) {
+			if ($term instanceof WP_Term && absint($term->term_id)) {
+				$by_id[absint($term->term_id)] = $term;
+			}
+		}
+		$leaf = $by_id;
+		foreach ($by_id as $candidate_id => $candidate) {
+			foreach ($by_id as $other_id => $other) {
+				if ($candidate_id === $other_id) {
+					continue;
+				}
+				$ancestors = array_map('absint', get_ancestors($other_id, 'product_cat', 'taxonomy'));
+				if (in_array($candidate_id, $ancestors, true)) {
+					unset($leaf[$candidate_id]);
+					break;
+				}
+			}
+		}
+		ksort($leaf, SORT_NUMERIC);
+		return array_values($leaf);
+	}
+
+	private static function classification_fingerprint($source_order_id, $source_signature, array $buckets) {
+		$evidence = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			/*
+			 * Stable term ID + frozen source-item allocations are authority. Term
+			 * slug/name remain display data and deliberately do not affect identity.
+			 */
+			$evidence[$bucket_key] = array(
+				'term_id' => isset($bucket['term_id']) ? absint($bucket['term_id']) : 0,
+				'items' => isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array(),
+			);
+		}
+		return WCOS_Mutation_Fingerprint::create(
+			'category_split_review',
+			absint($source_order_id),
+			array(
+				'policy_version' => self::POLICY_VERSION,
+				'source_signature' => (string) $source_signature,
+				'evidence' => $evidence,
+			)
+		);
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/inc/domain/class-wcos-category-split-planner.php
+++ b/inc/domain/class-wcos-category-split-planner.php
@@ -142,12 +142,21 @@ final class WCOS_Category_Split_Planner {
 		if (!isset($review['execution_policy']) || WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $review['execution_policy']) {
 			throw new RuntimeException(__('The Category Split review does not carry the required whole-line execution policy.', 'wc-order-splitter'));
 		}
-		if (empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
+		if (empty($review['order_id']) || empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
 			throw new RuntimeException(__('The Category Split review is missing frozen classification authority.', 'wc-order-splitter'));
 		}
 
-		$source_bucket_key = sanitize_key((string) $source_bucket_key);
 		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		$expected_fingerprint = self::classification_fingerprint(
+			absint($review['order_id']),
+			(string) $review['source_signature'],
+			$buckets
+		);
+		if (!hash_equals((string) $review['classification_fingerprint'], $expected_fingerprint)) {
+			throw new RuntimeException(__('The frozen Category Split review evidence failed its integrity fingerprint.', 'wc-order-splitter'));
+		}
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
 		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
 			throw new InvalidArgumentException(__('Choose one reviewed category bucket to remain on the source order.', 'wc-order-splitter'));
 		}

--- a/inc/domain/class-wcos-split-strategy-gates.php
+++ b/inc/domain/class-wcos-split-strategy-gates.php
@@ -1,0 +1,34 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Internal gates for individual Split planning strategies.
+ *
+ * The global WCOS_Feature_Gates::SPLIT gate controls the hardened mutation
+ * workflow. Strategy gates separately control which server-built planners may
+ * expose production surfaces. They are code-only and cannot be overridden by
+ * options, constants, filters, mu-plugins, or wp-config.php.
+ */
+final class WCOS_Split_Strategy_Gates {
+	const MANUAL_QUANTITY = 'manual_quantity';
+	const CATEGORY = 'category';
+	const STOCK_STATUS = 'stock_status';
+
+	private static $states = array(
+		self::MANUAL_QUANTITY => true,
+		self::CATEGORY => false,
+		self::STOCK_STATUS => false,
+	);
+
+	public static function enabled($strategy) {
+		$strategy = sanitize_key((string) $strategy);
+		return isset(self::$states[$strategy]) && true === self::$states[$strategy];
+	}
+
+	public static function assert_enabled($strategy) {
+		if (!self::enabled($strategy)) {
+			throw new RuntimeException(__('This Split planning strategy is not enabled for production use.', 'wc-order-splitter'));
+		}
+	}
+}

--- a/inc/domain/class-wcos-stock-status-split-planner.php
+++ b/inc/domain/class-wcos-stock-status-split-planner.php
@@ -136,12 +136,21 @@ final class WCOS_Stock_Status_Split_Planner {
 		if (!isset($review['execution_policy']) || WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $review['execution_policy']) {
 			throw new RuntimeException(__('The Stock-status Split review does not carry the required whole-line execution policy.', 'wc-order-splitter'));
 		}
-		if (empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
+		if (empty($review['order_id']) || empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
 			throw new RuntimeException(__('The Stock-status Split review is missing frozen classification authority.', 'wc-order-splitter'));
 		}
 
-		$source_bucket_key = sanitize_key((string) $source_bucket_key);
 		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		$expected_fingerprint = self::classification_fingerprint(
+			absint($review['order_id']),
+			(string) $review['source_signature'],
+			$buckets
+		);
+		if (!hash_equals((string) $review['classification_fingerprint'], $expected_fingerprint)) {
+			throw new RuntimeException(__('The frozen Stock-status Split review evidence failed its integrity fingerprint.', 'wc-order-splitter'));
+		}
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
 		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
 			throw new InvalidArgumentException(__('Choose one reviewed stock-status bucket to remain on the source order.', 'wc-order-splitter'));
 		}

--- a/inc/domain/class-wcos-stock-status-split-planner.php
+++ b/inc/domain/class-wcos-stock-status-split-planner.php
@@ -1,0 +1,206 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Read-only planner for a future Stock-status Split strategy.
+ *
+ * Catalog stock status is volatile. It is sampled only during Review and the
+ * resulting explicit quantity plan/evidence must be frozen in confirmation.
+ * Execute must never re-query product stock status.
+ */
+final class WCOS_Stock_Status_Split_Planner {
+	const STRATEGY = 'stock_status';
+	const POLICY_VERSION = 2;
+
+	private static $supported_statuses = array('instock', 'outofstock', 'onbackorder');
+
+	public static function review(WC_Order $source) {
+		$base = (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		$source_id = absint($source->get_id());
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'strategy' => self::STRATEGY,
+			'policy_version' => self::POLICY_VERSION,
+			'order_id' => $source_id,
+			'source_signature' => isset($base['source_signature']) ? (string) $base['source_signature'] : '',
+			'buckets' => array(),
+			'classification_fingerprint' => '',
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+		);
+
+		if (empty($base['supported'])) {
+			return self::reject(
+				$report,
+				'base_' . (isset($base['reason']) ? sanitize_key((string) $base['reason']) : 'unsupported'),
+				isset($base['message']) ? (string) $base['message'] : __('The source order is not compatible with the hardened Split engine.', 'wc-order-splitter')
+			);
+		}
+
+		$source = $source_id ? wc_get_order($source_id) : false;
+		if (!$source instanceof WC_Order) {
+			return self::reject($report, 'source_unavailable', __('The source order is no longer available for Stock-status Split review.', 'wc-order-splitter'));
+		}
+		$current_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+		if ('' === $report['source_signature'] || !hash_equals($report['source_signature'], $current_signature)) {
+			return self::reject(
+				$report,
+				'review_source_changed',
+				__('The source order changed while Stock-status Split review was being prepared. Review the order again.', 'wc-order-splitter')
+			);
+		}
+
+		$buckets = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				continue;
+			}
+			$product = $item->get_product();
+			if (!$product instanceof WC_Product) {
+				return self::reject(
+					$report,
+					'deleted_product_stock_status_unavailable',
+					__('A historical order line no longer has a catalog product, so its current stock-status classification cannot be proven.', 'wc-order-splitter')
+				);
+			}
+
+			$status = sanitize_key((string) $product->get_stock_status());
+			if (!in_array($status, self::$supported_statuses, true)) {
+				return self::reject(
+					$report,
+					'unsupported_stock_status',
+					sprintf(
+						/* translators: %s: sanitized WooCommerce product stock status. */
+						__('The catalog returned an unsupported stock status: %s.', 'wc-order-splitter'),
+						$status
+					)
+				);
+			}
+
+			$bucket_key = 'stock-' . $status;
+			if (!isset($buckets[$bucket_key])) {
+				$buckets[$bucket_key] = array(
+					'key' => $bucket_key,
+					'stock_status' => $status,
+					'label' => self::status_label($status),
+					'items' => array(),
+					'evidence' => array(),
+				);
+			}
+
+			$managed_id = method_exists($product, 'get_stock_managed_by_id')
+				? absint($product->get_stock_managed_by_id())
+				: absint($product->get_id());
+			$buckets[$bucket_key]['items'][(int) $item_id] = WCOS_Decimal::normalize($item->get_quantity(), 6);
+			$buckets[$bucket_key]['evidence'][(int) $item_id] = array(
+				'product_id' => absint($item->get_product_id()),
+				'variation_id' => absint($item->get_variation_id()),
+				'catalog_object_id' => absint($product->get_id()),
+				'stock_owner_id' => $managed_id,
+				'stock_status' => $status,
+			);
+		}
+
+		ksort($buckets, SORT_STRING);
+		foreach ($buckets as &$bucket) {
+			ksort($bucket['items'], SORT_NUMERIC);
+			ksort($bucket['evidence'], SORT_NUMERIC);
+		}
+		unset($bucket);
+
+		if (count($buckets) < 2) {
+			return self::reject($report, 'single_stock_status_bucket', __('Stock-status Split requires at least two reviewed stock-status buckets.', 'wc-order-splitter'));
+		}
+
+		$report['buckets'] = $buckets;
+		$report['classification_fingerprint'] = self::classification_fingerprint(
+			$source->get_id(),
+			$report['source_signature'],
+			$buckets
+		);
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('The order has multiple reviewed stock-status buckets that can be frozen into a Split plan.', 'wc-order-splitter');
+		return $report;
+	}
+
+	public static function build_plan(array $review, $source_bucket_key) {
+		if (empty($review['supported']) || self::STRATEGY !== sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '')) {
+			throw new InvalidArgumentException(__('A supported Stock-status Split review is required to build a plan.', 'wc-order-splitter'));
+		}
+		if (!isset($review['policy_version']) || self::POLICY_VERSION !== (int) $review['policy_version']) {
+			throw new RuntimeException(__('The Stock-status Split review policy no longer matches the current planner.', 'wc-order-splitter'));
+		}
+		if (!isset($review['execution_policy']) || WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $review['execution_policy']) {
+			throw new RuntimeException(__('The Stock-status Split review does not carry the required whole-line execution policy.', 'wc-order-splitter'));
+		}
+		if (empty($review['classification_fingerprint']) || empty($review['source_signature'])) {
+			throw new RuntimeException(__('The Stock-status Split review is missing frozen classification authority.', 'wc-order-splitter'));
+		}
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
+		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
+			throw new InvalidArgumentException(__('Choose one reviewed stock-status bucket to remain on the source order.', 'wc-order-splitter'));
+		}
+
+		$plan = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			if ($bucket_key === $source_bucket_key) {
+				continue;
+			}
+			$items = isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array();
+			if (!empty($items)) {
+				$plan[sanitize_key((string) $bucket_key)] = $items;
+			}
+		}
+		if (empty($plan)) {
+			throw new InvalidArgumentException(__('Stock-status Split must create at least one child bucket.', 'wc-order-splitter'));
+		}
+
+		ksort($plan, SORT_STRING);
+		return WCOS_Split_Plan::canonicalize_request($plan);
+	}
+
+	private static function classification_fingerprint($source_order_id, $source_signature, array $buckets) {
+		$evidence = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			$evidence[$bucket_key] = array(
+				'stock_status' => isset($bucket['stock_status']) ? sanitize_key((string) $bucket['stock_status']) : '',
+				'items' => isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array(),
+				'evidence' => isset($bucket['evidence']) && is_array($bucket['evidence']) ? $bucket['evidence'] : array(),
+			);
+		}
+		return WCOS_Mutation_Fingerprint::create(
+			'stock_status_split_review',
+			absint($source_order_id),
+			array(
+				'policy_version' => self::POLICY_VERSION,
+				'source_signature' => (string) $source_signature,
+				'evidence' => $evidence,
+			)
+		);
+	}
+
+	private static function status_label($status) {
+		switch ($status) {
+			case 'instock':
+				return __('In stock', 'wc-order-splitter');
+			case 'outofstock':
+				return __('Out of stock', 'wc-order-splitter');
+			case 'onbackorder':
+				return __('On backorder', 'wc-order-splitter');
+			default:
+				return (string) $status;
+		}
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -1,0 +1,222 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Global Split workflow is not production-enabled while planner foundation is tested.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Hardened Duplicate production gate was lost while planner foundation is tested.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual quantity Split strategy gate is not enabled.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy was production-enabled by the planner foundation.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was production-enabled by the planner foundation.');
+wcos_p2_adapter_assert(!class_exists('WCOS_Category_Split_Admin_Controller'), 'Category planner foundation unexpectedly exposed an admin controller.');
+wcos_p2_adapter_assert(!class_exists('WCOS_Stock_Status_Split_Admin_Controller'), 'Stock-status planner foundation unexpectedly exposed an admin controller.');
+wcos_p2_adapter_assert(!method_exists('WCOS_Mutation_Gateway', 'category_split'), 'Category planner foundation unexpectedly exposed a mutation gateway method.');
+wcos_p2_adapter_assert(!method_exists('WCOS_Mutation_Gateway', 'stock_status_split'), 'Stock-status planner foundation unexpectedly exposed a mutation gateway method.');
+
+$term_suffix = strtolower(wp_generate_password(6, false, false));
+$parent_term = wp_insert_term('WCOS Planner Parent ' . $term_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($parent_term), 'Unable to create planner parent category.');
+$child_term = wp_insert_term(
+	'WCOS Planner Child ' . $term_suffix,
+	'product_cat',
+	array('parent' => absint($parent_term['term_id']))
+);
+wcos_p2_adapter_assert(!is_wp_error($child_term), 'Unable to create planner child category.');
+$other_term = wp_insert_term('WCOS Planner Other ' . $term_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($other_term), 'Unable to create planner peer category.');
+
+$category_a = wcos_p2_adapter_product('WCOS Category planner A', '10.00');
+$category_b = wcos_p2_adapter_product('WCOS Category planner B', '8.00');
+wp_set_object_terms($category_a->get_id(), array(absint($parent_term['term_id']), absint($child_term['term_id'])), 'product_cat');
+wp_set_object_terms($category_b->get_id(), array(absint($other_term['term_id'])), 'product_cat');
+
+$category_order = wc_create_order();
+$category_order->set_status('pending');
+$category_order->set_currency('USD');
+$category_a_item = $category_order->add_product($category_a, 2);
+$category_b_item = $category_order->add_product($category_b, 3);
+$category_order->calculate_totals(false);
+$category_order->set_billing_first_name('PlannerPrivateProbe');
+$category_order->set_billing_email('planner-private@example.test');
+$category_order->save();
+$category_order = wc_get_order($category_order->get_id());
+$category_signature = WCOS_Order_Contract_Snapshot::source_signature($category_order);
+
+$category_review = WCOS_Category_Split_Planner::review($category_order);
+wcos_p2_adapter_assert(!empty($category_review['supported']), 'Deterministic category order failed planner review.');
+wcos_p2_adapter_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $category_review['execution_policy'], 'Category review is not bound to whole-line execution policy.');
+$child_bucket = 'category-' . absint($child_term['term_id']);
+$other_bucket = 'category-' . absint($other_term['term_id']);
+wcos_p2_adapter_assert(isset($category_review['buckets'][$child_bucket]), 'Parent+child assignment did not resolve to the single leaf category.');
+wcos_p2_adapter_assert(!isset($category_review['buckets']['category-' . absint($parent_term['term_id'])]), 'Ancestor category remained as a duplicate authority bucket.');
+wcos_p2_adapter_assert(isset($category_review['buckets'][$other_bucket]), 'Peer category bucket is missing.');
+wcos_p2_adapter_assert(!empty($category_review['classification_fingerprint']), 'Category review omitted classification fingerprint.');
+$category_json = wp_json_encode($category_review);
+wcos_p2_adapter_assert(false === strpos($category_json, 'PlannerPrivateProbe'), 'Category planner leaked billing PII.');
+wcos_p2_adapter_assert(false === strpos($category_json, 'planner-private@example.test'), 'Category planner leaked billing email.');
+
+$category_plan = WCOS_Category_Split_Planner::build_plan($category_review, $child_bucket);
+wcos_p2_adapter_assert(1 === count($category_plan), 'Category planner did not create exactly one child bucket.');
+wcos_p2_adapter_assert(isset($category_plan[$other_bucket][$category_b_item]), 'Category plan did not move the peer-category line.');
+wcos_p2_adapter_assert('3.000000' === $category_plan[$other_bucket][$category_b_item], 'Category plan did not freeze the full historical line quantity.');
+wcos_p2_adapter_assert(!isset($category_plan[$other_bucket][$category_a_item]), 'Category plan moved the selected source bucket.');
+wcos_p2_adapter_assert($category_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($category_order->get_id())), 'Category Review/build-plan mutated the source order.');
+
+$category_tampered = $category_review;
+$category_tampered['execution_policy'] = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+$category_policy_rejected = false;
+try {
+	WCOS_Category_Split_Planner::build_plan($category_tampered, $child_bucket);
+} catch (RuntimeException $exception) {
+	$category_policy_rejected = false !== strpos($exception->getMessage(), 'whole-line execution policy');
+}
+wcos_p2_adapter_assert($category_policy_rejected, 'Category planner accepted a tampered execution policy.');
+
+/* Term ID is authority: changing name and slug changes display data, not classification identity. */
+$category_fingerprint_before_display_change = $category_review['classification_fingerprint'];
+$updated_other = wp_update_term(
+	absint($other_term['term_id']),
+	'product_cat',
+	array(
+		'name' => 'Renamed Display Only ' . $term_suffix,
+		'slug' => 'renamed-display-' . $term_suffix,
+	)
+);
+wcos_p2_adapter_assert(!is_wp_error($updated_other), 'Unable to rename planner category display metadata.');
+$category_review_after_display_change = WCOS_Category_Split_Planner::review(wc_get_order($category_order->get_id()));
+wcos_p2_adapter_assert(!empty($category_review_after_display_change['supported']), 'Category review failed after a display-only term rename.');
+wcos_p2_adapter_assert(
+	$category_fingerprint_before_display_change === $category_review_after_display_change['classification_fingerprint'],
+	'Category classification fingerprint changed when only term display metadata changed.'
+);
+wcos_p2_adapter_assert(
+	'renamed-display-' . $term_suffix === $category_review_after_display_change['buckets'][$other_bucket]['term_slug'],
+	'Category review did not refresh display metadata after the term rename.'
+);
+$category_plan_after_display_change = WCOS_Category_Split_Planner::build_plan($category_review, $child_bucket);
+wcos_p2_adapter_assert($category_plan === $category_plan_after_display_change, 'Changing category display metadata altered the frozen reviewed plan.');
+
+/* Multiple unrelated leaf categories are ambiguous and fail closed. */
+$ambiguous_product = wcos_p2_adapter_product('WCOS Category ambiguous', '6.00');
+wp_set_object_terms($ambiguous_product->get_id(), array(absint($child_term['term_id']), absint($other_term['term_id'])), 'product_cat');
+list($ambiguous_order, $ambiguous_item_id) = wcos_p2_adapter_order($ambiguous_product, 2, 'pending');
+$ambiguous_report = WCOS_Category_Split_Planner::review($ambiguous_order);
+wcos_p2_adapter_assert(empty($ambiguous_report['supported']) && 'ambiguous_multiple_leaf_categories' === $ambiguous_report['reason'], 'Category planner guessed among multiple unrelated leaf categories.');
+$ambiguous_order->delete(true);
+wp_delete_post($ambiguous_product->get_id(), true);
+
+/* Uncategorized is explicit rather than silently dropped. */
+$uncategorized_product = wcos_p2_adapter_product('WCOS Category uncategorized', '4.00');
+$categorized_product = wcos_p2_adapter_product('WCOS Category categorized', '5.00');
+wp_set_object_terms($uncategorized_product->get_id(), array(), 'product_cat');
+wp_set_object_terms($categorized_product->get_id(), array(absint($child_term['term_id'])), 'product_cat');
+$uncategorized_order = wc_create_order();
+$uncategorized_order->set_status('pending');
+$uncategorized_order->set_currency('USD');
+$uncategorized_item = $uncategorized_order->add_product($uncategorized_product, 1);
+$categorized_item = $uncategorized_order->add_product($categorized_product, 1);
+$uncategorized_order->calculate_totals(false);
+$uncategorized_order->save();
+$uncategorized_report = WCOS_Category_Split_Planner::review(wc_get_order($uncategorized_order->get_id()));
+wcos_p2_adapter_assert(!empty($uncategorized_report['supported']), 'Explicit uncategorized/category pair failed planner review.');
+wcos_p2_adapter_assert(isset($uncategorized_report['buckets'][WCOS_Category_Split_Planner::UNCATEGORIZED_BUCKET]), 'Uncategorized line was silently dropped by Category planner.');
+$uncategorized_order->delete(true);
+wp_delete_post($uncategorized_product->get_id(), true);
+wp_delete_post($categorized_product->get_id(), true);
+
+/* Deleted catalog product cannot be reclassified from volatile catalog state. */
+$deleted_category_product = wcos_p2_adapter_product('WCOS Category deleted product', '7.00');
+$deleted_category_peer = wcos_p2_adapter_product('WCOS Category deleted peer', '9.00');
+wp_set_object_terms($deleted_category_product->get_id(), array(absint($child_term['term_id'])), 'product_cat');
+wp_set_object_terms($deleted_category_peer->get_id(), array(absint($other_term['term_id'])), 'product_cat');
+$deleted_category_order = wc_create_order();
+$deleted_category_order->set_status('pending');
+$deleted_category_order->set_currency('USD');
+$deleted_category_order->add_product($deleted_category_product, 1);
+$deleted_category_order->add_product($deleted_category_peer, 1);
+$deleted_category_order->calculate_totals(false);
+$deleted_category_order->save();
+wp_delete_post($deleted_category_product->get_id(), true);
+$deleted_category_report = WCOS_Category_Split_Planner::review(wc_get_order($deleted_category_order->get_id()));
+wcos_p2_adapter_assert(empty($deleted_category_report['supported']) && 'deleted_product_category_unavailable' === $deleted_category_report['reason'], 'Category planner guessed category for a deleted catalog product.');
+$deleted_category_order->delete(true);
+wp_delete_post($deleted_category_peer->get_id(), true);
+
+/* Stock-status planner freezes current catalog classification into evidence + explicit plan. */
+$stock_in = wcos_p2_adapter_product('WCOS Stock planner in', '10.00');
+$stock_out = wcos_p2_adapter_product('WCOS Stock planner out', '12.00');
+$stock_in->set_stock_status('instock');
+$stock_in->save();
+$stock_out->set_stock_status('outofstock');
+$stock_out->save();
+$stock_order = wc_create_order();
+$stock_order->set_status('pending');
+$stock_order->set_currency('USD');
+$stock_in_item = $stock_order->add_product($stock_in, 2);
+$stock_out_item = $stock_order->add_product($stock_out, 1);
+$stock_order->calculate_totals(false);
+$stock_order->save();
+$stock_order = wc_get_order($stock_order->get_id());
+$stock_signature = WCOS_Order_Contract_Snapshot::source_signature($stock_order);
+
+$stock_review = WCOS_Stock_Status_Split_Planner::review($stock_order);
+wcos_p2_adapter_assert(!empty($stock_review['supported']), 'Two-status order failed Stock-status planner review.');
+wcos_p2_adapter_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $stock_review['execution_policy'], 'Stock-status review is not bound to whole-line execution policy.');
+wcos_p2_adapter_assert(isset($stock_review['buckets']['stock-instock']), 'In-stock bucket is missing.');
+wcos_p2_adapter_assert(isset($stock_review['buckets']['stock-outofstock']), 'Out-of-stock bucket is missing.');
+wcos_p2_adapter_assert(!empty($stock_review['classification_fingerprint']), 'Stock-status review omitted classification fingerprint.');
+$stock_plan = WCOS_Stock_Status_Split_Planner::build_plan($stock_review, 'stock-instock');
+wcos_p2_adapter_assert(isset($stock_plan['stock-outofstock'][$stock_out_item]), 'Stock-status plan did not move the reviewed out-of-stock line.');
+wcos_p2_adapter_assert('1.000000' === $stock_plan['stock-outofstock'][$stock_out_item], 'Stock-status plan did not freeze full historical quantity.');
+
+$stock_tampered = $stock_review;
+$stock_tampered['execution_policy'] = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+$stock_policy_rejected = false;
+try {
+	WCOS_Stock_Status_Split_Planner::build_plan($stock_tampered, 'stock-instock');
+} catch (RuntimeException $exception) {
+	$stock_policy_rejected = false !== strpos($exception->getMessage(), 'whole-line execution policy');
+}
+wcos_p2_adapter_assert($stock_policy_rejected, 'Stock-status planner accepted a tampered execution policy.');
+
+/* Catalog changes after Review must not rewrite the already reviewed plan. */
+$stock_out = wc_get_product($stock_out->get_id());
+$stock_out->set_stock_status('instock');
+$stock_out->save();
+$frozen_plan = WCOS_Stock_Status_Split_Planner::build_plan($stock_review, 'stock-instock');
+wcos_p2_adapter_assert($stock_plan === $frozen_plan, 'Stock-status planner recomputed volatile catalog state while building a frozen Review plan.');
+$new_stock_review = WCOS_Stock_Status_Split_Planner::review(wc_get_order($stock_order->get_id()));
+wcos_p2_adapter_assert(empty($new_stock_review['supported']) && 'single_stock_status_bucket' === $new_stock_review['reason'], 'A fresh Stock-status Review did not observe the changed catalog classification.');
+wcos_p2_adapter_assert($stock_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($stock_order->get_id())), 'Stock-status Review/build-plan mutated the source order.');
+$stock_order->delete(true);
+wp_delete_post($stock_in->get_id(), true);
+wp_delete_post($stock_out->get_id(), true);
+
+$deleted_stock = wcos_p2_adapter_product('WCOS Stock planner deleted', '8.00');
+$deleted_stock_peer = wcos_p2_adapter_product('WCOS Stock planner deleted peer', '9.00');
+$deleted_stock->set_stock_status('outofstock');
+$deleted_stock->save();
+$deleted_stock_peer->set_stock_status('instock');
+$deleted_stock_peer->save();
+$deleted_stock_order = wc_create_order();
+$deleted_stock_order->set_status('pending');
+$deleted_stock_order->set_currency('USD');
+$deleted_stock_order->add_product($deleted_stock, 1);
+$deleted_stock_order->add_product($deleted_stock_peer, 1);
+$deleted_stock_order->calculate_totals(false);
+$deleted_stock_order->save();
+wp_delete_post($deleted_stock->get_id(), true);
+$deleted_stock_report = WCOS_Stock_Status_Split_Planner::review(wc_get_order($deleted_stock_order->get_id()));
+wcos_p2_adapter_assert(empty($deleted_stock_report['supported']) && 'deleted_product_stock_status_unavailable' === $deleted_stock_report['reason'], 'Stock-status planner guessed status for a deleted catalog product.');
+$deleted_stock_order->delete(true);
+wp_delete_post($deleted_stock_peer->get_id(), true);
+
+$category_order->delete(true);
+wp_delete_post($category_a->get_id(), true);
+wp_delete_post($category_b->get_id(), true);
+wp_delete_term(absint($child_term['term_id']), 'product_cat');
+wp_delete_term(absint($other_term['term_id']), 'product_cat');
+wp_delete_term(absint($parent_term['term_id']), 'product_cat');
+
+echo "p2-strategy-planners-ok\n";

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -73,6 +73,16 @@ try {
 }
 wcos_p2_adapter_assert($category_policy_rejected, 'Category planner accepted a tampered execution policy.');
 
+$category_evidence_tampered = $category_review;
+$category_evidence_tampered['buckets'][$other_bucket]['items'][$category_b_item] = '2.000000';
+$category_evidence_rejected = false;
+try {
+	WCOS_Category_Split_Planner::build_plan($category_evidence_tampered, $child_bucket);
+} catch (RuntimeException $exception) {
+	$category_evidence_rejected = false !== strpos($exception->getMessage(), 'integrity fingerprint');
+}
+wcos_p2_adapter_assert($category_evidence_rejected, 'Category planner accepted tampered frozen item allocation evidence.');
+
 /* Term ID is authority: changing name and slug changes display data, not classification identity. */
 $category_fingerprint_before_display_change = $category_review['classification_fingerprint'];
 $updated_other = wp_update_term(
@@ -179,6 +189,16 @@ try {
 	$stock_policy_rejected = false !== strpos($exception->getMessage(), 'whole-line execution policy');
 }
 wcos_p2_adapter_assert($stock_policy_rejected, 'Stock-status planner accepted a tampered execution policy.');
+
+$stock_evidence_tampered = $stock_review;
+$stock_evidence_tampered['buckets']['stock-outofstock']['evidence'][$stock_out_item]['stock_owner_id'] = 999999;
+$stock_evidence_rejected = false;
+try {
+	WCOS_Stock_Status_Split_Planner::build_plan($stock_evidence_tampered, 'stock-instock');
+} catch (RuntimeException $exception) {
+	$stock_evidence_rejected = false !== strpos($exception->getMessage(), 'integrity fingerprint');
+}
+wcos_p2_adapter_assert($stock_evidence_rejected, 'Stock-status planner accepted tampered frozen classification evidence.');
 
 /* Catalog changes after Review must not rewrite the already reviewed plan. */
 $stock_out = wc_get_product($stock_out->get_id());

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -116,10 +116,12 @@ wcos_p2_adapter_assert(empty($ambiguous_report['supported']) && 'ambiguous_multi
 $ambiguous_order->delete(true);
 wp_delete_post($ambiguous_product->get_id(), true);
 
-/* Uncategorized is explicit rather than silently dropped. */
+/* Force a truly termless product: WooCommerce normally assigns its default product category. */
 $uncategorized_product = wcos_p2_adapter_product('WCOS Category uncategorized', '4.00');
 $categorized_product = wcos_p2_adapter_product('WCOS Category categorized', '5.00');
-wp_set_object_terms($uncategorized_product->get_id(), array(), 'product_cat');
+wp_delete_object_term_relationships($uncategorized_product->get_id(), 'product_cat');
+$uncategorized_terms = wp_get_post_terms($uncategorized_product->get_id(), 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($uncategorized_terms) && empty($uncategorized_terms), 'Unable to construct a truly termless Category planner fixture.');
 wp_set_object_terms($categorized_product->get_id(), array(absint($child_term['term_id'])), 'product_cat');
 $uncategorized_order = wc_create_order();
 $uncategorized_order->set_status('pending');

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -87,3 +87,4 @@ echo "p2-whole-line-plan-ok\n";
 
 require __DIR__ . '/p2-whole-line-runtime-smoke.php';
 require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
+require __DIR__ . '/p2-strategy-planners-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_PLANNERS`

## Status

**TECHNICAL ACCEPTANCE COMPLETE.**

Final reviewed head:

`3f42e920d68a45474471e51aec2f5e609af1e7a1`

This is a read-only planner foundation. It introduces no production Category/Stock-status controller, AJAX route, launcher, Gateway mutation path, or enabled strategy gate.

## Current production state

- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Split strategy gates:

- `manual_quantity = true`
- `category = false`
- `stock_status = false`

## Planner architecture

Future strategy execution remains:

`Review planner -> frozen classification evidence -> explicit quantity plan -> confirmation -> hardened strategy adapter/gateway -> whole-line Split service`

The whole-line plan/runtime dependency is already merged, but whole-line execution remains internal-only and requires an active request-local stock side-effect guard.

## Accepted Category policy

- stable taxonomy term IDs are authority;
- term slug/name are display-only and excluded from classification identity;
- ancestor + descendant assignments collapse to the deepest assigned leaf;
- multiple unrelated leaf categories fail closed;
- truly termless products receive explicit `category-uncategorized` buckets;
- deleted catalog products fail closed;
- source order is rehydrated and its PII-free signature must still match hardened preflight before classification;
- frozen review evidence is fingerprinted and `build_plan()` rejects later bucket/item tampering;
- execution-policy tampering is rejected;
- one reviewed bucket must remain on source; every other bucket becomes a whole-line quantity plan.

## Accepted Stock-status policy

- supported statuses: `instock`, `outofstock`, `onbackorder`;
- evidence freezes product/variation/catalog-object/stock-owner IDs and reviewed status;
- source coherence is revalidated before classification;
- frozen review evidence is fingerprinted and `build_plan()` rejects later evidence tampering;
- catalog status changes after Review do not rewrite the reviewed plan; a new Review sees the new catalog state;
- deleted catalog products fail closed;
- execution-policy tampering is rejected.

## Final evidence

Canonical **CI #606** (`32227620884`) completed successfully on the exact final head:

- PHP 7.4 ✅
- PHP 8.1 ✅
- PHP 8.3 ✅
- architecture / approved production gate contract ✅
- package safety ✅
- WooCommerce legacy storage ✅
- HPOS-only ✅
- HPOS compatibility/sync ✅
- production Split + Duplicate regressions ✅
- whole-line plan/runtime/stock-owner regressions ✅
- Category planner acceptance ✅
- Stock-status planner acceptance ✅
- frozen-review tamper rejection ✅
- `Required CI` ✅

Independent technical review was recorded on exact head as review `4969484932`; no remaining blocker was found.

## Merge classification

Safe foundation merge only. Production Category and Stock-status enablement each remain separate future readiness + Human Gate milestones.