### PR TITLE
CI: prove single-success strategy Confirm concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
           grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'Legacy mutation handlers are deliberately never loaded here.' inc/cores/script.php
 
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
@@ -122,6 +125,10 @@ jobs:
           grep -Fq 'class-wcos-duplicate-woocommerce-adapter.php' inc/cores/script.php
           grep -Fq 'class-wcos-duplicate-confirmation-store.php' inc/cores/script.php
           grep -Fq 'class-wcos-duplicate-admin-controller.php' inc/cores/script.php
+          grep -Fq 'class-wcos-split-strategy-review-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-split-strategy-confirmation-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-split-strategy-admin-controller.php' inc/cores/script.php
+          grep -Fq 'WCOS_Split_Strategy_Admin_Controller::bootstrap();' inc/cores/script.php
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -148,6 +155,9 @@ jobs:
           grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
           telemetry_host='yoexpress''.''top'
@@ -214,7 +224,16 @@ jobs:
             'inc/domain/class-wcos-duplicate-woocommerce-adapter.php' \
             'inc/domain/class-wcos-duplicate-order-service.php' \
             'css/p2-duplicate-admin.css' \
-            'js/p2-duplicate-admin.js'; do
+            'js/p2-duplicate-admin.js' \
+            'inc/backend/class-wcos-split-strategy-review-store.php' \
+            'inc/backend/class-wcos-split-strategy-confirmation-store.php' \
+            'inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'inc/domain/class-wcos-split-strategy-gates.php' \
+            'inc/domain/class-wcos-category-split-planner.php' \
+            'inc/domain/class-wcos-stock-status-split-planner.php' \
+            'inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'css/p2-split-strategy-admin.css' \
+            'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
               echo "Required hardened mutation path is missing from package: $required_path" >&2
               exit 1
@@ -252,10 +271,21 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-duplicate-admin-controller.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-duplicate-woocommerce-adapter.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-duplicate-admin.js'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-duplicate-admin.css'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-review-store.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-confirmation-store.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-admin-controller.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-split-strategy-admin.js'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-split-strategy-admin.css'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
             echo 'Development-only content entered the ZIP.' >&2
             exit 1
@@ -352,6 +382,12 @@ jobs:
             ) as $disabled_workflow) {
               if (WCOS_Feature_Gates::enabled($disabled_workflow)) { exit(1); }
             }
