### PR TITLE
P2: add Split strategy UI readiness

### DIFF
--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -1,0 +1,169 @@
+body.wcos-strategy-modal-open {
+    overflow: hidden;
+}
+
+.wcos-strategy-launcher-description {
+    margin: 0 12px 0 6px;
+}
+
+.wcos-strategy-dialog[hidden] {
+    display: none;
+}
+
+.wcos-strategy-dialog {
+    position: fixed;
+    inset: 0;
+    z-index: 100001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.wcos-strategy-dialog__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.wcos-strategy-dialog__panel {
+    position: relative;
+    width: min(760px, 100%);
+    max-height: calc(100vh - 48px);
+    overflow: auto;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    padding: 24px;
+}
+
+.wcos-strategy-dialog__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+}
+
+.wcos-strategy-dialog__header h2 {
+    margin-top: 0;
+}
+
+.wcos-strategy-close {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 28px;
+    line-height: 1;
+}
+
+.wcos-strategy-policy {
+    margin-top: 16px;
+    padding: 12px 16px;
+    border-left: 4px solid #646970;
+    background: #f6f7f7;
+}
+
+.wcos-strategy-policy h3,
+.wcos-strategy-review h3,
+.wcos-strategy-confirmation h3 {
+    margin-top: 0;
+}
+
+.wcos-strategy-review-controls,
+.wcos-strategy-review,
+.wcos-strategy-confirmation,
+.wcos-strategy-status,
+.wcos-strategy-error,
+.wcos-strategy-result {
+    margin-top: 16px;
+}
+
+.wcos-strategy-buckets {
+    margin: 16px 0;
+    padding: 0;
+    border: 0;
+}
+
+.wcos-strategy-buckets legend {
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+
+.wcos-strategy-bucket-options {
+    display: grid;
+    gap: 8px;
+}
+
+.wcos-strategy-bucket-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+}
+
+.wcos-strategy-bucket-option:focus-within {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+}
+
+.wcos-strategy-bucket-option input[type="radio"] {
+    margin-top: 3px;
+}
+
+.wcos-strategy-bucket-content {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.wcos-strategy-confirm-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin: 12px 0;
+    font-weight: 600;
+}
+
+.wcos-strategy-error,
+.wcos-strategy-result {
+    padding: 10px 12px;
+}
+
+.wcos-strategy-result ul {
+    margin-left: 20px;
+}
+
+.wcos-strategy-dialog__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #dcdcde;
+}
+
+@media (max-width: 782px) {
+    .wcos-strategy-dialog {
+        padding: 12px;
+    }
+
+    .wcos-strategy-dialog__panel {
+        max-height: calc(100vh - 24px);
+        padding: 16px;
+    }
+
+    .wcos-strategy-dialog__actions {
+        flex-direction: column-reverse;
+    }
+
+    .wcos-strategy-dialog__actions .button,
+    .wcos-strategy-review-controls .button,
+    .wcos-strategy-review .button,
+    .wcos-strategy-confirmation .button {
+        width: 100%;
+        min-height: 44px;
+    }
+}

--- a/docs/p2-split-strategy-ui-readiness.md
+++ b/docs/p2-split-strategy-ui-readiness.md
@@ -1,0 +1,132 @@
+# P2 Split strategy UI readiness
+
+## Classification
+
+`P2_SPLIT_STRATEGY_UI_READINESS`
+
+This milestone adds the gate-aware admin routes and accessible Review -> source-bucket selection -> Confirm -> Execute UI required for future Category and Stock-status Split. It does not change either strategy gate.
+
+## Production state
+
+Mutation gates remain:
+
+- `SPLIT = true`
+- `DUPLICATE = true`
+- `MERGE = false`
+- `RETURN_ORDER = false`
+- `BULK_RETURN = false`
+
+Split strategy gates remain:
+
+- `manual_quantity = true`
+- `category = false`
+- `stock_status = false`
+
+With this exact state, `WCOS_Split_Strategy_Admin_Controller::bootstrap()` returns without registering strategy AJAX routes, launchers, dialogs, scripts, or styles.
+
+## Gate-aware bootstrap
+
+The plugin loads the strategy controller class and calls `bootstrap()` on every request. Hooks are registered only when:
+
+1. the global hardened Split workflow is enabled; and
+2. at least one of `category` or `stock_status` is enabled.
+
+Every Review, Confirm, and Execute request then rechecks the global gate, exact strategy gate, nonce, centralized authorization, and configured order-status policy. Hook registration is therefore not mutation authority.
+
+This architecture lets a later sandbox/production candidate enable a strategy by changing the internal strategy gate without introducing a second bootstrap path.
+
+## Admin launchers
+
+For each enabled strategy, authorized supported order screens receive a separate action:
+
+- **Split by category**;
+- **Split by stock status**.
+
+Each launcher is bound to a dedicated dialog through `aria-controls` and `aria-haspopup="dialog"`.
+
+## Server-authoritative UI flow
+
+The browser never authors a Split quantity plan.
+
+The flow is:
+
+1. **Review current buckets** — server planner classifies the current order and stores Review authority server-side;
+2. **Choose one source bucket** — the browser submits only the opaque Review ID/token and selected bucket key;
+3. **Confirm selected source bucket** — server Confirmation Store freezes the resulting explicit plan and semantic authority;
+4. **Acknowledge** the full-line movement policy;
+5. **Execute strategy Split** — browser submits only order/strategy/operation/token; server verification reconstructs all mutation authority.
+
+Client requests never send `classification_fingerprint`, execution policy, price precision, planner evidence, or a client-authored mutation plan.
+
+## Frozen classification UX
+
+The Review display lists each server bucket with:
+
+- server-provided label;
+- product-line count;
+- total reviewed quantity.
+
+The operator chooses exactly one bucket to remain on source. Every other reviewed bucket becomes one pending child order and its lines move completely.
+
+After Confirm, bucket selection is frozen. Category or Stock-status changes in the live catalog do not rewrite the already confirmed plan.
+
+## Accessibility
+
+Each strategy dialog provides:
+
+- `role="dialog"` and `aria-modal="true"`;
+- `aria-labelledby` / `aria-describedby`;
+- semantic `fieldset` / `legend` for source-bucket selection;
+- live status region with `role="status"` and `aria-live="polite"`;
+- focusable `role="alert"` error region;
+- explicit execution acknowledgement;
+- keyboard focus trap;
+- Escape close while not busy;
+- focus return to the launcher;
+- result focus after successful execution;
+- responsive controls with 44px mobile targets.
+
+Server-provided labels and results are rendered with DOM `textContent` / `createElement`; the client does not use `innerHTML` or blocking `window.alert()`.
+
+## Client-state safety
+
+The client maintains separate Review and Confirmation state.
+
+- async Review/Confirm/Execute requests freeze relevant controls;
+- selecting another bucket invalidates any pre-existing confirmation state;
+- successful Confirm consumes Review authority and locks bucket selection;
+- non-retryable Confirm errors require a new Review;
+- successful Execute enters a terminal state and cannot be re-enabled by `finally` cleanup;
+- non-retryable Execute errors discard confirmation state and require a new Review/Confirm sequence;
+- completed durable replay remains server-owned through the existing journal authority.
+
+## Acceptance
+
+Canonical acceptance runs under the real hard-off release state, then temporarily enables both strategy gates with test-only Reflection and restores them in `finally`.
+
+It proves:
+
+- real release bootstrap registers no strategy routes;
+- test-only enabled bootstrap registers Review/Confirm/Execute and order-screen hooks;
+- both Category and Stock-status launchers are rendered;
+- launcher/dialog ARIA relationships are correct;
+- dialog bucket selection is semantic and accessible;
+- live status, alert, acknowledgement, and result regions exist;
+- client code has busy/completed terminal state, focus trap, Escape and focus return;
+- server display data is rendered without `innerHTML`/`alert()`;
+- client code does not construct/send a mutation plan or classification fingerprint;
+- responsive admin styles are packaged;
+- hooks and exact release strategy gates are restored after test scope;
+- the previously accepted server transport E2E remains green across legacy, HPOS-only, and HPOS compatibility/sync storage.
+
+## Remaining sandbox-candidate work
+
+After this foundation is accepted, sandbox readiness requires a narrow candidate/enablement milestone that:
+
+1. proves a real two-worker Confirm race has only one successful confirmation authority;
+2. changes the intended sandbox strategy gates to `true` on the candidate build;
+3. runs production-enabled route/UI E2E under the real candidate gate state rather than Reflection;
+4. validates the distributable ZIP contains all planner/confirmation/transport/UI assets and no legacy mutation path;
+5. passes independent final technical/security/accessibility review.
+
+That candidate can be installed on the sandbox for hands-on testing before any production release Human Gate is granted.

