### PR TITLE
CI: align Release package with approved gates

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: Validate release metadata and hard-off runtime
+      - name: Validate release metadata and approved runtime
         shell: bash
         run: |
           set -euo pipefail
@@ -39,8 +39,15 @@ jobs:
           test -n "$plugin_version"
           test -n "$stable_tag"
           test "$plugin_version" = "$stable_tag"
-          grep -A2 -F 'public static function mutations_enabled()' inc/cores/safety.php | grep -Fq 'return false;'
-          grep -Fq 'private static $states = array(' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
+          grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
           telemetry_host='yoexpress''.''top'
@@ -91,6 +98,38 @@ jobs:
             fi
           done
 
+          for required_path in \
+            'inc/backend/class-wcos-split-admin-controller.php' \
+            'inc/backend/class-wcos-split-confirmation-store.php' \
+            'inc/backend/class-wcos-split-request-parser.php' \
+            'inc/domain/class-wcos-feature-gates.php' \
+            'inc/domain/class-wcos-mutation-gateway.php' \
+            'inc/domain/class-wcos-split-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-split-order-service.php' \
+            'css/p2-split-admin.css' \
+            'js/p2-split-admin.js' \
+            'inc/backend/class-wcos-duplicate-admin-controller.php' \
+            'inc/backend/class-wcos-duplicate-confirmation-store.php' \
+            'inc/domain/class-wcos-duplicate-preflight.php' \
+            'inc/domain/class-wcos-duplicate-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-duplicate-order-service.php' \
+            'css/p2-duplicate-admin.css' \
+            'js/p2-duplicate-admin.js' \
+            'inc/backend/class-wcos-split-strategy-review-store.php' \
+            'inc/backend/class-wcos-split-strategy-confirmation-store.php' \
+            'inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'inc/domain/class-wcos-split-strategy-gates.php' \
+            'inc/domain/class-wcos-category-split-planner.php' \
+            'inc/domain/class-wcos-stock-status-split-planner.php' \
+            'inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'css/p2-split-strategy-admin.css' \
+            'js/p2-split-strategy-admin.js'; do
+            if test ! -e "$package_root/$required_path"; then
+              echo "Required hardened mutation path is missing from package: $required_path" >&2
+              exit 1
+            fi
+          done
+
           if find "$package_root" -type l | grep -q .; then
             echo 'Release package must not contain symbolic links.' >&2
             exit 1
@@ -118,15 +157,37 @@ jobs:
           archive_stable_tag=$(unzip -p wc-order-splitter.zip wc-order-splitter/readme.txt | sed -n 's/^Stable tag: //p' | head -n 1)
           test -n "$archive_version"
           test "$archive_version" = "$archive_stable_tag"
+
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
             echo 'Development-only content entered the ZIP.' >&2
             exit 1
           fi
 
+          for required_archive_path in \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-review-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-confirmation-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php' \
+            'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php' \
+            'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php' \
+            'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'wc-order-splitter/css/p2-split-strategy-admin.css' \
+            'wc-order-splitter/js/p2-split-strategy-admin.js'; do
+            if ! unzip -Z1 wc-order-splitter.zip | grep -Fxq "$required_archive_path"; then
+              echo "Required strategy runtime asset is missing from ZIP: $required_archive_path" >&2
+              exit 1
+            fi
+          done
+
+          sha256sum wc-order-splitter.zip > wc-order-splitter.zip.sha256
+          cat wc-order-splitter.zip.sha256
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
           name: wc-order-splitter-${{ github.event.workflow_run.head_sha || github.sha }}
-          path: wc-order-splitter.zip
+          path: |
+            wc-order-splitter.zip
+            wc-order-splitter.zip.sha256
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
## Classification

`RELEASE_PACKAGE_CONTRACT`

## Mission

Fix the stale post-CI Release package workflow before creating a sandbox strategy candidate.

## Drift fixed

`build-plugin.yml` still enforced the emergency 1.4.12 contract that `WC_Order_Splitter_Safety_Guard::mutations_enabled()` must `return false;`. Current approved runtime correctly delegates to `WCOS_Feature_Gates::any_enabled()` with hardened Split + Duplicate enabled.

Without this fix, a green `main` CI could still fail the automatic reproducible ZIP job for an obsolete reason.

## Current approved main state

Mutation gates:
- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`

Strategy gates on main:
- `manual_quantity = true`
- `category = false`
- `stock_status = false`

## Package contract hardening

The Release package workflow now:
- validates the current approved safety/gate contract rather than 1.4.12 hard-off behavior;
- requires all hardened manual Split and Duplicate runtime paths;
- additionally requires Category/Stock-status planner, Review Store, Confirmation Store, strategy adapter/controller, JS and CSS paths in the package tree;
- verifies those strategy runtime assets are present in the actual ZIP;
- preserves all existing legacy/development exclusions and telemetry checks;
- emits `wc-order-splitter.zip.sha256` alongside the reproducible ZIP artifact.

## Scope

Workflow packaging only. No PHP runtime, strategy gate, UI behavior, version, readme, or mutation semantics change.