### PR TITLE
UI: streamline order actions and Split workflow

### DIFF
--- a/css/p2-duplicate-admin.css
+++ b/css/p2-duplicate-admin.css
@@ -3,7 +3,19 @@ body.wcos-duplicate-modal-open {
 }
 
 .wcos-duplicate-launcher-description {
-    margin-left: 8px;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+.wcos-duplicate-launcher {
+    margin-right: 6px;
 }
 
 .wcos-duplicate-dialog[hidden] {
@@ -32,7 +44,7 @@ body.wcos-duplicate-modal-open {
     max-height: calc(100vh - 48px);
     overflow: auto;
     background: #fff;
-    border-radius: 4px;
+    border-radius: 6px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
     padding: 24px;
 }

--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -3,78 +3,238 @@ body.wcos-split-modal-open {
 }
 
 .wcos-split-launcher-description {
-    margin-left: 8px;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
-.wcos-split-dialog[hidden] {
-    display: none;
+.wcos-split-launcher {
+    margin-right: 6px;
 }
 
-.wcos-split-dialog {
+.wcos-split-dialog[hidden],
+.wcos-split-method-dialog[hidden],
+.wcos-split-table th[hidden],
+.wcos-split-table td[hidden] {
+    display: none !important;
+}
+
+.wcos-split-dialog,
+.wcos-split-method-dialog {
     position: fixed;
     inset: 0;
-    z-index: 100000;
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 24px;
 }
 
-.wcos-split-dialog__backdrop {
+.wcos-split-dialog {
+    z-index: 100000;
+}
+
+.wcos-split-method-dialog {
+    z-index: 99999;
+}
+
+.wcos-split-dialog__backdrop,
+.wcos-split-method-dialog__backdrop {
     position: absolute;
     inset: 0;
     background: rgba(0, 0, 0, 0.55);
 }
 
-.wcos-split-dialog__panel {
+.wcos-split-dialog__panel,
+.wcos-split-method-dialog__panel {
     position: relative;
-    width: min(980px, 100%);
+    width: min(820px, 100%);
     max-height: calc(100vh - 48px);
     overflow: auto;
     background: #fff;
-    border-radius: 4px;
+    border-radius: 6px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
     padding: 24px;
 }
 
-.wcos-split-dialog__header {
+.wcos-split-method-dialog__panel {
+    width: min(560px, 100%);
+}
+
+.wcos-split-dialog__header,
+.wcos-split-method-dialog__header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: 20px;
 }
 
-.wcos-split-dialog__header h2 {
-    margin-top: 0;
+.wcos-split-dialog__header h2,
+.wcos-split-method-dialog__header h2 {
+    margin: 0 0 6px;
 }
 
-.wcos-split-close {
-    min-width: 44px;
-    min-height: 44px;
+.wcos-split-close,
+.wcos-split-method-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    min-height: 40px;
+    margin: -6px -6px 0 0;
     font-size: 28px;
     line-height: 1;
+    text-decoration: none;
+}
+
+.wcos-split-method-options {
+    display: grid;
+    gap: 10px;
+    margin-top: 18px;
+}
+
+.wcos-split-method-option {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    width: 100%;
+    padding: 14px 16px;
+    border: 1px solid #c3c4c7;
+    border-radius: 5px;
+    background: #fff;
+    color: #1d2327;
+    text-align: left;
+    cursor: pointer;
+}
+
+.wcos-split-method-option:hover,
+.wcos-split-method-option:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: none;
+}
+
+.wcos-split-method-option strong {
+    font-size: 14px;
+}
+
+.wcos-split-method-option span {
+    color: #50575e;
+    font-weight: 400;
+}
+
+.wcos-split-child-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 20px 0 10px;
+    padding: 10px 12px;
+    border: 1px solid #dcdcde;
+    border-radius: 5px;
+    background: #f6f7f7;
+}
+
+.wcos-split-child-count {
+    margin-right: auto;
+}
+
+.wcos-split-remove-child {
+    white-space: nowrap;
 }
 
 .wcos-split-table-wrap {
     overflow-x: auto;
-    margin: 20px 0;
+    margin: 0 0 18px;
+    border: 1px solid #dcdcde;
+    border-radius: 5px;
 }
 
-.wcos-split-table select,
-.wcos-split-table input[type="number"] {
+.wcos-split-table {
+    border: 0;
+    box-shadow: none;
+}
+
+.wcos-split-table th,
+.wcos-split-table td {
+    vertical-align: middle;
+}
+
+.wcos-split-table thead th {
+    background: #f6f7f7;
+}
+
+.wcos-split-table th:first-child {
+    min-width: 180px;
+}
+
+.wcos-split-table th:nth-child(2),
+.wcos-split-table td:nth-child(2) {
+    width: 130px;
     min-width: 130px;
+}
+
+.wcos-split-table input[type="number"] {
+    width: 108px;
+    min-width: 108px;
     max-width: 100%;
 }
 
+.wcos-split-remaining-hint {
+    display: block;
+    margin-top: 3px;
+    color: #646970;
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.wcos-split-remaining.is-invalid {
+    color: #b32d2e;
+}
+
 .wcos-split-policy {
-    padding: 12px 16px;
-    border-left: 4px solid #646970;
+    margin-top: 16px;
+    padding: 14px 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 5px;
     background: #f6f7f7;
 }
 
 .wcos-split-policy h3,
 .wcos-split-review h3 {
-    margin-top: 0;
+    margin: 0 0 6px;
+}
+
+.wcos-split-policy-summary {
+    max-width: 720px;
+    margin: 0 0 8px;
+    color: #50575e;
+}
+
+.wcos-split-policy-toggle {
+    font-weight: 600;
+}
+
+.wcos-split-policy ul {
+    margin: 12px 0 0 18px;
+}
+
+.wcos-split-review {
+    margin-top: 16px;
+    padding: 14px 16px;
+    border: 1px solid #c3c4c7;
+    border-radius: 5px;
+    background: #fff;
+}
+
+.wcos-split-review-summary {
+    margin: 0 0 10px;
+    color: #50575e;
 }
 
 .wcos-split-confirm-label {
@@ -86,8 +246,7 @@ body.wcos-split-modal-open {
 
 .wcos-split-status,
 .wcos-split-error,
-.wcos-split-result,
-.wcos-split-review {
+.wcos-split-result {
     margin-top: 16px;
 }
 
@@ -110,13 +269,34 @@ body.wcos-split-modal-open {
 }
 
 @media (max-width: 782px) {
-    .wcos-split-dialog {
+    .wcos-split-dialog,
+    .wcos-split-method-dialog {
         padding: 12px;
     }
 
-    .wcos-split-dialog__panel {
+    .wcos-split-dialog__panel,
+    .wcos-split-method-dialog__panel {
         max-height: calc(100vh - 24px);
         padding: 16px;
+    }
+
+    .wcos-split-child-toolbar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .wcos-split-child-count {
+        margin-right: 0;
+    }
+
+    .wcos-split-child-toolbar .button,
+    .wcos-split-child-toolbar .button-link-delete {
+        min-height: 44px;
+        text-align: center;
+    }
+
+    .wcos-split-table th:first-child {
+        min-width: 140px;
     }
 
     .wcos-split-dialog__actions {
@@ -126,5 +306,9 @@ body.wcos-split-modal-open {
     .wcos-split-dialog__actions .button {
         width: 100%;
         min-height: 44px;
+    }
+
+    .wcos-split-method-option {
+        min-height: 64px;
     }
 }

--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -2,8 +2,20 @@ body.wcos-strategy-modal-open {
     overflow: hidden;
 }
 
+.wcos-strategy-launcher {
+    display: none !important;
+}
+
 .wcos-strategy-launcher-description {
-    margin: 0 12px 0 6px;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
 .wcos-strategy-dialog[hidden] {
@@ -32,7 +44,7 @@ body.wcos-strategy-modal-open {
     max-height: calc(100vh - 48px);
     overflow: auto;
     background: #fff;
-    border-radius: 4px;
+    border-radius: 6px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
     padding: 24px;
 }
@@ -58,7 +70,8 @@ body.wcos-strategy-modal-open {
 .wcos-strategy-policy {
     margin-top: 16px;
     padding: 12px 16px;
-    border-left: 4px solid #646970;
+    border: 1px solid #dcdcde;
+    border-radius: 5px;
     background: #f6f7f7;
 }
 
@@ -99,7 +112,7 @@ body.wcos-strategy-modal-open {
     gap: 10px;
     padding: 12px;
     border: 1px solid #c3c4c7;
-    border-radius: 4px;
+    border-radius: 5px;
     background: #fff;
     cursor: pointer;
 }

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -7,8 +7,8 @@
         return;
     }
 
-    var dialogId = launcher.getAttribute('aria-controls');
-    var dialog = dialogId ? document.getElementById(dialogId) : null;
+    var quantityDialogId = launcher.getAttribute('aria-controls');
+    var dialog = quantityDialogId ? document.getElementById(quantityDialogId) : null;
     if (!dialog) {
         return;
     }
@@ -25,27 +25,54 @@
     var statusBox = dialog.querySelector('.wcos-split-status');
     var errorBox = dialog.querySelector('.wcos-split-error');
     var resultBox = dialog.querySelector('.wcos-split-result');
+    var table = dialog.querySelector('.wcos-split-table');
+    var tableWrap = dialog.querySelector('.wcos-split-table-wrap');
+    var policyBox = dialog.querySelector('.wcos-split-policy');
+    var actions = dialog.querySelector('.wcos-split-dialog__actions');
+    var strategyLaunchers = Array.prototype.slice.call(document.querySelectorAll('.wcos-strategy-launcher'));
     var state = null;
     var returnFocus = null;
     var busy = false;
     var completed = false;
+    var activeChildren = 1;
+    var maxChildren = 10;
+    var addChildButton = null;
+    var removeChildButton = null;
+    var childCountLabel = null;
+    var editButton = null;
+    var methodDialog = null;
+    var methodReturnFocus = null;
 
     function text(key, fallback) {
         return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
     }
 
-    function focusableElements() {
-        return Array.prototype.slice.call(dialog.querySelectorAll(
+    function humanDecimal(value) {
+        var normalized = String(value == null ? '' : value).trim();
+        if (normalized.indexOf('.') !== -1) {
+            normalized = normalized.replace(/0+$/, '').replace(/\.$/, '');
+        }
+        return normalized === '' ? '0' : normalized;
+    }
+
+    function quantityFocusableElements(targetDialog) {
+        return Array.prototype.slice.call(targetDialog.querySelectorAll(
             'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
         )).filter(function (element) {
             return !element.hidden && element.offsetParent !== null;
         });
     }
 
-    function openDialog() {
+    function syncBodyLock() {
+        var quantityOpen = !dialog.hidden;
+        var methodOpen = methodDialog && !methodDialog.hidden;
+        document.body.classList.toggle('wcos-split-modal-open', !!(quantityOpen || methodOpen));
+    }
+
+    function openQuantityDialog() {
         returnFocus = document.activeElement;
         dialog.hidden = false;
-        document.body.classList.add('wcos-split-modal-open');
+        syncBodyLock();
         window.setTimeout(function () {
             var preferred = completed && !resultBox.hidden
                 ? resultBox
@@ -54,12 +81,12 @@
         }, 0);
     }
 
-    function closeDialog() {
+    function closeQuantityDialog() {
         if (busy) {
             return;
         }
         dialog.hidden = true;
-        document.body.classList.remove('wcos-split-modal-open');
+        syncBodyLock();
         if (returnFocus && typeof returnFocus.focus === 'function') {
             returnFocus.focus();
         }
@@ -85,8 +112,192 @@
         resultBox.textContent = '';
     }
 
+    function childColumnElements(childIndex) {
+        var childKey = 'child-' + String(childIndex);
+        var fields = Array.prototype.slice.call(dialog.querySelectorAll('.wcos-split-quantity[data-child-key="' + childKey + '"]'));
+        var cells = fields.map(function (field) { return field.closest('td'); }).filter(Boolean);
+        var header = table && table.tHead && table.tHead.rows.length
+            ? table.tHead.rows[0].cells[childIndex + 1]
+            : null;
+        return { fields: fields, cells: cells, header: header };
+    }
+
+    function setChildVisible(childIndex, visible) {
+        var column = childColumnElements(childIndex);
+        if (column.header) {
+            column.header.hidden = !visible;
+        }
+        column.cells.forEach(function (cell) {
+            cell.hidden = !visible;
+        });
+    }
+
+    function updateChildToolbar() {
+        if (childCountLabel) {
+            childCountLabel.textContent = String(activeChildren) + (activeChildren === 1 ? ' child order' : ' child orders');
+        }
+        if (addChildButton) {
+            addChildButton.disabled = busy || completed || !!state || activeChildren >= maxChildren;
+        }
+        if (removeChildButton) {
+            removeChildButton.hidden = activeChildren <= 1;
+            removeChildButton.disabled = busy || completed || !!state || activeChildren <= 1;
+        }
+    }
+
+    function enhanceChildColumns() {
+        if (!table || !tableWrap) {
+            return;
+        }
+
+        for (var childIndex = 1; childIndex <= maxChildren; childIndex++) {
+            var column = childColumnElements(childIndex);
+            column.fields.forEach(function (field) {
+                if (field.value === '0') {
+                    field.value = '';
+                }
+                field.placeholder = '0';
+            });
+            setChildVisible(childIndex, childIndex === 1);
+        }
+
+        Array.prototype.forEach.call(table.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+            var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
+            var currentCell = row.cells.length > 1 ? row.cells[1] : null;
+            if (!currentCell) {
+                return;
+            }
+            currentCell.textContent = humanDecimal(sourceQuantity);
+            var remaining = document.createElement('span');
+            remaining.className = 'wcos-split-remaining-hint';
+            var label = document.createElement('span');
+            label.textContent = 'Remaining ';
+            var value = document.createElement('strong');
+            value.className = 'wcos-split-remaining';
+            value.setAttribute('data-item-id', row.getAttribute('data-item-id') || '');
+            value.textContent = humanDecimal(sourceQuantity);
+            remaining.appendChild(label);
+            remaining.appendChild(value);
+            currentCell.appendChild(remaining);
+        });
+
+        var toolbar = document.createElement('div');
+        toolbar.className = 'wcos-split-child-toolbar';
+        childCountLabel = document.createElement('strong');
+        childCountLabel.className = 'wcos-split-child-count';
+        addChildButton = document.createElement('button');
+        addChildButton.type = 'button';
+        addChildButton.className = 'button button-secondary wcos-split-add-child';
+        addChildButton.textContent = 'Add child order';
+        removeChildButton = document.createElement('button');
+        removeChildButton.type = 'button';
+        removeChildButton.className = 'button-link-delete wcos-split-remove-child';
+        removeChildButton.textContent = 'Remove last child';
+        toolbar.appendChild(childCountLabel);
+        toolbar.appendChild(addChildButton);
+        toolbar.appendChild(removeChildButton);
+        tableWrap.parentNode.insertBefore(toolbar, tableWrap);
+
+        addChildButton.addEventListener('click', function () {
+            if (busy || completed || state || activeChildren >= maxChildren) {
+                return;
+            }
+            activeChildren += 1;
+            setChildVisible(activeChildren, true);
+            updateChildToolbar();
+            updateRemaining();
+            updateReviewAvailability();
+            var next = childColumnElements(activeChildren).fields[0];
+            if (next) {
+                next.focus();
+            }
+        });
+
+        removeChildButton.addEventListener('click', function () {
+            if (busy || completed || state || activeChildren <= 1) {
+                return;
+            }
+            var column = childColumnElements(activeChildren);
+            column.fields.forEach(function (field) {
+                field.value = '';
+            });
+            setChildVisible(activeChildren, false);
+            activeChildren -= 1;
+            updateChildToolbar();
+            updateRemaining();
+            invalidateReview();
+            updateReviewAvailability();
+        });
+
+        updateChildToolbar();
+        updateRemaining();
+    }
+
+    function enhancePolicy() {
+        if (!policyBox) {
+            return;
+        }
+        var list = policyBox.querySelector('ul');
+        if (!list) {
+            return;
+        }
+        list.hidden = true;
+        var summary = document.createElement('p');
+        summary.className = 'wcos-split-policy-summary';
+        summary.textContent = 'Child orders are created as Pending payment. Shipping stays on the source order, historical prices and taxes are preserved, and this Split does not change physical product stock.';
+        var toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'button-link wcos-split-policy-toggle';
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.textContent = 'View safety details';
+        policyBox.insertBefore(summary, list);
+        policyBox.insertBefore(toggle, list);
+        toggle.addEventListener('click', function () {
+            var expanded = toggle.getAttribute('aria-expanded') === 'true';
+            toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+            toggle.textContent = expanded ? 'View safety details' : 'Hide safety details';
+            list.hidden = expanded;
+        });
+    }
+
+    function createEditButton() {
+        if (!actions || !reviewButton) {
+            return;
+        }
+        editButton = document.createElement('button');
+        editButton.type = 'button';
+        editButton.className = 'button wcos-split-edit-button';
+        editButton.textContent = 'Edit quantities';
+        editButton.hidden = true;
+        actions.insertBefore(editButton, reviewButton);
+        executeButton.hidden = true;
+
+        editButton.addEventListener('click', function () {
+            if (busy || completed) {
+                return;
+            }
+            state = null;
+            reviewBox.hidden = true;
+            reviewSummary.textContent = '';
+            confirmCheckbox.checked = false;
+            executeButton.disabled = true;
+            executeButton.hidden = true;
+            editButton.hidden = true;
+            reviewButton.hidden = false;
+            setStatus('');
+            clearError();
+            setBusy(false);
+            updateChildToolbar();
+            updateReviewAvailability();
+            var first = dialog.querySelector('.wcos-split-quantity:not([disabled])');
+            if (first) {
+                first.focus();
+            }
+        });
+    }
+
     function invalidateReview() {
-        if (completed) {
+        if (completed || !state) {
             return;
         }
         state = null;
@@ -94,7 +305,13 @@
         reviewSummary.textContent = '';
         confirmCheckbox.checked = false;
         executeButton.disabled = true;
+        executeButton.hidden = true;
+        if (editButton) {
+            editButton.hidden = true;
+        }
+        reviewButton.hidden = false;
         clearResult();
+        updateChildToolbar();
     }
 
     function decimalIsPositiveAndLessThan(value, sourceValue) {
@@ -117,6 +334,10 @@
             var movedForLine = 0;
 
             Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (quantityInput) {
+                var cell = quantityInput.closest('td');
+                if (cell && cell.hidden) {
+                    return;
+                }
                 var quantity = quantityInput.value.trim();
                 if (quantity === '' || Number(quantity) === 0) {
                     return;
@@ -156,6 +377,45 @@
         return plan;
     }
 
+    function updateRemaining() {
+        Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+            var source = Number(row.getAttribute('data-source-quantity') || 0);
+            var moved = 0;
+            Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (field) {
+                var cell = field.closest('td');
+                if (cell && cell.hidden) {
+                    return;
+                }
+                var value = Number(field.value || 0);
+                if (Number.isFinite(value) && value > 0) {
+                    moved += value;
+                }
+            });
+            var remaining = source - moved;
+            var output = row.querySelector('.wcos-split-remaining');
+            if (output) {
+                output.textContent = humanDecimal(String(Math.max(0, remaining).toFixed(6)));
+                output.classList.toggle('is-invalid', remaining <= 0);
+            }
+        });
+    }
+
+    function canBuildPlan() {
+        try {
+            buildPlan();
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function updateReviewAvailability() {
+        if (!reviewButton || reviewButton.hidden) {
+            return;
+        }
+        reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
+    }
+
     function request(action, data) {
         var body = new URLSearchParams();
         body.set('action', action);
@@ -183,6 +443,11 @@
                 throw error;
             }
             return payload.data || {};
+        }).catch(function (error) {
+            if (typeof error.retryable !== 'boolean') {
+                error.retryable = true;
+            }
+            throw error;
         });
     }
 
@@ -190,17 +455,21 @@
         busy = !!nextBusy;
         form.setAttribute('aria-busy', busy ? 'true' : 'false');
         Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-split-quantity'), function (field) {
-            field.disabled = busy || completed;
+            field.disabled = busy || completed || !!state;
         });
-        reviewButton.disabled = busy || completed;
-        confirmCheckbox.disabled = busy || completed;
+        reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
+        confirmCheckbox.disabled = busy || completed || !state;
         executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
         cancelButton.disabled = busy;
         closeButton.disabled = busy;
+        if (editButton) {
+            editButton.disabled = busy || completed;
+        }
+        updateChildToolbar();
     }
 
     function reviewPlan() {
-        if (busy || completed) {
+        if (busy || completed || state) {
             return;
         }
         clearError();
@@ -225,20 +494,34 @@
                 token: data.confirmation_token
             };
             var summary = data.summary || {};
-            reviewSummary.textContent = text('reviewSummary', 'Reviewed children / affected lines / moved quantity:') + ' ' +
-                String(summary.child_count || 0) + ' / ' +
-                String(summary.affected_line_count || 0) + ' / ' +
-                String(summary.moved_quantity || '0');
+            var childCount = Number(summary.child_count || 0);
+            var lineCount = Number(summary.affected_line_count || 0);
+            reviewSummary.textContent = String(childCount) + (childCount === 1 ? ' child order' : ' child orders') +
+                ' · ' + String(lineCount) + (lineCount === 1 ? ' product line' : ' product lines') +
+                ' · ' + humanDecimal(summary.moved_quantity || '0') + ' quantity moving';
             reviewBox.hidden = false;
             confirmCheckbox.checked = false;
+            reviewButton.hidden = true;
+            if (editButton) {
+                editButton.hidden = false;
+            }
+            executeButton.hidden = false;
             setStatus(text('reviewReady', 'The plan passed server review. Confirm the acknowledgement to execute it.'));
+            setBusy(false);
             confirmCheckbox.focus();
         }).catch(function (error) {
-            invalidateReview();
+            state = null;
+            reviewBox.hidden = true;
+            executeButton.hidden = true;
+            if (editButton) {
+                editButton.hidden = true;
+            }
+            reviewButton.hidden = false;
             setStatus('');
             showError(error.message);
         }).finally(function () {
             setBusy(false);
+            updateReviewAvailability();
         });
     }
 
@@ -294,24 +577,190 @@
         }).then(function (data) {
             completed = true;
             setStatus(text('completed', 'Split completed successfully.'));
-            Array.prototype.forEach.call(dialog.querySelectorAll('input, select'), function (field) {
-                field.disabled = true;
+            Array.prototype.forEach.call(dialog.querySelectorAll('input, select, button'), function (field) {
+                if (!field.classList.contains('wcos-split-cancel') && !field.classList.contains('wcos-split-close')) {
+                    field.disabled = true;
+                }
             });
+            if (editButton) {
+                editButton.hidden = true;
+            }
+            reviewButton.hidden = true;
+            executeButton.hidden = true;
             renderSuccess(data);
         }).catch(function (error) {
             if (!error.retryable) {
-                invalidateReview();
+                state = null;
+                reviewBox.hidden = true;
+                executeButton.hidden = true;
+                if (editButton) {
+                    editButton.hidden = true;
+                }
+                reviewButton.hidden = false;
             }
             setStatus('');
             showError(error.message);
         }).finally(function () {
             setBusy(false);
+            updateReviewAvailability();
         });
     }
 
-    launcher.addEventListener('click', openDialog);
-    closeButton.addEventListener('click', closeDialog);
-    cancelButton.addEventListener('click', closeDialog);
+    function trapDialogKeyboard(targetDialog, closeCallback, targetPanel) {
+        targetDialog.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeCallback();
+                return;
+            }
+            if (event.key !== 'Tab') {
+                return;
+            }
+            var focusable = quantityFocusableElements(targetDialog);
+            if (!focusable.length) {
+                event.preventDefault();
+                targetPanel.focus();
+                return;
+            }
+            var first = focusable[0];
+            var last = focusable[focusable.length - 1];
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        });
+    }
+
+    function methodLabel(raw) {
+        var label = String(raw || '').trim();
+        return label.replace(/^Split\s+/i, '').replace(/^by\s+/i, 'By ');
+    }
+
+    function createMethodOption(label, description, clickHandler) {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'wcos-split-method-option';
+        var title = document.createElement('strong');
+        title.textContent = label;
+        var detail = document.createElement('span');
+        detail.textContent = description;
+        button.appendChild(title);
+        button.appendChild(detail);
+        button.addEventListener('click', clickHandler);
+        return button;
+    }
+
+    function createMethodDialog() {
+        if (!strategyLaunchers.length) {
+            return null;
+        }
+        var orderId = dialog.getAttribute('data-order-id') || '';
+        var methodId = 'wcos-split-method-dialog-' + orderId;
+        var root = document.createElement('div');
+        root.id = methodId;
+        root.className = 'wcos-split-method-dialog';
+        root.setAttribute('role', 'dialog');
+        root.setAttribute('aria-modal', 'true');
+        root.setAttribute('aria-labelledby', methodId + '-title');
+        root.hidden = true;
+
+        var backdrop = document.createElement('div');
+        backdrop.className = 'wcos-split-method-dialog__backdrop';
+        backdrop.setAttribute('aria-hidden', 'true');
+        var methodPanel = document.createElement('div');
+        methodPanel.className = 'wcos-split-method-dialog__panel';
+        methodPanel.tabIndex = -1;
+        var header = document.createElement('div');
+        header.className = 'wcos-split-method-dialog__header';
+        var heading = document.createElement('h2');
+        heading.id = methodId + '-title';
+        heading.textContent = 'Split order';
+        var close = document.createElement('button');
+        close.type = 'button';
+        close.className = 'button-link wcos-split-method-close';
+        close.setAttribute('aria-label', 'Close split method chooser');
+        close.innerHTML = '<span aria-hidden="true">×</span>';
+        header.appendChild(heading);
+        header.appendChild(close);
+
+        var intro = document.createElement('p');
+        intro.className = 'description';
+        intro.textContent = 'Choose how this order should be split. You will review the result before anything is changed.';
+        var options = document.createElement('div');
+        options.className = 'wcos-split-method-options';
+        options.appendChild(createMethodOption(
+            'By quantity',
+            'Move exact quantities from one or more product lines into child orders.',
+            openQuantityDialog
+        ));
+
+        strategyLaunchers.forEach(function (strategyLauncher) {
+            var descriptionId = strategyLauncher.getAttribute('aria-describedby');
+            var descriptionElement = descriptionId ? document.getElementById(descriptionId) : null;
+            var description = descriptionElement ? descriptionElement.textContent.trim() : 'Build child orders from the reviewed product classification.';
+            options.appendChild(createMethodOption(
+                methodLabel(strategyLauncher.textContent),
+                description,
+                function () {
+                    strategyLauncher.click();
+                }
+            ));
+        });
+
+        methodPanel.appendChild(header);
+        methodPanel.appendChild(intro);
+        methodPanel.appendChild(options);
+        root.appendChild(backdrop);
+        root.appendChild(methodPanel);
+        document.body.appendChild(root);
+
+        function openMethodDialog() {
+            methodReturnFocus = document.activeElement;
+            root.hidden = false;
+            syncBodyLock();
+            window.setTimeout(function () {
+                var first = options.querySelector('.wcos-split-method-option');
+                (first || methodPanel).focus();
+            }, 0);
+        }
+
+        function closeMethodDialog() {
+            if (!dialog.hidden) {
+                return;
+            }
+            root.hidden = true;
+            syncBodyLock();
+            if (methodReturnFocus && typeof methodReturnFocus.focus === 'function') {
+                methodReturnFocus.focus();
+            }
+        }
+
+        close.addEventListener('click', closeMethodDialog);
+        backdrop.addEventListener('click', closeMethodDialog);
+        trapDialogKeyboard(root, closeMethodDialog, methodPanel);
+        root.open = openMethodDialog;
+        launcher.setAttribute('aria-controls', methodId);
+        return root;
+    }
+
+    enhanceChildColumns();
+    enhancePolicy();
+    createEditButton();
+    methodDialog = createMethodDialog();
+    updateReviewAvailability();
+
+    launcher.addEventListener('click', function () {
+        if (methodDialog && typeof methodDialog.open === 'function') {
+            methodDialog.open();
+        } else {
+            openQuantityDialog();
+        }
+    });
+    closeButton.addEventListener('click', closeQuantityDialog);
+    cancelButton.addEventListener('click', closeQuantityDialog);
     reviewButton.addEventListener('click', reviewPlan);
     executeButton.addEventListener('click', executePlan);
     confirmCheckbox.addEventListener('change', function () {
@@ -319,38 +768,17 @@
     });
 
     form.addEventListener('input', function (event) {
-        if (completed) {
+        if (completed || !event.target.classList.contains('wcos-split-quantity')) {
             return;
         }
-        if (event.target.classList.contains('wcos-split-quantity')) {
+        if (state) {
             invalidateReview();
-            clearError();
-            setStatus('');
         }
+        clearError();
+        setStatus('');
+        updateRemaining();
+        updateReviewAvailability();
     });
-    dialog.addEventListener('keydown', function (event) {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            closeDialog();
-            return;
-        }
-        if (event.key !== 'Tab') {
-            return;
-        }
-        var focusable = focusableElements();
-        if (!focusable.length) {
-            event.preventDefault();
-            panel.focus();
-            return;
-        }
-        var first = focusable[0];
-        var last = focusable[focusable.length - 1];
-        if (event.shiftKey && document.activeElement === first) {
-            event.preventDefault();
-            last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-            event.preventDefault();
-            first.focus();
-        }
-    });
+
+    trapDialogKeyboard(dialog, closeQuantityDialog, panel);
 })();

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -682,7 +682,10 @@
         close.type = 'button';
         close.className = 'button-link wcos-split-method-close';
         close.setAttribute('aria-label', 'Close split method chooser');
-        close.innerHTML = '<span aria-hidden="true">×</span>';
+        var closeGlyph = document.createElement('span');
+        closeGlyph.setAttribute('aria-hidden', 'true');
+        closeGlyph.textContent = '×';
+        close.appendChild(closeGlyph);
         header.appendChild(heading);
         header.appendChild(close);
 

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -11,23 +11,39 @@ wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split a
 foreach (array(
     'var completed = false;',
     "dialog.querySelectorAll('.wcos-split-quantity')",
-    'field.disabled = busy || completed;',
-    'reviewButton.disabled = busy || completed;',
-    'confirmCheckbox.disabled = busy || completed;',
+    'field.disabled = busy || completed || !!state;',
+    'reviewButton.disabled = busy || completed || !!state || !canBuildPlan();',
+    'confirmCheckbox.disabled = busy || completed || !state;',
     'executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;',
-    'if (busy || completed) {',
+    'executeButton.hidden = true;',
+    'editButton.hidden = true;',
+    'activeChildren = 1;',
+    'setChildVisible(childIndex, childIndex === 1);',
+    "addChildButton.textContent = 'Add child order';",
+    "removeChildButton.textContent = 'Remove last child';",
+    "value.className = 'wcos-split-remaining';",
+    "toggle.textContent = 'View safety details';",
+    "heading.textContent = 'Split order';",
+    "'By quantity'",
+    'strategyLauncher.click();',
     'completed = true;',
     'completed && !resultBox.hidden',
+    "typeof error.retryable !== 'boolean'",
+    'error.retryable = true;',
 ) as $needle) {
     wcos_p2_adapter_assert(
         false !== strpos($js, $needle),
-        'Split admin client is missing terminal/async-boundary protection: ' . $needle
+        'Split admin client is missing streamlined terminal/UX protection: ' . $needle
     );
 }
 
 wcos_p2_adapter_assert(
     false !== strpos($js, 'if (!error.retryable) {'),
     'Non-retryable execute failures do not invalidate the reviewed confirmation state.'
+);
+wcos_p2_adapter_assert(
+    false === strpos($js, 'window.alert'),
+    'Split admin client reintroduced blocking alert UI.'
 );
 
 echo "p2-admin-client-terminal-state-ok\n";


### PR DESCRIPTION
## Classification

`ADMIN_UI_OVERHAUL`

## Why

Hands-on sandbox testing exposed two concrete UX failures:

1. Order action descriptions were rendered inline after each button, causing the WooCommerce action area to become a long unreadable sentence.
2. Manual quantity Split exposed all ten child-order columns at once, canonical six-decimal quantities, a large safety-policy wall, and the final execute button before Review.

## Scope

Frontend/admin UI and acceptance only. No mutation service, transport, parser, journal, feature gate, strategy gate, version, or order semantics change.

## Order action redesign

- Split and Duplicate descriptions remain available to assistive technology but are removed from visual flow.
- Standalone Category / Stock-status buttons are visually removed from the order action row.
- When strategy launchers exist, the existing `Split order` button opens a compact method chooser:
  - By quantity
  - By category
  - By stock status
- Strategy controller/backend remains unchanged; the chooser invokes the already-reviewed strategy launcher/dialog path.
- With strategies hard-off on `main`, `Split order` continues to open manual quantity Split directly with no extra step.

## Quantity Split redesign

The server-rendered ten-child matrix remains the fallback/transport contract, but the client progressively enhances it:

- only Child 1 is visible initially;
- `Add child order` reveals Child 2..10 only when needed;
- `Remove last child` removes the latest unused allocation column;
- canonical values such as `2.000000` display as `2`;
- zero inputs start visually blank;
- remaining source quantity updates live;
- Review is disabled until the client plan is structurally valid;
- safety details are collapsed behind a concise summary;
- Execute is hidden until server Review succeeds;
- an explicit `Edit quantities` state returns from reviewed authority to editable allocation;
- unclassified network failures preserve retry authority;
- method chooser and quantity dialog retain Escape/focus-trap/focus-return semantics;
- no `innerHTML` or blocking alert rendering is introduced.

## Production state

Unchanged:
- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`
- `manual_quantity = true`
- `category = false`
- `stock_status = false`

The sandbox candidate will be regenerated from `main` only after this PR passes canonical CI and is merged.