### PR TITLE
P2: add hard-off Split strategy transport foundation

### DIFF
--- a/docs/p2-split-strategy-transport-foundation.md
+++ b/docs/p2-split-strategy-transport-foundation.md
@@ -1,0 +1,140 @@
+# P2 Split strategy transport foundation
+
+## Classification
+
+`P2_SPLIT_STRATEGY_TRANSPORT_FOUNDATION`
+
+This milestone establishes the server-side Review -> Confirm -> Execute transport contract for future Category and Stock-status Split while keeping both strategy gates hard-off and registering no production route or UI.
+
+## Production state
+
+Mutation gates remain unchanged:
+
+- `SPLIT = true`
+- `DUPLICATE = true`
+- `MERGE = false`
+- `RETURN_ORDER = false`
+- `BULK_RETURN = false`
+
+Split strategy gates remain:
+
+- `manual_quantity = true`
+- `category = false`
+- `stock_status = false`
+
+`WCOS_Split_Strategy_Admin_Controller` is loaded as a class definition only. It has no constructor hook registration and is not instantiated by the plugin bootstrap. No `wp_ajax_*` strategy action, launcher, dialog, JavaScript, option, filter, or other production surface is introduced.
+
+## Transport lifecycle
+
+The future production server contract is:
+
+`Review request -> server Review Store -> Confirm request -> strategy Confirmation Store -> Execute request -> WCOS_Mutation_Gateway -> strategy adapter -> hardened Split adapter/service`
+
+Every controller method enforces:
+
+- global hardened Split gate;
+- exact strategy gate;
+- order-specific nonce;
+- centralized order-mutation authorization;
+- configured source-order status policy.
+
+Since Category and Stock-status remain hard-off, direct controller use fails before any Review transient, confirmation, journal, or child order can be created.
+
+## Server-side Review authority
+
+`WCOS_Split_Strategy_Review_Store` is a short-lived server-side authority layer. The Review response may expose its PII-free planner report for display, but Confirm receives only:
+
+- opaque `review_id`;
+- opaque `review_token`;
+- source order ID;
+- semantic strategy;
+- selected `source_bucket_key`.
+
+Confirm never trusts a client-supplied planner Review payload. It reloads the authoritative server Review, verifies token/user/order/strategy ownership, expiry, and current source signature, then passes that server record to the accepted strategy confirmation foundation.
+
+## Review -> Confirm concurrency
+
+A server Review is single-use authority.
+
+Two concurrent Confirm requests may both observe the Review before either removes it. The controller therefore creates a candidate confirmation and then requires successful atomic-enough transient consumption of the Review before returning the candidate token. Only the request that successfully consumes the Review keeps its confirmation. A losing request deletes its unexposed candidate confirmation and fails closed with `review_already_consumed`.
+
+This prevents one Review from intentionally producing multiple usable operation IDs through a Confirm race.
+
+## Confirmation and Execute
+
+Execute accepts only an operation ID and confirmation token from the client. It verifies the server confirmation before entering the gateway and additionally requires the confirmed semantic strategy to equal the requested transport strategy.
+
+The gateway then re-applies:
+
+- global Split gate;
+- strategy gate;
+- centralized authorization;
+
+and delegates only to `WCOS_Split_Strategy_WooCommerce_Adapter::split_confirmed()`.
+
+Client-supplied plan, classification fingerprint, planner evidence, execution policy, price precision, or strategy authority are never Execute authority.
+
+## Frozen classification
+
+Category and Stock-status catalog classification is read during Review only. Confirm and Execute use the frozen server authority created from that Review.
+
+Canonical acceptance changes live taxonomy or stock status after confirmation and proves the frozen reviewed line still moves exactly as confirmed. Execute does not re-run either planner.
+
+## TOCTOU
+
+The transport closes source-order races at both ephemeral boundaries:
+
+1. Review Store creation rechecks the current PII-free source signature against planner Review;
+2. Review Store verification rechecks source signature before Confirm;
+3. strategy Confirmation verification rechecks source signature before first mutation;
+4. `WCOS_Split_WooCommerce_Adapter` rechecks the request-local verified signature immediately before hardened mutation.
+
+The acceptance fixture mutates public line-item business metadata between Review and Confirm. That metadata participates in `WCOS_Order_Contract_Snapshot::source_signature()` while leaving Category classification unchanged, proving the Review -> Confirm race check rather than merely changing planner classification.
+
+## Error contract
+
+The controller exposes structured `WCOS_Split_Transport_Exception` errors with HTTP status and retryability. Foundation coverage includes:
+
+- `workflow_disabled` / `strategy_disabled`;
+- `invalid_strategy`;
+- `invalid_order` / `order_not_found`;
+- `invalid_nonce`;
+- `authorization_failed`;
+- `status_disabled`;
+- Review token/owner/expiry/source-change failures;
+- `source_bucket_required`;
+- confirmation token/authority/policy failures;
+- `confirmation_strategy_mismatch`;
+- `review_already_consumed`;
+- `operation_busy` / `operation_conflict`;
+- preflight and manual-reconciliation failures.
+
+## Acceptance boundary
+
+Canonical legacy, HPOS-only, and HPOS compatibility/sync matrices must prove:
+
+- controller/review classes load but register no production route;
+- both strategy gates remain hard-off before and after test-only execution;
+- direct hard-off use creates no mutation authority;
+- nonce and authorization boundaries hold under a test-only temporary strategy gate;
+- Review output is PII-free;
+- Confirm ignores client-supplied Review evidence;
+- Review ownership and single-use semantics hold;
+- source changes between Review and Confirm fail closed;
+- invalid confirmation creates no journal;
+- Category executes frozen taxonomy authority and durably replays without another child;
+- durable Category authority cannot be replayed as Stock-status;
+- Stock-status executes frozen status authority after the live catalog status changes;
+- all existing manual Split, Duplicate, whole-line, recovery, stock, tax, concurrency, and journal contracts remain green.
+
+## Deferred production work
+
+This foundation is not the sandbox/production UI milestone. Before Category or Stock-status can be enabled, separate work must still provide:
+
+1. production route registration behind an exact strategy gate;
+2. server-rendered strategy launcher/dialog and client state machine;
+3. accessible bucket Review/selection/confirmation UX;
+4. production-enabled E2E acceptance for each strategy;
+5. exact-state package/CI assertions;
+6. independent technical/security/accessibility review;
+7. explicit Human Gate for each `false -> true` strategy enablement.

