### PR TITLE
P2: bind Split strategy confirmation authority

### DIFF
--- a/docs/p2-split-strategy-confirmation-foundation.md
+++ b/docs/p2-split-strategy-confirmation-foundation.md
@@ -1,0 +1,108 @@
+# P2 Split strategy confirmation foundation
+
+## Classification
+
+`P2_SPLIT_STRATEGY_CONFIRMATION_FOUNDATION`
+
+This milestone binds future Category/Stock-status Split confirmation semantics to the existing hardened Split journal while keeping both production strategy gates hard-off.
+
+## Production state
+
+The approved mutation gates remain unchanged:
+
+- `SPLIT = true`
+- `DUPLICATE = true`
+- `MERGE = false`
+- `RETURN_ORDER = false`
+- `BULK_RETURN = false`
+
+Split strategy gates remain:
+
+- `manual_quantity = true`
+- `category = false`
+- `stock_status = false`
+
+No Category/Stock-status controller, AJAX action, launcher, UI, option, filter, or production strategy route is introduced here.
+
+## Authority lifecycle
+
+Before the first mutation write:
+
+`planner Review -> source bucket choice -> short-lived strategy confirmation -> verify`
+
+The temporary confirmation binds:
+
+- source order ID;
+- confirming user ID;
+- semantic strategy (`category` or `stock_status`);
+- planner policy version;
+- reviewed source signature;
+- classification fingerprint;
+- selected source bucket;
+- canonical explicit quantity plan;
+- `ALLOW_WHOLE_LINE_TRANSFER` execution policy;
+- price precision;
+- current hardened Split preflight policy version.
+
+After the Split journal starts, the journal becomes the single durable replay authority. No second persistent strategy-operation store is introduced.
+
+## Durable strategy authority
+
+The confirmed semantic fields are normalized into `strategy_authority`:
+
+- `strategy`;
+- `planner_policy_version`;
+- `review_source_signature`;
+- `classification_fingerprint`;
+- `source_bucket_key`.
+
+`strategy_authority` participates in the Split mutation fingerprint and is persisted in the existing `WCOS_Operation_Journal` context. Journal mutation treats it as immutable alongside `execution_policy` and `fully_moved_item_ids`.
+
+This prevents one operation ID from being replayed with a different strategy identity, classification review, or source bucket even when the explicit quantity plan happens to be identical.
+
+## TOCTOU boundary
+
+Before the first journal exists, confirmation verification reloads the source order and requires its PII-free source signature to still equal the reviewed signature.
+
+`WCOS_Split_WooCommerce_Adapter` rechecks the verified strategy confirmation signature immediately before hardened Split preflight/mutation. This closes the verify -> mutation source-order race without making live catalog Category/Stock-status state part of Execute.
+
+Catalog taxonomy or stock-status changes after Review/confirmation do not rewrite the frozen explicit plan. Execute never reruns a planner.
+
+## Replay
+
+If the temporary confirmation expires or is deleted after a journal exists, verification reconstructs authority from the existing Split journal only.
+
+Durable replay requires:
+
+- matching Split source/order identity;
+- an open/replayable journal state;
+- a complete `strategy_authority`;
+- exact recorded plan;
+- whole-line execution policy;
+- recorded price precision;
+- current compatible hardened Split policy version.
+
+A raw transient record is not executable authority. `split_confirmed()` requires the record returned by successful verification or durable journal replay.
+
+## Gateway boundary
+
+`WCOS_Mutation_Gateway::split_strategy()` now delegates to `split_confirmed()` after the global Split gate, strategy gate, and centralized authorization checks.
+
+Because Category and Stock-status strategy gates remain false, this path is still production-unreachable. A later transport milestone must verify the strategy confirmation and pass the returned authority record to the gateway; it must not pass client-supplied authority fields directly.
+
+## Acceptance
+
+Canonical integration acceptance must prove:
+
+- strategy confirmation classes load without registering a production route;
+- Category/Stock-status gateway calls remain blocked before journal/child creation;
+- confirmation records contain no customer PII;
+- user/order ownership is checked before first journal creation;
+- source changes after Review/confirmation fail before journal creation;
+- unverified transient records cannot execute;
+- live taxonomy/status changes do not rewrite a frozen confirmed plan;
+- semantic strategy authority is present in the one durable Split journal;
+- `strategy_authority` cannot be overwritten by later journal checkpoints;
+- transient deletion/expiry can replay from the same journal;
+- replay under another strategy or source bucket fails closed;
+- existing manual Split, Duplicate, recovery, stock, tax, HPOS, and legacy-storage contracts remain green.

