### PR TITLE
P2: add hard-off Split strategy adapter foundation

### DIFF
--- a/docs/p2-split-strategy-adapter-foundation.md
+++ b/docs/p2-split-strategy-adapter-foundation.md
@@ -1,0 +1,97 @@
+# P2 Split strategy adapter foundation
+
+## Classification
+
+`P2_SPLIT_STRATEGY_ADAPTER_FOUNDATION`
+
+This milestone connects already-reviewed server-built strategy plans to the single hardened Split adapter/service without enabling a Category or Stock-status production surface.
+
+## Production boundary
+
+The approved strategy gate state remains:
+
+- `manual_quantity = true`
+- `category = false`
+- `stock_status = false`
+
+No Category/Stock-status controller, AJAX action, launcher, option/filter, confirmation endpoint, or UI is introduced here.
+
+`WCOS_Mutation_Gateway::split_strategy()` exists as the future mandatory production mutation boundary, but it rejects both server-built strategies while their code-only gates remain hard-off.
+
+## Execution architecture
+
+The execution path is:
+
+`frozen planner evidence -> explicit whole-line quantity plan -> WCOS_Split_Strategy_WooCommerce_Adapter -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`
+
+There is still one Split mutation service and one WooCommerce side-effect boundary.
+
+`WCOS_Split_WooCommerce_Adapter::split()` keeps `partial_lines_only` as its default argument, so the existing manual quantity Split controller/gateway has unchanged semantics. The dedicated strategy adapter is the only new caller that supplies `ALLOW_WHOLE_LINE_TRANSFER`.
+
+## Strategy-plan invariants
+
+The strategy adapter accepts only `category` and `stock_status`.
+
+Before a new operation starts it requires:
+
+- every plan allocation to reference a source line;
+- every assigned source line to be transferred completely;
+- every assigned source line to belong to exactly one child bucket;
+- at least one product line to remain on source, inherited from the whole-line plan contract.
+
+A partial allocation or a source line spread across multiple strategy child buckets is rejected before a mutation journal is created.
+
+## Frozen classification
+
+Execute never calls the Category or Stock-status planner. Planner Review/build-plan is separate from mutation execution.
+
+Changing taxonomy assignments or product stock status after Review does not change the explicit frozen plan supplied to the strategy adapter. This prevents live catalog reclassification during Execute.
+
+## Retry and recovery
+
+A whole-line mutation changes the source order by deleting fully moved items, so a retry cannot revalidate the original plan against current source quantities.
+
+For a new operation, strategy-plan semantics are proven against the current source before journal creation.
+
+Once a durable Split journal exists, retry/recovery validates against journal authority instead:
+
+- recorded execution policy must be `ALLOW_WHOLE_LINE_TRANSFER`;
+- requested canonical plan must exactly match the recorded plan;
+- every recorded assigned item must appear exactly once;
+- recorded assigned item IDs must exactly match `fully_moved_item_ids`.
+
+The hardened Split service remains responsible for fingerprint/idempotency/recovery state transitions.
+
+## Deliberately deferred transport authority
+
+This foundation does **not** yet durably bind the semantic strategy identity (`category` versus `stock_status`) to confirmation/journal authority. That binding is not needed while both production strategy gates are hard-off, but it is mandatory before either strategy can be enabled.
+
+The next confirmation/transport milestone must bind, at minimum:
+
+- strategy identity;
+- planner policy version;
+- source signature;
+- classification fingerprint;
+- selected source bucket;
+- canonical explicit plan;
+- `ALLOW_WHOLE_LINE_TRANSFER` execution policy;
+- confirmed price precision;
+- current Split preflight policy version;
+- operation ID / user / token / expiry or durable replay authority.
+
+Execute must consume that frozen confirmation and must not re-run live classification.
+
+## Acceptance
+
+Canonical integration acceptance must prove across legacy, HPOS-only, and HPOS compatibility/sync storage:
+
+- Category/Stock-status production strategy gates remain hard-off;
+- gateway mutation attempts are rejected before journal/child creation;
+- direct internal Category adapter execution consumes a frozen plan after taxonomy changes;
+- direct internal Stock-status execution consumes a frozen plan after live stock-status changes;
+- quantity/money/tax/_reduced_stock conservation remains intact;
+- physical stock does not change during Split execution;
+- durable operation context records whole-line policy and the exact fully moved source-item set;
+- exact retry returns the same child set;
+- partial and multi-child-per-line plans fail before journal creation;
+- manual quantity Split continues to use `PARTIAL_LINES_ONLY` by default.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -61,6 +61,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-split-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-category-split-planner.php';
 		include_once $root . 'domain/class-wcos-stock-status-split-planner.php';
