### PR TITLE
P2: refresh Category and Stock-status planner foundation

### DIFF
--- a/docs/p2-split-strategy-planners.md
+++ b/docs/p2-split-strategy-planners.md
@@ -37,7 +37,8 @@ Category Review uses stable taxonomy term IDs as classification authority.
 - names and slugs are display metadata only and do not participate in the classification fingerprint;
 - if both an assigned ancestor and descendant are present, the deepest assigned leaf is the bucket authority;
 - multiple unrelated assigned leaf categories are ambiguous and fail closed;
-- an item with no category is placed in the explicit `category-uncategorized` bucket;
+- WooCommerce's configured `default_product_cat` term is treated as the explicit `category-uncategorized` bucket when it is the product's only leaf category; this decision uses the stable term ID, never the mutable default-category name or slug;
+- a true no-term product state also maps to `category-uncategorized` as a defensive fallback;
 - a deleted catalog product fails closed because current category classification cannot be proven;
 - at least two deterministic buckets are required;
 - the operator must later choose one reviewed bucket to remain on the source order;
@@ -79,7 +80,7 @@ Canonical integration acceptance must prove:
 - Category ancestor/descendant collapse is deterministic;
 - taxonomy display metadata does not change stable category authority;
 - unrelated category leaves fail closed;
-- uncategorized and deleted-product cases are explicit;
+- WooCommerce default-category/uncategorized and deleted-product cases are explicit;
 - Stock-status plans remain frozen after live catalog changes;
 - variation identity and parent-managed stock-owner evidence are preserved;
 - Review/build-plan do not mutate the source order.