--- a/inc/backend/class-wcos-split-strategy-admin-controller.php
+++ b/inc/backend/class-wcos-split-strategy-admin-controller.php
@@ -1,0 +1,284 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Hard-off admin transport contract for future Category/Stock-status Split.
+ *
+ * This class intentionally registers no WordPress hooks. A later production
+ * enablement milestone may register strategy-specific routes only after its
+ * exact gate, UI, accessibility, and Human Gate acceptance. Direct method calls
+ * still enforce strategy gate, nonce, authorization, order-status policy, and
+ * server-side Review/Confirmation authority.
+ */
+final class WCOS_Split_Strategy_Admin_Controller {
+	const REVIEW_ACTION = 'wcos_split_strategy_review';
+	const CONFIRM_ACTION = 'wcos_split_strategy_confirm';
+	const EXECUTE_ACTION = 'wcos_split_strategy_execute';
+
+	public function review_request(array $request) {
+		$strategy = $this->strategy_from_request($request);
+		$this->assert_strategy_enabled($strategy);
+		$order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+		$order = $this->authorized_order($request, $order_id);
+
+		try {
+			$review = (new WCOS_Split_Strategy_WooCommerce_Adapter())->review($order, $strategy);
+		} catch (InvalidArgumentException $exception) {
+			throw new WCOS_Split_Transport_Exception('invalid_strategy_review', $exception->getMessage(), 422, false);
+		} catch (RuntimeException $exception) {
+			throw new WCOS_Split_Transport_Exception('strategy_review_failed', $exception->getMessage(), 409, false);
+		}
+
+		if (empty($review['supported'])) {
+			throw new WCOS_Split_Transport_Exception(
+				'preflight_' . (isset($review['reason']) ? sanitize_key((string) $review['reason']) : 'unsupported'),
+				isset($review['message']) ? (string) $review['message'] : __('This order is not supported by the selected Split strategy.', 'wc-order-splitter'),
+				409,
+				false,
+				array('strategy' => $strategy)
+			);
+		}
+
+		try {
+			$stored = WCOS_Split_Strategy_Review_Store::create($order, $strategy, $review, get_current_user_id());
+		} catch (WCOS_Split_Strategy_Review_Exception $exception) {
+			throw $this->review_transport_exception($exception);
+		}
+
+		return array(
+			'review_id' => $stored['review_id'],
+			'review_token' => $stored['review_token'],
+			'expires_at' => $stored['expires_at'],
+			'strategy' => $strategy,
+			'order_id' => $order->get_id(),
+			'review' => $review,
+		);
+	}
+
+	public function confirm_request(array $request) {
+		$strategy = $this->strategy_from_request($request);
+		$this->assert_strategy_enabled($strategy);
+		$order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+		$order = $this->authorized_order($request, $order_id);
+		$review_id = isset($request['review_id']) ? sanitize_key((string) $request['review_id']) : '';
+		$review_token = isset($request['review_token']) ? (string) $request['review_token'] : '';
+		$source_bucket_key = isset($request['source_bucket_key']) ? sanitize_key((string) $request['source_bucket_key']) : '';
+		if ('' === $source_bucket_key) {
+			throw new WCOS_Split_Transport_Exception('source_bucket_required', __('Choose one reviewed strategy bucket to remain on the source order.', 'wc-order-splitter'), 422, false);
+		}
+
+		try {
+			$review = WCOS_Split_Strategy_Review_Store::verify(
+				$order,
+				$strategy,
+				$review_id,
+				$review_token,
+				get_current_user_id()
+			);
+		} catch (WCOS_Split_Strategy_Review_Exception $exception) {
+			throw $this->review_transport_exception($exception);
+		}
+
+		try {
+			$confirmation = WCOS_Split_Strategy_Confirmation_Store::create(
+				$order,
+				$strategy,
+				$review,
+				$source_bucket_key,
+				get_current_user_id()
+			);
+		} catch (WCOS_Split_Strategy_Confirmation_Exception $exception) {
+			throw $this->confirmation_transport_exception($exception);
+		} catch (InvalidArgumentException $exception) {
+			throw new WCOS_Split_Transport_Exception('invalid_confirmation', $exception->getMessage(), 422, false);
+		}
+
+		/* Confirmation has copied the authoritative server-side Review. */
+		WCOS_Split_Strategy_Review_Store::consume($review_id);
+
+		return array(
+			'operation_id' => $confirmation['operation_id'],
+			'confirmation_token' => $confirmation['confirmation_token'],
+			'expires_at' => $confirmation['expires_at'],
+			'strategy' => $strategy,
+			'order_id' => $order->get_id(),
+			'source_bucket_key' => $source_bucket_key,
+		);
+	}
+
+	public function execute_request(array $request) {
+		$strategy = $this->strategy_from_request($request);
+		$this->assert_strategy_enabled($strategy);
+		$order_id = isset($request['order_id']) ? absint($request['order_id']) : 0;
+		$order = $this->authorized_order($request, $order_id);
+		$operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
+		$confirmation_token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
+
+		try {
+			$confirmation = WCOS_Split_Strategy_Confirmation_Store::verify(
+				$order,
+				$operation_id,
+				$confirmation_token,
+				get_current_user_id()
+			);
+		} catch (WCOS_Split_Strategy_Confirmation_Exception $exception) {
+			throw $this->confirmation_transport_exception($exception);
+		}
+
+		try {
+			$children = (new WCOS_Mutation_Gateway())->split_strategy(
+				$order,
+				$strategy,
+				$confirmation['plan'],
+				$operation_id,
+				$confirmation['price_precision'],
+				$confirmation
+			);
+		} catch (WCOS_Split_Preflight_Exception $exception) {
+			throw new WCOS_Split_Transport_Exception(
+				'preflight_' . $exception->get_reason(),
+				$exception->getMessage(),
+				409,
+				false,
+				array('preflight' => $exception->get_report())
+			);
+		} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+			throw new WCOS_Split_Transport_Exception(
+				'manual_reconciliation_required',
+				__('The strategy Split detected an unexpected physical-stock side effect and requires manual reconciliation.', 'wc-order-splitter'),
+				409,
+				false
+			);
+		} catch (RuntimeException $exception) {
+			$message = $exception->getMessage();
+			if (false !== strpos($message, 'Another order mutation is already in progress')) {
+				throw new WCOS_Split_Transport_Exception('operation_busy', $message, 409, true);
+			}
+			if (false !== strpos($message, 'different mutation request')
+				|| false !== strpos($message, 'does not match the durable operation journal')) {
+				throw new WCOS_Split_Transport_Exception('operation_conflict', $message, 409, false);
+			}
+			throw new WCOS_Split_Transport_Exception('strategy_split_failed', $message, 409, true);
+		}
+
+		$result_children = array();
+		foreach ($children as $child) {
+			if (!$child instanceof WC_Order) {
+				continue;
+			}
+			$result_children[] = array(
+				'id' => $child->get_id(),
+				'number' => (string) $child->get_order_number(),
+				'status' => (string) $child->get_status(),
+				'edit_url' => method_exists($child, 'get_edit_order_url') ? esc_url_raw((string) $child->get_edit_order_url()) : '',
+			);
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'status' => 'completed',
+			'strategy' => $strategy,
+			'source_order_id' => $order->get_id(),
+			'children' => $result_children,
+		);
+	}
+
+	private function strategy_from_request(array $request) {
+		$strategy = isset($request['strategy']) ? sanitize_key((string) $request['strategy']) : '';
+		try {
+			return WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		} catch (InvalidArgumentException $exception) {
+			throw new WCOS_Split_Transport_Exception('invalid_strategy', $exception->getMessage(), 422, false);
+		}
+	}
+
+	private function assert_strategy_enabled($strategy) {
+		if (!WCOS_Split_Strategy_Gates::enabled($strategy)) {
+			throw new WCOS_Split_Transport_Exception(
+				'strategy_disabled',
+				__('This Split strategy is not enabled for production use.', 'wc-order-splitter'),
+				503,
+				false
+			);
+		}
+	}
+
+	private function authorized_order(array $request, $order_id) {
+		if (!$order_id) {
+			throw new WCOS_Split_Transport_Exception('invalid_order', __('A valid order ID is required.', 'wc-order-splitter'), 400, false);
+		}
+		$nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
+		if (!wp_verify_nonce($nonce, 'wcos_split_strategy_order_' . $order_id)) {
+			throw new WCOS_Split_Transport_Exception('invalid_nonce', __('The Split strategy request failed nonce verification.', 'wc-order-splitter'), 403, false);
+		}
+
+		$order = wc_get_order($order_id);
+		if (!$order instanceof WC_Order) {
+			throw new WCOS_Split_Transport_Exception('order_not_found', __('The source order could not be found.', 'wc-order-splitter'), 404, false);
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Split_Transport_Exception('authorization_failed', __('You are not allowed to use a Split strategy on this order.', 'wc-order-splitter'), 403, false);
+		}
+		$this->assert_status_enabled($order);
+		return $order;
+	}
+
+	private function assert_status_enabled(WC_Order $order) {
+		$allowed = (array) get_option('order_splitter_status_allowed', array('wc-processing'));
+		$status = 'wc-' . $order->get_status();
+		if (!in_array($status, $allowed, true)) {
+			throw new WCOS_Split_Transport_Exception('status_disabled', __('This order status is disabled in the Order Splitter settings.', 'wc-order-splitter'), 409, false);
+		}
+	}
+
+	private function review_transport_exception(WCOS_Split_Strategy_Review_Exception $exception) {
+		$statuses = array(
+			'invalid_identity' => 400,
+			'invalid_token' => 403,
+			'owner_mismatch' => 403,
+			'expired' => 410,
+			'source_changed' => 409,
+			'source_missing' => 404,
+			'review_invalid' => 409,
+		);
+		$reason = $exception->get_reason();
+		return new WCOS_Split_Transport_Exception(
+			'review_' . $reason,
+			$exception->getMessage(),
+			isset($statuses[$reason]) ? $statuses[$reason] : 409,
+			false
+		);
+	}
+
+	private function confirmation_transport_exception(WCOS_Split_Strategy_Confirmation_Exception $exception) {
+		$statuses = array(
+			'invalid_identity' => 400,
+			'invalid_token' => 403,
+			'owner_mismatch' => 403,
+			'expired' => 410,
+			'source_changed' => 409,
+			'source_missing' => 404,
+			'review_mismatch' => 409,
+			'review_invalid' => 409,
+			'review_incomplete' => 409,
+			'planner_policy_changed' => 409,
+			'split_policy_changed' => 409,
+			'execution_policy_mismatch' => 409,
+			'journal_mismatch' => 409,
+			'manual_reconciliation' => 409,
+			'operation_closed' => 409,
+			'journal_incomplete' => 409,
+			'authority_incomplete' => 409,
+		);
+		$reason = $exception->get_reason();
+		return new WCOS_Split_Transport_Exception(
+			'confirmation_' . $reason,
+			$exception->getMessage(),
+			isset($statuses[$reason]) ? $statuses[$reason] : 409,
+			false
+		);
+	}
+}