--- a/inc/backend/class-wcos-split-strategy-admin-controller.php
+++ b/inc/backend/class-wcos-split-strategy-admin-controller.php
@@ -3,18 +3,63 @@
 defined('ABSPATH') || exit;
 
 /**
- * Hard-off admin transport contract for future Category/Stock-status Split.
+ * Gate-aware admin transport/UI for Category and Stock-status Split.
  *
- * This class intentionally registers no WordPress hooks. A later production
- * enablement milestone may register strategy-specific routes only after its
- * exact gate, UI, accessibility, and Human Gate acceptance. Direct method calls
- * still enforce strategy gate, nonce, authorization, order-status policy, and
- * server-side Review/Confirmation authority.
+ * The class may be loaded in every build, but bootstrap() registers hooks only
+ * while the global Split workflow and at least one server-built strategy are
+ * enabled. Request methods retain their own gate/nonce/authorization checks, so
+ * route registration is never mutation authority by itself.
  */
 final class WCOS_Split_Strategy_Admin_Controller {
 	const REVIEW_ACTION = 'wcos_split_strategy_review';
 	const CONFIRM_ACTION = 'wcos_split_strategy_confirm';
 	const EXECUTE_ACTION = 'wcos_split_strategy_execute';
+
+	private static $instance = null;
+	private $registered = false;
+	private $current_order = null;
+
+	public static function bootstrap() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)
+			|| (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)
+				&& !WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS))) {
+			return null;
+		}
+		if (!self::$instance instanceof self) {
+			self::$instance = new self();
+		}
+		self::$instance->register_hooks();
+		return self::$instance;
+	}
+
+	public function register_hooks() {
+		if ($this->registered
+			|| !WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)
+			|| (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)
+				&& !WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS))) {
+			return false;
+		}
+		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 30, 1);
+		add_action('admin_footer', array($this, 'render_dialogs'));
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+		$this->registered = true;
+		return true;
+	}
+
+	public function unregister_hooks() {
+		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		remove_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 30);
+		remove_action('admin_footer', array($this, 'render_dialogs'));
+		remove_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+		$this->registered = false;
+		$this->current_order = null;
+		return true;
+	}
 
 	public function review_request(array $request) {
 		$strategy = $this->strategy_from_request($request);
@@ -99,10 +144,9 @@ final class WCOS_Split_Strategy_Admin_Controller {
 		}
 
 		/*
-		 * The server-side Review is single-use confirmation authority. Two
-		 * concurrent Confirm requests may both pass verify(), but only the request
-		 * that consumes the Review may keep and return its new confirmation. The
-		 * loser deletes its unexposed confirmation token and fails closed.
+		 * Review is single-use authority. If another Confirm request consumed it
+		 * after our verify() but before this delete, discard the unexposed candidate
+		 * confirmation so one Review cannot yield two usable operations.
 		 */
 		if (!WCOS_Split_Strategy_Review_Store::consume($review_id)) {
 			WCOS_Split_Strategy_Confirmation_Store::delete($confirmation['operation_id']);
@@ -217,6 +261,152 @@ final class WCOS_Split_Strategy_Admin_Controller {
 		);
 	}
 
+	public function ajax_review() {
+		$this->send_ajax_request('review_request');
+	}
+
+	public function ajax_confirm() {
+		$this->send_ajax_request('confirm_request');
+	}
+
+	public function ajax_execute() {
+		$this->send_ajax_request('execute_request');
+	}
+
+	public function render_launcher($order) {
+		if (!$order instanceof WC_Order || !WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) {
+			return;
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
+			$this->assert_status_enabled($order);
+			$preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($order);
+			if (empty($preflight['supported'])) {
+				return;
+			}
+		} catch (Throwable $throwable) {
+			return;
+		}
+
+		$this->current_order = $order;
+		foreach ($this->enabled_strategies() as $strategy) {
+			$dialog_id = $this->dialog_id($order->get_id(), $strategy);
+			$description_id = $dialog_id . '-launcher-description';
+			echo '<button type="button" class="button wcos-strategy-launcher" data-strategy="' . esc_attr($strategy) . '" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '">';
+			echo esc_html($this->launcher_label($strategy));
+			echo '</button>';
+			echo '<span id="' . esc_attr($description_id) . '" class="description wcos-strategy-launcher-description">';
+			echo esc_html($this->launcher_description($strategy));
+			echo '</span>';
+		}
+	}
+
+	public function render_dialogs() {
+		if (!$this->current_order instanceof WC_Order) {
+			return;
+		}
+		foreach ($this->enabled_strategies() as $strategy) {
+			echo $this->dialog_html($this->current_order, $strategy); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	}
+
+	public function enqueue_assets() {
+		if (empty($this->enabled_strategies()) || !$this->is_order_edit_screen()) {
+			return;
+		}
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_style('wcos-split-strategy-admin', plugins_url('css/p2-split-strategy-admin.css', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION);
+		wp_enqueue_script('wcos-split-strategy-admin', plugins_url('js/p2-split-strategy-admin.js', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION, true);
+		wp_localize_script(
+			'wcos-split-strategy-admin',
+			'wcosSplitStrategyStrings',
+			array(
+				'reviewing' => __('Reviewing current strategy buckets…', 'wc-order-splitter'),
+				'reviewReady' => __('Choose the one bucket that must remain on the source order.', 'wc-order-splitter'),
+				'confirming' => __('Confirming the frozen strategy plan…', 'wc-order-splitter'),
+				'confirmationReady' => __('The plan is frozen. Acknowledge the policy and execute when ready.', 'wc-order-splitter'),
+				'executing' => __('Executing strategy Split…', 'wc-order-splitter'),
+				'completed' => __('Strategy Split completed successfully.', 'wc-order-splitter'),
+				'requestFailed' => __('The strategy Split request could not be completed.', 'wc-order-splitter'),
+				'chooseBucket' => __('Choose a source bucket before confirming.', 'wc-order-splitter'),
+				'bucketLines' => __('product lines', 'wc-order-splitter'),
+				'bucketQuantity' => __('total quantity', 'wc-order-splitter'),
+				'childOrder' => __('Child order', 'wc-order-splitter'),
+				'reloadOrder' => __('Reload source order', 'wc-order-splitter'),
+			)
+		);
+	}
+
+	public function dialog_html(WC_Order $order, $strategy) {
+		$strategy = WCOS_Split_Strategy_WooCommerce_Adapter::normalize_strategy($strategy);
+		if (!WCOS_Split_Strategy_Gates::enabled($strategy)) {
+			return '';
+		}
+		$dialog_id = $this->dialog_id($order->get_id(), $strategy);
+		$title_id = $dialog_id . '-title';
+		$description_id = $dialog_id . '-description';
+		$bucket_legend_id = $dialog_id . '-bucket-legend';
+		$ack_id = $dialog_id . '-ack';
+		$nonce = wp_create_nonce('wcos_split_strategy_order_' . $order->get_id());
+
+		ob_start();
+		?>
+		<div id="<?php echo esc_attr($dialog_id); ?>" class="wcos-strategy-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($title_id); ?>" aria-describedby="<?php echo esc_attr($description_id); ?>" data-order-id="<?php echo esc_attr($order->get_id()); ?>" data-strategy="<?php echo esc_attr($strategy); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" data-review-action="<?php echo esc_attr(self::REVIEW_ACTION); ?>" data-confirm-action="<?php echo esc_attr(self::CONFIRM_ACTION); ?>" data-execute-action="<?php echo esc_attr(self::EXECUTE_ACTION); ?>" hidden>
+			<div class="wcos-strategy-dialog__backdrop" aria-hidden="true"></div>
+			<div class="wcos-strategy-dialog__panel" tabindex="-1">
+				<div class="wcos-strategy-dialog__header">
+					<div>
+						<h2 id="<?php echo esc_attr($title_id); ?>"><?php echo esc_html($this->dialog_title($strategy)); ?></h2>
+						<p id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html($this->dialog_description($strategy)); ?></p>
+					</div>
+					<button type="button" class="button-link wcos-strategy-close" aria-label="<?php esc_attr_e('Close strategy Split dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
+				</div>
+
+				<form class="wcos-strategy-form" aria-busy="false" novalidate>
+					<div class="wcos-strategy-policy">
+						<h3><?php esc_html_e('How this Split works', 'wc-order-splitter'); ?></h3>
+						<p><?php esc_html_e('Review the current buckets, then choose exactly one bucket to remain on the source order. Every other reviewed bucket becomes a separate pending child order and its product lines move in full.', 'wc-order-splitter'); ?></p>
+						<p><?php esc_html_e('Shipping, positive fees, payment context, and other source-owned state remain on the source order. Product stock is not physically changed by the Split request.', 'wc-order-splitter'); ?></p>
+					</div>
+
+					<div class="wcos-strategy-review-controls">
+						<button type="button" class="button wcos-strategy-review-button"><?php esc_html_e('Review current buckets', 'wc-order-splitter'); ?></button>
+					</div>
+
+					<section class="wcos-strategy-review" hidden>
+						<h3><?php esc_html_e('Reviewed buckets', 'wc-order-splitter'); ?></h3>
+						<p class="wcos-strategy-review-summary"></p>
+						<fieldset class="wcos-strategy-buckets" aria-labelledby="<?php echo esc_attr($bucket_legend_id); ?>">
+							<legend id="<?php echo esc_attr($bucket_legend_id); ?>"><?php esc_html_e('Choose the bucket to keep on the source order', 'wc-order-splitter'); ?></legend>
+							<div class="wcos-strategy-bucket-options"></div>
+						</fieldset>
+						<button type="button" class="button button-secondary wcos-strategy-confirm-button" disabled><?php esc_html_e('Confirm selected source bucket', 'wc-order-splitter'); ?></button>
+					</section>
+
+					<section class="wcos-strategy-confirmation" hidden>
+						<h3><?php esc_html_e('Confirm execution', 'wc-order-splitter'); ?></h3>
+						<p class="wcos-strategy-confirmation-summary"></p>
+						<label class="wcos-strategy-confirm-label" for="<?php echo esc_attr($ack_id); ?>">
+							<input id="<?php echo esc_attr($ack_id); ?>" type="checkbox" class="wcos-strategy-confirm-checkbox">
+							<span><?php esc_html_e('I understand that every reviewed bucket except the selected source bucket will move to pending child order(s) using the frozen Review state.', 'wc-order-splitter'); ?></span>
+						</label>
+						<button type="button" class="button button-primary wcos-strategy-execute-button" disabled><?php esc_html_e('Execute strategy Split', 'wc-order-splitter'); ?></button>
+					</section>
+
+					<div class="wcos-strategy-status" role="status" aria-live="polite"></div>
+					<div class="notice notice-error wcos-strategy-error" role="alert" tabindex="-1" hidden></div>
+					<div class="notice notice-success wcos-strategy-result" tabindex="-1" hidden></div>
+
+					<div class="wcos-strategy-dialog__actions">
+						<button type="button" class="button wcos-strategy-cancel"><?php esc_html_e('Close', 'wc-order-splitter'); ?></button>
+					</div>
+				</form>
+			</div>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
 	private function strategy_from_request(array $request) {
 		$strategy = isset($request['strategy']) ? sanitize_key((string) $request['strategy']) : '';
 		try {
@@ -228,20 +418,10 @@ final class WCOS_Split_Strategy_Admin_Controller {
 
 	private function assert_strategy_enabled($strategy) {
 		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) {
-			throw new WCOS_Split_Transport_Exception(
-				'workflow_disabled',
-				__('Split is not enabled for production use.', 'wc-order-splitter'),
-				503,
-				false
-			);
+			throw new WCOS_Split_Transport_Exception('workflow_disabled', __('Split is not enabled for production use.', 'wc-order-splitter'), 503, false);
 		}
 		if (!WCOS_Split_Strategy_Gates::enabled($strategy)) {
-			throw new WCOS_Split_Transport_Exception(
-				'strategy_disabled',
-				__('This Split strategy is not enabled for production use.', 'wc-order-splitter'),
-				503,
-				false
-			);
+			throw new WCOS_Split_Transport_Exception('strategy_disabled', __('This Split strategy is not enabled for production use.', 'wc-order-splitter'), 503, false);
 		}
 	}
 
@@ -253,7 +433,6 @@ final class WCOS_Split_Strategy_Admin_Controller {
 		if (!wp_verify_nonce($nonce, 'wcos_split_strategy_order_' . $order_id)) {
 			throw new WCOS_Split_Transport_Exception('invalid_nonce', __('The Split strategy request failed nonce verification.', 'wc-order-splitter'), 403, false);
 		}
-
 		$order = wc_get_order($order_id);
 		if (!$order instanceof WC_Order) {
 			throw new WCOS_Split_Transport_Exception('order_not_found', __('The source order could not be found.', 'wc-order-splitter'), 404, false);
@@ -286,12 +465,7 @@ final class WCOS_Split_Strategy_Admin_Controller {
 			'review_invalid' => 409,
 		);
 		$reason = $exception->get_reason();
-		return new WCOS_Split_Transport_Exception(
-			'review_' . $reason,
-			$exception->getMessage(),
-			isset($statuses[$reason]) ? $statuses[$reason] : 409,
-			false
-		);
+		return new WCOS_Split_Transport_Exception('review_' . $reason, $exception->getMessage(), isset($statuses[$reason]) ? $statuses[$reason] : 409, false);
 	}
 
 	private function confirmation_transport_exception(WCOS_Split_Strategy_Confirmation_Exception $exception) {
@@ -315,11 +489,76 @@ final class WCOS_Split_Strategy_Admin_Controller {
 			'authority_incomplete' => 409,
 		);
 		$reason = $exception->get_reason();
-		return new WCOS_Split_Transport_Exception(
-			'confirmation_' . $reason,
-			$exception->getMessage(),
-			isset($statuses[$reason]) ? $statuses[$reason] : 409,
-			false
+		return new WCOS_Split_Transport_Exception('confirmation_' . $reason, $exception->getMessage(), isset($statuses[$reason]) ? $statuses[$reason] : 409, false);
+	}
+
+	private function send_ajax_request($method) {
+		try {
+			wp_send_json_success($this->{$method}(wp_unslash($_POST)));
+		} catch (WCOS_Split_Transport_Exception $exception) {
+			$this->send_transport_error($exception);
+		} catch (Throwable $throwable) {
+			$this->send_transport_error(new WCOS_Split_Transport_Exception('strategy_transport_failed', __('The strategy Split request could not be completed.', 'wc-order-splitter'), 500, true));
+		}
+	}
+
+	private function send_transport_error(WCOS_Split_Transport_Exception $exception) {
+		wp_send_json_error(
+			array(
+				'code' => $exception->get_error_code(),
+				'message' => $exception->getMessage(),
+				'retryable' => $exception->is_retryable(),
+				'context' => $exception->get_context(),
+			),
+			$exception->get_http_status()
 		);
+	}
+
+	private function enabled_strategies() {
+		$strategies = array();
+		foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $strategy) {
+			if (WCOS_Split_Strategy_Gates::enabled($strategy)) {
+				$strategies[] = $strategy;
+			}
+		}
+		return $strategies;
+	}
+
+	private function dialog_id($order_id, $strategy) {
+		return 'wcos-strategy-dialog-' . absint($order_id) . '-' . sanitize_key($strategy);
+	}
+
+	private function launcher_label($strategy) {
+		return WCOS_Split_Strategy_Gates::CATEGORY === $strategy
+			? __('Split by category', 'wc-order-splitter')
+			: __('Split by stock status', 'wc-order-splitter');
+	}
+
+	private function launcher_description($strategy) {
+		return WCOS_Split_Strategy_Gates::CATEGORY === $strategy
+			? __('Review current product-category buckets before splitting whole product lines.', 'wc-order-splitter')
+			: __('Review current product stock-status buckets before splitting whole product lines.', 'wc-order-splitter');
+	}
+
+	private function dialog_title($strategy) {
+		return WCOS_Split_Strategy_Gates::CATEGORY === $strategy
+			? __('Split order by category', 'wc-order-splitter')
+			: __('Split order by stock status', 'wc-order-splitter');
+	}
+
+	private function dialog_description($strategy) {
+		return WCOS_Split_Strategy_Gates::CATEGORY === $strategy
+			? __('Review the current category classification, choose one category bucket to keep on the source order, then confirm the frozen plan.', 'wc-order-splitter')
+			: __('Review the current stock-status classification, choose one status bucket to keep on the source order, then confirm the frozen plan.', 'wc-order-splitter');
+	}
+
+	private function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
 	}
 }

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -73,6 +73,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'backend/class-wcos-split-admin-controller.php';
 		new WCOS_Split_Admin_Controller();
 		include_once $root . 'backend/class-wcos-split-strategy-admin-controller.php';
+		WCOS_Split_Strategy_Admin_Controller::bootstrap();
 
 		include_once $root . 'backend/class-wcos-duplicate-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-duplicate-admin-controller.php';
@@ -86,9 +87,8 @@ class WC_Order_Splitter_Script {
 		/*
 		 * Legacy mutation handlers are deliberately never loaded here. Hardened
 		 * production transports must enter through WCOS_Mutation_Gateway. Category
-		 * and Stock-status planner/adapter/review/confirmation/controller contracts
-		 * loaded above remain internal; their strategy gates are hard-off and the
-		 * strategy controller is deliberately not instantiated or registered.
+		 * and Stock-status strategy UI/transport hooks are registered only by the
+		 * controller bootstrap when their internal strategy gate is enabled.
 		 */
 	}
 }

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -34,6 +34,17 @@
                 throw error;
             }
             return payload.data || {};
+        }).catch(function (error) {
+            /*
+             * An unclassified fetch/JSON transport failure may happen after the
+             * server accepted Execute. Preserve operation/token state so the
+             * same idempotent operation can be retried. Structured server errors
+             * already carry an explicit retryable boolean and are not changed.
+             */
+            if (typeof error.retryable !== 'boolean') {
+                error.retryable = true;
+            }
+            throw error;
         });
     }
 

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -1,0 +1,405 @@
+(function () {
+    'use strict';
+
+    var strings = window.wcosSplitStrategyStrings || {};
+
+    function text(key, fallback) {
+        return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
+    }
+
+    function request(dialog, action, data) {
+        var body = new URLSearchParams();
+        body.set('action', action);
+        Object.keys(data).forEach(function (key) {
+            body.set(key, String(data[key]));
+        });
+
+        return window.fetch(dialog.getAttribute('data-ajax-url'), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            body: body.toString()
+        }).then(function (response) {
+            return response.json().catch(function () {
+                throw new Error(text('requestFailed', 'The strategy Split request could not be completed.'));
+            });
+        }).then(function (payload) {
+            if (!payload || payload.success !== true) {
+                var failure = payload && payload.data ? payload.data : {};
+                var error = new Error(failure.message || text('requestFailed', 'The strategy Split request could not be completed.'));
+                error.code = failure.code || 'request_failed';
+                error.retryable = !!failure.retryable;
+                throw error;
+            }
+            return payload.data || {};
+        });
+    }
+
+    function setupLauncher(launcher) {
+        var dialogId = launcher.getAttribute('aria-controls');
+        var dialog = dialogId ? document.getElementById(dialogId) : null;
+        if (!dialog) {
+            return;
+        }
+
+        var panel = dialog.querySelector('.wcos-strategy-dialog__panel');
+        var form = dialog.querySelector('.wcos-strategy-form');
+        var closeButton = dialog.querySelector('.wcos-strategy-close');
+        var cancelButton = dialog.querySelector('.wcos-strategy-cancel');
+        var reviewButton = dialog.querySelector('.wcos-strategy-review-button');
+        var reviewSection = dialog.querySelector('.wcos-strategy-review');
+        var reviewSummary = dialog.querySelector('.wcos-strategy-review-summary');
+        var bucketOptions = dialog.querySelector('.wcos-strategy-bucket-options');
+        var confirmButton = dialog.querySelector('.wcos-strategy-confirm-button');
+        var confirmationSection = dialog.querySelector('.wcos-strategy-confirmation');
+        var confirmationSummary = dialog.querySelector('.wcos-strategy-confirmation-summary');
+        var confirmCheckbox = dialog.querySelector('.wcos-strategy-confirm-checkbox');
+        var executeButton = dialog.querySelector('.wcos-strategy-execute-button');
+        var statusBox = dialog.querySelector('.wcos-strategy-status');
+        var errorBox = dialog.querySelector('.wcos-strategy-error');
+        var resultBox = dialog.querySelector('.wcos-strategy-result');
+        var reviewState = null;
+        var confirmationState = null;
+        var selectedBucket = '';
+        var busy = false;
+        var completed = false;
+        var returnFocus = null;
+
+        function focusableElements() {
+            return Array.prototype.slice.call(dialog.querySelectorAll(
+                'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+            )).filter(function (element) {
+                return !element.hidden && element.offsetParent !== null;
+            });
+        }
+
+        function clearError() {
+            errorBox.hidden = true;
+            errorBox.textContent = '';
+        }
+
+        function showError(message) {
+            errorBox.textContent = message || text('requestFailed', 'The strategy Split request could not be completed.');
+            errorBox.hidden = false;
+            errorBox.focus();
+        }
+
+        function setStatus(message) {
+            statusBox.textContent = message || '';
+        }
+
+        function clearResult() {
+            resultBox.hidden = true;
+            resultBox.textContent = '';
+        }
+
+        function clearBucketOptions() {
+            bucketOptions.textContent = '';
+            selectedBucket = '';
+        }
+
+        function invalidateConfirmation() {
+            if (completed) {
+                return;
+            }
+            confirmationState = null;
+            confirmationSection.hidden = true;
+            confirmationSummary.textContent = '';
+            confirmCheckbox.checked = false;
+            executeButton.disabled = true;
+        }
+
+        function invalidateReview() {
+            if (completed) {
+                return;
+            }
+            reviewState = null;
+            invalidateConfirmation();
+            reviewSection.hidden = true;
+            reviewSummary.textContent = '';
+            clearBucketOptions();
+            confirmButton.disabled = true;
+        }
+
+        function setBusy(nextBusy) {
+            busy = !!nextBusy;
+            form.setAttribute('aria-busy', busy ? 'true' : 'false');
+            reviewButton.disabled = busy || completed || !!confirmationState;
+            Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-strategy-bucket-radio'), function (field) {
+                field.disabled = busy || completed || !!confirmationState;
+            });
+            confirmButton.disabled = busy || completed || !!confirmationState || !reviewState || !selectedBucket;
+            confirmCheckbox.disabled = busy || completed || !confirmationState;
+            executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
+            closeButton.disabled = busy;
+            cancelButton.disabled = busy;
+        }
+
+        function openDialog() {
+            returnFocus = document.activeElement;
+            dialog.hidden = false;
+            document.body.classList.add('wcos-strategy-modal-open');
+            window.setTimeout(function () {
+                var preferred = completed && !resultBox.hidden ? resultBox : reviewButton;
+                (preferred || panel).focus();
+            }, 0);
+        }
+
+        function closeDialog() {
+            if (busy) {
+                return;
+            }
+            dialog.hidden = true;
+            document.body.classList.remove('wcos-strategy-modal-open');
+            if (returnFocus && typeof returnFocus.focus === 'function') {
+                returnFocus.focus();
+            }
+        }
+
+        function bucketQuantity(items) {
+            var total = 0;
+            Object.keys(items || {}).forEach(function (itemId) {
+                var value = Number(items[itemId]);
+                if (Number.isFinite(value)) {
+                    total += value;
+                }
+            });
+            return total;
+        }
+
+        function renderBuckets(review) {
+            clearBucketOptions();
+            var buckets = review && review.buckets ? review.buckets : {};
+            var keys = Object.keys(buckets).sort();
+            if (keys.length < 2) {
+                throw new Error(text('requestFailed', 'The reviewed strategy did not return enough buckets to split.'));
+            }
+
+            keys.forEach(function (bucketKey, index) {
+                var bucket = buckets[bucketKey] || {};
+                var items = bucket.items || {};
+                var option = document.createElement('label');
+                option.className = 'wcos-strategy-bucket-option';
+
+                var radio = document.createElement('input');
+                radio.type = 'radio';
+                radio.name = dialogId + '-source-bucket';
+                radio.value = bucketKey;
+                radio.className = 'wcos-strategy-bucket-radio';
+                radio.id = dialogId + '-bucket-' + String(index + 1);
+
+                var content = document.createElement('span');
+                content.className = 'wcos-strategy-bucket-content';
+                var title = document.createElement('strong');
+                title.textContent = String(bucket.label || bucketKey);
+                var detail = document.createElement('span');
+                detail.className = 'description';
+                detail.textContent = String(Object.keys(items).length) + ' ' + text('bucketLines', 'product lines') +
+                    ' · ' + String(bucketQuantity(items)) + ' ' + text('bucketQuantity', 'total quantity');
+
+                content.appendChild(title);
+                content.appendChild(detail);
+                option.appendChild(radio);
+                option.appendChild(content);
+                bucketOptions.appendChild(option);
+            });
+        }
+
+        function reviewStrategy() {
+            if (busy || completed || confirmationState) {
+                return;
+            }
+            clearError();
+            clearResult();
+            invalidateReview();
+            setBusy(true);
+            setStatus(text('reviewing', 'Reviewing current strategy buckets…'));
+
+            request(dialog, dialog.getAttribute('data-review-action'), {
+                order_id: dialog.getAttribute('data-order-id'),
+                nonce: dialog.getAttribute('data-nonce'),
+                strategy: dialog.getAttribute('data-strategy')
+            }).then(function (data) {
+                reviewState = {
+                    reviewId: data.review_id,
+                    token: data.review_token
+                };
+                renderBuckets(data.review || {});
+                reviewSummary.textContent = data.review && data.review.message ? String(data.review.message) : '';
+                reviewSection.hidden = false;
+                setStatus(text('reviewReady', 'Choose the one bucket that must remain on the source order.'));
+                var firstRadio = bucketOptions.querySelector('.wcos-strategy-bucket-radio');
+                (firstRadio || reviewSection).focus();
+            }).catch(function (error) {
+                invalidateReview();
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+            });
+        }
+
+        function confirmStrategy() {
+            if (busy || completed || !reviewState || !selectedBucket || confirmationState) {
+                if (!selectedBucket) {
+                    showError(text('chooseBucket', 'Choose a source bucket before confirming.'));
+                }
+                return;
+            }
+            clearError();
+            setBusy(true);
+            setStatus(text('confirming', 'Confirming the frozen strategy plan…'));
+
+            request(dialog, dialog.getAttribute('data-confirm-action'), {
+                order_id: dialog.getAttribute('data-order-id'),
+                nonce: dialog.getAttribute('data-nonce'),
+                strategy: dialog.getAttribute('data-strategy'),
+                review_id: reviewState.reviewId,
+                review_token: reviewState.token,
+                source_bucket_key: selectedBucket
+            }).then(function (data) {
+                confirmationState = {
+                    operationId: data.operation_id,
+                    token: data.confirmation_token,
+                    sourceBucket: data.source_bucket_key
+                };
+                reviewState = null;
+                confirmationSummary.textContent = text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.');
+                confirmationSection.hidden = false;
+                confirmCheckbox.checked = false;
+                setStatus(text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.'));
+                confirmCheckbox.focus();
+            }).catch(function (error) {
+                if (!error.retryable) {
+                    invalidateReview();
+                }
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+            });
+        }
+
+        function renderSuccess(data) {
+            resultBox.textContent = '';
+            var message = document.createElement('p');
+            message.textContent = text('completed', 'Strategy Split completed successfully.');
+            resultBox.appendChild(message);
+
+            var children = Array.isArray(data.children) ? data.children : [];
+            if (children.length) {
+                var list = document.createElement('ul');
+                children.forEach(function (child) {
+                    var item = document.createElement('li');
+                    if (child.edit_url) {
+                        var link = document.createElement('a');
+                        link.href = child.edit_url;
+                        link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                        item.appendChild(link);
+                    } else {
+                        item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                    }
+                    list.appendChild(item);
+                });
+                resultBox.appendChild(list);
+            }
+
+            var reload = document.createElement('button');
+            reload.type = 'button';
+            reload.className = 'button';
+            reload.textContent = text('reloadOrder', 'Reload source order');
+            reload.addEventListener('click', function () {
+                window.location.reload();
+            });
+            resultBox.appendChild(reload);
+            resultBox.hidden = false;
+            resultBox.focus();
+        }
+
+        function executeStrategy() {
+            if (busy || completed || !confirmationState || !confirmCheckbox.checked) {
+                return;
+            }
+            clearError();
+            clearResult();
+            setBusy(true);
+            setStatus(text('executing', 'Executing strategy Split…'));
+
+            request(dialog, dialog.getAttribute('data-execute-action'), {
+                order_id: dialog.getAttribute('data-order-id'),
+                nonce: dialog.getAttribute('data-nonce'),
+                strategy: dialog.getAttribute('data-strategy'),
+                operation_id: confirmationState.operationId,
+                confirmation_token: confirmationState.token
+            }).then(function (data) {
+                completed = true;
+                setStatus(text('completed', 'Strategy Split completed successfully.'));
+                Array.prototype.forEach.call(dialog.querySelectorAll('input, button'), function (field) {
+                    if (!field.classList.contains('wcos-strategy-cancel') && !field.classList.contains('wcos-strategy-close')) {
+                        field.disabled = true;
+                    }
+                });
+                renderSuccess(data);
+            }).catch(function (error) {
+                if (!error.retryable) {
+                    confirmationState = null;
+                    confirmationSection.hidden = true;
+                    confirmCheckbox.checked = false;
+                }
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+            });
+        }
+
+        launcher.addEventListener('click', openDialog);
+        closeButton.addEventListener('click', closeDialog);
+        cancelButton.addEventListener('click', closeDialog);
+        reviewButton.addEventListener('click', reviewStrategy);
+        confirmButton.addEventListener('click', confirmStrategy);
+        executeButton.addEventListener('click', executeStrategy);
+        confirmCheckbox.addEventListener('change', function () {
+            executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
+        });
+        bucketOptions.addEventListener('change', function (event) {
+            if (completed || confirmationState || !event.target.classList.contains('wcos-strategy-bucket-radio')) {
+                return;
+            }
+            selectedBucket = event.target.value || '';
+            invalidateConfirmation();
+            clearError();
+            confirmButton.disabled = busy || !reviewState || !selectedBucket;
+        });
+
+        dialog.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeDialog();
+                return;
+            }
+            if (event.key !== 'Tab') {
+                return;
+            }
+            var focusable = focusableElements();
+            if (!focusable.length) {
+                event.preventDefault();
+                panel.focus();
+                return;
+            }
+            var first = focusable[0];
+            var last = focusable[focusable.length - 1];
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        });
+    }
+
+    Array.prototype.forEach.call(document.querySelectorAll('.wcos-strategy-launcher'), setupLauncher);
+})();

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -1,0 +1,136 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(method_exists('WCOS_Split_Strategy_Admin_Controller', 'bootstrap'), 'Strategy UI gate-aware bootstrap is missing.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review route is registered in the real hard-off release state.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm route is registered in the real hard-off release state.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute route is registered in the real hard-off release state.');
+wcos_p2_adapter_assert(null === WCOS_Split_Strategy_Admin_Controller::bootstrap(), 'Hard-off strategy UI bootstrap returned an active controller.');
+
+$ui_previous_user = get_current_user_id();
+$ui_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$ui_admin_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_ui_admin_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-ui-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($ui_admin_id), 'Unable to create strategy UI administrator.');
+
+$ui_product_a = wcos_p2_adapter_product('WCOS Strategy UI A', '10.00');
+$ui_product_b = wcos_p2_adapter_product('WCOS Strategy UI B', '7.00');
+$ui_order = wc_create_order();
+$ui_order->set_status('pending');
+$ui_order->set_currency('USD');
+$ui_order->add_product($ui_product_a, 1);
+$ui_order->add_product($ui_product_b, 1);
+$ui_order->calculate_totals(false);
+$ui_order->save();
+$ui_order_id = $ui_order->get_id();
+
+$ui_strategy_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
+$ui_states_property = $ui_strategy_reflection->getProperty('states');
+$ui_states_property->setAccessible(true);
+$ui_release_states = $ui_states_property->getValue();
+$ui_controller = null;
+
+try {
+	$ui_test_states = $ui_release_states;
+	$ui_test_states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
+	$ui_test_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
+	$ui_states_property->setValue(null, $ui_test_states);
+	update_option('order_splitter_status_allowed', array('wc-pending'));
+	wp_set_current_user($ui_admin_id);
+
+	$ui_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
+	wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Enabled test-only strategy UI did not bootstrap.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Enabled strategy UI did not register Review AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Enabled strategy UI did not register Confirm AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Enabled strategy UI did not register Execute AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons'), 'Enabled strategy UI did not register order launcher rendering.');
+
+	ob_start();
+	$ui_controller->render_launcher(wc_get_order($ui_order_id));
+	$launcher_html = (string) ob_get_clean();
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'wcos-strategy-launcher'), 'Strategy launcher markup is missing.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by category'), 'Category strategy launcher is missing.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by stock status'), 'Stock-status strategy launcher is missing.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-haspopup="dialog"'), 'Strategy launchers do not expose dialog semantics.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-category"'), 'Category launcher is not bound to its dialog.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Stock-status launcher is not bound to its dialog.');
+
+	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $ui_strategy) {
+		$dialog_html = $ui_controller->dialog_html(wc_get_order($ui_order_id), $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Strategy dialog is missing role=dialog: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-modal="true"'), 'Strategy dialog is missing aria-modal: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-labelledby='), 'Strategy dialog is missing aria-labelledby: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-describedby='), 'Strategy dialog is missing aria-describedby: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, '<fieldset class="wcos-strategy-buckets"'), 'Strategy dialog is missing semantic source-bucket fieldset: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, '<legend'), 'Strategy dialog is missing bucket legend: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="status" aria-live="polite"'), 'Strategy dialog is missing live status region: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="alert" tabindex="-1"'), 'Strategy dialog is missing focusable alert region: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'wcos-strategy-confirm-checkbox'), 'Strategy dialog is missing explicit execution acknowledgement: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-review-action="' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION . '"'), 'Strategy dialog is missing server Review route authority: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-confirm-action="' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION . '"'), 'Strategy dialog is missing server Confirm route authority: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-execute-action="' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION . '"'), 'Strategy dialog is missing server Execute route authority: ' . $ui_strategy);
+	}
+
+	$js_path = dirname(__DIR__, 2) . '/js/p2-split-strategy-admin.js';
+	$js = file_get_contents($js_path);
+	wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read strategy admin client script.');
+	foreach (array(
+		'var reviewState = null;',
+		'var confirmationState = null;',
+		'var busy = false;',
+		'var completed = false;',
+		"body.set('action', action);",
+		'document.createElement',
+		'title.textContent =',
+		'confirmationState = {',
+		'reviewState = null;',
+		'completed = true;',
+		"event.key === 'Escape'",
+		"event.key !== 'Tab'",
+		'returnFocus.focus()',
+		'field.disabled = busy || completed || !!confirmationState;',
+		"dialog.querySelectorAll('input, button')",
+	) as $needle) {
+		wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy client state/accessibility contract is missing: ' . $needle);
+	}
+	wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Strategy client uses innerHTML for server-provided display data.');
+	wcos_p2_adapter_assert(false === strpos($js, 'window.alert'), 'Strategy client uses blocking window.alert().');
+	wcos_p2_adapter_assert(false === strpos($js, 'JSON.stringify(plan'), 'Strategy client constructs or sends a client-authored mutation plan.');
+	wcos_p2_adapter_assert(false === strpos($js, 'classification_fingerprint'), 'Strategy client treats classification fingerprint as client authority.');
+
+	$css_path = dirname(__DIR__, 2) . '/css/p2-split-strategy-admin.css';
+	$css = file_get_contents($css_path);
+	wcos_p2_adapter_assert(is_string($css) && false !== strpos($css, '@media (max-width: 782px)'), 'Strategy UI is missing responsive admin styling.');
+	wcos_p2_adapter_assert(false !== strpos($css, 'min-height: 44px'), 'Strategy UI is missing mobile-sized action targets.');
+} finally {
+	if ($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller) {
+		$ui_controller->unregister_hooks();
+	}
+	$ui_states_property->setValue(null, $ui_release_states);
+	wp_set_current_user($ui_previous_user);
+	update_option('order_splitter_status_allowed', $ui_allowed_statuses);
+	$cleanup_ui_order = wc_get_order($ui_order_id);
+	if ($cleanup_ui_order instanceof WC_Order) {
+		$cleanup_ui_order->delete(true);
+	}
+	wp_delete_post($ui_product_a->get_id(), true);
+	wp_delete_post($ui_product_b->get_id(), true);
+	if (function_exists('wp_delete_user')) {
+		wp_delete_user($ui_admin_id);
+	}
+}
+
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category gate was not restored after strategy UI readiness acceptance.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status gate was not restored after strategy UI readiness acceptance.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX remained registered after test-only UI scope.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX remained registered after test-only UI scope.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX remained registered after test-only UI scope.');
+
+echo "p2-strategy-ui-readiness-ok\n";

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -47,10 +47,10 @@ try {
 
 	$ui_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
 	wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Enabled test-only strategy UI did not bootstrap.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Enabled strategy UI did not register Review AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Enabled strategy UI did not register Confirm AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Enabled strategy UI did not register Execute AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons'), 'Enabled strategy UI did not register order launcher rendering.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($ui_controller, 'ajax_review')), 'Enabled strategy UI did not register Review AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($ui_controller, 'ajax_confirm')), 'Enabled strategy UI did not register Confirm AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($ui_controller, 'ajax_execute')), 'Enabled strategy UI did not register Execute AJAX.');