+            if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY)) { exit(1); }
+            if (WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
+            if (WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
             foreach (array(
               "WC_ORDER_SPLITTER_MUTATIONS_ENABLED",
               "WC_ORDER_SPLITTER_SPLIT_ENABLED",
@@ -444,6 +480,62 @@ jobs:
           grep -Fq 'RELEASED worker-c' /tmp/wcos-worker-c.log
 
           npx wp-env run cli wp eval '$o = wc_get_order('"$order_id"'); if ($o) { $o->delete(true); }'
+
+      - name: Verify real concurrent strategy Confirm single-success authority
+        if: matrix.storage == 'hpos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-fixture.php'
+          worker='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-worker.php'
+          cleanup='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-cleanup.php'
+
+          cleanup_race() {
+            npx wp-env run cli wp eval-file "$cleanup" || true
+          }
+          trap cleanup_race EXIT
+
+          npx wp-env run cli wp eval-file "$fixture"
+          npx wp-env run cli wp eval-file "$worker" worker-a > /tmp/wcos-confirm-worker-a.log 2>&1 &
+          worker_a_pid=$!
+          npx wp-env run cli wp eval-file "$worker" worker-b > /tmp/wcos-confirm-worker-b.log 2>&1 &
+          worker_b_pid=$!
+          wait "$worker_a_pid"
+          wait "$worker_b_pid"
+
+          cat /tmp/wcos-confirm-worker-a.log
+          cat /tmp/wcos-confirm-worker-b.log
+
+          success_count="$(awk '/^CONFIRMED / { count++ } END { print count + 0 }' /tmp/wcos-confirm-worker-a.log /tmp/wcos-confirm-worker-b.log)"
+          rejected_count="$(awk '/^REJECTED / { count++ } END { print count + 0 }' /tmp/wcos-confirm-worker-a.log /tmp/wcos-confirm-worker-b.log)"
+          test "$success_count" -eq 1
+          test "$rejected_count" -eq 1
+
+          confirmed_line="$(awk '/^CONFIRMED / { print; exit }' /tmp/wcos-confirm-worker-a.log /tmp/wcos-confirm-worker-b.log)"
+          operation_id="$(printf '%s\n' "$confirmed_line" | awk '{ print $3 }')"
+          confirmation_token="$(printf '%s\n' "$confirmed_line" | awk '{ print $4 }')"
+          test -n "$operation_id"
+          test -n "$confirmation_token"
+
+          npx wp-env run cli wp eval '
+            $fixture = get_option("wcos_strategy_confirm_race_fixture", array());
+            $order = isset($fixture["order_id"]) ? wc_get_order(absint($fixture["order_id"])) : false;
+            if (!$order instanceof WC_Order) { exit(1); }
+            if (WCOS_Operation_Journal::get($order, "'"$operation_id"'")) { exit(1); }
+            $record = WCOS_Split_Strategy_Confirmation_Store::verify(
+              $order,
+              "'"$operation_id"'",
+              "'"$confirmation_token"'",
+              absint($fixture["user_id"])
+            );
+            if (!is_array($record) || "confirmation" !== $record["replay_authority"]) { exit(1); }
+            if (WCOS_Split_Strategy_Gates::CATEGORY !== $record["strategy"]) { exit(1); }
+            WCOS_Split_Strategy_Confirmation_Store::delete("'"$operation_id"'");
+            echo "strategy-confirm-race-authority-ok\n";
+          '
+
+          cleanup_race
+          trap - EXIT
 
       - name: Stop WordPress
         if: always()

--- a/tests/integration/strategy-confirm-race-cleanup.php
+++ b/tests/integration/strategy-confirm-race-cleanup.php
@@ -1,0 +1,43 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$fixture_key = 'wcos_strategy_confirm_race_fixture';
+$fixture = get_option($fixture_key, array());
+if (!is_array($fixture) || empty($fixture)) {
+	echo "RACE_FIXTURE_ALREADY_CLEAN\n";
+	exit(0);
+}
+
+if (!empty($fixture['review_id'])) {
+	WCOS_Split_Strategy_Review_Store::delete($fixture['review_id']);
+}
+
+$order = !empty($fixture['order_id']) ? wc_get_order(absint($fixture['order_id'])) : false;
+if ($order instanceof WC_Order) {
+	$order->delete(true);
+}
+foreach (array('keep_product_id', 'move_product_id') as $product_key) {
+	if (!empty($fixture[$product_key])) {
+		wp_delete_post(absint($fixture[$product_key]), true);
+	}
+}
+foreach (array('keep_term_id', 'move_term_id') as $term_key) {
+	if (!empty($fixture[$term_key])) {
+		wp_delete_term(absint($fixture[$term_key]), 'product_cat');
+	}
+}
+if (array_key_exists('previous_allowed_statuses', $fixture)) {
+	update_option('order_splitter_status_allowed', $fixture['previous_allowed_statuses']);
+}
+if (!function_exists('wp_delete_user')) {
+	require_once ABSPATH . 'wp-admin/includes/user.php';
+}
+if (!empty($fixture['user_id'])) {
+	wp_delete_user(absint($fixture['user_id']));
+}
+delete_option($fixture_key);
+
+echo "RACE_FIXTURE_CLEAN\n";

--- a/tests/integration/strategy-confirm-race-fixture.php
+++ b/tests/integration/strategy-confirm-race-fixture.php
@@ -1,0 +1,81 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$fixture_key = 'wcos_strategy_confirm_race_fixture';
+$previous = get_option('order_splitter_status_allowed', array('wc-processing'));
+update_option('order_splitter_status_allowed', array('wc-pending'));
+
+if (!function_exists('wp_delete_user')) {
+	require_once ABSPATH . 'wp-admin/includes/user.php';
+}
+
+$user_id = wp_insert_user(array(
+	'user_login' => 'wcos_strategy_confirm_race_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-strategy-confirm-race-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+if (is_wp_error($user_id)) {
+	fwrite(STDERR, "RACE_FIXTURE_USER_FAILED\n");
+	exit(2);
+}
+wp_set_current_user($user_id);
+
+$suffix = strtolower(wp_generate_password(6, false, false));
+$keep_term = wp_insert_term('WCOS Race Keep ' . $suffix, 'product_cat');
+$move_term = wp_insert_term('WCOS Race Move ' . $suffix, 'product_cat');
+if (is_wp_error($keep_term) || is_wp_error($move_term)) {
+	fwrite(STDERR, "RACE_FIXTURE_TERM_FAILED\n");
+	exit(3);
+}
+
+$keep_product = new WC_Product_Simple();
+$keep_product->set_name('WCOS Race Keep Product');
+$keep_product->set_regular_price('10.00');
+$keep_product->save();
+$move_product = new WC_Product_Simple();
+$move_product->set_name('WCOS Race Move Product');
+$move_product->set_regular_price('7.00');
+$move_product->save();
+wp_set_object_terms($keep_product->get_id(), array(absint($keep_term['term_id'])), 'product_cat');
+wp_set_object_terms($move_product->get_id(), array(absint($move_term['term_id'])), 'product_cat');
+
+$order = wc_create_order();
+$order->set_status('pending');
+$order->set_currency('USD');
+$order->add_product($keep_product, 1);
+$order->add_product($move_product, 1);
+$order->calculate_totals(false);
+$order->save();
+
+$adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
+$review = $adapter->review($order, WCOS_Split_Strategy_Gates::CATEGORY);
+if (empty($review['supported'])) {
+	fwrite(STDERR, "RACE_FIXTURE_REVIEW_UNSUPPORTED\n");
+	exit(4);
+}
+$stored = WCOS_Split_Strategy_Review_Store::create(
+	$order,
+	WCOS_Split_Strategy_Gates::CATEGORY,
+	$review,
+	$user_id
+);
+
+$fixture = array(
+	'order_id' => $order->get_id(),
+	'user_id' => absint($user_id),
+	'review_id' => sanitize_key($stored['review_id']),
+	'review_token' => (string) $stored['review_token'],
+	'source_bucket_key' => 'category-' . absint($keep_term['term_id']),
+	'keep_term_id' => absint($keep_term['term_id']),
+	'move_term_id' => absint($move_term['term_id']),
+	'keep_product_id' => $keep_product->get_id(),
+	'move_product_id' => $move_product->get_id(),
+	'previous_allowed_statuses' => $previous,
+);
+update_option($fixture_key, $fixture, false);
+
+echo 'RACE_FIXTURE_READY order=' . $order->get_id() . ' review=' . $stored['review_id'] . "\n";

--- a/tests/integration/strategy-confirm-race-worker.php
+++ b/tests/integration/strategy-confirm-race-worker.php
@@ -1,0 +1,43 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$label = isset($args[0]) ? sanitize_key((string) $args[0]) : '';
+$fixture = get_option('wcos_strategy_confirm_race_fixture', array());
+if ('' === $label || !is_array($fixture) || empty($fixture['order_id']) || empty($fixture['review_id']) || empty($fixture['review_token'])) {
+	fwrite(STDERR, "RACE_WORKER_INVALID_INPUT\n");
+	exit(2);
+}
+
+$reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
+$states_property = $reflection->getProperty('states');
+$states_property->setAccessible(true);
+$states = $states_property->getValue();
+$states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
+$states_property->setValue(null, $states);
+
+wp_set_current_user(absint($fixture['user_id']));
+$order_id = absint($fixture['order_id']);
+$nonce = wp_create_nonce('wcos_split_strategy_order_' . $order_id);
+$controller = new WCOS_Split_Strategy_Admin_Controller();
+
+try {
+	$result = $controller->confirm_request(array(
+		'order_id' => $order_id,
+		'nonce' => $nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'review_id' => sanitize_key((string) $fixture['review_id']),
+		'review_token' => (string) $fixture['review_token'],
+		'source_bucket_key' => sanitize_key((string) $fixture['source_bucket_key']),
+	));
+	echo 'CONFIRMED ' . $label . ' ' . sanitize_key((string) $result['operation_id']) . ' ' . (string) $result['confirmation_token'] . "\n";
+	exit(0);
+} catch (WCOS_Split_Transport_Exception $exception) {
+	echo 'REJECTED ' . $label . ' ' . $exception->get_error_code() . "\n";
+	exit(0);
+} catch (Throwable $throwable) {
+	fwrite(STDERR, 'RACE_WORKER_FAILED ' . $label . ' ' . get_class($throwable) . ': ' . $throwable->getMessage() . "\n");
+	exit(3);
+}


### PR DESCRIPTION
## Classification

`P2_SPLIT_STRATEGY_CONFIRM_CONCURRENCY_GATE`

## Mission

Prove with two independent WP-CLI workers that one server-side strategy Review cannot produce two usable confirmation authorities before a sandbox strategy candidate is built.

## Runtime scope

No plugin runtime PHP changes. Category and Stock-status remain hard-off on `main`.

## Real worker proof

The HPOS integration matrix now:

1. creates one persisted Category Review authority for a shared source order;
2. launches two independent WP-CLI workers against the exact same `review_id` / `review_token`;
3. each worker executes the real `WCOS_Split_Strategy_Admin_Controller::confirm_request()` path under a test-only Category gate;
4. requires exactly one `CONFIRMED` and exactly one `REJECTED` result;
5. verifies the winning confirmation is valid server authority;
6. proves Confirm created no mutation journal;
7. cleans the winning confirmation and all fixture data.

If current single-use Review consumption is insufficient under real concurrency, this PR must fail and runtime lease hardening will be added before merge. The test is not weakened to accept two confirmations.

## Canonical CI/package alignment

While touching CI, this PR also aligns the normal PR package contract with the Release package contract merged in #26:

- assert `manual_quantity=true`, `category=false`, `stock_status=false` on main;
- require strategy Review/Confirmation/controller/planner/adapter/JS/CSS files in the package tree and ZIP;
- verify strategy AJAX routes are absent in the real hard-off integration state.

## Sandbox boundary

This is the final concurrency/package evidence gate before the sandbox candidate. It does not enable a strategy and does not create a user-facing release.