--- a/inc/backend/class-wcos-split-strategy-admin-controller.php
+++ b/inc/backend/class-wcos-split-strategy-admin-controller.php
@@ -44,6 +44,8 @@ final class WCOS_Split_Strategy_Admin_Controller {
 			$stored = WCOS_Split_Strategy_Review_Store::create($order, $strategy, $review, get_current_user_id());
 		} catch (WCOS_Split_Strategy_Review_Exception $exception) {
 			throw $this->review_transport_exception($exception);
+		} catch (RuntimeException $exception) {
+			throw new WCOS_Split_Transport_Exception('review_store_failed', $exception->getMessage(), 500, true);
 		}
 
 		return array(
@@ -92,10 +94,25 @@ final class WCOS_Split_Strategy_Admin_Controller {
 			throw $this->confirmation_transport_exception($exception);
 		} catch (InvalidArgumentException $exception) {
 			throw new WCOS_Split_Transport_Exception('invalid_confirmation', $exception->getMessage(), 422, false);
+		} catch (RuntimeException $exception) {
+			throw new WCOS_Split_Transport_Exception('confirmation_store_failed', $exception->getMessage(), 500, true);
 		}
 
-		/* Confirmation has copied the authoritative server-side Review. */
-		WCOS_Split_Strategy_Review_Store::consume($review_id);
+		/*
+		 * The server-side Review is single-use confirmation authority. Two
+		 * concurrent Confirm requests may both pass verify(), but only the request
+		 * that consumes the Review may keep and return its new confirmation. The
+		 * loser deletes its unexposed confirmation token and fails closed.
+		 */
+		if (!WCOS_Split_Strategy_Review_Store::consume($review_id)) {
+			WCOS_Split_Strategy_Confirmation_Store::delete($confirmation['operation_id']);
+			throw new WCOS_Split_Transport_Exception(
+				'review_already_consumed',
+				__('This Split strategy Review was already consumed by another confirmation request. Review the order again.', 'wc-order-splitter'),
+				409,
+				false
+			);
+		}
 
 		return array(
 			'operation_id' => $confirmation['operation_id'],
@@ -124,6 +141,22 @@ final class WCOS_Split_Strategy_Admin_Controller {
 			);
 		} catch (WCOS_Split_Strategy_Confirmation_Exception $exception) {
 			throw $this->confirmation_transport_exception($exception);
+		}
+
+		try {
+			$confirmed_strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy(
+				isset($confirmation['strategy']) ? $confirmation['strategy'] : ''
+			);
+		} catch (InvalidArgumentException $exception) {
+			throw new WCOS_Split_Transport_Exception('confirmation_strategy_mismatch', __('The Split strategy confirmation has invalid semantic strategy authority.', 'wc-order-splitter'), 409, false);
+		}
+		if ($confirmed_strategy !== $strategy) {
+			throw new WCOS_Split_Transport_Exception(
+				'confirmation_strategy_mismatch',
+				__('The confirmed Split strategy does not match the requested strategy.', 'wc-order-splitter'),
+				409,
+				false
+			);
 		}
 
 		try {
@@ -194,6 +227,14 @@ final class WCOS_Split_Strategy_Admin_Controller {
 	}
 
 	private function assert_strategy_enabled($strategy) {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) {
+			throw new WCOS_Split_Transport_Exception(
+				'workflow_disabled',
+				__('Split is not enabled for production use.', 'wc-order-splitter'),
+				503,
+				false
+			);
+		}
 		if (!WCOS_Split_Strategy_Gates::enabled($strategy)) {
 			throw new WCOS_Split_Transport_Exception(
 				'strategy_disabled',

--- a/inc/backend/class-wcos-split-strategy-review-store.php
+++ b/inc/backend/class-wcos-split-strategy-review-store.php
@@ -1,0 +1,142 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Split_Strategy_Review_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/**
+ * Short-lived server-side authority for one Category/Stock-status Review.
+ *
+ * Clients receive only an opaque review ID/token plus the read-only review
+ * payload for display. Confirm must reload the authoritative review from this
+ * store; client-supplied review evidence is never confirmation authority.
+ */
+final class WCOS_Split_Strategy_Review_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 900;
+
+	public static function create(WC_Order $source, $strategy, array $review, $user_id) {
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		$user_id = absint($user_id);
+		$source_id = absint($source->get_id());
+		if (!$source_id || !$user_id) {
+			throw new InvalidArgumentException(__('A persisted order and signed-in user are required to store a Split strategy review.', 'wc-order-splitter'));
+		}
+		if (empty($review['supported'])
+			|| absint(isset($review['order_id']) ? $review['order_id'] : 0) !== $source_id
+			|| sanitize_key(isset($review['strategy']) ? (string) $review['strategy'] : '') !== $strategy
+			|| empty($review['source_signature'])
+			|| empty($review['classification_fingerprint'])
+			|| empty($review['buckets'])
+			|| !is_array($review['buckets'])) {
+			throw new WCOS_Split_Strategy_Review_Exception('review_invalid', __('The Split strategy review is incomplete or does not match this order.', 'wc-order-splitter'));
+		}
+
+		$current = wc_get_order($source_id);
+		if (!$current instanceof WC_Order) {
+			throw new WCOS_Split_Strategy_Review_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+		}
+		$actual_signature = WCOS_Order_Contract_Snapshot::source_signature($current);
+		if (!hash_equals((string) $review['source_signature'], $actual_signature)) {
+			throw new WCOS_Split_Strategy_Review_Exception('source_changed', __('The source order changed before its Split strategy review could be stored.', 'wc-order-splitter'));
+		}
+
+		$review_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$now = time();
+		$record = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'review_id' => $review_id,
+			'token_hash' => self::token_hash($token),
+			'source_order_id' => $source_id,
+			'user_id' => $user_id,
+			'strategy' => $strategy,
+			'review' => $review,
+			'created_at' => $now,
+			'expires_at' => $now + self::TTL,
+		);
+		if (!set_transient(self::key($review_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to store the temporary Split strategy review.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'review_id' => $review_id,
+			'review_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'review' => $review,
+		);
+	}
+
+	public static function verify(WC_Order $source, $strategy, $review_id, $token, $user_id) {
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		$review_id = sanitize_key((string) $review_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($review_id) || !$user_id) {
+			throw new WCOS_Split_Strategy_Review_Exception('invalid_identity', __('The Split strategy review identity is invalid.', 'wc-order-splitter'));
+		}
+
+		$record = get_transient(self::key($review_id));
+		if (!is_array($record)) {
+			throw new WCOS_Split_Strategy_Review_Exception('expired', __('The Split strategy review expired. Review the order again.', 'wc-order-splitter'));
+		}
+		if ('' === (string) $token || empty($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Split_Strategy_Review_Exception('invalid_token', __('The Split strategy review token is invalid.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0) !== $source->get_id()
+			|| absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id
+			|| sanitize_key(isset($record['strategy']) ? (string) $record['strategy'] : '') !== $strategy) {
+			throw new WCOS_Split_Strategy_Review_Exception('owner_mismatch', __('The Split strategy review does not belong to this user, order, and strategy.', 'wc-order-splitter'));
+		}
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($review_id);
+			throw new WCOS_Split_Strategy_Review_Exception('expired', __('The Split strategy review expired. Review the order again.', 'wc-order-splitter'));
+		}
+
+		$review = isset($record['review']) && is_array($record['review']) ? $record['review'] : array();
+		if (empty($review['source_signature'])) {
+			throw new WCOS_Split_Strategy_Review_Exception('review_invalid', __('The stored Split strategy review is incomplete.', 'wc-order-splitter'));
+		}
+		$current = wc_get_order($source->get_id());
+		if (!$current instanceof WC_Order) {
+			throw new WCOS_Split_Strategy_Review_Exception('source_missing', __('The source order is no longer available.', 'wc-order-splitter'));
+		}
+		$current_signature = WCOS_Order_Contract_Snapshot::source_signature($current);
+		if (!hash_equals((string) $review['source_signature'], $current_signature)) {
+			throw new WCOS_Split_Strategy_Review_Exception('source_changed', __('The source order changed after Review. Review the strategy again.', 'wc-order-splitter'));
+		}
+
+		return $review;
+	}
+
+	public static function consume($review_id) {
+		return self::delete($review_id);
+	}
+
+	public static function delete($review_id) {
+		$review_id = sanitize_key((string) $review_id);
+		return self::is_uuid($review_id) ? delete_transient(self::key($review_id)) : false;
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($review_id) {
+		return 'wcos_split_strategy_review_' . hash('sha256', sanitize_key((string) $review_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -68,9 +68,11 @@ class WC_Order_Splitter_Script {
 
 		include_once $root . 'backend/class-wcos-split-request-parser.php';
 		include_once $root . 'backend/class-wcos-split-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-split-strategy-review-store.php';
 		include_once $root . 'backend/class-wcos-split-strategy-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-split-admin-controller.php';
 		new WCOS_Split_Admin_Controller();
+		include_once $root . 'backend/class-wcos-split-strategy-admin-controller.php';
 
 		include_once $root . 'backend/class-wcos-duplicate-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-duplicate-admin-controller.php';
@@ -84,9 +86,9 @@ class WC_Order_Splitter_Script {
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Hardened
 		 * production transports must enter through WCOS_Mutation_Gateway. Category
-		 * and Stock-status planner/adapter/confirmation foundations loaded above
-		 * remain internal; their strategy gates are hard-off and no production
-		 * transport is registered.
+		 * and Stock-status planner/adapter/review/confirmation/controller contracts
+		 * loaded above remain internal; their strategy gates are hard-off and the
+		 * strategy controller is deliberately not instantiated or registered.
 		 */
 	}
 }

--- a/tests/integration/p2-strategy-transport-smoke.php
+++ b/tests/integration/p2-strategy-transport-smoke.php
@@ -1,0 +1,317 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_strategy_transport_expect($code, $http_status, callable $callback, $message) {
+	try {
+		$callback();
+	} catch (WCOS_Split_Transport_Exception $exception) {
+		wcos_p2_adapter_assert($code === $exception->get_error_code(), $message . ' Wrong code: ' . $exception->get_error_code());
+		wcos_p2_adapter_assert($http_status === $exception->get_http_status(), $message . ' Wrong HTTP status.');
+		return $exception;
+	}
+	throw new RuntimeException($message);
+}
+
+wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Review_Store'), 'Strategy Review store was not loaded.');
+wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Admin_Controller'), 'Strategy transport controller contract was not loaded.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Hard-off strategy Review AJAX route was registered.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Hard-off strategy Confirm AJAX route was registered.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Hard-off strategy Execute AJAX route was registered.');
+
+$transport_controller = new WCOS_Split_Strategy_Admin_Controller();
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Instantiating the hard-off strategy controller registered Review AJAX.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Instantiating the hard-off strategy controller registered Confirm AJAX.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Instantiating the hard-off strategy controller registered Execute AJAX.');
+
+$transport_previous_user = get_current_user_id();
+$transport_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$transport_manager_permission = get_option('order_splitter_shop_manager_permission', 'no');
+$transport_admin_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_transport_admin_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-transport-admin-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+$transport_other_admin_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_transport_other_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-transport-other-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+$transport_subscriber_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_transport_sub_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-transport-sub-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'subscriber',
+));
+wcos_p2_adapter_assert(!is_wp_error($transport_admin_id) && !is_wp_error($transport_other_admin_id) && !is_wp_error($transport_subscriber_id), 'Unable to create strategy transport users.');
+
+$transport_suffix = strtolower(wp_generate_password(6, false, false));
+$transport_keep_term = wp_insert_term('WCOS Transport Keep ' . $transport_suffix, 'product_cat');
+$transport_move_term = wp_insert_term('WCOS Transport Move ' . $transport_suffix, 'product_cat');
+wcos_p2_adapter_assert(!is_wp_error($transport_keep_term) && !is_wp_error($transport_move_term), 'Unable to create strategy transport categories.');
+$transport_keep = wcos_p2_adapter_product('WCOS Transport Keep', '11.00');
+$transport_move = wcos_p2_adapter_product('WCOS Transport Move', '9.00');
+wp_set_object_terms($transport_keep->get_id(), array(absint($transport_keep_term['term_id'])), 'product_cat');
+wp_set_object_terms($transport_move->get_id(), array(absint($transport_move_term['term_id'])), 'product_cat');
+$transport_order = wc_create_order();
+$transport_order->set_status('pending');
+$transport_order->set_currency('USD');
+$transport_keep_item = $transport_order->add_product($transport_keep, 2);
+$transport_move_item = $transport_order->add_product($transport_move, 2);
+$transport_order->calculate_totals(false);
+$transport_order->set_billing_email('strategy-transport-private@example.test');
+$transport_order->save();
+$transport_order_id = $transport_order->get_id();
+$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+
+$strategy_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
+$strategy_states_property = $strategy_reflection->getProperty('states');
+$strategy_states_property->setAccessible(true);
+$release_strategy_states = $strategy_states_property->getValue();
+
+enable_strategy_transport_test:
+try {
+	update_option('order_splitter_status_allowed', array('wc-pending'));
+	update_option('order_splitter_shop_manager_permission', 'no');
+	wp_set_current_user($transport_admin_id);
+
+	/* Real release state blocks direct controller use before nonce/order mutation. */
+	wcos_strategy_transport_expect(
+		'strategy_disabled',
+		503,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce) {
+			$transport_controller->review_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+			));
+		},
+		'Hard-off Category transport was directly usable.'
+	);
+
+	$test_strategy_states = $release_strategy_states;
+	$test_strategy_states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
+	$strategy_states_property->setValue(null, $test_strategy_states);
+
+	wcos_strategy_transport_expect(
+		'invalid_nonce',
+		403,
+		static function() use ($transport_controller, $transport_order_id) {
+			$transport_controller->review_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => 'invalid',
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+			));
+		},
+		'Strategy Review accepted an invalid nonce.'
+	);
+
+	wp_set_current_user($transport_subscriber_id);
+	$subscriber_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+	wcos_strategy_transport_expect(
+		'authorization_failed',
+		403,
+		static function() use ($transport_controller, $transport_order_id, $subscriber_nonce) {
+			$transport_controller->review_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $subscriber_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+			));
+		},
+		'Strategy Review accepted an unauthorized user.'
+	);
+
+	wp_set_current_user($transport_admin_id);
+	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+	$review_response = $transport_controller->review_request(array(
+		'order_id' => $transport_order_id,
+		'nonce' => $transport_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+	));
+	wcos_p2_adapter_assert(!empty($review_response['review_id']) && !empty($review_response['review_token']), 'Strategy Review did not create opaque server authority.');
+	wcos_p2_adapter_assert(!empty($review_response['review']['supported']), 'Strategy Review response is not supported.');
+	wcos_p2_adapter_assert(false === strpos(wp_json_encode($review_response), 'strategy-transport-private@example.test'), 'Strategy Review transport leaked billing PII.');
+
+	$keep_bucket = 'category-' . absint($transport_keep_term['term_id']);
+	wcos_strategy_transport_expect(
+		'review_invalid_token',
+		403,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $review_response, $keep_bucket) {
+			$transport_controller->confirm_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+				'review_id' => $review_response['review_id'],
+				'review_token' => 'invalid',
+				'source_bucket_key' => $keep_bucket,
+			));
+		},
+		'Strategy Confirm accepted an invalid server Review token.'
+	);
+
+	wp_set_current_user($transport_other_admin_id);
+	$other_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+	wcos_strategy_transport_expect(
+		'review_owner_mismatch',
+		403,
+		static function() use ($transport_controller, $transport_order_id, $other_nonce, $review_response, $keep_bucket) {
+			$transport_controller->confirm_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $other_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+				'review_id' => $review_response['review_id'],
+				'review_token' => $review_response['review_token'],
+				'source_bucket_key' => $keep_bucket,
+			));
+		},
+		'Strategy Confirm accepted another user\'s Review authority.'
+	);
+
+	wp_set_current_user($transport_admin_id);
+	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+	$transport_order = wc_get_order($transport_order_id);
+	$transport_order->set_customer_note('transport-review-became-stale');
+	$transport_order->save();
+	wcos_strategy_transport_expect(
+		'review_source_changed',
+		409,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $review_response, $keep_bucket) {
+			$transport_controller->confirm_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+				'review_id' => $review_response['review_id'],
+				'review_token' => $review_response['review_token'],
+				'source_bucket_key' => $keep_bucket,
+			));
+		},
+		'Strategy Confirm accepted a Review after source-order change.'
+	);
+	WCOS_Split_Strategy_Review_Store::delete($review_response['review_id']);
+
+	$review_response = $transport_controller->review_request(array(
+		'order_id' => $transport_order_id,
+		'nonce' => $transport_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+	));
+	$confirm_response = $transport_controller->confirm_request(array(
+		'order_id' => $transport_order_id,
+		'nonce' => $transport_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'review_id' => $review_response['review_id'],
+		'review_token' => $review_response['review_token'],
+		'source_bucket_key' => $keep_bucket,
+	));
+	wcos_p2_adapter_assert(!empty($confirm_response['operation_id']) && !empty($confirm_response['confirmation_token']), 'Strategy Confirm did not create operation authority.');
+	wcos_p2_adapter_assert(false === strpos(wp_json_encode($confirm_response), 'classification_fingerprint'), 'Strategy Confirm exposed internal classification authority to the client.');
+
+	wcos_strategy_transport_expect(
+		'review_expired',
+		410,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $review_response, $keep_bucket) {
+			$transport_controller->confirm_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+				'review_id' => $review_response['review_id'],
+				'review_token' => $review_response['review_token'],
+				'source_bucket_key' => $keep_bucket,
+			));
+		},
+		'Consumed server Review authority was reusable.'
+	);
+
+	wcos_strategy_transport_expect(
+		'confirmation_invalid_token',
+		403,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $confirm_response) {
+			$transport_controller->execute_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+				'operation_id' => $confirm_response['operation_id'],
+				'confirmation_token' => 'invalid',
+			));
+		},
+		'Strategy Execute accepted an invalid confirmation token.'
+	);
+	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($transport_order_id), $confirm_response['operation_id']), 'Invalid transport confirmation created a mutation journal.');
+
+	/* Execute must use only frozen server authority, not current catalog classification. */
+	wp_set_object_terms($transport_move->get_id(), array(absint($transport_keep_term['term_id'])), 'product_cat');
+	$execute_response = $transport_controller->execute_request(array(
+		'order_id' => $transport_order_id,
+		'nonce' => $transport_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'operation_id' => $confirm_response['operation_id'],
+		'confirmation_token' => $confirm_response['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $execute_response['status'] && 1 === count($execute_response['children']), 'Confirmed strategy transport did not complete exactly one child.');
+	$transport_child_id = absint($execute_response['children'][0]['id']);
+	$transport_order = wc_get_order($transport_order_id);
+	wcos_p2_adapter_assert($transport_order->get_item($transport_keep_item) instanceof WC_Order_Item_Product, 'Strategy transport removed the selected source bucket.');
+	wcos_p2_adapter_assert(!$transport_order->get_item($transport_move_item), 'Strategy transport did not execute the frozen moved line.');
+	$transport_journal = WCOS_Operation_Journal::get($transport_order, $confirm_response['operation_id']);
+	wcos_p2_adapter_assert(is_array($transport_journal) && 'completed' === $transport_journal['status'], 'Strategy transport did not complete its durable journal.');
+	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $transport_journal['context']['strategy_authority']['strategy'], 'Strategy transport journal lost semantic Category authority.');
+
+	WCOS_Split_Strategy_Confirmation_Store::delete($confirm_response['operation_id']);
+	$retry_response = $transport_controller->execute_request(array(
+		'order_id' => $transport_order_id,
+		'nonce' => $transport_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'operation_id' => $confirm_response['operation_id'],
+		'confirmation_token' => '',
+	));
+	wcos_p2_adapter_assert(1 === count($retry_response['children']) && $transport_child_id === absint($retry_response['children'][0]['id']), 'Strategy transport durable replay created a different child.');
+	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($transport_order_id, $confirm_response['operation_id'])), 'Strategy transport replay created duplicate children.');
+} finally {
+	$strategy_states_property->setValue(null, $release_strategy_states);
+	wp_set_current_user($transport_previous_user);
+	update_option('order_splitter_status_allowed', $transport_allowed_statuses);
+	update_option('order_splitter_shop_manager_permission', $transport_manager_permission);
+
+	if (isset($confirm_response['operation_id'])) {
+		WCOS_Split_Strategy_Confirmation_Store::delete($confirm_response['operation_id']);
+	}
+	if (isset($review_response['review_id'])) {
+		WCOS_Split_Strategy_Review_Store::delete($review_response['review_id']);
+	}
+	if (isset($transport_order_id)) {
+		$cleanup_order = wc_get_order($transport_order_id);
+		if ($cleanup_order instanceof WC_Order && isset($confirm_response['operation_id'])) {
+			wcos_p2_adapter_cleanup($transport_order_id, $confirm_response['operation_id']);
+		} elseif ($cleanup_order instanceof WC_Order) {
+			$cleanup_order->delete(true);
+		}
+	}
+	if ($transport_keep instanceof WC_Product) {
+		wp_delete_post($transport_keep->get_id(), true);
+	}
+	if ($transport_move instanceof WC_Product) {
+		wp_delete_post($transport_move->get_id(), true);
+	}
+	if (!is_wp_error($transport_keep_term)) {
+		wp_delete_term(absint($transport_keep_term['term_id']), 'product_cat');
+	}
+	if (!is_wp_error($transport_move_term)) {
+		wp_delete_term(absint($transport_move_term['term_id']), 'product_cat');
+	}
+	if (function_exists('wp_delete_user')) {
+		wp_delete_user($transport_admin_id);
+		wp_delete_user($transport_other_admin_id);
+		wp_delete_user($transport_subscriber_id);
+	}
+}
+
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate was not restored after transport acceptance.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy gate was not restored after transport acceptance.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX route was registered after transport acceptance.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX route was registered after transport acceptance.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX route was registered after transport acceptance.');
+
+echo "p2-strategy-transport-hard-off-ok\n";