+		include_once $root . 'domain/class-wcos-split-strategy-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
@@ -82,8 +83,8 @@ class WC_Order_Splitter_Script {
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Hardened
 		 * production transports must enter through WCOS_Mutation_Gateway. Category
-		 * and Stock-status classes loaded above are read-only planners only; their
-		 * strategy gates remain hard-off and no production transport is registered.
+		 * and Stock-status planner/adapter foundations loaded above remain internal;
+		 * their strategy gates are hard-off and no production transport is registered.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -6,8 +6,8 @@ defined('ABSPATH') || exit;
  * Mandatory boundary for all future HTTP/admin mutation controllers.
  *
  * Controllers must never instantiate mutation services directly. This gateway
- * applies the production feature gate first, then centralized authorization,
- * before delegating to a hardened WooCommerce adapter/service.
+ * applies the production feature/strategy gates first, then centralized
+ * authorization, before delegating to a hardened WooCommerce adapter/service.
  */
 final class WCOS_Mutation_Gateway {
 
@@ -20,6 +20,20 @@ final class WCOS_Mutation_Gateway {
 	public function split_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
 		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
+	}
+
+	public function split_strategy(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null) {
+		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::SPLIT);
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		WCOS_Split_Strategy_Gates::assert_enabled($strategy);
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
+		return (new WCOS_Split_Strategy_WooCommerce_Adapter())->split(
+			$source,
+			$strategy,
+			$plan,
+			$operation_id,
+			$confirmed_precision
+		);
 	}
 
 	public function duplicate(WC_Order $source, $operation_id, $confirmed_precision = null) {

--- a/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
@@ -42,13 +42,18 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 
 	public function split(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null) {
 		self::normalize_strategy($strategy);
+		$operation_id = sanitize_key((string) $operation_id);
+		if ('' === $operation_id) {
+			throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
+		}
+
 		$source_id = $source->get_id();
 		$source = $source_id ? wc_get_order($source_id) : false;
 		if (!$source instanceof WC_Order) {
 			throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
 		}
 
-		$normalized_plan = $this->assert_whole_line_bucket_plan($source, $plan);
+		$normalized_plan = $this->assert_whole_line_bucket_plan($source, $plan, $operation_id);
 		return (new WCOS_Split_WooCommerce_Adapter())->split(
 			$source,
 			$normalized_plan,
@@ -73,27 +78,19 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 		return $strategy;
 	}
 
-	private function assert_whole_line_bucket_plan(WC_Order $source, array $plan) {
-		$normalized = WCOS_Split_Plan::normalize(
-			$source,
-			$plan,
-			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
-		);
-
-		$assigned_item_ids = array();
-		foreach ($normalized as $items) {
-			foreach ($items as $item_id => $quantity) {
-				$item_id = absint($item_id);
-				if (isset($assigned_item_ids[$item_id])) {
-					throw new InvalidArgumentException(__('A server-built Split strategy may assign each source line to only one child bucket.', 'wc-order-splitter'));
-				}
-				$assigned_item_ids[$item_id] = true;
-			}
+	private function assert_whole_line_bucket_plan(WC_Order $source, array $plan, $operation_id) {
+		$canonical = WCOS_Split_Plan::canonicalize_request($plan);
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		if (is_array($record)) {
+			return $this->assert_recorded_bucket_plan($canonical, $record);
 		}
 
-		$assigned_item_ids = array_keys($assigned_item_ids);
-		$assigned_item_ids = array_values(array_map('absint', $assigned_item_ids));
-		sort($assigned_item_ids, SORT_NUMERIC);
+		$normalized = WCOS_Split_Plan::normalize(
+			$source,
+			$canonical,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+		);
+		$assigned_item_ids = $this->assigned_item_ids($normalized);
 		$fully_moved_item_ids = WCOS_Split_Plan::fully_moved_item_ids(
 			$source,
 			$normalized,
@@ -105,5 +102,51 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 		}
 
 		return $normalized;
+	}
+
+	private function assert_recorded_bucket_plan(array $canonical_plan, array $record) {
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$record_policy = isset($context['execution_policy'])
+			? WCOS_Split_Execution_Policy::normalize($context['execution_policy'])
+			: WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY;
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $record_policy) {
+			throw new RuntimeException(__('The durable Split operation does not carry server-built whole-line execution authority.', 'wc-order-splitter'));
+		}
+		if (!isset($context['plan']) || !is_array($context['plan'])) {
+			throw new RuntimeException(__('The durable Split operation is missing its frozen strategy plan.', 'wc-order-splitter'));
+		}
+
+		$recorded_plan = WCOS_Split_Plan::canonicalize_request($context['plan']);
+		if ($recorded_plan !== $canonical_plan) {
+			throw new RuntimeException(__('The requested strategy plan does not match the durable Split operation.', 'wc-order-splitter'));
+		}
+
+		$assigned_item_ids = $this->assigned_item_ids($recorded_plan);
+		$fully_moved_item_ids = isset($context['fully_moved_item_ids'])
+			? array_values(array_unique(array_filter(array_map('absint', (array) $context['fully_moved_item_ids']))))
+			: array();
+		sort($fully_moved_item_ids, SORT_NUMERIC);
+		if ($assigned_item_ids !== $fully_moved_item_ids) {
+			throw new RuntimeException(__('The durable Split operation does not prove whole-line bucket semantics for every assigned source line.', 'wc-order-splitter'));
+		}
+
+		return $recorded_plan;
+	}
+
+	private function assigned_item_ids(array $normalized_plan) {
+		$assigned = array();
+		foreach ($normalized_plan as $items) {
+			foreach ($items as $item_id => $quantity) {
+				$item_id = absint($item_id);
+				if (isset($assigned[$item_id])) {
+					throw new InvalidArgumentException(__('A server-built Split strategy may assign each source line to only one child bucket.', 'wc-order-splitter'));
+				}
+				$assigned[$item_id] = true;
+			}
+		}
+
+		$assigned = array_values(array_map('absint', array_keys($assigned)));
+		sort($assigned, SORT_NUMERIC);
+		return $assigned;
 	}
 }

--- a/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
@@ -1,0 +1,109 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Internal WooCommerce adapter for server-built Split strategies.
+ *
+ * This class is intentionally not a production gate. It validates strategy
+ * semantics and delegates execution to the single hardened Split adapter/service
+ * using the explicit whole-line policy. Production reachability is owned by
+ * WCOS_Mutation_Gateway + WCOS_Split_Strategy_Gates.
+ *
+ * Execute consumes only a frozen explicit quantity plan. It never re-runs a
+ * Category or Stock-status planner and therefore never reclassifies live catalog
+ * state during mutation.
+ */
+final class WCOS_Split_Strategy_WooCommerce_Adapter {
+
+	public function review(WC_Order $source, $strategy) {
+		$strategy = self::normalize_strategy($strategy);
+		switch ($strategy) {
+			case WCOS_Split_Strategy_Gates::CATEGORY:
+				return WCOS_Category_Split_Planner::review($source);
+			case WCOS_Split_Strategy_Gates::STOCK_STATUS:
+				return WCOS_Stock_Status_Split_Planner::review($source);
+		}
+
+		throw new InvalidArgumentException(__('Unsupported server-built Split strategy.', 'wc-order-splitter'));
+	}
+
+	public function build_plan(array $review, $source_bucket_key) {
+		$strategy = self::normalize_strategy(isset($review['strategy']) ? $review['strategy'] : '');
+		switch ($strategy) {
+			case WCOS_Split_Strategy_Gates::CATEGORY:
+				return WCOS_Category_Split_Planner::build_plan($review, $source_bucket_key);
+			case WCOS_Split_Strategy_Gates::STOCK_STATUS:
+				return WCOS_Stock_Status_Split_Planner::build_plan($review, $source_bucket_key);
+		}
+
+		throw new InvalidArgumentException(__('Unsupported server-built Split strategy.', 'wc-order-splitter'));
+	}
+
+	public function split(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null) {
+		self::normalize_strategy($strategy);
+		$source_id = $source->get_id();
+		$source = $source_id ? wc_get_order($source_id) : false;
+		if (!$source instanceof WC_Order) {
+			throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+		}
+
+		$normalized_plan = $this->assert_whole_line_bucket_plan($source, $plan);
+		return (new WCOS_Split_WooCommerce_Adapter())->split(
+			$source,
+			$normalized_plan,
+			$operation_id,
+			$confirmed_precision,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+		);
+	}
+
+	public static function normalize_strategy($strategy) {
+		$strategy = sanitize_key((string) $strategy);
+		if (!in_array(
+			$strategy,
+			array(
+				WCOS_Split_Strategy_Gates::CATEGORY,
+				WCOS_Split_Strategy_Gates::STOCK_STATUS,
+			),
+			true
+		)) {
+			throw new InvalidArgumentException(__('Unsupported server-built Split strategy.', 'wc-order-splitter'));
+		}
+		return $strategy;
+	}
+
+	private function assert_whole_line_bucket_plan(WC_Order $source, array $plan) {
+		$normalized = WCOS_Split_Plan::normalize(
+			$source,
+			$plan,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+		);
+
+		$assigned_item_ids = array();
+		foreach ($normalized as $items) {
+			foreach ($items as $item_id => $quantity) {
+				$item_id = absint($item_id);
+				if (isset($assigned_item_ids[$item_id])) {
+					throw new InvalidArgumentException(__('A server-built Split strategy may assign each source line to only one child bucket.', 'wc-order-splitter'));
+				}
+				$assigned_item_ids[$item_id] = true;
+			}
+		}
+
+		$assigned_item_ids = array_keys($assigned_item_ids);
+		$assigned_item_ids = array_values(array_map('absint', $assigned_item_ids));
+		sort($assigned_item_ids, SORT_NUMERIC);
+		$fully_moved_item_ids = WCOS_Split_Plan::fully_moved_item_ids(
+			$source,
+			$normalized,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER
+		);
+
+		if ($assigned_item_ids !== $fully_moved_item_ids) {
+			throw new InvalidArgumentException(__('Server-built Split strategies may move only complete source product lines.', 'wc-order-splitter'));
+		}
+
+		return $normalized;
+	}
+}

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -3,20 +3,22 @@
 defined('ABSPATH') || exit;
 
 /**
- * WooCommerce-facing adapter for the first P2 manual quantity-split workflow.
+ * WooCommerce-facing adapter for hardened Split execution.
  *
  * The production gateway owns authorization/gating; this adapter owns
- * WooCommerce compatibility preflight and request-local side-effect evidence.
- * Integration tests may instantiate it directly while the production gate is
- * still hard-off.
+ * WooCommerce compatibility preflight, operation-scoped price precision, and
+ * request-local physical-stock side-effect evidence. Manual quantity Split uses
+ * the default partial-line policy; reviewed server-built strategies may pass the
+ * explicit whole-line policy through their dedicated strategy adapter.
  */
 final class WCOS_Split_WooCommerce_Adapter {
 
-    public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null) {
+    public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY) {
         $operation_id = sanitize_key((string) $operation_id);
         if ('' === $operation_id) {
             throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
         }
+        $execution_policy = WCOS_Split_Execution_Policy::normalize($execution_policy);
 
         $source_id = $source->get_id();
         $precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
@@ -61,7 +63,12 @@ final class WCOS_Split_WooCommerce_Adapter {
             add_action('woocommerce_order_note_added', $boundary_guard, PHP_INT_MAX, 2);
 
             try {
-                $children = (new WCOS_Split_Order_Service())->split($source, $plan, $operation_id);
+                $children = (new WCOS_Split_Order_Service())->split(
+                    $source,
+                    $plan,
+                    $operation_id,
+                    $execution_policy
+                );
                 WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
                 return $children;
             } catch (Throwable $throwable) {

--- a/tests/integration/p2-strategy-adapter-smoke.php
+++ b/tests/integration/p2-strategy-adapter-smoke.php
@@ -1,0 +1,225 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_WooCommerce_Adapter'), 'Strategy Split adapter was not loaded by the plugin bootstrap.');
+wcos_p2_adapter_assert(method_exists('WCOS_Mutation_Gateway', 'split_strategy'), 'Strategy Split gateway boundary is missing.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy was enabled by the adapter foundation.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was enabled by the adapter foundation.');
+
+$strategy_adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
+$strategy_gateway = new WCOS_Mutation_Gateway();
+
+/* Production gateway must remain hard-off for both future strategies. */
+$gateway_product_a = wcos_p2_adapter_product('WCOS strategy gateway A', '5.00');
+$gateway_product_b = wcos_p2_adapter_product('WCOS strategy gateway B', '4.00');
+$gateway_order = wc_create_order();
+$gateway_order->set_status('pending');
+$gateway_order->set_currency('USD');
+$gateway_item_a = $gateway_order->add_product($gateway_product_a, 2);
+$gateway_item_b = $gateway_order->add_product($gateway_product_b, 1);
+$gateway_order->calculate_totals(false);
+$gateway_order->save();
+
+foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $blocked_strategy) {
+	$blocked_operation = 'p2-strategy-gateway-' . $blocked_strategy . '-' . wp_generate_uuid4();
+	$blocked = false;
+	try {
+		$strategy_gateway->split_strategy(
+			wc_get_order($gateway_order->get_id()),
+			$blocked_strategy,
+			array('child-1' => array($gateway_item_a => '2.000000')),
+			$blocked_operation
+		);
+	} catch (RuntimeException $exception) {
+		$blocked = false !== strpos($exception->getMessage(), 'not enabled for production use');
+	}
+	wcos_p2_adapter_assert($blocked, 'Strategy gateway allowed a hard-off production strategy: ' . $blocked_strategy);
+	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($gateway_order, $blocked_operation), 'Hard-off strategy gateway created a mutation journal.');
+	wcos_p2_adapter_assert(0 === count(wcos_p2_adapter_children($gateway_order->get_id(), $blocked_operation)), 'Hard-off strategy gateway created a child order.');
+}
+$gateway_order->delete(true);
+wp_delete_post($gateway_product_a->get_id(), true);
+wp_delete_post($gateway_product_b->get_id(), true);
+
+/* Category Review -> frozen plan -> whole-line adapter execution. */
+$category_suffix = strtolower(wp_generate_password(6, false, false));
+$category_keep_term = wp_insert_term('WCOS Strategy Keep ' . $category_suffix, 'product_cat');
+$category_move_term = wp_insert_term('WCOS Strategy Move ' . $category_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($category_keep_term) && !is_wp_error($category_move_term), 'Unable to create strategy adapter category fixtures.');
+
+$manage_stock_before_strategy_adapter = get_option('woocommerce_manage_stock', 'yes');
+update_option('woocommerce_manage_stock', 'yes');
+
+$category_keep = wcos_p2_adapter_product('WCOS Strategy Category Keep', '12.00', 20);
+$category_move = wcos_p2_adapter_product('WCOS Strategy Category Move', '7.00', 20);
+wp_set_object_terms($category_keep->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+wp_set_object_terms($category_move->get_id(), array(absint($category_move_term['term_id'])), 'product_cat');
+$category_order = wc_create_order();
+$category_order->set_status('pending');
+$category_order->set_currency('USD');
+$category_keep_item = $category_order->add_product($category_keep, 2);
+$category_move_item = $category_order->add_product($category_move, 2);
+$category_order->calculate_totals(false);
+$category_order->save();
+$category_order_id = $category_order->get_id();
+$category_order->update_status('processing');
+$category_order = wc_get_order($category_order_id);
+$category_stock_keep = wc_get_product($category_keep->get_id())->get_stock_quantity();
+$category_stock_move = wc_get_product($category_move->get_id())->get_stock_quantity();
+$category_before = WCOS_Order_Contract_Snapshot::aggregate(array($category_order));
+
+$category_review = $strategy_adapter->review($category_order, WCOS_Split_Strategy_Gates::CATEGORY);
+$category_keep_bucket = 'category-' . absint($category_keep_term['term_id']);
+$category_move_bucket = 'category-' . absint($category_move_term['term_id']);
+$category_plan = $strategy_adapter->build_plan($category_review, $category_keep_bucket);
+wcos_p2_adapter_assert(isset($category_plan[$category_move_bucket][$category_move_item]), 'Category strategy adapter did not build the expected frozen whole-line plan.');
+
+/* Live catalog classification may change after Review; Execute must not reclassify. */
+wp_set_object_terms($category_move->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+$category_operation = 'p2-strategy-category-' . wp_generate_uuid4();
+$category_children = $strategy_adapter->split(
+	wc_get_order($category_order_id),
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$category_plan,
+	$category_operation
+);
+wcos_p2_adapter_assert(1 === count($category_children), 'Category strategy adapter did not create exactly one frozen-plan child.');
+$category_source = wc_get_order($category_order_id);
+$category_child = wc_get_order($category_children[0]->get_id());
+wcos_p2_adapter_assert($category_source->get_item($category_keep_item) instanceof WC_Order_Item_Product, 'Category strategy adapter removed the selected source bucket.');
+wcos_p2_adapter_assert(!$category_source->get_item($category_move_item), 'Category strategy adapter did not remove the frozen moved line from source.');
+$category_child_items = array_values($category_child->get_items('line_item'));
+wcos_p2_adapter_assert(1 === count($category_child_items) && 2 === (int) $category_child_items[0]->get_quantity(), 'Category strategy child does not contain the complete frozen source line.');
+WCOS_Mutation_Contract::assert_conserved(
+	$category_before,
+	WCOS_Order_Contract_Snapshot::aggregate(array($category_source, $category_child)),
+	wc_get_price_decimals()
+);
+wcos_p2_adapter_assert($category_stock_keep == wc_get_product($category_keep->get_id())->get_stock_quantity(), 'Category strategy adapter changed physical stock for the retained line.');
+wcos_p2_adapter_assert($category_stock_move == wc_get_product($category_move->get_id())->get_stock_quantity(), 'Category strategy adapter changed physical stock for the moved line.');
+$category_record = WCOS_Operation_Journal::get($category_source, $category_operation);
+wcos_p2_adapter_assert(
+	is_array($category_record)
+	&& 'completed' === $category_record['status']
+	&& WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $category_record['context']['execution_policy'],
+	'Category strategy adapter did not durably use whole-line execution policy.'
+);
+wcos_p2_adapter_assert(array($category_move_item) === array_values($category_record['context']['fully_moved_item_ids']), 'Category strategy journal recorded the wrong destructive source-item set.');
+$category_retry = $strategy_adapter->split(
+	wc_get_order($category_order_id),
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$category_plan,
+	$category_operation
+);
+wcos_p2_adapter_assert(1 === count($category_retry) && $category_child->get_id() === $category_retry[0]->get_id(), 'Category strategy retry created a different child order.');
+wcos_p2_adapter_cleanup($category_order_id, $category_operation);
+wp_delete_post($category_keep->get_id(), true);
+wp_delete_post($category_move->get_id(), true);
+wp_delete_term(absint($category_keep_term['term_id']), 'product_cat');
+wp_delete_term(absint($category_move_term['term_id']), 'product_cat');
+
+/* Stock-status Review remains frozen when live status changes before Execute. */
+$stock_keep = wcos_p2_adapter_product('WCOS Strategy Stock Keep', '11.00');
+$stock_move = wcos_p2_adapter_product('WCOS Strategy Stock Move', '6.00');
+$stock_keep->set_stock_status('instock');
+$stock_keep->save();
+$stock_move->set_stock_status('outofstock');
+$stock_move->save();
+$stock_order = wc_create_order();
+$stock_order->set_status('pending');
+$stock_order->set_currency('USD');
+$stock_keep_item = $stock_order->add_product($stock_keep, 1);
+$stock_move_item = $stock_order->add_product($stock_move, 2);
+$stock_order->calculate_totals(false);
+$stock_order->save();
+$stock_order_id = $stock_order->get_id();
+$stock_before = WCOS_Order_Contract_Snapshot::aggregate(array(wc_get_order($stock_order_id)));
+$stock_review = $strategy_adapter->review(wc_get_order($stock_order_id), WCOS_Split_Strategy_Gates::STOCK_STATUS);
+$stock_plan = $strategy_adapter->build_plan($stock_review, 'stock-instock');
+wcos_p2_adapter_assert(isset($stock_plan['stock-outofstock'][$stock_move_item]), 'Stock-status strategy adapter did not freeze the reviewed out-of-stock line.');
+
+$stock_move = wc_get_product($stock_move->get_id());
+$stock_move->set_stock_status('instock');
+$stock_move->save();
+$stock_operation = 'p2-strategy-stock-' . wp_generate_uuid4();
+$stock_children = $strategy_adapter->split(
+	wc_get_order($stock_order_id),
+	WCOS_Split_Strategy_Gates::STOCK_STATUS,
+	$stock_plan,
+	$stock_operation
+);
+wcos_p2_adapter_assert(1 === count($stock_children), 'Stock-status strategy adapter did not execute the frozen reviewed plan.');
+$stock_source = wc_get_order($stock_order_id);
+$stock_child = wc_get_order($stock_children[0]->get_id());
+wcos_p2_adapter_assert($stock_source->get_item($stock_keep_item) instanceof WC_Order_Item_Product, 'Stock-status strategy adapter removed the selected source bucket.');
+wcos_p2_adapter_assert(!$stock_source->get_item($stock_move_item), 'Stock-status strategy adapter reclassified live status instead of executing the frozen plan.');
+WCOS_Mutation_Contract::assert_conserved(
+	$stock_before,
+	WCOS_Order_Contract_Snapshot::aggregate(array($stock_source, $stock_child)),
+	wc_get_price_decimals()
+);
+wcos_p2_adapter_cleanup($stock_order_id, $stock_operation);
+wp_delete_post($stock_keep->get_id(), true);
+wp_delete_post($stock_move->get_id(), true);
+
+/* Strategy adapter rejects partial lines even though the whole-line service policy could represent them. */
+$partial_a = wcos_p2_adapter_product('WCOS Strategy Partial A', '4.00');
+$partial_b = wcos_p2_adapter_product('WCOS Strategy Partial B', '3.00');
+$partial_order = wc_create_order();
+$partial_order->set_status('pending');
+$partial_order->set_currency('USD');
+$partial_a_item = $partial_order->add_product($partial_a, 2);
+$partial_b_item = $partial_order->add_product($partial_b, 1);
+$partial_order->calculate_totals(false);
+$partial_order->save();
+$partial_operation = 'p2-strategy-partial-' . wp_generate_uuid4();
+$partial_rejected = false;
+try {
+	$strategy_adapter->split(
+		$partial_order,
+		WCOS_Split_Strategy_Gates::CATEGORY,
+		array('child-1' => array($partial_a_item => '1.000000')),
+		$partial_operation
+	);
+} catch (InvalidArgumentException $exception) {
+	$partial_rejected = false !== strpos($exception->getMessage(), 'only complete source product lines');
+}
+wcos_p2_adapter_assert($partial_rejected, 'Strategy adapter accepted a partial source-line allocation.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($partial_order, $partial_operation), 'Rejected partial strategy plan started a mutation journal.');
+
+/* A single source line may not be spread across multiple strategy children. */
+$multi_operation = 'p2-strategy-multi-child-' . wp_generate_uuid4();
+$multi_rejected = false;
+try {
+	$strategy_adapter->split(
+		$partial_order,
+		WCOS_Split_Strategy_Gates::CATEGORY,
+		array(
+			'child-1' => array($partial_a_item => '1.000000'),
+			'child-2' => array($partial_a_item => '1.000000'),
+		),
+		$multi_operation
+	);
+} catch (InvalidArgumentException $exception) {
+	$multi_rejected = false !== strpos($exception->getMessage(), 'only one child bucket');
+}
+wcos_p2_adapter_assert($multi_rejected, 'Strategy adapter allowed one source line to span multiple child buckets.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($partial_order, $multi_operation), 'Rejected multi-child strategy plan started a mutation journal.');
+
+$manual_strategy_rejected = false;
+try {
+	WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY);
+} catch (InvalidArgumentException $exception) {
+	$manual_strategy_rejected = true;
+}
+wcos_p2_adapter_assert($manual_strategy_rejected, 'Strategy adapter accepted manual_quantity as a server-built whole-line strategy.');
+
+$partial_order->delete(true);
+wp_delete_post($partial_a->get_id(), true);
+wp_delete_post($partial_b->get_id(), true);
+update_option('woocommerce_manage_stock', $manage_stock_before_strategy_adapter);
+
+echo "p2-strategy-adapter-foundation-ok\n";

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -89,3 +89,4 @@ require __DIR__ . '/p2-whole-line-runtime-smoke.php';
 require __DIR__ . '/p2-whole-line-blocker-fallback-smoke.php';
 require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
 require __DIR__ . '/p2-strategy-planners-smoke.php';
+require __DIR__ . '/p2-strategy-adapter-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_ADAPTER_FOUNDATION`

## Status

**TECHNICAL ACCEPTANCE COMPLETE.**

Final reviewed head: `46f6c1f6f76decbb47be4a3f3184a2bb563a706d`

Independent review: `4970398610`.

## Mission

Connect the accepted Category/Stock-status frozen planner plans to the single hardened Split WooCommerce adapter/service while keeping both production strategy gates hard-off.

## Production boundary

Strategy gates remain unchanged:

- `manual_quantity = true`
- `category = false`
- `stock_status = false`

No Category/Stock-status controller, AJAX action, UI launcher, option/filter, confirmation endpoint, or production strategy route is registered.

`WCOS_Mutation_Gateway::split_strategy()` is the future mandatory mutation boundary and rejects Category/Stock-status while their strategy gates remain false.

## Architecture

Execution path:

`frozen planner plan -> WCOS_Split_Strategy_WooCommerce_Adapter -> WCOS_Split_WooCommerce_Adapter -> WCOS_Split_Order_Service`

There remains one Split mutation service and one request-local WooCommerce stock side-effect boundary.

`WCOS_Split_WooCommerce_Adapter::split()` gains an optional final execution-policy parameter whose default remains `PARTIAL_LINES_ONLY`; existing manual quantity Split callers are unchanged. The strategy adapter supplies `ALLOW_WHOLE_LINE_TRANSFER` explicitly.

## Strategy semantics

For a new operation the strategy adapter requires:

- strategy is exactly `category` or `stock_status`;
- every assigned source line is transferred completely;
- every assigned source line belongs to exactly one strategy child bucket;
- at least one product line remains on source.

Partial lines and one source line spread across multiple child buckets fail before journal creation.

## Frozen classification

Execute never calls a planner. Canonical acceptance changes Category assignment / Stock-status after Review and proves the already-built explicit plan executes unchanged.

## Durable retry

Once a Split journal exists the strategy adapter validates against durable authority rather than the already-mutated source:

- execution policy is `ALLOW_WHOLE_LINE_TRANSFER`;
- requested canonical plan equals the recorded plan;
- every assigned item appears exactly once;
- assigned item IDs exactly equal journal `fully_moved_item_ids`.

The hardened Split service remains the fingerprint/idempotency/recovery authority.

## Deliberately deferred transport authority

Semantic strategy identity (`category` versus `stock_status`) is not yet durably bound into confirmation/journal authority in this adapter-only milestone. Both production strategy gates are hard-off, so this is not production-reachable. Durable strategy identity plus planner/source/classification/source-bucket/plan confirmation binding is mandatory before either strategy can be enabled.

## Final acceptance evidence

Canonical **CI #614** (`32235262665`) completed successfully on exact final head:

- PHP 7.4 ✅
- PHP 8.1 ✅
- PHP 8.3 ✅
- architecture / approved production gate contract ✅
- package safety ✅
- WooCommerce 11.0.1 legacy storage ✅
- HPOS-only ✅
- HPOS compatibility/sync ✅
- hard-off Category/Stock-status gateway before journal/child creation ✅
- frozen Category plan executes after taxonomy change ✅
- frozen Stock-status plan executes after live status change ✅
- quantity/money/tax/`_reduced_stock` conservation ✅
- no physical-stock writes during strategy Split ✅
- durable whole-line policy + exact `fully_moved_item_ids` ✅
- exact idempotent retry ✅
- partial and multi-child-per-line rejection before journal ✅
- all existing Split/Duplicate/recovery/concurrency regressions ✅
- `Required CI` ✅

## Merge classification

Adapter-only foundation. Category and Stock-status remain unavailable until separate confirmation/transport and enablement milestones are accepted.