### PR TITLE
P2: validate whole-line Split plan policy

### DIFF
--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -36,6 +36,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-mutation-authorizer.php';
 		include_once $root . 'domain/class-wcos-order-item-meta-policy.php';
 		include_once $root . 'domain/class-wcos-order-item-cloner.php';
+		include_once $root . 'domain/class-wcos-split-execution-policy.php';
 		include_once $root . 'domain/class-wcos-split-plan.php';
 		include_once $root . 'domain/class-wcos-order-totals-rebuilder.php';
 		include_once $root . 'domain/class-wcos-tax-item-synchronizer.php';

--- a/inc/domain/class-wcos-split-execution-policy.php
+++ b/inc/domain/class-wcos-split-execution-policy.php
@@ -1,0 +1,30 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Immutable policy selector for one Split operation.
+ *
+ * Manual quantity Split keeps its current positive-residual rule. Future
+ * server-built planners may opt into whole-line transfer only by supplying the
+ * explicit internal policy value.
+ */
+final class WCOS_Split_Execution_Policy {
+	const PARTIAL_LINES_ONLY = 'partial_lines_only';
+	const ALLOW_WHOLE_LINE_TRANSFER = 'allow_whole_line_transfer';
+
+	public static function normalize($policy) {
+		$policy = sanitize_key((string) $policy);
+		if ('' === $policy) {
+			$policy = self::PARTIAL_LINES_ONLY;
+		}
+		if (!in_array($policy, array(self::PARTIAL_LINES_ONLY, self::ALLOW_WHOLE_LINE_TRANSFER), true)) {
+			throw new InvalidArgumentException(__('Unknown Split execution policy.', 'wc-order-splitter'));
+		}
+		return $policy;
+	}
+
+	public static function allows_whole_line_transfer($policy) {
+		return self::ALLOW_WHOLE_LINE_TRANSFER === self::normalize($policy);
+	}
+}

--- a/inc/domain/class-wcos-split-plan.php
+++ b/inc/domain/class-wcos-split-plan.php
@@ -44,15 +44,21 @@ final class WCOS_Split_Plan {
 		return $canonical;
 	}
 