--- a/tests/integration/p2-strategy-transport-smoke.php
+++ b/tests/integration/p2-strategy-transport-smoke.php
@@ -66,35 +66,53 @@ $transport_order->calculate_totals(false);
 $transport_order->set_billing_email('strategy-transport-private@example.test');
 $transport_order->save();
 $transport_order_id = $transport_order->get_id();
-$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
+
+$stock_keep = wcos_p2_adapter_product('WCOS Transport Stock Keep', '8.00');
+$stock_move = wcos_p2_adapter_product('WCOS Transport Stock Move', '6.00');
+$stock_keep->set_stock_status('instock');
+$stock_keep->save();
+$stock_move->set_stock_status('outofstock');
+$stock_move->save();
+$stock_order = wc_create_order();
+$stock_order->set_status('pending');
+$stock_order->set_currency('USD');
+$stock_keep_item = $stock_order->add_product($stock_keep, 1);
+$stock_move_item = $stock_order->add_product($stock_move, 2);
+$stock_order->calculate_totals(false);
+$stock_order->save();
+$stock_order_id = $stock_order->get_id();
 
 $strategy_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
 $strategy_states_property = $strategy_reflection->getProperty('states');
 $strategy_states_property->setAccessible(true);
 $release_strategy_states = $strategy_states_property->getValue();
 
