### PR TITLE
Release 1.4.14: document hardened Duplicate enablement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,14 @@
 
 == Changelog ==
 
+= 1.4.14 (Aug 19, 2026) =
+* New: Enabled the hardened single-order Duplicate workflow for supported WooCommerce orders.
+* Safety: Added server-reviewed Duplicate confirmation, nonce/capability enforcement, source-state verification, operation leases, durable journals, and idempotent retry under the approved production gate.
+* Integrity: Duplicate creates fresh order-item objects and preserves supported historical line, shipping, fee, tax, coupon, and configured business metadata without recalculating current catalog values.
+* Payment/Stock: Duplicate targets remain Pending payment and do not inherit the source transaction ID, paid state, order-level stock-reduction state, or line `_reduced_stock`; Duplicate does not intentionally write physical product stock.
+* Compatibility: Validated production Duplicate across legacy order storage, HPOS-only, and HPOS compatibility/synchronization modes, including 0/2/3-decimal precision, deleted products, configured lines, retries, source races, and side-effect contracts.
+* Safety: Merge, Return, and Bulk Return remain disabled until their hardened production workflows are completed.
+
 = 1.4.13 (Aug 19, 2026) =
 * New: Re-enabled hardened manual quantity Split for supported WooCommerce orders.
 * Safety: Added server-side review/confirmation, strict plan parsing, nonce/capability checks, operation leases, durable journals, idempotent retry, and fail-closed recovery contracts.

--- a/readme.txt
+++ b/readme.txt
@@ -5,45 +5,55 @@ Requires at least: 6.5
 Tested up to: 7.0
 WC tested up to: 11.0
 Requires PHP: 7.4
-Stable tag: 1.4.13
+Stable tag: 1.4.14
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Safely split WooCommerce orders by quantity with server-side review, HPOS support, idempotent retries, and preserved historical order values.
+Safely split and duplicate WooCommerce orders with server-side review, HPOS support, idempotent retries, and preserved historical order values.
 
 == Description ==
 
 Order Splitter for WooCommerce provides administrative tooling for WooCommerce order operations and split-order relationships.
 
+= Hardened Duplicate in 1.4.14 =
+
+Version 1.4.14 enables the hardened single-order Duplicate workflow from the WooCommerce order edit screen.
+
+Duplicate uses the same fail-closed production architecture as the hardened Split workflow: server-side review, order-scoped authorization, confirmation tokens, durable operation journals, operation leases, source-state verification, idempotent retries, and HPOS-safe WooCommerce CRUD persistence.
+
+The duplicated order is always created as Pending payment. Historical line, shipping, fee, tax, and coupon rows are copied through fresh order-item objects, while the source transaction ID, paid state, order-level stock-reduction state, and line `_reduced_stock` markers are deliberately not copied. The Duplicate request is designed not to write physical product stock.
+
+Merge, Return, and Bulk Return remain unavailable while their hardened replacements complete the same production-readiness process.
+
 = Manual quantity Split in 1.4.13 =
 
-Version 1.4.13 re-enables the first hardened mutation workflow: manual quantity Split from the WooCommerce order edit screen.
+Version 1.4.13 re-enabled hardened manual quantity Split from the WooCommerce order edit screen.
 
 The workflow uses a server-reviewed confirmation flow and preserves historical order amounts and tax context instead of recalculating against current catalog values. Split operations are journaled and idempotent so an interrupted or retried request reuses the same child orders rather than creating duplicates.
 
 The Split request is designed as an order-only mutation and must not change physical product stock. Stock-reduction markers are redistributed with the source and child orders so later WooCommerce cancellation/restock lifecycle behavior remains consistent.
 