--- a/docs/p2-split-strategy-planners.md
+++ b/docs/p2-split-strategy-planners.md
@@ -1,0 +1,87 @@
+# P2 Split strategy planner foundation
+
+## Classification
+
+`P2_SPLIT_STRATEGY_PLANNERS`
+
+This foundation adds deterministic, read-only Review planners for future Category and Stock-status Split workflows. It does **not** add a production controller, AJAX action, UI launcher, option, filter, or executable mutation route for either strategy.
+
+## Strategy gates
+
+The strategy map is code-only:
+
+- `manual_quantity = true`
+- `category = false`
+- `stock_status = false`
+
+`WCOS_Feature_Gates::SPLIT` remains the global hardened Split workflow gate. `WCOS_Split_Strategy_Gates` is a separate authority boundary for future strategy surfaces.
+
+## Required lifecycle
+
+Future strategy execution must preserve this boundary:
+
+`Review planner -> frozen evidence -> explicit quantity plan -> confirmation -> hardened adapter/gateway/service`
+
+Review may read current catalog classification. Execute must never recompute Category or Stock-status classification from live catalog state. Confirmation must bind the reviewed source signature, classification fingerprint, execution policy, chosen source bucket, and explicit plan before a mutation is allowed.
+
+## Whole-line dependency
+
+Category and Stock-status planners produce full-line allocation plans. Their reports therefore carry `WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER` as explicit execution authority.
+
+The guarded whole-line runtime foundation is already merged, but production strategy transport remains unavailable until a separate milestone hardens confirmation, request-local stock guarding, recovery behavior, authorization, and UI/transport wiring.
+
+## Category policy
+
+Category Review uses stable taxonomy term IDs as classification authority.
+
+- names and slugs are display metadata only and do not participate in the classification fingerprint;
+- if both an assigned ancestor and descendant are present, the deepest assigned leaf is the bucket authority;
+- multiple unrelated assigned leaf categories are ambiguous and fail closed;
+- an item with no category is placed in the explicit `category-uncategorized` bucket;
+- a deleted catalog product fails closed because current category classification cannot be proven;
+- at least two deterministic buckets are required;
+- the operator must later choose one reviewed bucket to remain on the source order;
+- `build_plan()` consumes only frozen Review evidence and never queries taxonomy.
+
+## Stock-status policy
+
+Stock-status Review accepts only WooCommerce `instock`, `outofstock`, and `onbackorder`.
+
+For each historical order item it freezes:
+
+- source order-item ID and full historical quantity;
+- parent product ID;
+- variation ID;
+- catalog object ID used for status classification;
+- effective stock-owner ID;
+- reviewed stock status.
+
+A catalog status change after Review does not rewrite the frozen plan. A new Review observes the new catalog state. A deleted catalog product fails closed.
+
+## Review authority
+
+Both planners require a supported Review with:
+
+- matching planner policy version;
+- `ALLOW_WHOLE_LINE_TRANSFER` execution policy;
+- non-empty source signature;
+- non-empty classification fingerprint.
+
+`build_plan()` rejects downgraded or incomplete Review authority. This is structural validation only; future production confirmation must provide durable anti-tamper binding before Execute is enabled.
+
+## Acceptance boundary
+
+Canonical integration acceptance must prove:
+
+- planner classes are loaded by the plugin bootstrap;
+- Category and Stock-status strategy gates remain hard-off;
+- Review reports contain no billing PII;
+- Category ancestor/descendant collapse is deterministic;
+- taxonomy display metadata does not change stable category authority;
+- unrelated category leaves fail closed;
+- uncategorized and deleted-product cases are explicit;
+- Stock-status plans remain frozen after live catalog changes;
+- variation identity and parent-managed stock-owner evidence are preserved;
+- Review/build-plan do not mutate the source order.
+
+No production strategy may be enabled by this planner-only milestone.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -58,6 +58,9 @@ class WC_Order_Splitter_Script {
 		WCOS_Mutation_Recovery_Coordinator::bootstrap();
 		include_once $root . 'domain/class-wcos-split-preflight.php';
 		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
+		include_once $root . 'domain/class-wcos-split-strategy-gates.php';
+		include_once $root . 'domain/class-wcos-category-split-planner.php';
+		include_once $root . 'domain/class-wcos-stock-status-split-planner.php';
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';

--- a/inc/domain/class-wcos-category-split-planner.php
+++ b/inc/domain/class-wcos-category-split-planner.php
@@ -1,0 +1,226 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Read-only planner for a future Category Split strategy.
+ *
+ * Category classification is performed only during Review. Execution must use
+ * the frozen quantity plan produced from this report and must never re-query
+ * catalog categories.
+ */
+final class WCOS_Category_Split_Planner {
+	const STRATEGY = 'category';
+	const POLICY_VERSION = 1;
+	const UNCATEGORIZED_BUCKET = 'category-uncategorized';
+
+	public static function review(WC_Order $source) {
+		$base = (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'strategy' => self::STRATEGY,
+			'policy_version' => self::POLICY_VERSION,
+			'order_id' => absint($source->get_id()),
+			'source_signature' => isset($base['source_signature']) ? (string) $base['source_signature'] : '',
+			'buckets' => array(),
+			'classification_fingerprint' => '',
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+		);
+
+		if (empty($base['supported'])) {
+			return self::reject(
+				$report,
+				'base_' . (isset($base['reason']) ? sanitize_key((string) $base['reason']) : 'unsupported'),
+				isset($base['message']) ? (string) $base['message'] : __('The source order is not compatible with the hardened Split engine.', 'wc-order-splitter')
+			);
+		}
+
+		$buckets = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				continue;
+			}
+
+			$product = $item->get_product();
+			if (!$product instanceof WC_Product) {
+				return self::reject(
+					$report,
+					'deleted_product_category_unavailable',
+					__('A historical order line no longer has a catalog product, so its current category classification cannot be proven.', 'wc-order-splitter')
+				);
+			}
+
+			/* Product categories are owned by the parent product for variations. */
+			$product_id = absint($item->get_product_id());
+			$terms = wp_get_post_terms($product_id, 'product_cat');
+			if (is_wp_error($terms)) {
+				return self::reject(
+					$report,
+					'category_lookup_failed',
+					__('Product categories could not be read safely for this order.', 'wc-order-splitter')
+				);
+			}
+
+			$leaf_terms = self::leaf_assigned_terms((array) $terms);
+			if (count($leaf_terms) > 1) {
+				return self::reject(
+					$report,
+					'ambiguous_multiple_leaf_categories',
+					sprintf(
+						/* translators: %d: source order item ID. */
+						__('Order item %d belongs to multiple unrelated leaf categories. Choose an explicit category assignment before using Category Split.', 'wc-order-splitter'),
+						absint($item_id)
+					)
+				);
+			}
+
+			if (empty($leaf_terms)) {
+				$bucket_key = self::UNCATEGORIZED_BUCKET;
+				$bucket = array(
+					'key' => $bucket_key,
+					'term_id' => 0,
+					'term_slug' => '',
+					'label' => __('Uncategorized', 'wc-order-splitter'),
+					'items' => array(),
+				);
+			} else {
+				$term = reset($leaf_terms);
+				$bucket_key = 'category-' . absint($term->term_id);
+				$bucket = array(
+					'key' => $bucket_key,
+					'term_id' => absint($term->term_id),
+					'term_slug' => sanitize_title((string) $term->slug),
+					'label' => (string) $term->name,
+					'items' => array(),
+				);
+			}
+
+			if (!isset($buckets[$bucket_key])) {
+				$buckets[$bucket_key] = $bucket;
+			}
+			$buckets[$bucket_key]['items'][(int) $item_id] = WCOS_Decimal::normalize($item->get_quantity(), 6);
+		}
+
+		ksort($buckets, SORT_STRING);
+		foreach ($buckets as &$bucket) {
+			ksort($bucket['items'], SORT_NUMERIC);
+		}
+		unset($bucket);
+
+		if (count($buckets) < 2) {
+			return self::reject(
+				$report,
+				'single_category_bucket',
+				__('Category Split requires at least two deterministic category buckets.', 'wc-order-splitter')
+			);
+		}
+
+		$report['buckets'] = $buckets;
+		$report['classification_fingerprint'] = self::classification_fingerprint($source, $buckets);
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('The order has deterministic category buckets that can be reviewed for a future Category Split.', 'wc-order-splitter');
+		return $report;
+	}
+
+	public static function build_plan(array $review, $source_bucket_key) {
+		self::assert_review_authority($review);
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
+		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
+			throw new InvalidArgumentException(__('Choose one reviewed category bucket to remain on the source order.', 'wc-order-splitter'));
+		}
+
+		$plan = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			if ($bucket_key === $source_bucket_key) {
+				continue;
+			}
+			$items = isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array();
+			if (empty($items)) {
+				continue;
+			}
+			$plan[sanitize_key((string) $bucket_key)] = $items;
+		}
+
+		if (empty($plan)) {
+			throw new InvalidArgumentException(__('Category Split must create at least one child bucket.', 'wc-order-splitter'));
+		}
+
+		ksort($plan, SORT_STRING);
+		return WCOS_Split_Plan::canonicalize_request($plan);
+	}
+
+	private static function assert_review_authority(array $review) {
+		if (empty($review['supported']) || self::STRATEGY !== sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '')) {
+			throw new InvalidArgumentException(__('A supported Category Split review is required to build a plan.', 'wc-order-splitter'));
+		}
+		if (!isset($review['policy_version']) || self::POLICY_VERSION !== (int) $review['policy_version']) {
+			throw new RuntimeException(__('The Category Split review policy no longer matches the current planner.', 'wc-order-splitter'));
+		}
+		$policy = isset($review['execution_policy']) ? WCOS_Split_Execution_Policy::normalize($review['execution_policy']) : '';
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $policy) {
+			throw new RuntimeException(__('The Category Split review does not carry whole-line execution authority.', 'wc-order-splitter'));
+		}
+		if (empty($review['source_signature']) || empty($review['classification_fingerprint'])) {
+			throw new RuntimeException(__('The Category Split review is missing frozen source or classification authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function leaf_assigned_terms(array $terms) {
+		$by_id = array();
+		foreach ($terms as $term) {
+			if ($term instanceof WP_Term && absint($term->term_id)) {
+				$by_id[absint($term->term_id)] = $term;
+			}
+		}
+
+		$leaf = $by_id;
+		foreach ($by_id as $candidate_id => $candidate) {
+			foreach ($by_id as $other_id => $other) {
+				if ($candidate_id === $other_id) {
+					continue;
+				}
+				$ancestors = array_map('absint', get_ancestors($other_id, 'product_cat', 'taxonomy'));
+				if (in_array($candidate_id, $ancestors, true)) {
+					unset($leaf[$candidate_id]);
+					break;
+				}
+			}
+		}
+
+		ksort($leaf, SORT_NUMERIC);
+		return array_values($leaf);
+	}
+
+	private static function classification_fingerprint(WC_Order $source, array $buckets) {
+		$evidence = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			/* Stable term IDs and historical item quantities are authority. */
+			$evidence[$bucket_key] = array(
+				'term_id' => isset($bucket['term_id']) ? absint($bucket['term_id']) : 0,
+				'items' => isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array(),
+			);
+		}
+
+		return WCOS_Mutation_Fingerprint::create(
+			'category_split_review',
+			$source->get_id(),
+			array(
+				'policy_version' => self::POLICY_VERSION,
+				'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
+				'evidence' => $evidence,
+			)
+		);
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/inc/domain/class-wcos-category-split-planner.php
+++ b/inc/domain/class-wcos-category-split-planner.php
@@ -37,6 +37,14 @@ final class WCOS_Category_Split_Planner {
 			);
 		}
 
+		/*
+		 * WooCommerce guarantees a default product category and normally assigns
+		 * it when a persisted product has no explicit category. Treat the stable
+		 * default term ID as the semantic Uncategorized bucket when it is the
+		 * product's only leaf category. Never depend on the mutable term name or
+		 * slug for this classification.
+		 */
+		$default_category_id = absint(get_option('default_product_cat', 0));
 		$buckets = array();
 		foreach ($source->get_items('line_item') as $item_id => $item) {
 			if (!$item instanceof WC_Order_Item_Product) {
@@ -76,17 +84,21 @@ final class WCOS_Category_Split_Planner {
 				);
 			}
 
-			if (empty($leaf_terms)) {
+			$term = empty($leaf_terms) ? null : reset($leaf_terms);
+			$is_default_category = $term instanceof WP_Term
+				&& $default_category_id > 0
+				&& $default_category_id === absint($term->term_id);
+
+			if (!$term instanceof WP_Term || $is_default_category) {
 				$bucket_key = self::UNCATEGORIZED_BUCKET;
 				$bucket = array(
 					'key' => $bucket_key,
-					'term_id' => 0,
-					'term_slug' => '',
-					'label' => __('Uncategorized', 'wc-order-splitter'),
+					'term_id' => $is_default_category ? absint($term->term_id) : 0,
+					'term_slug' => $is_default_category ? sanitize_title((string) $term->slug) : '',
+					'label' => $is_default_category ? (string) $term->name : __('Uncategorized', 'wc-order-splitter'),
 					'items' => array(),
 				);
 			} else {
-				$term = reset($leaf_terms);
 				$bucket_key = 'category-' . absint($term->term_id);
 				$bucket = array(
 					'key' => $bucket_key,

--- a/inc/domain/class-wcos-split-strategy-gates.php
+++ b/inc/domain/class-wcos-split-strategy-gates.php
@@ -1,0 +1,34 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Internal gates for individual Split planning strategies.
+ *
+ * The global WCOS_Feature_Gates::SPLIT gate controls the hardened mutation
+ * workflow. Strategy gates separately control which server-built planners may
+ * expose production surfaces. They are code-only and cannot be overridden by
+ * options, constants, filters, mu-plugins, or wp-config.php.
+ */
+final class WCOS_Split_Strategy_Gates {
+	const MANUAL_QUANTITY = 'manual_quantity';
+	const CATEGORY = 'category';
+	const STOCK_STATUS = 'stock_status';
+
+	private static $states = array(
+		self::MANUAL_QUANTITY => true,
+		self::CATEGORY => false,
+		self::STOCK_STATUS => false,
+	);
+
+	public static function enabled($strategy) {
+		$strategy = sanitize_key((string) $strategy);
+		return isset(self::$states[$strategy]) && true === self::$states[$strategy];
+	}
+
+	public static function assert_enabled($strategy) {
+		if (!self::enabled($strategy)) {
+			throw new RuntimeException(__('This Split planning strategy is not enabled for production use.', 'wc-order-splitter'));
+		}
+	}
+}

--- a/inc/domain/class-wcos-stock-status-split-planner.php
+++ b/inc/domain/class-wcos-stock-status-split-planner.php
@@ -1,0 +1,200 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Read-only planner for a future Stock-status Split strategy.
+ *
+ * Catalog stock status is volatile. It is sampled only during Review and the
+ * resulting explicit quantity plan/evidence must be frozen in confirmation.
+ * Execute must never re-query product stock status.
+ */
+final class WCOS_Stock_Status_Split_Planner {
+	const STRATEGY = 'stock_status';
+	const POLICY_VERSION = 1;
+
+	private static $supported_statuses = array('instock', 'outofstock', 'onbackorder');
+
+	public static function review(WC_Order $source) {
+		$base = (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'strategy' => self::STRATEGY,
+			'policy_version' => self::POLICY_VERSION,
+			'order_id' => absint($source->get_id()),
+			'source_signature' => isset($base['source_signature']) ? (string) $base['source_signature'] : '',
+			'buckets' => array(),
+			'classification_fingerprint' => '',
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+		);
+
+		if (empty($base['supported'])) {
+			return self::reject(
+				$report,
+				'base_' . (isset($base['reason']) ? sanitize_key((string) $base['reason']) : 'unsupported'),
+				isset($base['message']) ? (string) $base['message'] : __('The source order is not compatible with the hardened Split engine.', 'wc-order-splitter')
+			);
+		}
+
+		$buckets = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				continue;
+			}
+
+			$product = $item->get_product();
+			if (!$product instanceof WC_Product) {
+				return self::reject(
+					$report,
+					'deleted_product_stock_status_unavailable',
+					__('A historical order line no longer has a catalog product, so its current stock-status classification cannot be proven.', 'wc-order-splitter')
+				);
+			}
+
+			$status = sanitize_key((string) $product->get_stock_status());
+			if (!in_array($status, self::$supported_statuses, true)) {
+				return self::reject(
+					$report,
+					'unsupported_stock_status',
+					sprintf(
+						/* translators: %s: sanitized WooCommerce product stock status. */
+						__('The catalog returned an unsupported stock status: %s.', 'wc-order-splitter'),
+						$status
+					)
+				);
+			}
+
+			$bucket_key = 'stock-' . $status;
+			if (!isset($buckets[$bucket_key])) {
+				$buckets[$bucket_key] = array(
+					'key' => $bucket_key,
+					'stock_status' => $status,
+					'label' => self::status_label($status),
+					'items' => array(),
+					'evidence' => array(),
+				);
+			}
+
+			$managed_id = method_exists($product, 'get_stock_managed_by_id')
+				? absint($product->get_stock_managed_by_id())
+				: absint($product->get_id());
+			$buckets[$bucket_key]['items'][(int) $item_id] = WCOS_Decimal::normalize($item->get_quantity(), 6);
+			$buckets[$bucket_key]['evidence'][(int) $item_id] = array(
+				'product_id' => absint($item->get_product_id()),
+				'variation_id' => absint($item->get_variation_id()),
+				'catalog_object_id' => absint($product->get_id()),
+				'stock_owner_id' => $managed_id,
+				'stock_status' => $status,
+			);
+		}
+
+		ksort($buckets, SORT_STRING);
+		foreach ($buckets as &$bucket) {
+			ksort($bucket['items'], SORT_NUMERIC);
+			ksort($bucket['evidence'], SORT_NUMERIC);
+		}
+		unset($bucket);
+
+		if (count($buckets) < 2) {
+			return self::reject(
+				$report,
+				'single_stock_status_bucket',
+				__('Stock-status Split requires at least two reviewed stock-status buckets.', 'wc-order-splitter')
+			);
+		}
+
+		$report['buckets'] = $buckets;
+		$report['classification_fingerprint'] = self::classification_fingerprint($source, $buckets);
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('The order has multiple reviewed stock-status buckets that can be frozen into a Split plan.', 'wc-order-splitter');
+		return $report;
+	}
+
+	public static function build_plan(array $review, $source_bucket_key) {
+		self::assert_review_authority($review);
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
+		$buckets = isset($review['buckets']) && is_array($review['buckets']) ? $review['buckets'] : array();
+		if ('' === $source_bucket_key || !isset($buckets[$source_bucket_key])) {
+			throw new InvalidArgumentException(__('Choose one reviewed stock-status bucket to remain on the source order.', 'wc-order-splitter'));
+		}
+
+		$plan = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			if ($bucket_key === $source_bucket_key) {
+				continue;
+			}
+			$items = isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array();
+			if (!empty($items)) {
+				$plan[sanitize_key((string) $bucket_key)] = $items;
+			}
+		}
+
+		if (empty($plan)) {
+			throw new InvalidArgumentException(__('Stock-status Split must create at least one child bucket.', 'wc-order-splitter'));
+		}
+
+		ksort($plan, SORT_STRING);
+		return WCOS_Split_Plan::canonicalize_request($plan);
+	}
+
+	private static function assert_review_authority(array $review) {
+		if (empty($review['supported']) || self::STRATEGY !== sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '')) {
+			throw new InvalidArgumentException(__('A supported Stock-status Split review is required to build a plan.', 'wc-order-splitter'));
+		}
+		if (!isset($review['policy_version']) || self::POLICY_VERSION !== (int) $review['policy_version']) {
+			throw new RuntimeException(__('The Stock-status Split review policy no longer matches the current planner.', 'wc-order-splitter'));
+		}
+		$policy = isset($review['execution_policy']) ? WCOS_Split_Execution_Policy::normalize($review['execution_policy']) : '';
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $policy) {
+			throw new RuntimeException(__('The Stock-status Split review does not carry whole-line execution authority.', 'wc-order-splitter'));
+		}
+		if (empty($review['source_signature']) || empty($review['classification_fingerprint'])) {
+			throw new RuntimeException(__('The Stock-status Split review is missing frozen source or classification authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function classification_fingerprint(WC_Order $source, array $buckets) {
+		$evidence = array();
+		foreach ($buckets as $bucket_key => $bucket) {
+			$evidence[$bucket_key] = array(
+				'stock_status' => isset($bucket['stock_status']) ? sanitize_key((string) $bucket['stock_status']) : '',
+				'items' => isset($bucket['items']) && is_array($bucket['items']) ? $bucket['items'] : array(),
+				'evidence' => isset($bucket['evidence']) && is_array($bucket['evidence']) ? $bucket['evidence'] : array(),
+			);
+		}
+
+		return WCOS_Mutation_Fingerprint::create(
+			'stock_status_split_review',
+			$source->get_id(),
+			array(
+				'policy_version' => self::POLICY_VERSION,
+				'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
+				'evidence' => $evidence,
+			)
+		);
+	}
+
+	private static function status_label($status) {
+		switch ($status) {
+			case 'instock':
+				return __('In stock', 'wc-order-splitter');
+			case 'outofstock':
+				return __('Out of stock', 'wc-order-splitter');
+			case 'onbackorder':
+				return __('On backorder', 'wc-order-splitter');
+			default:
+				return (string) $status;
+		}
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -137,6 +137,7 @@ wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
 require __DIR__ . '/p2-production-duplicate-enabled-smoke.php';
 require __DIR__ . '/p2-whole-line-plan-smoke.php';
+require __DIR__ . '/p2-strategy-planners-smoke.php';
 require __DIR__ . '/p2-duplicate-side-effects-smoke.php';
 require __DIR__ . '/p2-duplicate-precision-replay-smoke.php';
 require __DIR__ . '/p2-duplicate-compatibility-smoke.php';

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -1,0 +1,235 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Gates'), 'Split strategy gates were not loaded by the plugin bootstrap.');
+wcos_p2_adapter_assert(class_exists('WCOS_Category_Split_Planner'), 'Category Split planner was not loaded by the plugin bootstrap.');
+wcos_p2_adapter_assert(class_exists('WCOS_Stock_Status_Split_Planner'), 'Stock-status Split planner was not loaded by the plugin bootstrap.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual quantity strategy gate is not enabled.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy was production-enabled by the planner foundation.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was production-enabled by the planner foundation.');
+
+$term_suffix = strtolower(wp_generate_password(6, false, false));
+$parent_term = wp_insert_term('WCOS Planner Parent ' . $term_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($parent_term), 'Unable to create planner parent category.');
+$child_term = wp_insert_term(
+	'WCOS Planner Child ' . $term_suffix,
+	'product_cat',
+	array('parent' => absint($parent_term['term_id']))
+);
+wcos_p2_adapter_assert(!is_wp_error($child_term), 'Unable to create planner child category.');
+$other_term = wp_insert_term('WCOS Planner Other ' . $term_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($other_term), 'Unable to create planner peer category.');
+
+/* Category Review uses stable term IDs, collapses ancestors, and remains PII-free. */
+$category_a = wcos_p2_adapter_product('WCOS Category planner A', '10.00');
+$category_b = wcos_p2_adapter_product('WCOS Category planner B', '8.00');
+wp_set_object_terms($category_a->get_id(), array(absint($parent_term['term_id']), absint($child_term['term_id'])), 'product_cat');
+wp_set_object_terms($category_b->get_id(), array(absint($other_term['term_id'])), 'product_cat');
+
+$category_order = wc_create_order();
+$category_order->set_status('pending');
+$category_order->set_currency('USD');
+$category_a_item = $category_order->add_product($category_a, 2);
+$category_b_item = $category_order->add_product($category_b, 3);
+$category_order->calculate_totals(false);
+$category_order->set_billing_first_name('PlannerPrivateProbe');
+$category_order->set_billing_email('planner-private@example.test');
+$category_order->save();
+$category_order = wc_get_order($category_order->get_id());
+$category_signature = WCOS_Order_Contract_Snapshot::source_signature($category_order);
+
+$category_review = WCOS_Category_Split_Planner::review($category_order);
+wcos_p2_adapter_assert(!empty($category_review['supported']), 'Deterministic category order failed planner review.');
+wcos_p2_adapter_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $category_review['execution_policy'], 'Category planner exposed the wrong execution policy.');
+$child_bucket = 'category-' . absint($child_term['term_id']);
+$other_bucket = 'category-' . absint($other_term['term_id']);
+wcos_p2_adapter_assert(isset($category_review['buckets'][$child_bucket]), 'Parent+child assignment did not resolve to the single leaf category.');
+wcos_p2_adapter_assert(!isset($category_review['buckets']['category-' . absint($parent_term['term_id'])]), 'Ancestor category remained as a duplicate authority bucket.');
+wcos_p2_adapter_assert(isset($category_review['buckets'][$other_bucket]), 'Peer category bucket is missing.');
+wcos_p2_adapter_assert(!empty($category_review['classification_fingerprint']), 'Category review omitted classification fingerprint.');
+$category_fingerprint = $category_review['classification_fingerprint'];
+$category_json = wp_json_encode($category_review);
+wcos_p2_adapter_assert(false === strpos($category_json, 'PlannerPrivateProbe'), 'Category planner leaked billing PII.');
+wcos_p2_adapter_assert(false === strpos($category_json, 'planner-private@example.test'), 'Category planner leaked billing email.');
+
+$category_plan = WCOS_Category_Split_Planner::build_plan($category_review, $child_bucket);
+wcos_p2_adapter_assert(1 === count($category_plan), 'Category planner did not create exactly one child bucket.');
+wcos_p2_adapter_assert(isset($category_plan[$other_bucket][$category_b_item]), 'Category plan did not move the peer-category line.');
+wcos_p2_adapter_assert('3.000000' === $category_plan[$other_bucket][$category_b_item], 'Category plan did not freeze the full historical line quantity.');
+wcos_p2_adapter_assert(!isset($category_plan[$other_bucket][$category_a_item]), 'Category plan moved the selected source bucket.');
+wcos_p2_adapter_assert($category_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($category_order->get_id())), 'Category Review/build-plan mutated the source order.');
+
+/* Display metadata is not category classification authority. */
+$term_update = wp_update_term(
+	absint($other_term['term_id']),
+	'product_cat',
+	array(
+		'name' => 'Renamed Display Only ' . $term_suffix,
+		'slug' => 'renamed-display-only-' . $term_suffix,
+	)
+);
+wcos_p2_adapter_assert(!is_wp_error($term_update), 'Unable to update category display metadata for authority test.');
+$category_plan_after_display_change = WCOS_Category_Split_Planner::build_plan($category_review, $child_bucket);
+wcos_p2_adapter_assert($category_plan === $category_plan_after_display_change, 'Changing category display metadata altered a frozen reviewed plan.');
+$fresh_category_review = WCOS_Category_Split_Planner::review(wc_get_order($category_order->get_id()));
+wcos_p2_adapter_assert(!empty($fresh_category_review['supported']), 'Fresh Category Review failed after display-only taxonomy changes.');
+wcos_p2_adapter_assert($category_fingerprint === $fresh_category_review['classification_fingerprint'], 'Category display metadata changed the stable term-ID classification fingerprint.');
+
+$tampered_category_review = $category_review;
+$tampered_category_review['execution_policy'] = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+$category_authority_rejected = false;
+try {
+	WCOS_Category_Split_Planner::build_plan($tampered_category_review, $child_bucket);
+} catch (RuntimeException $exception) {
+	$category_authority_rejected = false !== strpos($exception->getMessage(), 'whole-line execution authority');
+}
+wcos_p2_adapter_assert($category_authority_rejected, 'Category planner accepted a review with downgraded execution authority.');
+
+/* Multiple unrelated leaf categories are ambiguous and fail closed. */
+$ambiguous_product = wcos_p2_adapter_product('WCOS Category ambiguous', '6.00');
+wp_set_object_terms($ambiguous_product->get_id(), array(absint($child_term['term_id']), absint($other_term['term_id'])), 'product_cat');
+list($ambiguous_order, $ambiguous_item_id) = wcos_p2_adapter_order($ambiguous_product, 2, 'pending');
+$ambiguous_report = WCOS_Category_Split_Planner::review($ambiguous_order);
+wcos_p2_adapter_assert(empty($ambiguous_report['supported']) && 'ambiguous_multiple_leaf_categories' === $ambiguous_report['reason'], 'Category planner guessed among multiple unrelated leaf categories.');
+$ambiguous_order->delete(true);
+wp_delete_post($ambiguous_product->get_id(), true);
+
+/* Uncategorized is explicit rather than silently dropped. */
+$uncategorized_product = wcos_p2_adapter_product('WCOS Category uncategorized', '4.00');
+$categorized_product = wcos_p2_adapter_product('WCOS Category categorized', '5.00');
+wp_set_object_terms($uncategorized_product->get_id(), array(), 'product_cat');
+wp_set_object_terms($categorized_product->get_id(), array(absint($child_term['term_id'])), 'product_cat');
+$uncategorized_order = wc_create_order();
+$uncategorized_order->set_status('pending');
+$uncategorized_order->set_currency('USD');
+$uncategorized_item = $uncategorized_order->add_product($uncategorized_product, 1);
+$categorized_item = $uncategorized_order->add_product($categorized_product, 1);
+$uncategorized_order->calculate_totals(false);
+$uncategorized_order->save();
+$uncategorized_report = WCOS_Category_Split_Planner::review(wc_get_order($uncategorized_order->get_id()));
+wcos_p2_adapter_assert(!empty($uncategorized_report['supported']), 'Explicit uncategorized/category pair failed planner review.');
+wcos_p2_adapter_assert(isset($uncategorized_report['buckets'][WCOS_Category_Split_Planner::UNCATEGORIZED_BUCKET]), 'Uncategorized line was silently dropped by Category planner.');
+$uncategorized_order->delete(true);
+wp_delete_post($uncategorized_product->get_id(), true);
+wp_delete_post($categorized_product->get_id(), true);
+
+/* Deleted catalog product cannot be reclassified from volatile catalog state. */
+$deleted_category_product = wcos_p2_adapter_product('WCOS Category deleted product', '7.00');
+$deleted_category_peer = wcos_p2_adapter_product('WCOS Category deleted peer', '9.00');
+wp_set_object_terms($deleted_category_product->get_id(), array(absint($child_term['term_id'])), 'product_cat');
+wp_set_object_terms($deleted_category_peer->get_id(), array(absint($other_term['term_id'])), 'product_cat');
+$deleted_category_order = wc_create_order();
+$deleted_category_order->set_status('pending');
+$deleted_category_order->set_currency('USD');
+$deleted_category_order->add_product($deleted_category_product, 1);
+$deleted_category_order->add_product($deleted_category_peer, 1);
+$deleted_category_order->calculate_totals(false);
+$deleted_category_order->save();
+wp_delete_post($deleted_category_product->get_id(), true);
+$deleted_category_report = WCOS_Category_Split_Planner::review(wc_get_order($deleted_category_order->get_id()));
+wcos_p2_adapter_assert(empty($deleted_category_report['supported']) && 'deleted_product_category_unavailable' === $deleted_category_report['reason'], 'Category planner guessed category for a deleted catalog product.');
+$deleted_category_order->delete(true);
+wp_delete_post($deleted_category_peer->get_id(), true);
+
+/* Stock-status Review freezes volatile classification and stays PII-free. */
+$stock_in = wcos_p2_adapter_product('WCOS Stock planner in', '10.00');
+$stock_out = wcos_p2_adapter_product('WCOS Stock planner out', '12.00');
+$stock_in->set_stock_status('instock');
+$stock_in->save();
+$stock_out->set_stock_status('outofstock');
+$stock_out->save();
+$stock_order = wc_create_order();
+$stock_order->set_status('pending');
+$stock_order->set_currency('USD');
+$stock_in_item = $stock_order->add_product($stock_in, 2);
+$stock_out_item = $stock_order->add_product($stock_out, 1);
+$stock_order->calculate_totals(false);
+$stock_order->set_billing_first_name('StockPlannerPrivateProbe');
+$stock_order->set_billing_email('stock-planner-private@example.test');
+$stock_order->save();
+$stock_order = wc_get_order($stock_order->get_id());
+$stock_signature = WCOS_Order_Contract_Snapshot::source_signature($stock_order);
+
+$stock_review = WCOS_Stock_Status_Split_Planner::review($stock_order);
+wcos_p2_adapter_assert(!empty($stock_review['supported']), 'Two-status order failed Stock-status planner review.');
+wcos_p2_adapter_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $stock_review['execution_policy'], 'Stock-status planner exposed the wrong execution policy.');
+wcos_p2_adapter_assert(isset($stock_review['buckets']['stock-instock']), 'In-stock bucket is missing.');
+wcos_p2_adapter_assert(isset($stock_review['buckets']['stock-outofstock']), 'Out-of-stock bucket is missing.');
+wcos_p2_adapter_assert(!empty($stock_review['classification_fingerprint']), 'Stock-status review omitted classification fingerprint.');
+$stock_json = wp_json_encode($stock_review);
+wcos_p2_adapter_assert(false === strpos($stock_json, 'StockPlannerPrivateProbe'), 'Stock-status planner leaked billing PII.');
+wcos_p2_adapter_assert(false === strpos($stock_json, 'stock-planner-private@example.test'), 'Stock-status planner leaked billing email.');
+$stock_plan = WCOS_Stock_Status_Split_Planner::build_plan($stock_review, 'stock-instock');
+wcos_p2_adapter_assert(isset($stock_plan['stock-outofstock'][$stock_out_item]), 'Stock-status plan did not move the reviewed out-of-stock line.');
+wcos_p2_adapter_assert('1.000000' === $stock_plan['stock-outofstock'][$stock_out_item], 'Stock-status plan did not freeze full historical quantity.');
+
+/* Catalog changes after Review must not rewrite the already reviewed plan. */
+$stock_out = wc_get_product($stock_out->get_id());
+$stock_out->set_stock_status('instock');
+$stock_out->save();
+$frozen_plan = WCOS_Stock_Status_Split_Planner::build_plan($stock_review, 'stock-instock');
+wcos_p2_adapter_assert($stock_plan === $frozen_plan, 'Stock-status planner recomputed volatile catalog state while building a frozen Review plan.');
+$new_stock_review = WCOS_Stock_Status_Split_Planner::review(wc_get_order($stock_order->get_id()));
+wcos_p2_adapter_assert(empty($new_stock_review['supported']) && 'single_stock_status_bucket' === $new_stock_review['reason'], 'A fresh Stock-status Review did not observe the changed catalog classification.');
+wcos_p2_adapter_assert($stock_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($stock_order->get_id())), 'Stock-status Review/build-plan mutated the source order.');
+$stock_order->delete(true);
+wp_delete_post($stock_in->get_id(), true);
+wp_delete_post($stock_out->get_id(), true);
+
+/* Parent-managed variation evidence freezes variation identity and stock owner. */
+list($stock_parent, $stock_variation) = wcos_p2_stock_variable_pair('WCOS Stock planner parent owner', true, false, 20, 0);
+$stock_peer = wcos_p2_adapter_product('WCOS Stock planner parent peer', '7.00');
+$stock_peer->set_stock_status('outofstock');
+$stock_peer->save();
+$variation_order = wc_create_order();
+$variation_order->set_status('pending');
+$variation_order->set_currency('USD');
+$variation_item_id = $variation_order->add_product($stock_variation, 2);
+$variation_peer_item_id = $variation_order->add_product($stock_peer, 1);
+$variation_order->calculate_totals(false);
+$variation_order->save();
+$variation_review = WCOS_Stock_Status_Split_Planner::review(wc_get_order($variation_order->get_id()));
+wcos_p2_adapter_assert(!empty($variation_review['supported']), 'Parent-managed variation failed Stock-status planner review.');
+$variation_evidence = isset($variation_review['buckets']['stock-instock']['evidence'][$variation_item_id])
+	? $variation_review['buckets']['stock-instock']['evidence'][$variation_item_id]
+	: array();
+wcos_p2_adapter_assert(absint($stock_parent->get_id()) === absint(isset($variation_evidence['product_id']) ? $variation_evidence['product_id'] : 0), 'Stock-status evidence lost parent product identity.');
+wcos_p2_adapter_assert(absint($stock_variation->get_id()) === absint(isset($variation_evidence['variation_id']) ? $variation_evidence['variation_id'] : 0), 'Stock-status evidence lost variation identity.');
+wcos_p2_adapter_assert(absint($stock_variation->get_id()) === absint(isset($variation_evidence['catalog_object_id']) ? $variation_evidence['catalog_object_id'] : 0), 'Stock-status evidence recorded the wrong catalog object.');
+wcos_p2_adapter_assert(absint($stock_parent->get_id()) === absint(isset($variation_evidence['stock_owner_id']) ? $variation_evidence['stock_owner_id'] : 0), 'Stock-status evidence recorded the wrong parent-managed stock owner.');
+$variation_order->delete(true);
+wcos_p2_stock_delete_product($stock_variation);
+wcos_p2_stock_delete_product($stock_parent);
+wp_delete_post($stock_peer->get_id(), true);
+
+/* Deleted catalog product cannot be reclassified by current stock status. */
+$deleted_stock = wcos_p2_adapter_product('WCOS Stock planner deleted', '8.00');
+$deleted_stock_peer = wcos_p2_adapter_product('WCOS Stock planner deleted peer', '9.00');
+$deleted_stock->set_stock_status('outofstock');
+$deleted_stock->save();
+$deleted_stock_peer->set_stock_status('instock');
+$deleted_stock_peer->save();
+$deleted_stock_order = wc_create_order();
+$deleted_stock_order->set_status('pending');
+$deleted_stock_order->set_currency('USD');
+$deleted_stock_order->add_product($deleted_stock, 1);
+$deleted_stock_order->add_product($deleted_stock_peer, 1);
+$deleted_stock_order->calculate_totals(false);
+$deleted_stock_order->save();
+wp_delete_post($deleted_stock->get_id(), true);
+$deleted_stock_report = WCOS_Stock_Status_Split_Planner::review(wc_get_order($deleted_stock_order->get_id()));
+wcos_p2_adapter_assert(empty($deleted_stock_report['supported']) && 'deleted_product_stock_status_unavailable' === $deleted_stock_report['reason'], 'Stock-status planner guessed status for a deleted catalog product.');
+$deleted_stock_order->delete(true);
+wp_delete_post($deleted_stock_peer->get_id(), true);
+
+$category_order->delete(true);
+wp_delete_post($category_a->get_id(), true);
+wp_delete_post($category_b->get_id(), true);
+wp_delete_term(absint($child_term['term_id']), 'product_cat');
+wp_delete_term(absint($other_term['term_id']), 'product_cat');
+wp_delete_term(absint($parent_term['term_id']), 'product_cat');
+
+echo "p2-strategy-planners-ok\n";


### PR DESCRIPTION
## Superseded

This PR is intentionally closed without merge.

While its refresh/hardening work was being validated, the original planner branch was independently advanced, technically accepted, and merged as **PR #14** at `ee78b1baea788d15375a5a723c24e75cb7a15507`.

The merged #14 implementation is newer than this branch in important areas, including `POLICY_VERSION=2`, source rehydration/signature coherence, and frozen-evidence integrity verification in `build_plan()`. Therefore merging #19 would regress or conflict with the accepted implementation.

CI #605 on #19 remains useful diagnostic evidence: it exposed WooCommerce default-category fixture semantics, but any future hardening must be applied as a narrow follow-up based on current `main`, not by merging this superseded branch.