-enable_strategy_transport_test:
 try {
 	update_option('order_splitter_status_allowed', array('wc-pending'));
 	update_option('order_splitter_shop_manager_permission', 'no');
 	wp_set_current_user($transport_admin_id);
+	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
 
-	/* Real release state blocks direct controller use before nonce/order mutation. */
-	wcos_strategy_transport_expect(
-		'strategy_disabled',
-		503,
-		static function() use ($transport_controller, $transport_order_id, $transport_nonce) {
-			$transport_controller->review_request(array(
-				'order_id' => $transport_order_id,
-				'nonce' => $transport_nonce,
-				'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
-			));
-		},
-		'Hard-off Category transport was directly usable.'
-	);
+	/* Real release state blocks both future strategies before any transport write. */
+	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $hard_off_strategy) {
+		wcos_strategy_transport_expect(
+			'strategy_disabled',
+			503,
+			static function() use ($transport_controller, $transport_order_id, $transport_nonce, $hard_off_strategy) {
+				$transport_controller->review_request(array(
+					'order_id' => $transport_order_id,
+					'nonce' => $transport_nonce,
+					'strategy' => $hard_off_strategy,
+				));
+			},
+			'Hard-off strategy transport was directly usable: ' . $hard_off_strategy
+		);
+	}
 
