### PR TITLE
P2: harden whole-line reconciliation blocker persistence

### DIFF
--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -5,14 +5,18 @@ defined('ABSPATH') || exit;
 /**
  * Fail-closed source-order blocker for physical-stock incidents.
  *
- * This record is intentionally persisted before the journal transitions into
- * manual_reconciliation. If the process dies between those two writes, the
- * source remains blocked rather than creating a false-negative preflight gap.
- * The record contains only source/operation identifiers and timestamps.
+ * The primary record is a non-autoloaded option so it remains independent of
+ * order-storage mode. If that primary option cannot be persisted, a narrowly
+ * scoped source-order metadata fallback is written before the journal may move
+ * into manual_reconciliation. Preflight treats either store as authoritative.
+ *
+ * Records contain only source/operation identifiers, timestamps, and journal
+ * revisions. No customer, address, payment, or catalog PII is stored here.
  */
 final class WCOS_Manual_Reconciliation_Blocker {
-    const SCHEMA_VERSION = 1;
+    const SCHEMA_VERSION = 2;
     const KEY_PREFIX = 'wcos_manual_reconcile_block_';
+    const FALLBACK_META_PREFIX = '_wcos_manual_reconcile_fallback_';
 
     public static function block(WC_Order $order, $operation_id) {
         $operation_id = sanitize_key((string) $operation_id);
@@ -20,87 +24,56 @@ final class WCOS_Manual_Reconciliation_Blocker {
             return false;
         }
 
-        $key = self::key($order->get_id());
-        for ($attempt = 0; $attempt < 5; $attempt++) {
-            $current = get_option($key, null);
-            $incident = self::incident($order, $operation_id);
-            if (!is_array($current)) {
-                $record = array(
-                    'schema_version' => self::SCHEMA_VERSION,
-                    'source_order_id' => $order->get_id(),
-                    'revision' => 1,
-                    'operations' => array(
-                        $operation_id => $incident,
-                    ),
-                );
-                if (add_option($key, $record, '', false)) {
-                    return self::contains($order->get_id(), $operation_id);
-                }
-                wp_cache_delete($key, 'options');
-                continue;
-            }
-
-            $replacement = $current;
-            $replacement['schema_version'] = self::SCHEMA_VERSION;
-            $replacement['source_order_id'] = $order->get_id();
-            $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
-            $replacement['operations'] = isset($current['operations']) && is_array($current['operations'])
-                ? $current['operations']
-                : array();
-            $replacement['operations'][$operation_id] = $incident;
-            ksort($replacement['operations'], SORT_STRING);
-
-            if (self::compare_and_swap($key, $current, $replacement)) {
-                return self::contains($order->get_id(), $operation_id);
-            }
+        $incident = self::incident($order, $operation_id);
+        if (self::block_primary($order, $operation_id, $incident)) {
+            return true;
         }
 
-        return false;
+        return self::block_fallback($order, $operation_id, $incident);
     }
 
     /**
      * Return unresolved operation IDs. Missing/non-manual journals are still
-     * treated as unresolved because they can represent a crash after the blocker
+     * treated as unresolved because they can represent a crash after a blocker
      * was durably written but before the journal transition completed.
      *
-     * A manual_reconciled journal clears a blocker only when its journal revision
-     * is newer than the revision captured by that stock incident. This prevents a
-     * later incident on the same operation from being mistaken for an older
-     * reconciliation merely because both happened in the same wall-clock second.
+     * Primary-option and fallback-meta incidents are unioned. A reconciliation
+     * resolves an operation only when its journal revision is newer than every
+     * persisted incident for that operation.
      */
     public static function active_operation_ids(WC_Order $order) {
         if (!$order->get_id()) {
             return array();
         }
 
-        $record = get_option(self::key($order->get_id()), null);
-        if (!is_array($record) || empty($record['operations']) || !is_array($record['operations'])) {
+        $fresh = wc_get_order($order->get_id());
+        if (!$fresh instanceof WC_Order) {
+            return array();
+        }
+
+        $incidents = self::all_incidents($fresh);
+        if (empty($incidents)) {
             return array();
         }
 
         $active = array();
-        $resolved = array();
-        foreach ($record['operations'] as $operation_id => $incident) {
-            $operation_id = sanitize_key((string) $operation_id);
-            if ('' === $operation_id) {
-                continue;
-            }
+        foreach ($incidents as $operation_id => $operation_incidents) {
             $journal = class_exists('WCOS_Operation_Journal')
-                ? WCOS_Operation_Journal::get($order, $operation_id)
+                ? WCOS_Operation_Journal::get($fresh, $operation_id)
                 : null;
-            if (self::journal_resolves_incident($journal, $incident)) {
-                $resolved[] = $operation_id;
-                continue;
+            $latest_incident = self::latest_incident($operation_incidents);
+            if (self::journal_resolves_incident($journal, $latest_incident)) {
+                $primary_cleared = self::clear_primary($fresh, $operation_id);
+                $fallback_cleared = self::clear_fallback($fresh, $operation_id);
+                if ($primary_cleared && $fallback_cleared) {
+                    continue;
+                }
             }
 
             $active[] = $operation_id;
         }
 
-        foreach ($resolved as $operation_id) {
-            self::clear($order, $operation_id);
-        }
-
-        $active = array_values(array_unique($active));
+        $active = array_values(array_unique(array_filter(array_map('sanitize_key', $active))));
         sort($active, SORT_STRING);
         return $active;
     }
@@ -119,27 +92,31 @@ final class WCOS_Manual_Reconciliation_Blocker {
             return false;
         }
 
-        $record = get_option(self::key($order->get_id()), null);
-        if (!is_array($record) || empty($record['operations']) || !is_array($record['operations'])) {
-            return true;
+        $fresh = wc_get_order($order->get_id());
+        if (!$fresh instanceof WC_Order) {
+            return false;
         }
-        if (!isset($record['operations'][$operation_id])) {
+
+        $incidents = self::incidents_for_operation($fresh, $operation_id);
+        if (empty($incidents)) {
             return true;
         }
 
         $journal = class_exists('WCOS_Operation_Journal')
-            ? WCOS_Operation_Journal::get($order, $operation_id)
+            ? WCOS_Operation_Journal::get($fresh, $operation_id)
             : null;
-        if (!self::journal_resolves_incident($journal, $record['operations'][$operation_id])) {
+        if (!self::journal_resolves_incident($journal, self::latest_incident($incidents))) {
             return false;
         }
 
-        return self::clear($order, $operation_id);
+        $primary_cleared = self::clear_primary($fresh, $operation_id);
+        $fallback_cleared = self::clear_fallback($fresh, $operation_id);
+        return $primary_cleared && $fallback_cleared;
     }
 
     /**
      * Retention uses this to avoid deleting the authoritative resolution proof
-     * while a blocker record still exists because an eager clear failed.
+     * while either blocker store still exists because cleanup failed.
      */
     public static function contains_operation($source_order_id, $operation_id) {
         $source_order_id = absint($source_order_id);
@@ -147,7 +124,69 @@ final class WCOS_Manual_Reconciliation_Blocker {
         if (!$source_order_id || '' === $operation_id) {
             return false;
         }
-        return self::contains($source_order_id, $operation_id);
+
+        if (self::contains_primary($source_order_id, $operation_id)) {
+            return true;
+        }
+
+        $order = wc_get_order($source_order_id);
+        return $order instanceof WC_Order && self::contains_fallback($order, $operation_id);
+    }
+
+    private static function block_primary(WC_Order $order, $operation_id, array $incident) {
+        $key = self::key($order->get_id());
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $current = get_option($key, null);
+            if (!is_array($current)) {
+                $record = array(
+                    'schema_version' => self::SCHEMA_VERSION,
+                    'source_order_id' => $order->get_id(),
+                    'revision' => 1,
+                    'operations' => array(
+                        $operation_id => $incident,
+                    ),
+                );
+                if (add_option($key, $record, '', false)) {
+                    return self::contains_primary($order->get_id(), $operation_id);
+                }
+                wp_cache_delete($key, 'options');
+                continue;
+            }
+
+            $replacement = $current;
+            $replacement['schema_version'] = self::SCHEMA_VERSION;
+            $replacement['source_order_id'] = $order->get_id();
+            $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
+            $replacement['operations'] = isset($current['operations']) && is_array($current['operations'])
+                ? $current['operations']
+                : array();
+            $replacement['operations'][$operation_id] = $incident;
+            ksort($replacement['operations'], SORT_STRING);
+
+            if (self::compare_and_swap($key, $current, $replacement)) {
+                return self::contains_primary($order->get_id(), $operation_id);
+            }
+        }
+
+        return false;
+    }
+
+    private static function block_fallback(WC_Order $order, $operation_id, array $incident) {
+        try {
+            $fresh = wc_get_order($order->get_id());
+            if (!$fresh instanceof WC_Order) {
+                return false;
+            }
+
+            $incident['operation_id'] = $operation_id;
+            $fresh->update_meta_data(self::fallback_key($operation_id), $incident);
+            $fresh->save_meta_data();
+
+            $reloaded = wc_get_order($order->get_id());
+            return $reloaded instanceof WC_Order && self::contains_fallback($reloaded, $operation_id);
+        } catch (Throwable $throwable) {
+            return false;
+        }
     }
 
     private static function incident(WC_Order $order, $operation_id) {
@@ -155,11 +194,82 @@ final class WCOS_Manual_Reconciliation_Blocker {
             ? WCOS_Operation_Journal::get($order, $operation_id)
             : null;
         return array(
+            'operation_id' => sanitize_key((string) $operation_id),
             'blocked_at' => gmdate('c'),
             'journal_revision_at_block' => is_array($journal) && isset($journal['revision'])
                 ? (int) $journal['revision']
                 : 0,
         );
+    }
+
+    private static function all_incidents(WC_Order $order) {
+        $incidents = array();
+
+        $primary = get_option(self::key($order->get_id()), null);
+        if (is_array($primary) && !empty($primary['operations']) && is_array($primary['operations'])) {
+            foreach ($primary['operations'] as $operation_id => $incident) {
+                $operation_id = sanitize_key((string) $operation_id);
+                if ('' === $operation_id || !is_array($incident)) {
+                    continue;
+                }
+                $incidents[$operation_id][] = $incident;
+            }
+        }
+
+        foreach (self::fallback_incidents($order) as $operation_id => $incident) {
+            $incidents[$operation_id][] = $incident;
+        }
+
+        ksort($incidents, SORT_STRING);
+        return $incidents;
+    }
+
+    private static function incidents_for_operation(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $all = self::all_incidents($order);
+        return isset($all[$operation_id]) ? $all[$operation_id] : array();
+    }
+
+    private static function fallback_incidents(WC_Order $order) {
+        $incidents = array();
+        foreach ($order->get_meta_data() as $meta) {
+            if (!is_object($meta) || !method_exists($meta, 'get_data')) {
+                continue;
+            }
+            $data = $meta->get_data();
+            $key = isset($data['key']) ? (string) $data['key'] : '';
+            if (0 !== strpos($key, self::FALLBACK_META_PREFIX)) {
+                continue;
+            }
+
+            $operation_id = sanitize_key(substr($key, strlen(self::FALLBACK_META_PREFIX)));
+            $value = isset($data['value']) && is_array($data['value']) ? $data['value'] : array();
+            if ('' === $operation_id || empty($value)) {
+                continue;
+            }
+            $value['operation_id'] = $operation_id;
+            $incidents[$operation_id] = $value;
+        }
+        ksort($incidents, SORT_STRING);
+        return $incidents;
+    }
+
+    private static function latest_incident(array $incidents) {
+        $latest = array('journal_revision_at_block' => PHP_INT_MAX);
+        $latest_revision = -1;
+        foreach ($incidents as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+            $revision = isset($incident['journal_revision_at_block'])
+                ? (int) $incident['journal_revision_at_block']
+                : PHP_INT_MAX;
+            if ($revision > $latest_revision) {
+                $latest = $incident;
+                $latest_revision = $revision;
+            }
+        }
+        return $latest;
     }
 
     private static function journal_resolves_incident($journal, $incident) {
@@ -175,7 +285,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
         return 'manual_reconciled' === $status && $journal_revision > $blocked_revision;
     }
 
-    private static function clear(WC_Order $order, $operation_id) {
+    private static function clear_primary(WC_Order $order, $operation_id) {
         $operation_id = sanitize_key((string) $operation_id);
         $key = self::key($order->get_id());
 
@@ -228,12 +338,54 @@ final class WCOS_Manual_Reconciliation_Blocker {
         return false;
     }
 
-    private static function contains($order_id, $operation_id) {
+    private static function clear_fallback(WC_Order $order, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        if ('' === $operation_id) {
+            return false;
+        }
+
+        try {
+            $fresh = wc_get_order($order->get_id());
+            if (!$fresh instanceof WC_Order) {
+                return false;
+            }
+
+            $key = self::fallback_key($operation_id);
+            $incident = $fresh->get_meta($key, true);
+            if (!is_array($incident) || empty($incident)) {
+                return true;
+            }
+
+            $journal = class_exists('WCOS_Operation_Journal')
+                ? WCOS_Operation_Journal::get($fresh, $operation_id)
+                : null;
+            if (!self::journal_resolves_incident($journal, $incident)) {
+                return false;
+            }
+
+            $fresh->delete_meta_data($key);
+            $fresh->save_meta_data();
+            $reloaded = wc_get_order($order->get_id());
+            return $reloaded instanceof WC_Order && !self::contains_fallback($reloaded, $operation_id);
+        } catch (Throwable $throwable) {
+            return false;
+        }
+    }
+
+    private static function contains_primary($order_id, $operation_id) {
         $record = get_option(self::key($order_id), null);
         return is_array($record)
             && isset($record['operations'])
             && is_array($record['operations'])
             && isset($record['operations'][$operation_id]);
+    }
+
+    private static function contains_fallback(WC_Order $order, $operation_id) {
+        $incident = $order->get_meta(self::fallback_key($operation_id), true);
+        return is_array($incident)
+            && !empty($incident)
+            && isset($incident['operation_id'])
+            && sanitize_key((string) $incident['operation_id']) === sanitize_key((string) $operation_id);
     }
 
     private static function compare_and_swap($key, array $current, array $replacement) {
@@ -253,5 +405,9 @@ final class WCOS_Manual_Reconciliation_Blocker {
 
     private static function key($order_id) {
         return self::KEY_PREFIX . absint($order_id);
+    }
+
+    private static function fallback_key($operation_id) {
+        return self::FALLBACK_META_PREFIX . sanitize_key((string) $operation_id);
     }
 }

--- a/tests/integration/p2-whole-line-blocker-fallback-smoke.php
+++ b/tests/integration/p2-whole-line-blocker-fallback-smoke.php
@@ -4,10 +4,134 @@ if (!defined('ABSPATH')) {
 	exit(1);
 }
 
+function wcos_whole_line_primary_blocker_failure_filter($source_order_id) {
+	return static function($pre_option, $option, $default_value) use ($source_order_id) {
+		return array(
+			'schema_version' => WCOS_Manual_Reconciliation_Blocker::SCHEMA_VERSION,
+			'source_order_id' => absint($source_order_id),
+			'revision' => 999999,
+			'operations' => array(),
+		);
+	};
+}
+
 /*
- * Fault-inject primary blocker-option persistence failure after a destructive
- * whole-line source deletion has already reached durable storage. The source
- * must remain fail-closed through the independent order-meta fallback.
+ * First prove the exact crash window in isolation: destructive source state is
+ * durable, primary blocker persistence fails, the fallback is durable, and the
+ * process may die before the journal can transition to manual_reconciliation.
+ * Preflight must still block from fallback evidence alone.
+ */
+$window_a = wcos_p2_adapter_product('WCOS whole-line blocker window A', '8.00');
+$window_b = wcos_p2_adapter_product('WCOS whole-line blocker window B', '3.00');
+list($window_source, $window_a_item, $window_b_item) = wcos_whole_line_runtime_order(
+	$window_a,
+	2,
+	$window_b,
+	2,
+	'pending'
+);
+$window_source_id = $window_source->get_id();
+$window_operation = 'p2-whole-line-blocker-window-' . wp_generate_uuid4();
+$window_fingerprint = hash('sha256', $window_operation);
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal::start(
+		$window_source,
+		$window_operation,
+		'split',
+		array(
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			'fully_moved_item_ids' => array($window_a_item),
+		),
+		$window_fingerprint
+	),
+	'Unable to start the fallback crash-window journal fixture.'
+);
+
+/* Persist the destructive deletion while the journal is still only started. */
+wcos_p2_adapter_assert(false !== $window_source->remove_item($window_a_item), 'Unable to stage the fallback crash-window source deletion.');
+$window_source->save();
+$window_source = wc_get_order($window_source_id);
+wcos_p2_adapter_assert(!$window_source->get_item($window_a_item), 'Fallback crash-window source deletion did not persist.');
+
+$window_option_key = WCOS_Manual_Reconciliation_Blocker::KEY_PREFIX . $window_source_id;
+$window_meta_key = WCOS_Manual_Reconciliation_Blocker::FALLBACK_META_PREFIX . $window_operation;
+$window_primary_failure_filter = wcos_whole_line_primary_blocker_failure_filter($window_source_id);
+add_filter('pre_option_' . $window_option_key, $window_primary_failure_filter, 10, 3);
+try {
+	wcos_p2_adapter_assert(
+		WCOS_Manual_Reconciliation_Blocker::block($window_source, $window_operation),
+		'Fallback crash-window blocker could not persist after primary option failure.'
+	);
+} finally {
+	remove_filter('pre_option_' . $window_option_key, $window_primary_failure_filter, 10);
+}
+
+$window_source = wc_get_order($window_source_id);
+wcos_p2_adapter_assert(null === get_option($window_option_key, null), 'Fallback crash-window unexpectedly persisted its primary blocker option.');
+$window_incident = $window_source->get_meta($window_meta_key, true);
+wcos_p2_adapter_assert(
+	is_array($window_incident)
+	&& isset($window_incident['operation_id'])
+	&& $window_operation === sanitize_key((string) $window_incident['operation_id']),
+	'Fallback crash-window order metadata was not durably persisted.'
+);
+$window_record = WCOS_Operation_Journal::get($window_source, $window_operation);
+wcos_p2_adapter_assert(
+	is_array($window_record) && 'started' === $window_record['status'],
+	'Fallback crash-window journal advanced unexpectedly before the simulated process death.'
+);
+wcos_p2_adapter_assert(
+	empty($window_source->get_meta(WCOS_Operation_Journal::MANUAL_RECONCILIATION_META_KEY, true)),
+	'Fallback crash-window unexpectedly wrote the manual-reconciliation journal index.'
+);
+$window_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($window_source);
+wcos_p2_adapter_assert(
+	empty($window_report['supported']) && 'manual_reconciliation_required' === $window_report['reason'],
+	'Fallback-only crash-window evidence did not keep the destructively modified source fail-closed.'
+);
+wcos_p2_adapter_assert(
+	in_array($window_operation, (array) $window_report['manual_reconciliation_operation_ids'], true),
+	'Fallback-only crash-window preflight omitted its PII-free operation ID.'
+);
+
+/* Finish the interrupted transition and prove authoritative cleanup. */
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal::mark_manual_reconciliation(
+		$window_source,
+		$window_operation,
+		array(
+			'reason' => 'primary-blocker-option-failure-crash-window',
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			'fully_moved_item_ids' => array($window_a_item),
+			'automatic_compensation_allowed' => false,
+		)
+	),
+	'Unable to finish the fallback crash-window manual-reconciliation transition.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal::mark_manual_reconciled(
+		wc_get_order($window_source_id),
+		$window_operation,
+		array('reconciliation_note' => 'fallback-crash-window-test-cleanup')
+	),
+	'Unable to resolve the fallback crash-window fixture.'
+);
+$window_source = wc_get_order($window_source_id);
+wcos_p2_adapter_assert(
+	!WCOS_Manual_Reconciliation_Blocker::contains_operation($window_source_id, $window_operation),
+	'Resolved fallback crash-window blocker remained persisted.'
+);
+wcos_p2_adapter_assert(empty($window_source->get_meta($window_meta_key, true)), 'Resolved fallback crash-window metadata remained persisted.');
+WCOS_Operation_Journal::delete($window_source, $window_operation);
+$window_source->delete(true);
+wp_delete_post($window_a->get_id(), true);
+wp_delete_post($window_b->get_id(), true);
+
+/*
+ * Now exercise the actual whole-line service recovery path: force primary
+ * blocker-option persistence failure after a destructive source deletion has
+ * already reached durable storage. The source must remain fail-closed through
+ * the independent order-meta fallback while the journal also transitions.
  */
 $fallback_a = wcos_p2_adapter_product('WCOS whole-line blocker fallback A', '8.00');
 $fallback_b = wcos_p2_adapter_product('WCOS whole-line blocker fallback B', '3.00');
@@ -24,19 +148,7 @@ $fallback_option_key = WCOS_Manual_Reconciliation_Blocker::KEY_PREFIX . $fallbac
 $fallback_meta_key = WCOS_Manual_Reconciliation_Blocker::FALLBACK_META_PREFIX . $fallback_operation;
 $fallback_injected = false;
 
-/*
- * Force every primary get_option() read to observe a synthetic record that does
- * not exist in the database. The primary CAS can therefore never match/update
- * a persisted row and must exhaust its retries before fallback storage is used.
- */
-$primary_failure_filter = static function($pre_option, $option, $default_value) use ($fallback_source_id) {
-	return array(
-		'schema_version' => WCOS_Manual_Reconciliation_Blocker::SCHEMA_VERSION,
-		'source_order_id' => $fallback_source_id,
-		'revision' => 999999,
-		'operations' => array(),
-	);
-};
+$primary_failure_filter = wcos_whole_line_primary_blocker_failure_filter($fallback_source_id);
 add_filter('pre_option_' . $fallback_option_key, $primary_failure_filter, 10, 3);
 
 $fallback_callback = static function($stage, $mutating_source, $children) use (&$fallback_injected) {
@@ -105,7 +217,7 @@ wcos_p2_adapter_assert(
 $fallback_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($fallback_source);
 wcos_p2_adapter_assert(
 	empty($fallback_report['supported']) && 'manual_reconciliation_required' === $fallback_report['reason'],
-	'Split preflight did not reject a source protected only by the blocker fallback store.'
+	'Split preflight did not reject a source protected by fallback blocker evidence.'
 );
 wcos_p2_adapter_assert(
 	in_array($fallback_operation, (array) $fallback_report['manual_reconciliation_operation_ids'], true),

--- a/tests/integration/p2-whole-line-blocker-fallback-smoke.php
+++ b/tests/integration/p2-whole-line-blocker-fallback-smoke.php
@@ -1,0 +1,134 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+/*
+ * Fault-inject primary blocker-option persistence failure after a destructive
+ * whole-line source deletion has already reached durable storage. The source
+ * must remain fail-closed through the independent order-meta fallback.
+ */
+$fallback_a = wcos_p2_adapter_product('WCOS whole-line blocker fallback A', '8.00');
+$fallback_b = wcos_p2_adapter_product('WCOS whole-line blocker fallback B', '3.00');
+list($fallback_source, $fallback_a_item, $fallback_b_item) = wcos_whole_line_runtime_order(
+	$fallback_a,
+	2,
+	$fallback_b,
+	2,
+	'pending'
+);
+$fallback_source_id = $fallback_source->get_id();
+$fallback_operation = 'p2-whole-line-blocker-fallback-' . wp_generate_uuid4();
+$fallback_option_key = WCOS_Manual_Reconciliation_Blocker::KEY_PREFIX . $fallback_source_id;
+$fallback_injected = false;
+
+/*
+ * Force every primary get_option() read to observe a synthetic record that does
+ * not exist in the database. The primary CAS can therefore never match/update
+ * a persisted row and must exhaust its retries before fallback storage is used.
+ */
+$primary_failure_filter = static function($pre_option, $option, $default_value) use ($fallback_source_id) {
+	return array(
+		'schema_version' => WCOS_Manual_Reconciliation_Blocker::SCHEMA_VERSION,
+		'source_order_id' => $fallback_source_id,
+		'revision' => 999999,
+		'operations' => array(),
+	);
+};
+add_filter('pre_option_' . $fallback_option_key, $primary_failure_filter, 10, 3);
+
+$fallback_callback = static function($stage, $mutating_source, $children) use (&$fallback_injected) {
+	if (!$fallback_injected && 'before_source_save' === $stage && $mutating_source instanceof WC_Order) {
+		$fallback_injected = true;
+
+		/* Persist the destructive source deletion first. */
+		$mutating_source->save();
+
+		/* Corrupt the child so persisted source + child evidence is ambiguous. */
+		$child = reset($children);
+		if ($child instanceof WC_Order) {
+			$line = current($child->get_items('line_item'));
+			if ($line instanceof WC_Order_Item_Product) {
+				$line->set_quantity(((float) $line->get_quantity()) + 1);
+				$line->save();
+			}
+		}
+
+		throw new RuntimeException('Injected whole-line blocker primary persistence failure.');
+	}
+};
+add_action('wcos_split_mutation_checkpoint', $fallback_callback, 10, 4);
+
+$fallback_failed = false;
+try {
+	wcos_whole_line_runtime_call(
+		$fallback_source,
+		array('child-1' => array($fallback_a_item => '2.000000')),
+		$fallback_operation
+	);
+} catch (RuntimeException $exception) {
+	$fallback_failed = true;
+} finally {
+	remove_action('wcos_split_mutation_checkpoint', $fallback_callback, 10);
+	remove_filter('pre_option_' . $fallback_option_key, $primary_failure_filter, 10);
+}
+
+wcos_p2_adapter_assert($fallback_injected && $fallback_failed, 'Primary blocker persistence fault fixture did not reach the destructive failure path.');
+$fallback_source = wc_get_order($fallback_source_id);
+wcos_p2_adapter_assert($fallback_source instanceof WC_Order, 'Fallback fixture source order disappeared.');
+wcos_p2_adapter_assert(!$fallback_source->get_item($fallback_a_item), 'Fallback fixture did not persist the destructive source-item deletion.');
+wcos_p2_adapter_assert(null === get_option($fallback_option_key, null), 'Primary blocker option unexpectedly persisted despite the injected CAS failure.');
+
+$fallback_record = WCOS_Operation_Journal::get($fallback_source, $fallback_operation);
+wcos_p2_adapter_assert(
+	is_array($fallback_record) && 'manual_reconciliation' === $fallback_record['status'],
+	'Fallback blocker fixture did not durably enter manual reconciliation.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Manual_Reconciliation_Blocker::contains_operation($fallback_source_id, $fallback_operation),
+	'Fallback blocker was not visible through the unified retention/preflight authority.'
+);
+wcos_p2_adapter_assert(
+	WCOS_Manual_Reconciliation_Blocker::has_active($fallback_source),
+	'Fallback blocker did not keep the destructively modified source fail-closed.'
+);
+
+$fallback_report = (new WCOS_Split_WooCommerce_Adapter())->preflight($fallback_source);
+wcos_p2_adapter_assert(
+	empty($fallback_report['supported']) && 'manual_reconciliation_required' === $fallback_report['reason'],
+	'Split preflight did not reject a source protected only by the blocker fallback store.'
+);
+wcos_p2_adapter_assert(
+	in_array($fallback_operation, (array) $fallback_report['manual_reconciliation_operation_ids'], true),
+	'Fallback blocker operation ID was not exposed in the PII-free preflight evidence.'
+);
+
+/* Resolution must clear the fallback only after a newer journal revision proves it. */
+wcos_p2_adapter_assert(
+	WCOS_Operation_Journal::mark_manual_reconciled(
+		$fallback_source,
+		$fallback_operation,
+		array('reconciliation_note' => 'whole-line-blocker-fallback-test-cleanup')
+	),
+	'Unable to resolve the fallback blocker fixture.'
+);
+$fallback_source = wc_get_order($fallback_source_id);
+wcos_p2_adapter_assert(
+	!WCOS_Manual_Reconciliation_Blocker::contains_operation($fallback_source_id, $fallback_operation),
+	'Resolved fallback blocker remained persisted after authoritative reconciliation.'
+);
+wcos_p2_adapter_assert(
+	!WCOS_Manual_Reconciliation_Blocker::has_active($fallback_source),
+	'Resolved fallback blocker remained active.'
+);
+
+foreach (wcos_p2_adapter_children($fallback_source_id, $fallback_operation) as $fallback_child) {
+	$fallback_child->delete(true);
+}
+WCOS_Operation_Journal::delete($fallback_source, $fallback_operation);
+$fallback_source->delete(true);
+wp_delete_post($fallback_a->get_id(), true);
+wp_delete_post($fallback_b->get_id(), true);
+
+echo "p2-whole-line-blocker-fallback-ok\n";

--- a/tests/integration/p2-whole-line-blocker-fallback-smoke.php
+++ b/tests/integration/p2-whole-line-blocker-fallback-smoke.php
@@ -21,6 +21,7 @@ list($fallback_source, $fallback_a_item, $fallback_b_item) = wcos_whole_line_run
 $fallback_source_id = $fallback_source->get_id();
 $fallback_operation = 'p2-whole-line-blocker-fallback-' . wp_generate_uuid4();
 $fallback_option_key = WCOS_Manual_Reconciliation_Blocker::KEY_PREFIX . $fallback_source_id;
+$fallback_meta_key = WCOS_Manual_Reconciliation_Blocker::FALLBACK_META_PREFIX . $fallback_operation;
 $fallback_injected = false;
 
 /*
@@ -79,6 +80,13 @@ $fallback_source = wc_get_order($fallback_source_id);
 wcos_p2_adapter_assert($fallback_source instanceof WC_Order, 'Fallback fixture source order disappeared.');
 wcos_p2_adapter_assert(!$fallback_source->get_item($fallback_a_item), 'Fallback fixture did not persist the destructive source-item deletion.');
 wcos_p2_adapter_assert(null === get_option($fallback_option_key, null), 'Primary blocker option unexpectedly persisted despite the injected CAS failure.');
+$fallback_incident = $fallback_source->get_meta($fallback_meta_key, true);
+wcos_p2_adapter_assert(
+	is_array($fallback_incident)
+	&& isset($fallback_incident['operation_id'])
+	&& $fallback_operation === sanitize_key((string) $fallback_incident['operation_id']),
+	'Order-meta fallback incident was not durably persisted for the destructive operation.'
+);
 
 $fallback_record = WCOS_Operation_Journal::get($fallback_source, $fallback_operation);
 wcos_p2_adapter_assert(
@@ -121,6 +129,10 @@ wcos_p2_adapter_assert(
 wcos_p2_adapter_assert(
 	!WCOS_Manual_Reconciliation_Blocker::has_active($fallback_source),
 	'Resolved fallback blocker remained active.'
+);
+wcos_p2_adapter_assert(
+	empty($fallback_source->get_meta($fallback_meta_key, true)),
+	'Resolved fallback order metadata remained persisted after authoritative reconciliation.'
 );
 
 foreach (wcos_p2_adapter_children($fallback_source_id, $fallback_operation) as $fallback_child) {

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -86,5 +86,6 @@ wp_delete_post($product_b->get_id(), true);
 echo "p2-whole-line-plan-ok\n";
 
 require __DIR__ . '/p2-whole-line-runtime-smoke.php';
+require __DIR__ . '/p2-whole-line-blocker-fallback-smoke.php';
 require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
 require __DIR__ . '/p2-strategy-planners-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_WHOLE_LINE_PRODUCTION_GUARDRAIL`

## Status

**TECHNICAL ACCEPTANCE COMPLETE.**

Final reviewed head: `699b5a994cdb02cd2927af52bfdd0a29b3989f85`

Independent review: `4970266945`.

## Mission

Close the remaining fail-closed persistence gap identified during whole-line runtime review before any Category/Stock-status strategy transport can become production-reachable.

## Risk addressed

Whole-line recovery persists a source-level manual-reconciliation blocker before transitioning the operation journal. If the primary non-autoloaded blocker option itself cannot be persisted after a destructive source-line deletion has already reached storage, later mutation preflight must still have durable evidence that the source is unsafe.

## Implementation

`WCOS_Manual_Reconciliation_Blocker` now has two independent PII-free persistence stores:

1. primary non-autoloaded source-order option (existing CAS-safe authority);
2. private source-order metadata fallback keyed per `operation_id`, used only after primary option persistence exhausts its retries.

Preflight/retention/resolution union both stores. A blocker is considered resolved only when a newer authoritative `manual_reconciled` journal revision resolves the latest persisted incident; cleanup must succeed for every store before the source is considered unblocked.

## Fault injection

Canonical acceptance proves both critical windows:

### Fallback-only crash window

- destructive source deletion is already durable;
- primary blocker option CAS is forced to fail;
- fallback meta persists;
- journal remains only `started` and the manual-reconciliation journal index is still absent;
- Split preflight nevertheless returns `manual_reconciliation_required` from fallback authority alone.

### Actual whole-line recovery

- destructive source deletion is durable;
- persisted child evidence is corrupted so automatic reconstruction is forbidden;
- primary blocker option persistence is fault-injected to fail;
- fallback blocker persists and the journal enters `manual_reconciliation`;
- explicit newer `manual_reconciled` authority clears the fallback.

## Final acceptance evidence

Canonical CI **#612** (`32234167924`) passed on the exact final PR merge-ref against `main=c0a66fd30b1dd73e409b6599b8349dce3343dc73`:

- PHP 7.4 ✅
- PHP 8.1 ✅
- PHP 8.3 ✅
- architecture / approved production gate contract ✅
- package safety ✅
- WooCommerce 11.0.1 legacy storage ✅
- HPOS-only ✅
- HPOS compatibility/sync ✅
- fallback-only crash window ✅
- actual destructive whole-line fallback path ✅
- all existing Split/Duplicate/recovery/concurrency regressions ✅
- `Required CI` ✅

## Production boundary

No feature gate, Split strategy gate, controller, AJAX route, UI, gateway method, version, or release metadata changes. `category=false` and `stock_status=false` remain hard-off.