+	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons', array($ui_controller, 'render_launcher')), 'Enabled strategy UI did not register its order launcher callback.');
 
 	ob_start();
 	$ui_controller->render_launcher(wc_get_order($ui_order_id));
@@ -97,6 +97,8 @@ try {
 		'returnFocus.focus()',
 		'field.disabled = busy || completed || !!confirmationState;',
 		"dialog.querySelectorAll('input, button')",
+		"typeof error.retryable !== 'boolean'",
+		'error.retryable = true;',
 	) as $needle) {
 		wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy client state/accessibility contract is missing: ' . $needle);
 	}

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -92,3 +92,4 @@ require __DIR__ . '/p2-strategy-planners-smoke.php';
 require __DIR__ . '/p2-strategy-adapter-smoke.php';
 require __DIR__ . '/p2-strategy-confirmation-smoke.php';
 require __DIR__ . '/p2-strategy-transport-smoke.php';
+require __DIR__ . '/p2-strategy-ui-readiness-smoke.php';


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_UI_READINESS`

## Mission

Add the gate-aware admin routes and accessible Review -> source-bucket selection -> Confirm -> Execute UI required for future Category and Stock-status Split without changing either production strategy gate.

## Production boundary

Mutation gates remain unchanged:
- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Strategy gates remain:
- `manual_quantity = true`
- `category = false`
- `stock_status = false`

`WCOS_Split_Strategy_Admin_Controller::bootstrap()` is called by plugin bootstrap but registers nothing unless global Split and at least one strategy gate are enabled. Therefore current `main` continues to expose zero Category/Stock-status route or UI.

## UI flow

For an enabled strategy:

`Launcher -> Review current server buckets -> choose exactly one bucket to remain on source -> Confirm frozen authority -> explicit acknowledgement -> Execute -> result/audit links`

The browser never authors a Split quantity plan. It never sends planner evidence, classification fingerprint, execution policy, price precision, or semantic strategy authority. Confirm and Execute continue to consume only the server-side Review/Confirmation foundations merged previously.

## Accessibility / client state

- separate launchers for Category and Stock-status;
- `role=dialog`, `aria-modal`, labelled/described dialogs;
- semantic `fieldset`/`legend` source-bucket choice;
- live status + focusable alert regions;
- focus trap, Escape close, launcher focus return;
- explicit execution acknowledgement;
- async Review/Confirm/Execute controls frozen while busy;
- Confirm consumes Review and locks bucket selection;
- success is a terminal client state;
- non-retryable failures invalidate the relevant authority;
- server data rendered with `textContent`/`createElement`, no `innerHTML` or blocking `alert()`;
- responsive 44px mobile action targets.

## Sandbox architecture

This PR deliberately uses the same gate-aware bootstrap the later sandbox candidate will use. No separate sandbox-only controller path is introduced: enabling a strategy gate on the candidate automatically registers the already-reviewed routes/UI.

## Acceptance

Canonical acceptance runs first under the real hard-off strategy map, then uses test-only Reflection to enable both strategies and proves:
- real release bootstrap registers no routes;
- enabled bootstrap registers Review/Confirm/Execute + order-screen hooks;
- both launchers render with correct ARIA dialog relationships;
- Category/Stock-status dialogs satisfy semantic accessibility contracts;
- JS has busy/completed state, focus trap, Escape and focus return;
- client does not construct/send a mutation plan or classification fingerprint;
- responsive assets exist;
- routes and exact gate map are restored after test scope;
- all previously accepted transport/confirmation/adapter/whole-line/manual Split/Duplicate regressions remain green across legacy, HPOS-only, and HPOS sync.

## Remaining sandbox candidate gate

After this PR is technically accepted, the next milestone is a narrow sandbox candidate: real two-worker Confirm race proof, exact candidate strategy enablement, production-enabled route/UI E2E, package ZIP assertions, final independent review, then ZIP generation for hands-on sandbox testing.