-	public static function normalize(WC_Order $source, array $plan) {
+	public static function normalize(WC_Order $source, array $plan, $execution_policy = 'partial_lines_only') {
+		$execution_policy = WCOS_Split_Execution_Policy::normalize($execution_policy);
+		$whole_line_allowed = WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy);
 		$normalized = self::canonicalize_request($plan);
 		$source_quantities = array();
 		foreach ($source->get_items('line_item') as $item_id => $item) {
-			$source_quantities[(int) $item_id] = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			$quantity_units = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			if ($quantity_units <= 0) {
+				throw new InvalidArgumentException(__('Every source line must have a positive quantity before Split.', 'wc-order-splitter'));
+			}
+			$source_quantities[(int) $item_id] = $quantity_units;
 		}
 
 		$totals_by_item = array();
-		foreach ($normalized as $child_key => $items) {
+		foreach ($normalized as $items) {
 			foreach ($items as $item_id => $quantity) {
 				if (!isset($source_quantities[$item_id])) {
 					throw new InvalidArgumentException(__('The split plan references an item outside the source order.', 'wc-order-splitter'));
@@ -64,13 +70,55 @@ final class WCOS_Split_Plan {
 			}
 		}
 
+		$fully_moved_items = array();
 		foreach ($totals_by_item as $item_id => $split_units) {
-			if ($split_units >= $source_quantities[$item_id]) {
-				throw new InvalidArgumentException(__('The hardened split engine requires every affected source line to retain a positive quantity.', 'wc-order-splitter'));
+			if ($split_units > $source_quantities[$item_id]) {
+				throw new InvalidArgumentException(__('The split plan allocates more than the source line quantity.', 'wc-order-splitter'));
+			}
+			if ($split_units === $source_quantities[$item_id]) {
+				if (!$whole_line_allowed) {
+					throw new InvalidArgumentException(__('The manual quantity Split policy requires every affected source line to retain a positive quantity.', 'wc-order-splitter'));
+				}
+				$fully_moved_items[$item_id] = true;
+			}
+		}
+
+		if ($whole_line_allowed && !empty($fully_moved_items)) {
+			if ((count($source_quantities) - count($fully_moved_items)) <= 0) {
+				throw new InvalidArgumentException(__('Whole-line Split must leave at least one product line on the source order.', 'wc-order-splitter'));
 			}
 		}
 
 		return $normalized;
+	}
+
+	public static function fully_moved_item_ids(WC_Order $source, array $normalized_plan, $execution_policy = 'partial_lines_only') {
+		if (!WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy)) {
+			return array();
+		}
+
+		$source_quantities = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			$source_quantities[(int) $item_id] = WCOS_Decimal::to_units($item->get_quantity(), 6);
+		}
+		$allocated = array();
+		foreach ($normalized_plan as $items) {
+			foreach ($items as $item_id => $quantity) {
+				$quantity_units = WCOS_Decimal::to_units($quantity, 6);
+				$allocated[$item_id] = isset($allocated[$item_id])
+					? self::safe_add($allocated[$item_id], $quantity_units)
+					: $quantity_units;
+			}
+		}
+
+		$fully_moved = array();
+		foreach ($allocated as $item_id => $quantity_units) {
+			if (isset($source_quantities[$item_id]) && $quantity_units === $source_quantities[$item_id]) {
+				$fully_moved[] = (int) $item_id;
+			}
+		}
+		sort($fully_moved, SORT_NUMERIC);
+		return $fully_moved;
 	}
 
 	public static function child_keys(array $normalized_plan) {

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -136,6 +136,7 @@ wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety
 
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
 require __DIR__ . '/p2-production-duplicate-enabled-smoke.php';
+require __DIR__ . '/p2-whole-line-plan-smoke.php';
 require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
 require __DIR__ . '/p2-duplicate-precision-replay-smoke.php';
 require __DIR__ . '/p2-duplicate-compatibility-smoke.php';

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -1,0 +1,86 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$product_a = wcos_p2_adapter_product('WCOS whole-line plan A', '10.00');
+$product_b = wcos_p2_adapter_product('WCOS whole-line plan B', '5.00');
+$order = wc_create_order();
+$order->set_status('pending');
+$order->set_currency('USD');
+$item_a = $order->add_product($product_a, 2);
+$item_b = $order->add_product($product_b, 1);
+$order->calculate_totals(false);
+$order->save();
+$order = wc_get_order($order->get_id());
+
+wcos_p2_adapter_assert(
+	WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === WCOS_Split_Execution_Policy::normalize(''),
+	'Whole-line policy default no longer preserves manual quantity Split semantics.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Split_Execution_Policy::allows_whole_line_transfer(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER),
+	'Whole-line execution policy is not recognized.'
+);
+
+$manual_rejected = false;
+try {
+	WCOS_Split_Plan::normalize(
+		$order,
+		array('child-1' => array($item_a => '2.000000'))
+	);
+} catch (InvalidArgumentException $exception) {
+	$manual_rejected = false !== strpos($exception->getMessage(), 'positive quantity');
+}
+wcos_p2_adapter_assert($manual_rejected, 'Default/manual Split policy accepted residual=0.');
+
+$whole_plan = WCOS_Split_Plan::normalize(
+	$order,
+	array('child-1' => array($item_a => '2.000000')),
+	WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+);
+wcos_p2_adapter_assert('2.000000' === $whole_plan['child-1'][$item_a], 'Whole-line plan did not preserve the full source quantity.');
+wcos_p2_adapter_assert(
+	array($item_a) === WCOS_Split_Plan::fully_moved_item_ids(
+		$order,
+		$whole_plan,
+		WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+	),
+	'Whole-line plan did not identify its destructive source-item set deterministically.'
+);
+
+$all_lines_rejected = false;
+try {
+	WCOS_Split_Plan::normalize(
+		$order,
+		array(
+			'child-1' => array(
+				$item_a => '2.000000',
+				$item_b => '1.000000',
+			),
+		),
+		WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+	);
+} catch (InvalidArgumentException $exception) {
+	$all_lines_rejected = false !== strpos($exception->getMessage(), 'at least one product line');
+}
+wcos_p2_adapter_assert($all_lines_rejected, 'Whole-line policy allowed every product line to leave the source.');
+
+$overallocated_rejected = false;
+try {
+	WCOS_Split_Plan::normalize(
+		$order,
+		array('child-1' => array($item_a => '2.000001')),
+		WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+	);
+} catch (InvalidArgumentException $exception) {
+	$overallocated_rejected = false !== strpos($exception->getMessage(), 'more than the source line quantity');
+}
+wcos_p2_adapter_assert($overallocated_rejected, 'Whole-line policy allowed allocation beyond source quantity.');
+
+$order->delete(true);
+wp_delete_post($product_a->get_id(), true);
+wp_delete_post($product_b->get_id(), true);
+
+echo "p2-whole-line-plan-ok\n";


### PR DESCRIPTION
## Classification

`P2_SPLIT_WHOLE_LINE_PLAN_FOUNDATION`

## Status

Refreshed cleanly onto current `main` 1.4.14 after Duplicate production enablement. This PR still changes plan/policy validation only; the production Split mutation service is unchanged.

## Mission

Introduce and validate the execution-policy / plan layer required for future whole-line Split without changing the current production mutation service yet.

## Step A scope

- add internal `WCOS_Split_Execution_Policy`;
- keep default/manual behavior `partial_lines_only`;
- allow `WCOS_Split_Plan` to validate residual=0 only when explicitly passed `allow_whole_line_transfer`;
- require at least one product line to remain on source;
- expose deterministic `fully_moved_item_ids()`;
- load the policy before Split plan validation;
- add canonical integration acceptance under the current `SPLIT=true / DUPLICATE=true` release map.

## Production boundary

No mutation service behavior changes. Existing production manual quantity Split and hardened Duplicate remain unchanged. No Category/Stock-status controller, launcher, AJAX route, or strategy gate is enabled.

Only after this plan/API layer is green will whole-line mutation/recovery be implemented as Step B.