-Other mutation workflows — Duplicate, Merge, Return, and Bulk Return — remain unavailable while they complete the same production-readiness process.
-
 [Premium version](https://yoohw.com/product/woocommerce-advanced-order-actions/) | [Documentation](https://docs.yoohw.com/category/woocommerce-advanced-order-actions/) | [Support](https://yoohw.com/support/) | [Demo](https://sandbox.yoohw.com/demo/wcaoa_demo.html)
 
 == Current functionality ==
 
-In 1.4.13:
+In 1.4.14:
 
 * Manual quantity Split is available on supported WooCommerce orders.
-* A server-side review step validates the source order and requested quantity allocation before execution.
-* Child orders are created as Pending payment and do not inherit the source payment transaction ID.
-* Historical line totals and taxes are preserved at the order's captured price precision.
-* The Split operation does not intentionally write physical product stock.
-* Operation IDs, durable journals, leases, confirmation tokens, and idempotent retry handling protect against duplicate execution.
+* Hardened single-order Duplicate is available on supported WooCommerce orders.
+* Server-side review validates the source order before either production mutation executes.
+* Split child orders and Duplicate targets are created as Pending payment and do not inherit the source payment transaction ID.
+* Duplicate preserves supported historical line, shipping, fee, tax, coupon, and business-metadata state through fresh order-item objects.
+* Historical line totals and taxes are preserved at the operation's captured price precision.
+* Split and Duplicate do not intentionally write physical product stock.
+* Operation IDs, durable journals, leases, confirmation tokens, source-state verification, and idempotent retry handling protect against duplicate execution.
 * Legacy split-order relationship labels remain available.
 * WooCommerce legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode are supported by the production acceptance matrix.
-* Duplicate, Merge, Return, and Bulk Return remain disabled in the free plugin.
+* Merge, Return, and Bulk Return remain disabled in the free plugin.
 
 == Split safety policy ==
 
-The first production-enabled manual quantity Split intentionally fails closed for unsupported cases instead of guessing how third-party business rules should be redistributed.
+The hardened manual quantity Split intentionally fails closed for unsupported cases instead of guessing how third-party business rules should be redistributed.
 
 The workflow currently rejects before mutation when an order contains unsupported conditions such as:
 
@@ -56,9 +66,17 @@ The workflow currently rejects before mutation when an order contains unsupporte
 
 Shipping and positive fees remain on the source order. Historical line taxes are allocated without recalculating current tax rates. Fractional quantities are accepted only when the active WooCommerce quantity integration actually preserves fractional stock amounts.
 
+== Duplicate safety policy ==
+
+The hardened Duplicate workflow creates one fresh Pending payment order from the reviewed historical source state.
+
+Duplicate fails closed for unsupported conditions such as refunds, unresolved manual-reconciliation state, unclassified or inconsistently classified private line-item metadata, unsupported fractional state, or internally inconsistent historical totals/taxes.
+
+The source transaction ID, paid state, order-level stock-reduced state, and line `_reduced_stock` markers are not copied. Arbitrary custom order-level metadata is not copied by the first hardened Duplicate workflow. Deleted catalog products remain supported when their persisted historical order-line state can be proven.
+
 == High-Performance Order Storage (HPOS) ==
 
-The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual quantity Split is validated in CI against legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode.
+The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual quantity Split and hardened Duplicate are validated in CI against legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode.
 
 == Installation ==
 
@@ -66,25 +84,29 @@ The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual qu
 2. Activate the plugin from Plugins in the WordPress admin.
 3. Make sure WooCommerce is installed and active.
 4. Go to WooCommerce > Settings > Orders to review Order Splitter settings.
-5. Open a supported WooCommerce order and use the Split order action to review and confirm a quantity allocation.
+5. Open a supported WooCommerce order and use Split or Duplicate to review and confirm the requested operation.
 
 == Frequently Asked Questions ==
 
-= Which mutation workflow is enabled in 1.4.13? =
+= Which mutation workflows are enabled in 1.4.14? =
 
-Manual quantity Split is enabled. Duplicate, Merge, Return, and Bulk Return remain disabled until their hardened replacements complete production acceptance.
+Manual quantity Split and hardened single-order Duplicate are enabled. Merge, Return, and Bulk Return remain disabled until their hardened replacements complete production acceptance.
 
 = Does Split change physical product stock? =
 
 The Split request is an order-only mutation and is designed not to write physical product stock. It redistributes WooCommerce stock-reduction markers between the source and child orders so later cancellation/restock lifecycle behavior remains consistent.
 
-= Why can a Split request be rejected before execution? =
+= What does Duplicate copy? =
 
-The first hardened workflow intentionally fails closed when it cannot prove conservation and compatibility, including orders with coupons, refunds, negative fees, nested Split state, or unclassified private line-item metadata.
+Duplicate copies supported historical line, shipping, fee, tax, coupon, payment-method context, addresses, and business item metadata into fresh WooCommerce order-item objects. It does not copy the source transaction ID, paid state, order-level stock-reduction state, line `_reduced_stock`, or arbitrary custom order-level metadata.
 
-= What happens if I retry an interrupted Split? =
+= Why can a Split or Duplicate request be rejected before execution? =
 
-The operation uses a server-generated operation ID, durable journal, source-order lease, and idempotent child discovery. A valid retry resumes or returns the original child set instead of creating duplicate child orders.
+The hardened workflows intentionally fail closed when they cannot prove conservation, source-state integrity, or compatibility. Split and Duplicate have different operation policies, but both reject ambiguous or unsupported state before mutation.
+
+= What happens if I retry an interrupted operation? =
+
+The workflows use server-generated operation IDs, durable journals, source-order leases, confirmation authority, and idempotent target discovery. A valid retry resumes or returns the original child/target set instead of creating duplicate orders.
 
 = Are existing split-order relationships preserved? =
 
@@ -99,6 +121,14 @@ No. The automatic external subscription request was removed in 1.4.12 and remain
 Older release notes are available in `changelog.txt`.
 
 == Changelog ==
+
+= 1.4.14 (Aug 19, 2026) =
+* New: Enabled the hardened single-order Duplicate workflow for supported WooCommerce orders.
+* Safety: Added server-reviewed Duplicate confirmation, nonce/capability enforcement, source-state verification, operation leases, durable journals, and idempotent retry under the approved production gate.
+* Integrity: Duplicate creates fresh order-item objects and preserves supported historical line, shipping, fee, tax, coupon, and configured business metadata without recalculating current catalog values.
+* Payment/Stock: Duplicate targets remain Pending payment and do not inherit the source transaction ID, paid state, order-level stock-reduction state, or line `_reduced_stock`; Duplicate does not intentionally write physical product stock.
+* Compatibility: Validated production Duplicate across legacy order storage, HPOS-only, and HPOS compatibility/synchronization modes, including 0/2/3-decimal precision, deleted products, configured lines, retries, source races, and side-effect contracts.
+* Safety: Merge, Return, and Bulk Return remain disabled until their hardened production workflows are completed.
 
 = 1.4.13 (Aug 19, 2026) =
 * New: Re-enabled hardened manual quantity Split for supported WooCommerce orders.
@@ -125,5 +155,5 @@ Older release notes are available in `changelog.txt`.
 
 == Upgrade Notice ==
 
-= 1.4.13 =
-Manual quantity Split is re-enabled through the new hardened production path. Other mutation workflows remain fail-closed.
+= 1.4.14 =
+Hardened Duplicate is now production-enabled alongside manual quantity Split. Merge, Return, and Bulk Return remain fail-closed.

--- a/wc-order-splitter.php
+++ b/wc-order-splitter.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: Order Splitter for WooCommerce
  * Plugin URI: https://github.com/yoohwz/wc-order-splitter
- * Description: Safely split WooCommerce orders by quantity with review, idempotency, HPOS support, and preserved historical order values.
- * Version: 1.4.13
+ * Description: Safely split and duplicate WooCommerce orders with server-side review, idempotency, HPOS support, and preserved historical order values.
+ * Version: 1.4.14
  * Author: YoOhw.com
  * Author URI: https://yoohw.com
  * Requires at least: 6.5


### PR DESCRIPTION
## Classification

`RELEASE_BOOKKEEPING_1_4_14`

## Mission

Synchronize release metadata and WordPress.org-facing documentation with the production state already merged in PR #16.

## Runtime state documented

- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

## Scope

This PR contains no mutation-engine, adapter, controller, gate, recovery, stock, or transport changes. It only:

- bumps plugin header version from 1.4.13 to 1.4.14;
- bumps WordPress.org stable tag to 1.4.14;
- updates the public description/current functionality/FAQ/upgrade notice for hardened Duplicate;
- adds 1.4.14 changelog entries while preserving prior release history.

Canonical CI/package must prove version == stable tag and retain the already-approved Split + Duplicate production gate state before merge.