+	/* Test-only scope exercises the future transport contract without changing source gates. */
 	$test_strategy_states = $release_strategy_states;
 	$test_strategy_states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
+	$test_strategy_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
 	$strategy_states_property->setValue(null, $test_strategy_states);
 
 	wcos_strategy_transport_expect(
@@ -171,11 +189,13 @@ try {
 		'Strategy Confirm accepted another user\'s Review authority.'
 	);
 
+	/* Change source business metadata: included in source_signature, not Category classification. */
 	wp_set_current_user($transport_admin_id);
 	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
 	$transport_order = wc_get_order($transport_order_id);
-	$transport_order->set_customer_note('transport-review-became-stale');
-	$transport_order->save();
+	$stale_item = $transport_order->get_item($transport_keep_item);
+	$stale_item->update_meta_data('transport_review_revision', 'changed-after-review');
+	$stale_item->save();
 	wcos_strategy_transport_expect(
 		'review_source_changed',
 		409,
@@ -205,8 +225,11 @@ try {
 		'review_id' => $review_response['review_id'],
 		'review_token' => $review_response['review_token'],
 		'source_bucket_key' => $keep_bucket,
+		/* Client-supplied review evidence must be ignored. */
+		'review' => array('strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS, 'supported' => true),
 	));
 	wcos_p2_adapter_assert(!empty($confirm_response['operation_id']) && !empty($confirm_response['confirmation_token']), 'Strategy Confirm did not create operation authority.');
+	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $confirm_response['strategy'], 'Client-supplied Review payload changed server confirmation strategy.');
 	wcos_p2_adapter_assert(false === strpos(wp_json_encode($confirm_response), 'classification_fingerprint'), 'Strategy Confirm exposed internal classification authority to the client.');
 
 	wcos_strategy_transport_expect(
@@ -241,7 +264,7 @@ try {
 	);
 	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get(wc_get_order($transport_order_id), $confirm_response['operation_id']), 'Invalid transport confirmation created a mutation journal.');
 
-	/* Execute must use only frozen server authority, not current catalog classification. */
+	/* Execute consumes frozen Category authority, not live taxonomy. */
 	wp_set_object_terms($transport_move->get_id(), array(absint($transport_keep_term['term_id'])), 'product_cat');
 	$execute_response = $transport_controller->execute_request(array(
 		'order_id' => $transport_order_id,
@@ -250,14 +273,14 @@ try {
 		'operation_id' => $confirm_response['operation_id'],
 		'confirmation_token' => $confirm_response['confirmation_token'],
 	));
-	wcos_p2_adapter_assert('completed' === $execute_response['status'] && 1 === count($execute_response['children']), 'Confirmed strategy transport did not complete exactly one child.');
+	wcos_p2_adapter_assert('completed' === $execute_response['status'] && 1 === count($execute_response['children']), 'Confirmed Category transport did not complete exactly one child.');
 	$transport_child_id = absint($execute_response['children'][0]['id']);
 	$transport_order = wc_get_order($transport_order_id);
-	wcos_p2_adapter_assert($transport_order->get_item($transport_keep_item) instanceof WC_Order_Item_Product, 'Strategy transport removed the selected source bucket.');
-	wcos_p2_adapter_assert(!$transport_order->get_item($transport_move_item), 'Strategy transport did not execute the frozen moved line.');
+	wcos_p2_adapter_assert($transport_order->get_item($transport_keep_item) instanceof WC_Order_Item_Product, 'Category transport removed the selected source bucket.');
+	wcos_p2_adapter_assert(!$transport_order->get_item($transport_move_item), 'Category transport did not execute the frozen moved line.');
 	$transport_journal = WCOS_Operation_Journal::get($transport_order, $confirm_response['operation_id']);
-	wcos_p2_adapter_assert(is_array($transport_journal) && 'completed' === $transport_journal['status'], 'Strategy transport did not complete its durable journal.');
-	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $transport_journal['context']['strategy_authority']['strategy'], 'Strategy transport journal lost semantic Category authority.');
+	wcos_p2_adapter_assert(is_array($transport_journal) && 'completed' === $transport_journal['status'], 'Category transport did not complete its durable journal.');
+	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $transport_journal['context']['strategy_authority']['strategy'], 'Category transport journal lost semantic strategy authority.');
 
 	WCOS_Split_Strategy_Confirmation_Store::delete($confirm_response['operation_id']);
 	$retry_response = $transport_controller->execute_request(array(
@@ -267,8 +290,58 @@ try {
 		'operation_id' => $confirm_response['operation_id'],
 		'confirmation_token' => '',
 	));
-	wcos_p2_adapter_assert(1 === count($retry_response['children']) && $transport_child_id === absint($retry_response['children'][0]['id']), 'Strategy transport durable replay created a different child.');
-	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($transport_order_id, $confirm_response['operation_id'])), 'Strategy transport replay created duplicate children.');
+	wcos_p2_adapter_assert(1 === count($retry_response['children']) && $transport_child_id === absint($retry_response['children'][0]['id']), 'Category transport durable replay created a different child.');
+	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($transport_order_id, $confirm_response['operation_id'])), 'Category transport replay created duplicate children.');
+
+	wcos_strategy_transport_expect(
+		'confirmation_strategy_mismatch',
+		409,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $confirm_response) {
+			$transport_controller->execute_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+				'operation_id' => $confirm_response['operation_id'],
+				'confirmation_token' => '',
+			));
+		},
+		'Durable Category operation was replayable as Stock-status.'
+	);
+
+	/* Stock-status goes through the same Review -> Confirm -> Execute transport. */
+	$stock_nonce = wp_create_nonce('wcos_split_strategy_order_' . $stock_order_id);
+	$stock_review_response = $transport_controller->review_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+	));
+	wcos_p2_adapter_assert(isset($stock_review_response['review']['buckets']['stock-instock']), 'Stock-status transport Review omitted in-stock bucket.');
+	wcos_p2_adapter_assert(isset($stock_review_response['review']['buckets']['stock-outofstock']), 'Stock-status transport Review omitted out-of-stock bucket.');
+	$stock_confirm_response = $transport_controller->confirm_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+		'review_id' => $stock_review_response['review_id'],
+		'review_token' => $stock_review_response['review_token'],
+		'source_bucket_key' => 'stock-instock',
+	));
+
+	$stock_move = wc_get_product($stock_move->get_id());
+	$stock_move->set_stock_status('instock');
+	$stock_move->save();
+	$stock_execute_response = $transport_controller->execute_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+		'operation_id' => $stock_confirm_response['operation_id'],
+		'confirmation_token' => $stock_confirm_response['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $stock_execute_response['status'] && 1 === count($stock_execute_response['children']), 'Confirmed Stock-status transport did not complete exactly one child.');
+	$stock_source = wc_get_order($stock_order_id);
+	wcos_p2_adapter_assert($stock_source->get_item($stock_keep_item) instanceof WC_Order_Item_Product, 'Stock-status transport removed the selected source bucket.');
+	wcos_p2_adapter_assert(!$stock_source->get_item($stock_move_item), 'Stock-status transport reclassified live status instead of executing frozen authority.');
+	$stock_journal = WCOS_Operation_Journal::get($stock_source, $stock_confirm_response['operation_id']);
+	wcos_p2_adapter_assert(is_array($stock_journal) && WCOS_Split_Strategy_Gates::STOCK_STATUS === $stock_journal['context']['strategy_authority']['strategy'], 'Stock-status transport journal lost semantic strategy authority.');
 } finally {
 	$strategy_states_property->setValue(null, $release_strategy_states);
 	wp_set_current_user($transport_previous_user);
@@ -278,8 +351,14 @@ try {
 	if (isset($confirm_response['operation_id'])) {
 		WCOS_Split_Strategy_Confirmation_Store::delete($confirm_response['operation_id']);
 	}
+	if (isset($stock_confirm_response['operation_id'])) {
+		WCOS_Split_Strategy_Confirmation_Store::delete($stock_confirm_response['operation_id']);
+	}
 	if (isset($review_response['review_id'])) {
 		WCOS_Split_Strategy_Review_Store::delete($review_response['review_id']);
+	}
+	if (isset($stock_review_response['review_id'])) {
+		WCOS_Split_Strategy_Review_Store::delete($stock_review_response['review_id']);
 	}
 	if (isset($transport_order_id)) {
 		$cleanup_order = wc_get_order($transport_order_id);
@@ -289,11 +368,25 @@ try {
 			$cleanup_order->delete(true);
 		}
 	}
+	if (isset($stock_order_id)) {
+		$cleanup_stock_order = wc_get_order($stock_order_id);
+		if ($cleanup_stock_order instanceof WC_Order && isset($stock_confirm_response['operation_id'])) {
+			wcos_p2_adapter_cleanup($stock_order_id, $stock_confirm_response['operation_id']);
+		} elseif ($cleanup_stock_order instanceof WC_Order) {
+			$cleanup_stock_order->delete(true);
+		}
+	}
 	if ($transport_keep instanceof WC_Product) {
 		wp_delete_post($transport_keep->get_id(), true);
 	}
 	if ($transport_move instanceof WC_Product) {
 		wp_delete_post($transport_move->get_id(), true);
+	}
+	if ($stock_keep instanceof WC_Product) {
+		wp_delete_post($stock_keep->get_id(), true);
+	}
+	if ($stock_move instanceof WC_Product) {
+		wp_delete_post($stock_move->get_id(), true);
 	}
 	if (!is_wp_error($transport_keep_term)) {
 		wp_delete_term(absint($transport_keep_term['term_id']), 'product_cat');

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -91,3 +91,4 @@ require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
 require __DIR__ . '/p2-strategy-planners-smoke.php';
 require __DIR__ . '/p2-strategy-adapter-smoke.php';
 require __DIR__ . '/p2-strategy-confirmation-smoke.php';
+require __DIR__ . '/p2-strategy-transport-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_TRANSPORT_FOUNDATION`

## Mission

Establish the server-side Review -> Confirm -> Execute transport contract for future Category and Stock-status Split while keeping both production strategy gates hard-off and registering no production route or UI.

## Production boundary

Mutation gates remain unchanged:

- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Split strategy gates remain:

- `manual_quantity = true`
- `category = false`
- `stock_status = false`

`WCOS_Split_Strategy_Admin_Controller` is loaded as a class definition only. It registers no WordPress hooks and is not instantiated by bootstrap. No strategy AJAX route, launcher, dialog, JavaScript, option, filter, or production write surface is added.

## Server transport chain

Future production transport is constrained to:

`Review request -> server Review Store -> Confirm request -> strategy Confirmation Store -> Execute request -> WCOS_Mutation_Gateway -> strategy adapter -> hardened Split adapter/service`

Every controller method enforces global Split gate, exact strategy gate, order nonce, centralized authorization, and configured source-order status policy.

## Server-side Review authority

A new `WCOS_Split_Strategy_Review_Store` keeps planner Review authority server-side. Clients receive an opaque `review_id` / `review_token` plus PII-free display data, but Confirm reloads the server record and never trusts a client-supplied Review payload.

Review authority is single-use. If two Confirm requests race after both verifying the same Review, only the request that successfully consumes the Review may retain/return its candidate confirmation; the losing request deletes its unexposed confirmation and fails closed.

## Confirmation / Execute authority

Confirm hands only the authoritative server Review to the accepted strategy confirmation foundation. Execute accepts operation ID + token, verifies server confirmation, requires semantic strategy equality, then enters `WCOS_Mutation_Gateway::split_strategy()`.

Client-supplied plan, classification fingerprint, planner evidence, execution policy, price precision, or strategy authority are never Execute authority.

## TOCTOU and frozen classification

Review Store creation/verification and strategy confirmation verification all bind the PII-free source signature. The canonical TOCTOU fixture mutates public line-item business metadata between Review and Confirm; that metadata participates in `source_signature` while leaving Category classification unchanged.

Live taxonomy / stock-status changes after Confirm do not rewrite the frozen plan. Execute never reruns a planner.

## Acceptance

Canonical integration acceptance is connected to the existing whole-line chain and exercises:

- no strategy `wp_ajax_*` hooks before/after controller instantiation;
- both strategy gates hard-off in real release state;
- nonce and authorization boundaries under a test-only temporary gate scope;
- PII-free Review output;
- client-supplied Review payload ignored by Confirm;
- Review token/user/source ownership;
- Review -> Confirm source-change TOCTOU;
- single-use Review authority;
- invalid confirmation rejected before journal creation;
- Category frozen taxonomy execution + durable replay without duplicate child;
- durable Category operation rejected as Stock-status;
- Stock-status frozen-status execution after live status change;
- exact restoration of release strategy gates and absence of routes after test;
- all existing Split/Duplicate/whole-line/recovery/stock/tax/concurrency regressions.

## Merge classification

Foundation only. Category and Stock-status remain unavailable to users after merge. Production route/UI registration, production-enabled E2E, accessibility acceptance, exact strategy enablement, Human Gate, and sandbox candidate packaging remain separate milestones.