--- a/inc/backend/class-wcos-split-strategy-confirmation-store.php
+++ b/inc/backend/class-wcos-split-strategy-confirmation-store.php
@@ -1,0 +1,334 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Split_Strategy_Confirmation_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/**
+ * Short-lived confirmation authority for future Category/Stock-status Split.
+ *
+ * Before the first mutation, authority lives only in a transient. Once the
+ * Split journal starts, the journal becomes the single durable replay source of
+ * truth. No second persistent strategy-operation store is introduced.
+ */
+final class WCOS_Split_Strategy_Confirmation_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 1800;
+
+	private static $verified_source_signatures = array();
+
+	public static function create(WC_Order $source, $strategy, array $review, $source_bucket_key, $user_id) {
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		$user_id = absint($user_id);
+		$source_id = absint($source->get_id());
+		if (!$source_id || !$user_id) {
+			throw new InvalidArgumentException(__('A persisted order and signed-in user are required to confirm a Split strategy.', 'wc-order-splitter'));
+		}
+		if (absint(isset($review['order_id']) ? $review['order_id'] : 0) !== $source_id
+			|| $strategy !== sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '')) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'review_mismatch',
+				__('The Split strategy review does not belong to this order and strategy.', 'wc-order-splitter')
+			);
+		}
+
+		$source_bucket_key = sanitize_key((string) $source_bucket_key);
+		$adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
+		try {
+			$plan = $adapter->build_plan($review, $source_bucket_key);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('review_invalid', $throwable->getMessage());
+		}
+
+		$preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($source);
+		if (empty($preflight['supported'])) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'preflight_unsupported',
+				isset($preflight['message']) ? (string) $preflight['message'] : __('The source order is no longer supported by the Split safety policy.', 'wc-order-splitter')
+			);
+		}
+
+		$reviewed_signature = isset($review['source_signature']) ? (string) $review['source_signature'] : '';
+		$preflight_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
+		if ('' === $reviewed_signature || '' === $preflight_signature || !hash_equals($reviewed_signature, $preflight_signature)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'source_changed',
+				__('The source order changed after the Split strategy review. Review the strategy again before confirming it.', 'wc-order-splitter')
+			);
+		}
+
+		$scoped_source = wc_get_order($source_id);
+		if (!$scoped_source instanceof WC_Order) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+		}
+		$current_signature = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+		if (!hash_equals($reviewed_signature, $current_signature)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'source_changed',
+				__('The source order changed while the Split strategy confirmation was being created.', 'wc-order-splitter')
+			);
+		}
+
+		$planner_policy_version = absint(isset($review['policy_version']) ? $review['policy_version'] : 0);
+		if (!$planner_policy_version || $planner_policy_version !== self::current_planner_policy_version($strategy)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'planner_policy_changed',
+				__('The Split strategy planner policy changed after Review. Review the strategy again.', 'wc-order-splitter')
+			);
+		}
+		if (!isset($review['execution_policy'])
+			|| WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== WCOS_Split_Execution_Policy::normalize($review['execution_policy'])) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'execution_policy_mismatch',
+				__('The Split strategy review does not carry whole-line execution authority.', 'wc-order-splitter')
+			);
+		}
+
+		$classification_fingerprint = isset($review['classification_fingerprint']) ? sanitize_key((string) $review['classification_fingerprint']) : '';
+		if ('' === $classification_fingerprint || '' === $source_bucket_key) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception(
+				'review_incomplete',
+				__('The Split strategy review is missing frozen classification or source-bucket authority.', 'wc-order-splitter')
+			);
+		}
+
+		$operation_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$precision = WCOS_Price_Precision_Scope::validate(isset($preflight['price_precision']) ? $preflight['price_precision'] : wc_get_price_decimals());
+		$split_policy_version = isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0;
+		if (!$split_policy_version) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('review_incomplete', __('The Split safety policy version is missing from strategy confirmation.', 'wc-order-splitter'));
+		}
+
+		$now = time();
+		$record = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => $operation_id,
+			'token_hash' => self::token_hash($token),
+			'source_order_id' => $source_id,
+			'user_id' => $user_id,
+			'strategy' => $strategy,
+			'planner_policy_version' => $planner_policy_version,
+			'source_signature' => $current_signature,
+			'classification_fingerprint' => $classification_fingerprint,
+			'source_bucket_key' => $source_bucket_key,
+			'plan' => WCOS_Split_Plan::canonicalize_request($plan),
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			'price_precision' => $precision,
+			'split_policy_version' => $split_policy_version,
+			'created_at' => $now,
+			'expires_at' => $now + self::TTL,
+		);
+
+		if (!set_transient(self::key($operation_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to create the temporary Split strategy confirmation record.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'confirmation_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'record' => $record,
+		);
+	}
+
+	public static function verify(WC_Order $source, $operation_id, $token, $user_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$user_id = absint($user_id);
+		unset(self::$verified_source_signatures[$operation_id]);
+		if (!self::is_uuid($operation_id) || !$user_id) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('invalid_identity', __('The Split strategy confirmation identity is invalid.', 'wc-order-splitter'));
+		}
+
+		$record = get_transient(self::key($operation_id));
+		if (!is_array($record)) {
+			return self::durable_replay($source, $operation_id);
+		}
+		if ('' === (string) $token || empty($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('invalid_token', __('The Split strategy confirmation token is invalid.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0) !== $source->get_id()
+			|| absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('owner_mismatch', __('The Split strategy confirmation does not belong to this user and order.', 'wc-order-splitter'));
+		}
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($operation_id);
+			return self::durable_replay($source, $operation_id);
+		}
+
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy(isset($record['strategy']) ? $record['strategy'] : '');
+		$journal = WCOS_Operation_Journal::get($source, $operation_id);
+		if (is_array($journal)) {
+			$durable = self::durable_replay($source, $operation_id);
+			self::assert_confirmation_matches_durable($record, $durable);
+			return $durable;
+		}
+
+		if (absint(isset($record['planner_policy_version']) ? $record['planner_policy_version'] : 0) !== self::current_planner_policy_version($strategy)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('planner_policy_changed', __('The Split strategy planner policy changed after confirmation. Review the strategy again.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['split_policy_version']) ? $record['split_policy_version'] : 0) !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('split_policy_changed', __('The Split safety policy changed after strategy confirmation. Review the strategy again.', 'wc-order-splitter'));
+		}
+
+		$precision = WCOS_Price_Precision_Scope::validate(isset($record['price_precision']) ? $record['price_precision'] : null);
+		$precision_token = WCOS_Price_Precision_Scope::begin($precision);
+		try {
+			$scoped_source = wc_get_order($source->get_id());
+			if (!$scoped_source instanceof WC_Order) {
+				throw new WCOS_Split_Strategy_Confirmation_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+			}
+			$expected = isset($record['source_signature']) ? (string) $record['source_signature'] : '';
+			$actual = WCOS_Order_Contract_Snapshot::source_signature($scoped_source);
+			if ('' === $expected || !hash_equals($expected, $actual)) {
+				throw new WCOS_Split_Strategy_Confirmation_Exception('source_changed', __('The source order changed after strategy confirmation. Review the strategy again.', 'wc-order-splitter'));
+			}
+			self::$verified_source_signatures[$operation_id] = $expected;
+		} finally {
+			WCOS_Price_Precision_Scope::end($precision_token);
+		}
+
+		$record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
+		$record['price_precision'] = $precision;
+		$record['replay_authority'] = 'confirmation';
+		return $record;
+	}
+
+	public static function operation_authority(array $record) {
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy(isset($record['strategy']) ? $record['strategy'] : '');
+		$authority = array(
+			'strategy' => $strategy,
+			'planner_policy_version' => absint(isset($record['planner_policy_version']) ? $record['planner_policy_version'] : 0),
+			'review_source_signature' => isset($record['source_signature']) ? sanitize_key((string) $record['source_signature']) : '',
+			'classification_fingerprint' => isset($record['classification_fingerprint']) ? sanitize_key((string) $record['classification_fingerprint']) : '',
+			'source_bucket_key' => sanitize_key(isset($record['source_bucket_key']) ? (string) $record['source_bucket_key'] : ''),
+		);
+		if (!$authority['planner_policy_version'] || '' === $authority['review_source_signature']
+			|| '' === $authority['classification_fingerprint'] || '' === $authority['source_bucket_key']) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('authority_incomplete', __('The Split strategy confirmation is missing durable authority fields.', 'wc-order-splitter'));
+		}
+		return $authority;
+	}
+
+	public static function verified_source_signature($operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		return isset(self::$verified_source_signatures[$operation_id]) ? (string) self::$verified_source_signatures[$operation_id] : '';
+	}
+
+	public static function delete($operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		unset(self::$verified_source_signatures[$operation_id]);
+		return self::is_uuid($operation_id) ? delete_transient(self::key($operation_id)) : false;
+	}
+
+	private static function durable_replay(WC_Order $source, $operation_id) {
+		$journal = WCOS_Operation_Journal::get($source, $operation_id);
+		if (!is_array($journal)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('expired', __('The Split strategy confirmation expired. Review the strategy again.', 'wc-order-splitter'));
+		}
+		if (!isset($journal['type']) || 'split' !== sanitize_key((string) $journal['type'])
+			|| absint(isset($journal['source_order_id']) ? $journal['source_order_id'] : 0) !== $source->get_id()) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('journal_mismatch', __('The durable Split strategy operation does not match this source order.', 'wc-order-splitter'));
+		}
+
+		$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		if ('manual_reconciliation' === $status) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('manual_reconciliation', __('This Split strategy operation requires manual reconciliation.', 'wc-order-splitter'));
+		}
+		if (in_array($status, array('manual_reconciled', 'compensated'), true)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('operation_closed', __('This Split strategy operation is closed and cannot be replayed.', 'wc-order-splitter'));
+		}
+
+		$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+		if (empty($context['strategy_authority']) || !is_array($context['strategy_authority'])
+			|| empty($context['plan']) || !is_array($context['plan'])
+			|| !array_key_exists('price_precision', $context)
+			|| !array_key_exists('policy_version', $context)) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('journal_incomplete', __('The durable Split strategy operation is missing replay authority.', 'wc-order-splitter'));
+		}
+		if ((int) $context['policy_version'] !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('split_policy_changed', __('The Split safety policy changed after this strategy operation started.', 'wc-order-splitter'));
+		}
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== WCOS_Split_Execution_Policy::normalize(isset($context['execution_policy']) ? $context['execution_policy'] : '')) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('execution_policy_mismatch', __('The durable Split strategy operation lost whole-line execution authority.', 'wc-order-splitter'));
+		}
+
+		$authority = self::normalize_durable_authority($context['strategy_authority']);
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => $operation_id,
+			'source_order_id' => $source->get_id(),
+			'strategy' => $authority['strategy'],
+			'planner_policy_version' => $authority['planner_policy_version'],
+			'source_signature' => $authority['review_source_signature'],
+			'classification_fingerprint' => $authority['classification_fingerprint'],
+			'source_bucket_key' => $authority['source_bucket_key'],
+			'plan' => WCOS_Split_Plan::canonicalize_request($context['plan']),
+			'execution_policy' => WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			'price_precision' => WCOS_Price_Precision_Scope::validate($context['price_precision']),
+			'split_policy_version' => (int) $context['policy_version'],
+			'replay_authority' => 'journal',
+		);
+	}
+
+	private static function normalize_durable_authority(array $authority) {
+		$record = array(
+			'strategy' => WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy(isset($authority['strategy']) ? $authority['strategy'] : ''),
+			'planner_policy_version' => absint(isset($authority['planner_policy_version']) ? $authority['planner_policy_version'] : 0),
+			'review_source_signature' => isset($authority['review_source_signature']) ? sanitize_key((string) $authority['review_source_signature']) : '',
+			'classification_fingerprint' => isset($authority['classification_fingerprint']) ? sanitize_key((string) $authority['classification_fingerprint']) : '',
+			'source_bucket_key' => sanitize_key(isset($authority['source_bucket_key']) ? (string) $authority['source_bucket_key'] : ''),
+		);
+		if (!$record['planner_policy_version'] || '' === $record['review_source_signature']
+			|| '' === $record['classification_fingerprint'] || '' === $record['source_bucket_key']) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('journal_incomplete', __('The durable Split strategy authority is incomplete.', 'wc-order-splitter'));
+		}
+		return $record;
+	}
+
+	private static function assert_confirmation_matches_durable(array $record, array $durable) {
+		$fields = array('strategy', 'planner_policy_version', 'source_signature', 'classification_fingerprint', 'source_bucket_key', 'execution_policy', 'price_precision', 'split_policy_version');
+		foreach ($fields as $field) {
+			if (!array_key_exists($field, $record) || !array_key_exists($field, $durable)
+				|| (string) $record[$field] !== (string) $durable[$field]) {
+				throw new WCOS_Split_Strategy_Confirmation_Exception('journal_mismatch', __('The temporary Split strategy confirmation no longer matches durable journal authority.', 'wc-order-splitter'));
+			}
+		}
+		if (WCOS_Split_Plan::canonicalize_request($record['plan']) !== WCOS_Split_Plan::canonicalize_request($durable['plan'])) {
+			throw new WCOS_Split_Strategy_Confirmation_Exception('journal_mismatch', __('The temporary Split strategy plan no longer matches durable journal authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function current_planner_policy_version($strategy) {
+		switch (WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy)) {
+			case WCOS_Split_Strategy_Gates::CATEGORY:
+				return (int) WCOS_Category_Split_Planner::POLICY_VERSION;
+			case WCOS_Split_Strategy_Gates::STOCK_STATUS:
+				return (int) WCOS_Stock_Status_Split_Planner::POLICY_VERSION;
+		}
+		return 0;
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($operation_id) {
+		return 'wcos_split_strategy_confirm_' . hash('sha256', sanitize_key((string) $operation_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -68,6 +68,7 @@ class WC_Order_Splitter_Script {
 
 		include_once $root . 'backend/class-wcos-split-request-parser.php';
 		include_once $root . 'backend/class-wcos-split-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-split-strategy-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-split-admin-controller.php';
 		new WCOS_Split_Admin_Controller();
 
@@ -83,8 +84,9 @@ class WC_Order_Splitter_Script {
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Hardened
 		 * production transports must enter through WCOS_Mutation_Gateway. Category
-		 * and Stock-status planner/adapter foundations loaded above remain internal;
-		 * their strategy gates are hard-off and no production transport is registered.
+		 * and Stock-status planner/adapter/confirmation foundations loaded above
+		 * remain internal; their strategy gates are hard-off and no production
+		 * transport is registered.
 		 */
 	}
 }

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -22,17 +22,18 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
-	public function split_strategy(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null) {
+	public function split_strategy(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null, array $confirmation = array()) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::SPLIT);
 		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
 		WCOS_Split_Strategy_Gates::assert_enabled($strategy);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
-		return (new WCOS_Split_Strategy_WooCommerce_Adapter())->split(
+		return (new WCOS_Split_Strategy_WooCommerce_Adapter())->split_confirmed(
 			$source,
 			$strategy,
 			$plan,
 			$operation_id,
-			$confirmed_precision
+			$confirmed_precision,
+			$confirmation
 		);
 	}
 

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -440,7 +440,7 @@ final class WCOS_Operation_Journal {
             }
         }
 
-        foreach (array('execution_policy', 'fully_moved_item_ids') as $field) {
+        foreach (array('execution_policy', 'fully_moved_item_ids', 'strategy_authority') as $field) {
             if (array_key_exists($field, $current_context)) {
                 if (!array_key_exists($field, $replacement_context)
                     || $current_context[$field] !== $replacement_context[$field]) {

--- a/inc/domain/class-wcos-split-order-service.php
+++ b/inc/domain/class-wcos-split-order-service.php
@@ -23,9 +23,10 @@ final class WCOS_Split_Order_Service {
 	const OPERATION_META = '_wcos_operation_id';
 	const CHILD_KEY_META = '_wcos_split_child_key';
 
-	public function split(WC_Order $source, array $plan, $operation_id, $execution_policy = 'partial_lines_only') {
+	public function split(WC_Order $source, array $plan, $operation_id, $execution_policy = 'partial_lines_only', array $operation_context = array()) {
 		$operation_id = sanitize_key($operation_id);
 		$execution_policy = WCOS_Split_Execution_Policy::normalize($execution_policy);
+		$operation_context = $this->normalize_operation_context($operation_context, $execution_policy);
 		if (WCOS_Split_Execution_Policy::allows_whole_line_transfer($execution_policy)
 			&& (!class_exists('WCOS_Stock_Side_Effect_Guard') || !WCOS_Stock_Side_Effect_Guard::has_active_scope())) {
 			throw new RuntimeException(__('Whole-line Split requires an active request-local stock side-effect guard.', 'wc-order-splitter'));
@@ -54,6 +55,9 @@ final class WCOS_Split_Order_Service {
 		);
 		if (!$legacy_journal) {
 			$fingerprint_context['execution_policy'] = $execution_policy;
+		}
+		if (isset($operation_context['strategy_authority'])) {
+			$fingerprint_context['strategy_authority'] = $operation_context['strategy_authority'];
 		}
 		$fingerprint = WCOS_Mutation_Fingerprint::create(self::TYPE, $source->get_id(), $fingerprint_context);
 
@@ -140,6 +144,9 @@ final class WCOS_Split_Order_Service {
 					'before_contract' => $before_contract,
 					'source_stock_reduced' => $source_stock_reduced,
 				);
+				if (isset($operation_context['strategy_authority'])) {
+					$context['strategy_authority'] = $operation_context['strategy_authority'];
+				}
 				if (!WCOS_Operation_Journal::start($source, $operation_id, self::TYPE, $context, $fingerprint)) {
 					throw new RuntimeException(__('Unable to start the split operation journal.', 'wc-order-splitter'));
 				}
@@ -257,6 +264,23 @@ final class WCOS_Split_Order_Service {
 		} finally {
 			WCOS_Operation_Lock::release($source_id, $lease_token);
 		}
+	}
+
+	private function normalize_operation_context(array $operation_context, $execution_policy) {
+		foreach (array_keys($operation_context) as $key) {
+			if ('strategy_authority' !== $key) {
+				throw new InvalidArgumentException(__('Unknown Split operation authority context.', 'wc-order-splitter'));
+			}
+		}
+		if (!array_key_exists('strategy_authority', $operation_context)) {
+			return array();
+		}
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $execution_policy
+			|| !is_array($operation_context['strategy_authority'])
+			|| empty($operation_context['strategy_authority'])) {
+			throw new InvalidArgumentException(__('Semantic Split strategy authority requires the whole-line execution policy.', 'wc-order-splitter'));
+		}
+		return array('strategy_authority' => $operation_context['strategy_authority']);
 	}
 
 	private function assert_supported_source(WC_Order $source) {

--- a/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
@@ -129,6 +129,10 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 	}
 
 	private function assert_confirmation_matches_request(WC_Order $source, $strategy, array $canonical_plan, $operation_id, $confirmed_precision, array $confirmation) {
+		$replay_authority = sanitize_key(isset($confirmation['replay_authority']) ? (string) $confirmation['replay_authority'] : '');
+		if (!in_array($replay_authority, array('confirmation', 'journal'), true)) {
+			throw new RuntimeException(__('A verified Split strategy confirmation is required before execution.', 'wc-order-splitter'));
+		}
 		if (sanitize_key(isset($confirmation['operation_id']) ? (string) $confirmation['operation_id'] : '') !== $operation_id) {
 			throw new RuntimeException(__('The Split strategy confirmation does not match this operation ID.', 'wc-order-splitter'));
 		}

--- a/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php
@@ -40,6 +40,13 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 		throw new InvalidArgumentException(__('Unsupported server-built Split strategy.', 'wc-order-splitter'));
 	}
 
+	/**
+	 * Internal foundation execution used by canonical adapter tests.
+	 *
+	 * No production controller may call this method. Future production strategy
+	 * transport must use split_confirmed() through WCOS_Mutation_Gateway so the
+	 * semantic strategy authority is durably bound to the Split journal.
+	 */
 	public function split(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null) {
 		self::normalize_strategy($strategy);
 		$operation_id = sanitize_key((string) $operation_id);
@@ -63,6 +70,49 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 		);
 	}
 
+	/**
+	 * Confirmed execution boundary for future production strategy transport.
+	 */
+	public function split_confirmed(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision, array $confirmation) {
+		$strategy = self::normalize_strategy($strategy);
+		$operation_id = sanitize_key((string) $operation_id);
+		if ('' === $operation_id) {
+			throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
+		}
+
+		$source_id = absint($source->get_id());
+		$source = $source_id ? wc_get_order($source_id) : false;
+		if (!$source instanceof WC_Order) {
+			throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+		}
+
+		$canonical_plan = WCOS_Split_Plan::canonicalize_request($plan);
+		$this->assert_confirmation_matches_request(
+			$source,
+			$strategy,
+			$canonical_plan,
+			$operation_id,
+			$confirmed_precision,
+			$confirmation
+		);
+		$normalized_plan = $this->assert_whole_line_bucket_plan($source, $canonical_plan, $operation_id);
+		$authority = WCOS_Split_Strategy_Confirmation_Store::operation_authority($confirmation);
+
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		if (is_array($record)) {
+			$this->assert_recorded_strategy_authority($record, $authority);
+		}
+
+		return (new WCOS_Split_WooCommerce_Adapter())->split(
+			$source,
+			$normalized_plan,
+			$operation_id,
+			$confirmed_precision,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			array('strategy_authority' => $authority)
+		);
+	}
+
 	public static function normalize_strategy($strategy) {
 		$strategy = sanitize_key((string) $strategy);
 		if (!in_array(
@@ -76,6 +126,33 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 			throw new InvalidArgumentException(__('Unsupported server-built Split strategy.', 'wc-order-splitter'));
 		}
 		return $strategy;
+	}
+
+	private function assert_confirmation_matches_request(WC_Order $source, $strategy, array $canonical_plan, $operation_id, $confirmed_precision, array $confirmation) {
+		if (sanitize_key(isset($confirmation['operation_id']) ? (string) $confirmation['operation_id'] : '') !== $operation_id) {
+			throw new RuntimeException(__('The Split strategy confirmation does not match this operation ID.', 'wc-order-splitter'));
+		}
+		if (absint(isset($confirmation['source_order_id']) ? $confirmation['source_order_id'] : 0) !== $source->get_id()) {
+			throw new RuntimeException(__('The Split strategy confirmation does not match this source order.', 'wc-order-splitter'));
+		}
+		if (self::normalize_strategy(isset($confirmation['strategy']) ? $confirmation['strategy'] : '') !== $strategy) {
+			throw new RuntimeException(__('The Split strategy confirmation does not match the requested strategy.', 'wc-order-splitter'));
+		}
+		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== WCOS_Split_Execution_Policy::normalize(isset($confirmation['execution_policy']) ? $confirmation['execution_policy'] : '')) {
+			throw new RuntimeException(__('The Split strategy confirmation does not carry whole-line execution authority.', 'wc-order-splitter'));
+		}
+		$confirmed_plan = WCOS_Split_Plan::canonicalize_request(isset($confirmation['plan']) && is_array($confirmation['plan']) ? $confirmation['plan'] : array());
+		if ($confirmed_plan !== $canonical_plan) {
+			throw new RuntimeException(__('The Split strategy confirmation plan does not match the requested plan.', 'wc-order-splitter'));
+		}
+		$precision = WCOS_Price_Precision_Scope::validate($confirmed_precision);
+		$authority_precision = WCOS_Price_Precision_Scope::validate(isset($confirmation['price_precision']) ? $confirmation['price_precision'] : null);
+		if ($precision !== $authority_precision) {
+			throw new RuntimeException(__('The Split strategy confirmation precision does not match the requested operation precision.', 'wc-order-splitter'));
+		}
+		if (absint(isset($confirmation['split_policy_version']) ? $confirmation['split_policy_version'] : 0) !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
+			throw new RuntimeException(__('The Split strategy confirmation safety policy no longer matches the current Split policy.', 'wc-order-splitter'));
+		}
 	}
 
 	private function assert_whole_line_bucket_plan(WC_Order $source, array $plan, $operation_id) {
@@ -131,6 +208,16 @@ final class WCOS_Split_Strategy_WooCommerce_Adapter {
 		}
 
 		return $recorded_plan;
+	}
+
+	private function assert_recorded_strategy_authority(array $record, array $authority) {
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		if (empty($context['strategy_authority']) || !is_array($context['strategy_authority'])) {
+			throw new RuntimeException(__('The durable Split operation is missing semantic strategy authority.', 'wc-order-splitter'));
+		}
+		if ($context['strategy_authority'] !== $authority) {
+			throw new RuntimeException(__('The requested Split strategy authority does not match the durable operation journal.', 'wc-order-splitter'));
+		}
 	}
 
 	private function assigned_item_ids(array $normalized_plan) {

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -13,7 +13,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Split_WooCommerce_Adapter {
 
-    public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY) {
+    public function split(WC_Order $source, array $plan, $operation_id, $confirmed_precision = null, $execution_policy = WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY, array $operation_context = array()) {
         $operation_id = sanitize_key((string) $operation_id);
         if ('' === $operation_id) {
             throw new InvalidArgumentException(__('A split operation ID is required.', 'wc-order-splitter'));
@@ -67,7 +67,8 @@ final class WCOS_Split_WooCommerce_Adapter {
                     $source,
                     $plan,
                     $operation_id,
-                    $execution_policy
+                    $execution_policy,
+                    $operation_context
                 );
                 WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
                 return $children;
@@ -116,10 +117,13 @@ final class WCOS_Split_WooCommerce_Adapter {
     }
 
     private function assert_verified_confirmation_source(WC_Order $source, $operation_id) {
-        if (!class_exists('WCOS_Split_Confirmation_Store')) {
-            return;
+        $expected = '';
+        if (class_exists('WCOS_Split_Confirmation_Store')) {
+            $expected = WCOS_Split_Confirmation_Store::verified_source_signature($operation_id);
         }
-        $expected = WCOS_Split_Confirmation_Store::verified_source_signature($operation_id);
+        if ('' === $expected && class_exists('WCOS_Split_Strategy_Confirmation_Store')) {
+            $expected = WCOS_Split_Strategy_Confirmation_Store::verified_source_signature($operation_id);
+        }
         if ('' === $expected) {
             return;
         }

--- a/tests/integration/p2-strategy-confirmation-smoke.php
+++ b/tests/integration/p2-strategy-confirmation-smoke.php
@@ -1,0 +1,246 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Confirmation_Store'), 'Strategy confirmation store was not loaded by the plugin bootstrap.');
+wcos_p2_adapter_assert(method_exists('WCOS_Split_Strategy_WooCommerce_Adapter', 'split_confirmed'), 'Confirmed strategy adapter boundary is missing.');
+
+$confirmation_user_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_confirm_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-confirm-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+$other_user_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_other_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-other-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($confirmation_user_id) && !is_wp_error($other_user_id), 'Unable to create strategy confirmation test users.');
+
+$strategy_confirmation_adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
+
+/* Review -> confirmation must fail closed if the source changes before verify. */
+$toctou_suffix = strtolower(wp_generate_password(6, false, false));
+$toctou_keep_term = wp_insert_term('WCOS Confirm TOCTOU Keep ' . $toctou_suffix, 'product_cat');
+$toctou_move_term = wp_insert_term('WCOS Confirm TOCTOU Move ' . $toctou_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($toctou_keep_term) && !is_wp_error($toctou_move_term), 'Unable to create strategy confirmation TOCTOU terms.');
+$toctou_keep = wcos_p2_adapter_product('WCOS Confirm TOCTOU Keep', '8.00');
+$toctou_move = wcos_p2_adapter_product('WCOS Confirm TOCTOU Move', '6.00');
+wp_set_object_terms($toctou_keep->get_id(), array(absint($toctou_keep_term['term_id'])), 'product_cat');
+wp_set_object_terms($toctou_move->get_id(), array(absint($toctou_move_term['term_id'])), 'product_cat');
+$toctou_order = wc_create_order();
+$toctou_order->set_status('pending');
+$toctou_order->set_currency('USD');
+$toctou_keep_item = $toctou_order->add_product($toctou_keep, 1);
+$toctou_move_item = $toctou_order->add_product($toctou_move, 1);
+$toctou_order->calculate_totals(false);
+$toctou_order->save();
+$toctou_review = $strategy_confirmation_adapter->review($toctou_order, WCOS_Split_Strategy_Gates::CATEGORY);
+$toctou_keep_bucket = 'category-' . absint($toctou_keep_term['term_id']);
+$toctou_confirmation = WCOS_Split_Strategy_Confirmation_Store::create(
+	$toctou_order,
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$toctou_review,
+	$toctou_keep_bucket,
+	$confirmation_user_id
+);
+$toctou_order->set_customer_note('changed-after-strategy-confirmation');
+$toctou_order->save();
+$toctou_changed = false;
+try {
+	WCOS_Split_Strategy_Confirmation_Store::verify(
+		wc_get_order($toctou_order->get_id()),
+		$toctou_confirmation['operation_id'],
+		$toctou_confirmation['confirmation_token'],
+		$confirmation_user_id
+	);
+} catch (WCOS_Split_Strategy_Confirmation_Exception $exception) {
+	$toctou_changed = 'source_changed' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($toctou_changed, 'Strategy confirmation accepted a source order changed after Review.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($toctou_order->get_id()), $toctou_confirmation['operation_id']), 'Strategy confirmation TOCTOU failure created a mutation journal.');
+WCOS_Split_Strategy_Confirmation_Store::delete($toctou_confirmation['operation_id']);
+$toctou_order->delete(true);
+wp_delete_post($toctou_keep->get_id(), true);
+wp_delete_post($toctou_move->get_id(), true);
+wp_delete_term(absint($toctou_keep_term['term_id']), 'product_cat');
+wp_delete_term(absint($toctou_move_term['term_id']), 'product_cat');
+
+/* Confirmed Category authority is bound into the one durable Split journal. */
+$category_suffix = strtolower(wp_generate_password(6, false, false));
+$category_keep_term = wp_insert_term('WCOS Confirm Keep ' . $category_suffix, 'product_cat');
+$category_move_term = wp_insert_term('WCOS Confirm Move ' . $category_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($category_keep_term) && !is_wp_error($category_move_term), 'Unable to create confirmed Category terms.');
+$category_keep = wcos_p2_adapter_product('WCOS Confirm Category Keep', '12.00');
+$category_move = wcos_p2_adapter_product('WCOS Confirm Category Move', '7.00');
+wp_set_object_terms($category_keep->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+wp_set_object_terms($category_move->get_id(), array(absint($category_move_term['term_id'])), 'product_cat');
+$category_order = wc_create_order();
+$category_order->set_status('pending');
+$category_order->set_currency('USD');
+$category_keep_item = $category_order->add_product($category_keep, 2);
+$category_move_item = $category_order->add_product($category_move, 2);
+$category_order->calculate_totals(false);
+$category_order->set_billing_email('strategy-confirmation-private@example.test');
+$category_order->save();
+$category_order_id = $category_order->get_id();
+$category_review = $strategy_confirmation_adapter->review($category_order, WCOS_Split_Strategy_Gates::CATEGORY);
+$category_keep_bucket = 'category-' . absint($category_keep_term['term_id']);
+$category_move_bucket = 'category-' . absint($category_move_term['term_id']);
+$category_plan = $strategy_confirmation_adapter->build_plan($category_review, $category_keep_bucket);
+$category_confirmation = WCOS_Split_Strategy_Confirmation_Store::create(
+	$category_order,
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$category_review,
+	$category_keep_bucket,
+	$confirmation_user_id
+);
+$category_record_json = wp_json_encode($category_confirmation['record']);
+wcos_p2_adapter_assert(false === strpos($category_record_json, 'strategy-confirmation-private@example.test'), 'Strategy confirmation record leaked billing PII.');
+
+/* A raw unverified transient record is not execution authority. */
+$raw_rejected = false;
+try {
+	$strategy_confirmation_adapter->split_confirmed(
+		wc_get_order($category_order_id),
+		WCOS_Split_Strategy_Gates::CATEGORY,
+		$category_plan,
+		$category_confirmation['operation_id'],
+		$category_confirmation['record']['price_precision'],
+		$category_confirmation['record']
+	);
+} catch (RuntimeException $exception) {
+	$raw_rejected = false !== strpos($exception->getMessage(), 'verified Split strategy confirmation');
+}
+wcos_p2_adapter_assert($raw_rejected, 'Strategy adapter accepted an unverified transient confirmation record.');
+wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($category_order_id), $category_confirmation['operation_id']), 'Unverified strategy authority created a mutation journal.');
+
+/* Confirmation ownership is explicit before the first journal exists. */
+$owner_rejected = false;
+try {
+	WCOS_Split_Strategy_Confirmation_Store::verify(
+		wc_get_order($category_order_id),
+		$category_confirmation['operation_id'],
+		$category_confirmation['confirmation_token'],
+		$other_user_id
+	);
+} catch (WCOS_Split_Strategy_Confirmation_Exception $exception) {
+	$owner_rejected = 'owner_mismatch' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($owner_rejected, 'Strategy confirmation was usable by a different user before journal creation.');
+
+$verified = WCOS_Split_Strategy_Confirmation_Store::verify(
+	wc_get_order($category_order_id),
+	$category_confirmation['operation_id'],
+	$category_confirmation['confirmation_token'],
+	$confirmation_user_id
+);
+wcos_p2_adapter_assert('confirmation' === $verified['replay_authority'], 'Fresh strategy verification did not use transient confirmation authority.');
+
+/* Live taxonomy may change after confirmation; Execute consumes the frozen plan. */
+wp_set_object_terms($category_move->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+$children = $strategy_confirmation_adapter->split_confirmed(
+	wc_get_order($category_order_id),
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$verified['plan'],
+	$verified['operation_id'],
+	$verified['price_precision'],
+	$verified
+);
+wcos_p2_adapter_assert(1 === count($children), 'Confirmed Category strategy did not create exactly one child.');
+$category_child_id = $children[0]->get_id();
+$category_source = wc_get_order($category_order_id);
+wcos_p2_adapter_assert($category_source->get_item($category_keep_item) instanceof WC_Order_Item_Product, 'Confirmed Category strategy removed the selected source bucket.');
+wcos_p2_adapter_assert(!$category_source->get_item($category_move_item), 'Confirmed Category strategy did not execute the frozen moved line.');
+
+$journal = WCOS_Operation_Journal::get($category_source, $verified['operation_id']);
+$expected_authority = WCOS_Split_Strategy_Confirmation_Store::operation_authority($verified);
+wcos_p2_adapter_assert(is_array($journal) && 'completed' === $journal['status'], 'Confirmed strategy journal did not complete.');
+wcos_p2_adapter_assert(isset($journal['context']['strategy_authority']) && $expected_authority === $journal['context']['strategy_authority'], 'Confirmed strategy semantic authority was not durably journaled.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $journal['context']['strategy_authority']['strategy'], 'Durable strategy identity is incorrect.');
+wcos_p2_adapter_assert($category_keep_bucket === $journal['context']['strategy_authority']['source_bucket_key'], 'Durable source-bucket authority is incorrect.');
+wcos_p2_adapter_assert($category_review['classification_fingerprint'] === $journal['context']['strategy_authority']['classification_fingerprint'], 'Durable classification fingerprint is incorrect.');
+
+$tampered_authority = $expected_authority;
+$tampered_authority['source_bucket_key'] = $category_move_bucket;
+wcos_p2_adapter_assert(
+	!WCOS_Operation_Journal::checkpoint(
+		$category_source,
+		$verified['operation_id'],
+		'strategy_authority_tamper',
+		array('strategy_authority' => $tampered_authority)
+	),
+	'Durable strategy authority was mutable after journal creation.'
+);
+
+/* After transient deletion, the same Split journal is the only replay authority. */
+WCOS_Split_Strategy_Confirmation_Store::delete($verified['operation_id']);
+$durable = WCOS_Split_Strategy_Confirmation_Store::verify(
+	wc_get_order($category_order_id),
+	$verified['operation_id'],
+	'',
+	$confirmation_user_id
+);
+wcos_p2_adapter_assert('journal' === $durable['replay_authority'], 'Strategy replay did not fall back to the durable Split journal.');
+wcos_p2_adapter_assert($expected_authority === WCOS_Split_Strategy_Confirmation_Store::operation_authority($durable), 'Durable strategy replay returned different semantic authority.');
+$retry = $strategy_confirmation_adapter->split_confirmed(
+	wc_get_order($category_order_id),
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$durable['plan'],
+	$durable['operation_id'],
+	$durable['price_precision'],
+	$durable
+);
+wcos_p2_adapter_assert(1 === count($retry) && $category_child_id === $retry[0]->get_id(), 'Durable strategy replay created a different child order.');
+
+/* The same operation ID cannot be replayed under another strategy identity. */
+$wrong_strategy = $durable;
+$wrong_strategy['strategy'] = WCOS_Split_Strategy_Gates::STOCK_STATUS;
+$strategy_swap_rejected = false;
+try {
+	$strategy_confirmation_adapter->split_confirmed(
+		wc_get_order($category_order_id),
+		WCOS_Split_Strategy_Gates::STOCK_STATUS,
+		$wrong_strategy['plan'],
+		$wrong_strategy['operation_id'],
+		$wrong_strategy['price_precision'],
+		$wrong_strategy
+	);
+} catch (RuntimeException $exception) {
+	$strategy_swap_rejected = false !== strpos($exception->getMessage(), 'does not match the durable operation journal')
+		|| false !== strpos($exception->getMessage(), 'different mutation request');
+}
+wcos_p2_adapter_assert($strategy_swap_rejected, 'Durable Category operation was replayable as Stock-status.');
+
+$wrong_bucket = $durable;
+$wrong_bucket['source_bucket_key'] = $category_move_bucket;
+$bucket_swap_rejected = false;
+try {
+	$strategy_confirmation_adapter->split_confirmed(
+		wc_get_order($category_order_id),
+		WCOS_Split_Strategy_Gates::CATEGORY,
+		$wrong_bucket['plan'],
+		$wrong_bucket['operation_id'],
+		$wrong_bucket['price_precision'],
+		$wrong_bucket
+	);
+} catch (RuntimeException $exception) {
+	$bucket_swap_rejected = false !== strpos($exception->getMessage(), 'does not match the durable operation journal')
+		|| false !== strpos($exception->getMessage(), 'different mutation request');
+}
+wcos_p2_adapter_assert($bucket_swap_rejected, 'Durable strategy operation accepted a different source bucket.');
+wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($category_order_id, $durable['operation_id'])), 'Rejected strategy-authority replay created an extra child.');
+
+wcos_p2_adapter_cleanup($category_order_id, $durable['operation_id']);
+wp_delete_post($category_keep->get_id(), true);
+wp_delete_post($category_move->get_id(), true);
+wp_delete_term(absint($category_keep_term['term_id']), 'product_cat');
+wp_delete_term(absint($category_move_term['term_id']), 'product_cat');
+wp_delete_user($confirmation_user_id);
+wp_delete_user($other_user_id);
+
+echo "p2-strategy-confirmation-authority-ok\n";

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -90,3 +90,4 @@ require __DIR__ . '/p2-whole-line-blocker-fallback-smoke.php';
 require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
 require __DIR__ . '/p2-strategy-planners-smoke.php';
 require __DIR__ . '/p2-strategy-adapter-smoke.php';
+require __DIR__ . '/p2-strategy-confirmation-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_CONFIRMATION_FOUNDATION`

## Mission

Bind future Category/Stock-status confirmation semantics into the existing hardened Split fingerprint/journal while keeping both production strategy gates hard-off.

## Current production state

Mutation gates remain unchanged:

- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Split strategy gates remain:

- `manual_quantity = true`
- `category = false`
- `stock_status = false`

No Category/Stock-status controller, AJAX action, UI launcher, option, filter, or production strategy route is registered.

## Authority lifecycle

Before the first mutation, `WCOS_Split_Strategy_Confirmation_Store` binds user/order ownership, semantic strategy identity, planner policy version, reviewed source signature, classification fingerprint, selected source bucket, canonical explicit plan, whole-line execution policy, price precision, and current Split safety policy.

A raw transient record is not executable. `split_confirmed()` requires the record returned by successful confirmation verification.

Once the Split saga creates its existing durable journal, normalized `strategy_authority` participates in the Split mutation fingerprint and is stored in journal context. The existing Split journal then becomes the single durable replay authority; no second persistent strategy-operation store is introduced.

## Durable strategy authority

The journal binds immutable:

- `strategy`;
- `planner_policy_version`;
- `review_source_signature`;
- `classification_fingerprint`;
- `source_bucket_key`.

`strategy_authority` is protected by `WCOS_Operation_Journal::immutable_fields_match()` alongside `execution_policy` and `fully_moved_item_ids`.

This prevents the same operation ID from being replayed under another strategy or reviewed source bucket even when the explicit quantity plan is otherwise identical.

## TOCTOU

Before journal creation, verification reloads the source order and requires the current PII-free source signature to match Review. `WCOS_Split_WooCommerce_Adapter` rechecks that verified strategy signature immediately before hardened preflight/mutation.

Catalog Category or Stock-status changes are deliberately not re-read by Execute; the frozen explicit plan remains authoritative.

## Gateway boundary

`WCOS_Mutation_Gateway::split_strategy()` now delegates to `split_confirmed()` after global Split gate, strategy gate, and centralized authorization. Since Category and Stock-status gates remain false, the production path is still unreachable.

A later transport milestone must call strategy confirmation verification server-side and pass its returned authority record to the gateway. Client-supplied authority fields must never be trusted directly.

## Acceptance

Canonical integration acceptance adds coverage for:

- confirmation store bootstrap without production routes;
- PII-free confirmation records;
- owner/order binding before first journal;
- source-change failure before journal creation;
- unverified confirmation rejection;
- frozen plan execution after live taxonomy changes;
- strategy authority stored in the one Split journal;
- immutable strategy authority;
- durable replay after transient deletion;
- strategy/source-bucket swap rejection;
- no duplicate child on replay;
- all existing manual Split, Duplicate, whole-line, recovery, tax, stock, HPOS, and legacy-storage regressions.
