### PR TITLE
UI: move order workflows to WooCommerce Backbone modals

### DIFF
--- a/css/p2-duplicate-admin.css
+++ b/css/p2-duplicate-admin.css
@@ -1,7 +1,3 @@
-body.wcos-duplicate-modal-open {
-    overflow: hidden;
-}
-
 .wcos-duplicate-launcher-description {
     position: absolute !important;
     width: 1px !important;
@@ -18,59 +14,27 @@ body.wcos-duplicate-modal-open {
     margin-right: 6px;
 }
 
-.wcos-duplicate-dialog[hidden] {
-    display: none;
-}
-
+/* Server-rendered source markup is a non-visible cloning source only. */
 .wcos-duplicate-dialog {
-    position: fixed;
-    inset: 0;
-    z-index: 100000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
+    display: none !important;
 }
 
-.wcos-duplicate-dialog__backdrop {
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.55);
+.wcos-duplicate-backbone-modal .wc-backbone-modal-content {
+    width: min(720px, calc(100% - 40px));
+    max-width: 720px;
+    min-width: 0;
 }
 
-.wcos-duplicate-dialog__panel {
-    position: relative;
-    width: min(760px, 100%);
-    max-height: calc(100vh - 48px);
-    overflow: auto;
-    background: #fff;
-    border-radius: 6px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 24px;
-}
-
-.wcos-duplicate-dialog__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 20px;
-}
-
-.wcos-duplicate-dialog__header h2 {
-    margin-top: 0;
-}
-
-.wcos-duplicate-close {
-    min-width: 44px;
-    min-height: 44px;
-    font-size: 28px;
-    line-height: 1;
+.wcos-duplicate-backbone-modal .wcos-admin-backbone-modal__description {
+    margin: 0 0 18px;
+    color: #50575e;
 }
 
 .wcos-duplicate-policy {
-    margin-top: 20px;
+    margin-top: 0;
     padding: 12px 16px;
-    border-left: 4px solid #646970;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
     background: #f6f7f7;
 }
 
@@ -98,31 +62,14 @@ body.wcos-duplicate-modal-open {
     padding: 10px 12px;
 }
 
-.wcos-duplicate-dialog__actions {
-    display: flex;
-    justify-content: flex-end;
+.wcos-duplicate-backbone-modal footer .inner {
     gap: 8px;
-    margin-top: 20px;
-    padding-top: 16px;
-    border-top: 1px solid #dcdcde;
 }
 
 @media (max-width: 782px) {
-    .wcos-duplicate-dialog {
-        padding: 12px;
-    }
-
-    .wcos-duplicate-dialog__panel {
-        max-height: calc(100vh - 24px);
-        padding: 16px;
-    }
-
-    .wcos-duplicate-dialog__actions {
-        flex-direction: column-reverse;
-    }
-
-    .wcos-duplicate-dialog__actions .button {
-        width: 100%;
-        min-height: 44px;
+    .wcos-duplicate-backbone-modal .wc-backbone-modal-content {
+        width: calc(100% - 24px);
+        max-width: none;
+        min-width: 0;
     }
 }

--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -1,7 +1,3 @@
-body.wcos-split-modal-open {
-    overflow: hidden;
-}
-
 .wcos-split-launcher-description {
     position: absolute !important;
     width: 1px !important;
@@ -18,84 +14,37 @@ body.wcos-split-modal-open {
     margin-right: 6px;
 }
 
-.wcos-split-dialog[hidden],
-.wcos-split-method-dialog[hidden],
+/* Server-rendered source markup is a non-visible cloning source only. */
+.wcos-split-dialog {
+    display: none !important;
+}
+
 .wcos-split-table th[hidden],
 .wcos-split-table td[hidden] {
     display: none !important;
 }
 
-.wcos-split-dialog,
-.wcos-split-method-dialog {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
+.wcos-split-backbone-modal .wc-backbone-modal-content {
+    width: min(900px, calc(100% - 40px));
+    max-width: 900px;
+    min-width: 0;
 }
 
-.wcos-split-dialog {
-    z-index: 100000;
+.wcos-split-method-backbone-modal .wc-backbone-modal-content {
+    width: min(560px, calc(100% - 40px));
+    max-width: 560px;
+    min-width: 0;
 }
 
-.wcos-split-method-dialog {
-    z-index: 99999;
-}
-
-.wcos-split-dialog__backdrop,
-.wcos-split-method-dialog__backdrop {
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.55);
-}
-
-.wcos-split-dialog__panel,
-.wcos-split-method-dialog__panel {
-    position: relative;
-    width: min(820px, 100%);
-    max-height: calc(100vh - 48px);
-    overflow: auto;
-    background: #fff;
-    border-radius: 6px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 24px;
-}
-
-.wcos-split-method-dialog__panel {
-    width: min(560px, 100%);
-}
-
-.wcos-split-dialog__header,
-.wcos-split-method-dialog__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 20px;
-}
-
-.wcos-split-dialog__header h2,
-.wcos-split-method-dialog__header h2 {
-    margin: 0 0 6px;
-}
-
-.wcos-split-close,
-.wcos-split-method-close {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 40px;
-    min-height: 40px;
-    margin: -6px -6px 0 0;
-    font-size: 28px;
-    line-height: 1;
-    text-decoration: none;
+.wcos-split-backbone-modal .wcos-admin-backbone-modal__description,
+.wcos-split-method-backbone-modal .wcos-admin-backbone-modal__description {
+    margin: 0 0 18px;
+    color: #50575e;
 }
 
 .wcos-split-method-options {
     display: grid;
     gap: 10px;
-    margin-top: 18px;
 }
 
 .wcos-split-method-option {
@@ -106,7 +55,7 @@ body.wcos-split-modal-open {
     width: 100%;
     padding: 14px 16px;
     border: 1px solid #c3c4c7;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #fff;
     color: #1d2327;
     text-align: left;
@@ -133,10 +82,10 @@ body.wcos-split-modal-open {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin: 20px 0 10px;
+    margin: 0 0 10px;
     padding: 10px 12px;
     border: 1px solid #dcdcde;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #f6f7f7;
 }
 
@@ -145,14 +94,20 @@ body.wcos-split-modal-open {
 }
 
 .wcos-split-remove-child {
+    color: #b32d2e;
     white-space: nowrap;
+}
+
+.wcos-split-remove-child:hover,
+.wcos-split-remove-child:focus {
+    color: #8a2424;
 }
 
 .wcos-split-table-wrap {
     overflow-x: auto;
     margin: 0 0 18px;
     border: 1px solid #dcdcde;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 .wcos-split-table {
@@ -201,7 +156,7 @@ body.wcos-split-modal-open {
     margin-top: 16px;
     padding: 14px 16px;
     border: 1px solid #dcdcde;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #f6f7f7;
 }
 
@@ -228,7 +183,7 @@ body.wcos-split-modal-open {
     margin-top: 16px;
     padding: 14px 16px;
     border: 1px solid #c3c4c7;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #fff;
 }
 
@@ -259,25 +214,17 @@ body.wcos-split-modal-open {
     margin-left: 20px;
 }
 
-.wcos-split-dialog__actions {
-    display: flex;
-    justify-content: flex-end;
+.wcos-split-backbone-modal footer .inner,
+.wcos-split-method-backbone-modal footer .inner {
     gap: 8px;
-    margin-top: 20px;
-    padding-top: 16px;
-    border-top: 1px solid #dcdcde;
 }
 
 @media (max-width: 782px) {
-    .wcos-split-dialog,
-    .wcos-split-method-dialog {
-        padding: 12px;
-    }
-
-    .wcos-split-dialog__panel,
-    .wcos-split-method-dialog__panel {
-        max-height: calc(100vh - 24px);
-        padding: 16px;
+    .wcos-split-backbone-modal .wc-backbone-modal-content,
+    .wcos-split-method-backbone-modal .wc-backbone-modal-content {
+        width: calc(100% - 24px);
+        max-width: none;
+        min-width: 0;
     }
 
     .wcos-split-child-toolbar {
@@ -289,23 +236,13 @@ body.wcos-split-modal-open {
         margin-right: 0;
     }
 
-    .wcos-split-child-toolbar .button,
-    .wcos-split-child-toolbar .button-link-delete {
+    .wcos-split-child-toolbar .button {
         min-height: 44px;
         text-align: center;
     }
 
     .wcos-split-table th:first-child {
         min-width: 140px;
-    }
-
-    .wcos-split-dialog__actions {
-        flex-direction: column-reverse;
-    }
-
-    .wcos-split-dialog__actions .button {
-        width: 100%;
-        min-height: 44px;
     }
 
     .wcos-split-method-option {

--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -1,7 +1,3 @@
-body.wcos-strategy-modal-open {
-    overflow: hidden;
-}
-
 .wcos-strategy-launcher {
     display: none !important;
 }
@@ -18,60 +14,27 @@ body.wcos-strategy-modal-open {
     border: 0 !important;
 }
 
-.wcos-strategy-dialog[hidden] {
-    display: none;
-}
-
+/* Server-rendered source markup is a non-visible cloning source only. */
 .wcos-strategy-dialog {
-    position: fixed;
-    inset: 0;
-    z-index: 100001;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
+    display: none !important;
 }
 
-.wcos-strategy-dialog__backdrop {
-    position: absolute;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.55);
+.wcos-strategy-backbone-modal .wc-backbone-modal-content {
+    width: min(760px, calc(100% - 40px));
+    max-width: 760px;
+    min-width: 0;
 }
 
-.wcos-strategy-dialog__panel {
-    position: relative;
-    width: min(760px, 100%);
-    max-height: calc(100vh - 48px);
-    overflow: auto;
-    background: #fff;
-    border-radius: 6px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 24px;
-}
-
-.wcos-strategy-dialog__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 20px;
-}
-
-.wcos-strategy-dialog__header h2 {
-    margin-top: 0;
-}
-
-.wcos-strategy-close {
-    min-width: 44px;
-    min-height: 44px;
-    font-size: 28px;
-    line-height: 1;
+.wcos-strategy-backbone-modal .wcos-admin-backbone-modal__description {
+    margin: 0 0 18px;
+    color: #50575e;
 }
 
 .wcos-strategy-policy {
-    margin-top: 16px;
+    margin-top: 0;
     padding: 12px 16px;
     border: 1px solid #dcdcde;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #f6f7f7;
 }
 
@@ -112,7 +75,7 @@ body.wcos-strategy-modal-open {
     gap: 10px;
     padding: 12px;
     border: 1px solid #c3c4c7;
-    border-radius: 5px;
+    border-radius: 4px;
     background: #fff;
     cursor: pointer;
 }
@@ -149,30 +112,17 @@ body.wcos-strategy-modal-open {
     margin-left: 20px;
 }
 
-.wcos-strategy-dialog__actions {
-    display: flex;
-    justify-content: flex-end;
+.wcos-strategy-backbone-modal footer .inner {
     gap: 8px;
-    margin-top: 20px;
-    padding-top: 16px;
-    border-top: 1px solid #dcdcde;
 }
 
 @media (max-width: 782px) {
-    .wcos-strategy-dialog {
-        padding: 12px;
+    .wcos-strategy-backbone-modal .wc-backbone-modal-content {
+        width: calc(100% - 24px);
+        max-width: none;
+        min-width: 0;
     }
 
-    .wcos-strategy-dialog__panel {
-        max-height: calc(100vh - 24px);
-        padding: 16px;
-    }
-
-    .wcos-strategy-dialog__actions {
-        flex-direction: column-reverse;
-    }
-
-    .wcos-strategy-dialog__actions .button,
     .wcos-strategy-review-controls .button,
     .wcos-strategy-review .button,
     .wcos-strategy-confirmation .button {

--- a/inc/backend/class-wcos-admin-backbone-modal-assets.php
+++ b/inc/backend/class-wcos-admin-backbone-modal-assets.php
@@ -1,0 +1,42 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Shared admin dependency for all Order Splitter modal workflows.
+ *
+ * WooCommerce registers wc-backbone-modal as a supported admin script handle.
+ * This bridge is loaded only on order-edit screens and is enqueued before the
+ * Split, strategy Split, and Duplicate clients.
+ */
+final class WCOS_Admin_Backbone_Modal_Assets {
+	public static function bootstrap() {
+		add_action('admin_enqueue_scripts', array(__CLASS__, 'enqueue'), 5);
+	}
+
+	public static function enqueue() {
+		if (!self::is_order_edit_screen()) {
+			return;
+		}
+
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_script('wc-backbone-modal');
+		wp_enqueue_script(
+			'wcos-admin-backbone-modal',
+			plugins_url('js/p2-backbone-modal.js', $plugin_file),
+			array('jquery', 'wc-backbone-modal'),
+			WC_ORDER_SPLITTER_VERSION,
+			true
+		);
+	}
+
+	private static function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
+	}
+}

--- a/inc/backend/class-wcos-admin-backbone-modal-assets.php
+++ b/inc/backend/class-wcos-admin-backbone-modal-assets.php
@@ -6,12 +6,13 @@ defined('ABSPATH') || exit;
  * Shared admin dependency for all Order Splitter modal workflows.
  *
  * WooCommerce registers wc-backbone-modal as a supported admin script handle.
- * This bridge is loaded only on order-edit screens and is enqueued before the
- * Split, strategy Split, and Duplicate clients.
+ * This bridge is loaded only on order-edit screens and becomes an explicit
+ * dependency of every Order Splitter workflow client.
  */
 final class WCOS_Admin_Backbone_Modal_Assets {
 	public static function bootstrap() {
 		add_action('admin_enqueue_scripts', array(__CLASS__, 'enqueue'), 5);
+		add_action('admin_enqueue_scripts', array(__CLASS__, 'bind_workflow_dependencies'), 100);
 	}
 
 	public static function enqueue() {
@@ -28,6 +29,28 @@ final class WCOS_Admin_Backbone_Modal_Assets {
 			WC_ORDER_SPLITTER_VERSION,
 			true
 		);
+	}
+
+	public static function bind_workflow_dependencies() {
+		if (!self::is_order_edit_screen()) {
+			return;
+		}
+
+		$scripts = wp_scripts();
+		if (!$scripts || !isset($scripts->registered['wcos-admin-backbone-modal'])) {
+			return;
+		}
+
+		foreach (array('wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin') as $handle) {
+			if (!isset($scripts->registered[$handle])) {
+				continue;
+			}
+			$deps = (array) $scripts->registered[$handle]->deps;
+			if (!in_array('wcos-admin-backbone-modal', $deps, true)) {
+				$deps[] = 'wcos-admin-backbone-modal';
+				$scripts->registered[$handle]->deps = array_values(array_unique($deps));
+			}
+		}
 	}
 
 	private static function is_order_edit_screen() {

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -66,6 +66,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 
+		include_once $root . 'backend/class-wcos-admin-backbone-modal-assets.php';
+		WCOS_Admin_Backbone_Modal_Assets::bootstrap();
 		include_once $root . 'backend/class-wcos-split-request-parser.php';
 		include_once $root . 'backend/class-wcos-split-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-split-strategy-review-store.php';

--- a/js/p2-backbone-modal.js
+++ b/js/p2-backbone-modal.js
@@ -44,6 +44,42 @@
         return document.getElementById('wc-backbone-modal-dialog');
     }
 
+    function remapClonedIds(container, instanceId) {
+        if (!container) {
+            return;
+        }
+
+        var idMap = {};
+        Array.prototype.forEach.call(container.querySelectorAll('[id]'), function (element) {
+            var oldId = element.id;
+            if (!oldId) {
+                return;
+            }
+            var newId = 'wcos-modal-' + String(instanceId) + '-' + oldId;
+            idMap[oldId] = newId;
+            element.id = newId;
+        });
+
+        function remapTokens(value) {
+            return String(value || '').split(/\s+/).filter(Boolean).map(function (token) {
+                return idMap[token] || token;
+            }).join(' ');
+        }
+
+        Array.prototype.forEach.call(container.querySelectorAll('[for]'), function (element) {
+            var oldFor = element.getAttribute('for');
+            if (oldFor && idMap[oldFor]) {
+                element.setAttribute('for', idMap[oldFor]);
+            }
+        });
+
+        ['aria-labelledby', 'aria-describedby', 'aria-controls', 'aria-owns'].forEach(function (attribute) {
+            Array.prototype.forEach.call(container.querySelectorAll('[' + attribute + ']'), function (element) {
+                element.setAttribute(attribute, remapTokens(element.getAttribute(attribute)));
+            });
+        });
+    }
+
     function open(options) {
         options = options || {};
         if (!ensureTemplate()) {
@@ -55,7 +91,8 @@
 
         var previousFocus = document.activeElement;
         var trigger = options.trigger || document.body;
-        var namespace = '.wcosBackboneModal' + String(++sequence);
+        var instanceId = ++sequence;
+        var namespace = '.wcosBackboneModal' + String(instanceId);
         var restoreFocus = options.restoreFocus !== false;
         var removed = false;
 
@@ -114,6 +151,7 @@
         if (typeof options.build === 'function') {
             options.build(body, footer, root, handle);
         }
+        remapClonedIds(body, instanceId);
 
         root.addEventListener('click', function (event) {
             if (!event.target.closest('.modal-close')) {

--- a/js/p2-backbone-modal.js
+++ b/js/p2-backbone-modal.js
@@ -1,0 +1,155 @@
+(function ($) {
+    'use strict';
+
+    var templateName = 'wcos-admin-backbone-modal-shell';
+    var templateId = 'tmpl-' + templateName;
+    var sequence = 0;
+
+    function ensureTemplate() {
+        if (document.getElementById(templateId)) {
+            return true;
+        }
+        if (!window.wp || typeof window.wp.template !== 'function' || !$ || !$.fn || typeof $.fn.WCBackboneModal !== 'function') {
+            return false;
+        }
+
+        var template = document.createElement('script');
+        template.type = 'text/template';
+        template.id = templateId;
+        template.textContent = [
+            '<div class="wc-backbone-modal wcos-admin-backbone-modal">',
+            '<div class="wc-backbone-modal-content">',
+            '<section class="wc-backbone-modal-main" role="main">',
+            '<header class="wc-backbone-modal-header">',
+            '<h1 class="wcos-admin-backbone-modal__title"></h1>',
+            '<button class="modal-close modal-close-link dashicons dashicons-no-alt" type="button">',
+            '<span class="screen-reader-text">Close modal panel</span>',
+            '</button>',
+            '</header>',
+            '<article>',
+            '<p class="wcos-admin-backbone-modal__description description"></p>',
+            '<div class="wcos-admin-backbone-modal__body"></div>',
+            '</article>',
+            '<footer><div class="inner wcos-admin-backbone-modal__footer"></div></footer>',
+            '</section>',
+            '</div>',
+            '</div>',
+            '<div class="wc-backbone-modal-backdrop modal-close"></div>'
+        ].join('');
+        document.body.appendChild(template);
+        return true;
+    }
+
+    function currentRoot() {
+        return document.getElementById('wc-backbone-modal-dialog');
+    }
+
+    function open(options) {
+        options = options || {};
+        if (!ensureTemplate()) {
+            throw new Error('WooCommerce Backbone modal is unavailable on this screen.');
+        }
+        if (currentRoot()) {
+            throw new Error('Another WooCommerce modal is already open.');
+        }
+
+        var previousFocus = document.activeElement;
+        var trigger = options.trigger || document.body;
+        var namespace = '.wcosBackboneModal' + String(++sequence);
+        var restoreFocus = options.restoreFocus !== false;
+        var removed = false;
+
+        $(trigger).WCBackboneModal({
+            template: templateName,
+            variable: {}
+        });
+
+        var root = currentRoot();
+        if (!root) {
+            throw new Error('WooCommerce Backbone modal failed to render.');
+        }
+
+        var shell = root.querySelector('.wc-backbone-modal');
+        var title = root.querySelector('.wcos-admin-backbone-modal__title');
+        var description = root.querySelector('.wcos-admin-backbone-modal__description');
+        var body = root.querySelector('.wcos-admin-backbone-modal__body');
+        var footer = root.querySelector('.wcos-admin-backbone-modal__footer');
+        var content = root.querySelector('.wc-backbone-modal-content');
+
+        if (shell && options.modalClass) {
+            String(options.modalClass).split(/\s+/).filter(Boolean).forEach(function (className) {
+                shell.classList.add(className);
+            });
+        }
+        if (title) {
+            title.textContent = options.title || '';
+        }
+        if (description) {
+            description.textContent = options.description || '';
+            description.hidden = !options.description;
+        }
+        if (content && options.label) {
+            content.setAttribute('aria-label', options.label);
+        }
+
+        var handle = {
+            root: root,
+            shell: shell,
+            body: body,
+            footer: footer,
+            close: function (shouldRestoreFocus) {
+                restoreFocus = shouldRestoreFocus !== false;
+                var close = root.querySelector('.wc-backbone-modal-header .modal-close') || root.querySelector('.modal-close');
+                if (close) {
+                    close.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                }
+            },
+            focusContent: function () {
+                if (content && typeof content.focus === 'function') {
+                    content.focus();
+                }
+            }
+        };
+
+        if (typeof options.build === 'function') {
+            options.build(body, footer, root, handle);
+        }
+
+        root.addEventListener('click', function (event) {
+            if (!event.target.closest('.modal-close')) {
+                return;
+            }
+            if (typeof options.isBusy === 'function' && options.isBusy()) {
+                event.preventDefault();
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+            }
+        }, true);
+
+        $(document.body).on('wc_backbone_modal_removed' + namespace, function (event, target) {
+            if (target !== templateName || removed) {
+                return;
+            }
+            removed = true;
+            $(document.body).off(namespace);
+            if (typeof options.onRemoved === 'function') {
+                options.onRemoved();
+            }
+            if (restoreFocus && previousFocus && previousFocus.isConnected && typeof previousFocus.focus === 'function') {
+                previousFocus.focus();
+            }
+        });
+
+        if (typeof options.onReady === 'function') {
+            options.onReady(root, handle);
+        }
+
+        return handle;
+    }
+
+    window.WCOSBackboneModal = {
+        open: open,
+        currentRoot: currentRoot,
+        templateName: templateName
+    };
+})(window.jQuery);

--- a/js/p2-duplicate-admin.js
+++ b/js/p2-duplicate-admin.js
@@ -3,259 +3,259 @@
 
     var strings = window.wcosDuplicateAdminStrings || {};
     var launcher = document.querySelector('.wcos-duplicate-launcher');
-    if (!launcher) {
+    if (!launcher || !window.WCOSBackboneModal) {
         return;
     }
 
-    var dialogId = launcher.getAttribute('aria-controls');
-    var dialog = dialogId ? document.getElementById(dialogId) : null;
-    if (!dialog) {
+    var sourceDialogId = launcher.getAttribute('aria-controls');
+    var sourceDialog = sourceDialogId ? document.getElementById(sourceDialogId) : null;
+    if (!sourceDialog) {
         return;
     }
-
-    var panel = dialog.querySelector('.wcos-duplicate-dialog__panel');
-    var closeButton = dialog.querySelector('.wcos-duplicate-close');
-    var cancelButton = dialog.querySelector('.wcos-duplicate-cancel');
-    var reviewButton = dialog.querySelector('.wcos-duplicate-review-button');
-    var executeButton = dialog.querySelector('.wcos-duplicate-execute-button');
-    var confirmCheckbox = dialog.querySelector('.wcos-duplicate-confirm-checkbox');
-    var reviewBox = dialog.querySelector('.wcos-duplicate-review');
-    var reviewSummary = dialog.querySelector('.wcos-duplicate-review-summary');
-    var statusBox = dialog.querySelector('.wcos-duplicate-status');
-    var errorBox = dialog.querySelector('.wcos-duplicate-error');
-    var resultBox = dialog.querySelector('.wcos-duplicate-result');
-    var state = null;
-    var returnFocus = null;
-    var busy = false;
-    var completed = false;
 
     function text(key, fallback) {
         return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
     }
 
-    function focusableElements() {
-        return Array.prototype.slice.call(dialog.querySelectorAll(
-            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        )).filter(function (element) {
-            return !element.hidden && element.offsetParent !== null;
-        });
-    }
-
-    function openDialog() {
-        returnFocus = document.activeElement;
-        dialog.hidden = false;
-        document.body.classList.add('wcos-duplicate-modal-open');
-        window.setTimeout(function () {
-            var preferred = completed && !resultBox.hidden ? resultBox : reviewButton;
-            (preferred || panel).focus();
-        }, 0);
-    }
-
-    function closeDialog() {
-        if (busy) {
-            return;
+    function removeExternalDescription(button) {
+        var descriptionId = button.getAttribute('aria-describedby');
+        var description = descriptionId ? document.getElementById(descriptionId) : null;
+        var value = description ? description.textContent.trim() : '';
+        if (description && description.parentNode) {
+            description.parentNode.removeChild(description);
         }
-        dialog.hidden = true;
-        document.body.classList.remove('wcos-duplicate-modal-open');
-        if (returnFocus && typeof returnFocus.focus === 'function') {
-            returnFocus.focus();
-        }
+        button.removeAttribute('aria-describedby');
+        return value;
     }
 
-    function clearError() {
-        errorBox.hidden = true;
-        errorBox.textContent = '';
-    }
+    var launcherDescription = removeExternalDescription(launcher);
+    launcher.removeAttribute('aria-controls');
 
-    function showError(message) {
-        errorBox.textContent = message || text('requestFailed', 'The Duplicate request could not be completed.');
-        errorBox.hidden = false;
-        errorBox.focus();
-    }
-
-    function setStatus(message) {
-        statusBox.textContent = message || '';
-    }
-
-    function clearResult() {
-        resultBox.hidden = true;
-        resultBox.textContent = '';
-    }
-
-    function invalidateReview() {
-        if (completed) {
-            return;
-        }
-        state = null;
-        reviewBox.hidden = true;
-        reviewSummary.textContent = '';
-        confirmCheckbox.checked = false;
-        executeButton.disabled = true;
-        clearResult();
-    }
-
-    function request(action, data) {
-        var body = new URLSearchParams();
-        body.set('action', action);
-        Object.keys(data).forEach(function (key) {
-            body.set(key, String(data[key]));
-        });
-
-        return window.fetch(dialog.getAttribute('data-ajax-url'), {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            },
-            body: body.toString()
-        }).then(function (response) {
-            return response.json().catch(function () {
-                throw new Error(text('requestFailed', 'The Duplicate request could not be completed.'));
-            });
-        }).then(function (payload) {
-            if (!payload || payload.success !== true) {
-                var failure = payload && payload.data ? payload.data : {};
-                var error = new Error(failure.message || text('requestFailed', 'The Duplicate request could not be completed.'));
-                error.code = failure.code || 'request_failed';
-                error.retryable = !!failure.retryable;
-                throw error;
+    function cloneBody(sourcePanel, body) {
+        Array.prototype.forEach.call(sourcePanel.children, function (child) {
+            if (child.classList.contains('wcos-duplicate-dialog__header') || child.classList.contains('wcos-duplicate-dialog__actions')) {
+                return;
             }
-            return payload.data || {};
+            body.appendChild(child.cloneNode(true));
         });
     }
 
-    function setBusy(nextBusy) {
-        busy = !!nextBusy;
-        dialog.setAttribute('aria-busy', busy ? 'true' : 'false');
-        reviewButton.disabled = busy || completed;
-        confirmCheckbox.disabled = busy || completed;
-        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
-        cancelButton.disabled = busy;
-        closeButton.disabled = busy;
+    function cloneFooter(sourceActions, footer) {
+        Array.prototype.forEach.call(sourceActions ? sourceActions.children : [], function (sourceButton) {
+            var button = sourceButton.cloneNode(true);
+            if (button.classList.contains('wcos-duplicate-cancel')) {
+                button.classList.add('modal-close');
+                button.classList.add('button-large');
+            }
+            footer.appendChild(button);
+        });
     }
 
-    function reviewDuplicate() {
-        if (busy || completed) {
-            return;
-        }
-        clearError();
-        clearResult();
-        invalidateReview();
-        setBusy(true);
-        setStatus(text('reviewing', 'Reviewing Duplicate…'));
+    function openDuplicateModal() {
+        var busy = false;
+        var completed = false;
+        var state = null;
+        var dialog = null;
+        var closeButton = null;
+        var cancelButton = null;
+        var reviewButton = null;
+        var executeButton = null;
+        var confirmCheckbox = null;
+        var reviewBox = null;
+        var reviewSummary = null;
+        var statusBox = null;
+        var errorBox = null;
+        var resultBox = null;
 
-        request('wcos_duplicate_review', {
-            order_id: dialog.getAttribute('data-order-id'),
-            nonce: dialog.getAttribute('data-nonce')
-        }).then(function (data) {
-            state = {
-                operationId: data.operation_id,
-                token: data.confirmation_token
-            };
-            var summary = data.summary || {};
-            reviewSummary.textContent = text('reviewSummary', 'Reviewed lines / shipping / fees / coupons:') + ' ' +
-                String(summary.line_count || 0) + ' / ' +
-                String(summary.shipping_count || 0) + ' / ' +
-                String(summary.fee_count || 0) + ' / ' +
-                String(summary.coupon_count || 0);
-            reviewBox.hidden = false;
+        function clearError() {
+            errorBox.hidden = true;
+            errorBox.textContent = '';
+        }
+
+        function showError(message) {
+            errorBox.textContent = message || text('requestFailed', 'The Duplicate request could not be completed.');
+            errorBox.hidden = false;
+            errorBox.focus();
+        }
+
+        function setStatus(message) {
+            statusBox.textContent = message || '';
+        }
+
+        function clearResult() {
+            resultBox.hidden = true;
+            resultBox.textContent = '';
+        }
+
+        function invalidateReview() {
+            if (completed) {
+                return;
+            }
+            state = null;
+            reviewBox.hidden = true;
+            reviewSummary.textContent = '';
             confirmCheckbox.checked = false;
-            setStatus(text('reviewReady', 'The order passed server review. Confirm the acknowledgement to duplicate it.'));
-            confirmCheckbox.focus();
-        }).catch(function (error) {
+            executeButton.disabled = true;
+            clearResult();
+        }
+
+        function request(action, data) {
+            var body = new URLSearchParams();
+            body.set('action', action);
+            Object.keys(data).forEach(function (key) {
+                body.set(key, String(data[key]));
+            });
+
+            return window.fetch(sourceDialog.getAttribute('data-ajax-url'), {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+                body: body.toString()
+            }).then(function (response) {
+                return response.json().catch(function () {
+                    throw new Error(text('requestFailed', 'The Duplicate request could not be completed.'));
+                });
+            }).then(function (payload) {
+                if (!payload || payload.success !== true) {
+                    var failure = payload && payload.data ? payload.data : {};
+                    var error = new Error(failure.message || text('requestFailed', 'The Duplicate request could not be completed.'));
+                    error.code = failure.code || 'request_failed';
+                    error.retryable = !!failure.retryable;
+                    throw error;
+                }
+                return payload.data || {};
+            });
+        }
+
+        function setBusy(nextBusy) {
+            busy = !!nextBusy;
+            dialog.setAttribute('aria-busy', busy ? 'true' : 'false');
+            reviewButton.disabled = busy || completed;
+            confirmCheckbox.disabled = busy || completed;
+            executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+            cancelButton.disabled = busy;
+            closeButton.disabled = busy;
+        }
+
+        function reviewDuplicate() {
+            if (busy || completed) {
+                return;
+            }
+            clearError();
+            clearResult();
             invalidateReview();
-            setStatus('');
-            showError(error.message);
-        }).finally(function () {
-            setBusy(false);
-        });
-    }
+            setBusy(true);
+            setStatus(text('reviewing', 'Reviewing Duplicate…'));
 
-    function renderSuccess(data) {
-        resultBox.textContent = '';
-        var message = document.createElement('p');
-        message.textContent = text('completed', 'Order duplicated successfully.');
-        resultBox.appendChild(message);
-
-        var target = data && data.target ? data.target : null;
-        if (target) {
-            var detail = document.createElement('p');
-            if (target.edit_url) {
-                var link = document.createElement('a');
-                link.href = target.edit_url;
-                link.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
-                detail.appendChild(link);
-            } else {
-                detail.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
-            }
-            resultBox.appendChild(detail);
-        }
-        resultBox.hidden = false;
-        resultBox.focus();
-    }
-
-    function executeDuplicate() {
-        if (busy || completed || !state || !confirmCheckbox.checked) {
-            return;
-        }
-        clearError();
-        clearResult();
-        setBusy(true);
-        setStatus(text('executing', 'Duplicating order…'));
-
-        request('wcos_duplicate_execute', {
-            order_id: dialog.getAttribute('data-order-id'),
-            nonce: dialog.getAttribute('data-nonce'),
-            operation_id: state.operationId,
-            confirmation_token: state.token
-        }).then(function (data) {
-            completed = true;
-            setStatus(text('completed', 'Order duplicated successfully.'));
-            confirmCheckbox.disabled = true;
-            renderSuccess(data);
-        }).catch(function (error) {
-            if (!error.retryable) {
+            request('wcos_duplicate_review', {
+                order_id: sourceDialog.getAttribute('data-order-id'),
+                nonce: sourceDialog.getAttribute('data-nonce')
+            }).then(function (data) {
+                state = { operationId: data.operation_id, token: data.confirmation_token };
+                var summary = data.summary || {};
+                reviewSummary.textContent = text('reviewSummary', 'Reviewed lines / shipping / fees / coupons:') + ' ' +
+                    String(summary.line_count || 0) + ' / ' +
+                    String(summary.shipping_count || 0) + ' / ' +
+                    String(summary.fee_count || 0) + ' / ' +
+                    String(summary.coupon_count || 0);
+                reviewBox.hidden = false;
+                confirmCheckbox.checked = false;
+                setStatus(text('reviewReady', 'The order passed server review. Confirm the acknowledgement to duplicate it.'));
+                confirmCheckbox.focus();
+            }).catch(function (error) {
                 invalidateReview();
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+            });
+        }
+
+        function renderSuccess(data) {
+            resultBox.textContent = '';
+            var message = document.createElement('p');
+            message.textContent = text('completed', 'Order duplicated successfully.');
+            resultBox.appendChild(message);
+            var target = data && data.target ? data.target : null;
+            if (target) {
+                var detail = document.createElement('p');
+                if (target.edit_url) {
+                    var link = document.createElement('a');
+                    link.href = target.edit_url;
+                    link.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
+                    detail.appendChild(link);
+                } else {
+                    detail.textContent = text('targetOrder', 'Duplicated order') + ' #' + String(target.number || target.id || '');
+                }
+                resultBox.appendChild(detail);
             }
-            setStatus('');
-            showError(error.message);
-        }).finally(function () {
-            setBusy(false);
+            resultBox.hidden = false;
+            resultBox.focus();
+        }
+
+        function executeDuplicate() {
+            if (busy || completed || !state || !confirmCheckbox.checked) {
+                return;
+            }
+            clearError();
+            clearResult();
+            setBusy(true);
+            setStatus(text('executing', 'Duplicating order…'));
+
+            request('wcos_duplicate_execute', {
+                order_id: sourceDialog.getAttribute('data-order-id'),
+                nonce: sourceDialog.getAttribute('data-nonce'),
+                operation_id: state.operationId,
+                confirmation_token: state.token
+            }).then(function (data) {
+                completed = true;
+                setStatus(text('completed', 'Order duplicated successfully.'));
+                confirmCheckbox.disabled = true;
+                renderSuccess(data);
+            }).catch(function (error) {
+                if (!error.retryable) {
+                    invalidateReview();
+                }
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+            });
+        }
+
+        window.WCOSBackboneModal.open({
+            trigger: launcher,
+            title: (sourceDialog.querySelector('.wcos-duplicate-dialog__header h2') || {}).textContent || 'Review order duplicate',
+            description: (sourceDialog.querySelector('.wcos-duplicate-dialog__header p') || {}).textContent || launcherDescription,
+            modalClass: 'wcos-duplicate-backbone-modal',
+            isBusy: function () { return busy; },
+            build: function (body, footer, root) {
+                var sourcePanel = sourceDialog.querySelector('.wcos-duplicate-dialog__panel');
+                var sourceActions = sourceDialog.querySelector('.wcos-duplicate-dialog__actions');
+                cloneBody(sourcePanel, body);
+                cloneFooter(sourceActions, footer);
+                dialog = root;
+                closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
+                cancelButton = root.querySelector('.wcos-duplicate-cancel');
+                reviewButton = root.querySelector('.wcos-duplicate-review-button');
+                executeButton = root.querySelector('.wcos-duplicate-execute-button');
+                confirmCheckbox = root.querySelector('.wcos-duplicate-confirm-checkbox');
+                reviewBox = root.querySelector('.wcos-duplicate-review');
+                reviewSummary = root.querySelector('.wcos-duplicate-review-summary');
+                statusBox = root.querySelector('.wcos-duplicate-status');
+                errorBox = root.querySelector('.wcos-duplicate-error');
+                resultBox = root.querySelector('.wcos-duplicate-result');
+            },
+            onReady: function () {
+                reviewButton.addEventListener('click', reviewDuplicate);
+                executeButton.addEventListener('click', executeDuplicate);
+                confirmCheckbox.addEventListener('change', function () {
+                    executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+                });
+                reviewButton.focus();
+            }
         });
     }
 
-    launcher.addEventListener('click', openDialog);
-    closeButton.addEventListener('click', closeDialog);
-    cancelButton.addEventListener('click', closeDialog);
-    reviewButton.addEventListener('click', reviewDuplicate);
-    executeButton.addEventListener('click', executeDuplicate);
-    confirmCheckbox.addEventListener('change', function () {
-        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
-    });
-
-    dialog.addEventListener('keydown', function (event) {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            closeDialog();
-            return;
-        }
-        if (event.key !== 'Tab') {
-            return;
-        }
-        var focusable = focusableElements();
-        if (!focusable.length) {
-            event.preventDefault();
-            panel.focus();
-            return;
-        }
-        var first = focusable[0];
-        var last = focusable[focusable.length - 1];
-        if (event.shiftKey && document.activeElement === first) {
-            event.preventDefault();
-            last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-            event.preventDefault();
-            first.focus();
-        }
-    });
+    launcher.addEventListener('click', openDuplicateModal);
 })();

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -3,45 +3,17 @@
 
     var strings = window.wcosSplitAdminStrings || {};
     var launcher = document.querySelector('.wcos-split-launcher');
-    if (!launcher) {
+    if (!launcher || !window.WCOSBackboneModal) {
         return;
     }
 
-    var quantityDialogId = launcher.getAttribute('aria-controls');
-    var dialog = quantityDialogId ? document.getElementById(quantityDialogId) : null;
-    if (!dialog) {
+    var sourceDialogId = launcher.getAttribute('aria-controls');
+    var sourceDialog = sourceDialogId ? document.getElementById(sourceDialogId) : null;
+    if (!sourceDialog) {
         return;
     }
 
-    var panel = dialog.querySelector('.wcos-split-dialog__panel');
-    var form = dialog.querySelector('.wcos-split-form');
-    var closeButton = dialog.querySelector('.wcos-split-close');
-    var cancelButton = dialog.querySelector('.wcos-split-cancel');
-    var reviewButton = dialog.querySelector('.wcos-split-review-button');
-    var executeButton = dialog.querySelector('.wcos-split-execute-button');
-    var confirmCheckbox = dialog.querySelector('.wcos-split-confirm-checkbox');
-    var reviewBox = dialog.querySelector('.wcos-split-review');
-    var reviewSummary = dialog.querySelector('.wcos-split-review-summary');
-    var statusBox = dialog.querySelector('.wcos-split-status');
-    var errorBox = dialog.querySelector('.wcos-split-error');
-    var resultBox = dialog.querySelector('.wcos-split-result');
-    var table = dialog.querySelector('.wcos-split-table');
-    var tableWrap = dialog.querySelector('.wcos-split-table-wrap');
-    var policyBox = dialog.querySelector('.wcos-split-policy');
-    var actions = dialog.querySelector('.wcos-split-dialog__actions');
     var strategyLaunchers = Array.prototype.slice.call(document.querySelectorAll('.wcos-strategy-launcher'));
-    var state = null;
-    var returnFocus = null;
-    var busy = false;
-    var completed = false;
-    var activeChildren = 1;
-    var maxChildren = 10;
-    var addChildButton = null;
-    var removeChildButton = null;
-    var childCountLabel = null;
-    var editButton = null;
-    var methodDialog = null;
-    var methodReturnFocus = null;
 
     function text(key, fallback) {
         return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
@@ -55,581 +27,583 @@
         return normalized === '' ? '0' : normalized;
     }
 
-    function quantityFocusableElements(targetDialog) {
-        return Array.prototype.slice.call(targetDialog.querySelectorAll(
-            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        )).filter(function (element) {
-            return !element.hidden && element.offsetParent !== null;
+    function removeExternalDescription(button) {
+        var descriptionId = button.getAttribute('aria-describedby');
+        var description = descriptionId ? document.getElementById(descriptionId) : null;
+        var value = description ? description.textContent.trim() : '';
+        if (description && description.parentNode) {
+            description.parentNode.removeChild(description);
+        }
+        button.removeAttribute('aria-describedby');
+        return value;
+    }
+
+    var launcherDescription = removeExternalDescription(launcher);
+    strategyLaunchers.forEach(function (strategyLauncher) {
+        strategyLauncher._wcosDescription = removeExternalDescription(strategyLauncher);
+        strategyLauncher.hidden = true;
+    });
+    launcher.removeAttribute('aria-controls');
+
+    function cloneFooterButtons(sourceActions, footer) {
+        Array.prototype.forEach.call(sourceActions ? sourceActions.children : [], function (sourceButton) {
+            var button = sourceButton.cloneNode(true);
+            if (button.classList.contains('wcos-split-cancel')) {
+                button.classList.add('modal-close');
+                button.classList.add('button-large');
+            }
+            footer.appendChild(button);
         });
     }
 
-    function syncBodyLock() {
-        var quantityOpen = !dialog.hidden;
-        var methodOpen = methodDialog && !methodDialog.hidden;
-        document.body.classList.toggle('wcos-split-modal-open', !!(quantityOpen || methodOpen));
-    }
+    function openQuantityDialog(trigger) {
+        var busy = false;
+        var completed = false;
+        var state = null;
+        var activeChildren = 1;
+        var maxChildren = 10;
+        var modal = null;
+        var dialog = null;
+        var form = null;
+        var reviewButton = null;
+        var executeButton = null;
+        var confirmCheckbox = null;
+        var reviewBox = null;
+        var reviewSummary = null;
+        var statusBox = null;
+        var errorBox = null;
+        var resultBox = null;
+        var table = null;
+        var tableWrap = null;
+        var policyBox = null;
+        var addChildButton = null;
+        var removeChildButton = null;
+        var childCountLabel = null;
+        var editButton = null;
+        var cancelButton = null;
+        var closeButton = null;
 
-    function openQuantityDialog() {
-        returnFocus = document.activeElement;
-        dialog.hidden = false;
-        syncBodyLock();
-        window.setTimeout(function () {
-            var preferred = completed && !resultBox.hidden
-                ? resultBox
-                : dialog.querySelector('.wcos-split-quantity:not([disabled])');
-            (preferred || panel).focus();
-        }, 0);
-    }
-
-    function closeQuantityDialog() {
-        if (busy) {
-            return;
-        }
-        dialog.hidden = true;
-        syncBodyLock();
-        if (returnFocus && typeof returnFocus.focus === 'function') {
-            returnFocus.focus();
-        }
-    }
-
-    function clearError() {
-        errorBox.hidden = true;
-        errorBox.textContent = '';
-    }
-
-    function showError(message) {
-        errorBox.textContent = message || text('requestFailed', 'The Split request could not be completed.');
-        errorBox.hidden = false;
-        errorBox.focus();
-    }
-
-    function setStatus(message) {
-        statusBox.textContent = message || '';
-    }
-
-    function clearResult() {
-        resultBox.hidden = true;
-        resultBox.textContent = '';
-    }
-
-    function childColumnElements(childIndex) {
-        var childKey = 'child-' + String(childIndex);
-        var fields = Array.prototype.slice.call(dialog.querySelectorAll('.wcos-split-quantity[data-child-key="' + childKey + '"]'));
-        var cells = fields.map(function (field) { return field.closest('td'); }).filter(Boolean);
-        var header = table && table.tHead && table.tHead.rows.length
-            ? table.tHead.rows[0].cells[childIndex + 1]
-            : null;
-        return { fields: fields, cells: cells, header: header };
-    }
-
-    function setChildVisible(childIndex, visible) {
-        var column = childColumnElements(childIndex);
-        if (column.header) {
-            column.header.hidden = !visible;
-        }
-        column.cells.forEach(function (cell) {
-            cell.hidden = !visible;
-        });
-    }
-
-    function updateChildToolbar() {
-        if (childCountLabel) {
-            childCountLabel.textContent = String(activeChildren) + (activeChildren === 1 ? ' child order' : ' child orders');
-        }
-        if (addChildButton) {
-            addChildButton.disabled = busy || completed || !!state || activeChildren >= maxChildren;
-        }
-        if (removeChildButton) {
-            removeChildButton.hidden = activeChildren <= 1;
-            removeChildButton.disabled = busy || completed || !!state || activeChildren <= 1;
-        }
-    }
-
-    function enhanceChildColumns() {
-        if (!table || !tableWrap) {
-            return;
+        function clearError() {
+            errorBox.hidden = true;
+            errorBox.textContent = '';
         }
 
-        for (var childIndex = 1; childIndex <= maxChildren; childIndex++) {
+        function showError(message) {
+            errorBox.textContent = message || text('requestFailed', 'The Split request could not be completed.');
+            errorBox.hidden = false;
+            errorBox.focus();
+        }
+
+        function setStatus(message) {
+            statusBox.textContent = message || '';
+        }
+
+        function clearResult() {
+            resultBox.hidden = true;
+            resultBox.textContent = '';
+        }
+
+        function childColumnElements(childIndex) {
+            var childKey = 'child-' + String(childIndex);
+            var fields = Array.prototype.slice.call(dialog.querySelectorAll('.wcos-split-quantity[data-child-key="' + childKey + '"]'));
+            var cells = fields.map(function (field) { return field.closest('td'); }).filter(Boolean);
+            var header = table && table.tHead && table.tHead.rows.length
+                ? table.tHead.rows[0].cells[childIndex + 1]
+                : null;
+            return { fields: fields, cells: cells, header: header };
+        }
+
+        function setChildVisible(childIndex, visible) {
             var column = childColumnElements(childIndex);
-            column.fields.forEach(function (field) {
-                if (field.value === '0') {
+            if (column.header) {
+                column.header.hidden = !visible;
+            }
+            column.cells.forEach(function (cell) {
+                cell.hidden = !visible;
+            });
+        }
+
+        function updateChildToolbar() {
+            if (childCountLabel) {
+                childCountLabel.textContent = String(activeChildren) + (activeChildren === 1 ? ' child order' : ' child orders');
+            }
+            if (addChildButton) {
+                addChildButton.disabled = busy || completed || !!state || activeChildren >= maxChildren;
+            }
+            if (removeChildButton) {
+                removeChildButton.hidden = activeChildren <= 1;
+                removeChildButton.disabled = busy || completed || !!state || activeChildren <= 1;
+            }
+        }
+
+        function enhanceChildColumns() {
+            for (var childIndex = 1; childIndex <= maxChildren; childIndex++) {
+                var column = childColumnElements(childIndex);
+                column.fields.forEach(function (field) {
+                    if (field.value === '0') {
+                        field.value = '';
+                    }
+                    field.placeholder = '0';
+                });
+                setChildVisible(childIndex, childIndex === 1);
+            }
+
+            Array.prototype.forEach.call(table.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+                var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
+                var currentCell = row.cells.length > 1 ? row.cells[1] : null;
+                if (!currentCell) {
+                    return;
+                }
+                currentCell.textContent = humanDecimal(sourceQuantity);
+                var remaining = document.createElement('span');
+                remaining.className = 'wcos-split-remaining-hint';
+                var label = document.createElement('span');
+                label.textContent = 'Remaining ';
+                var value = document.createElement('strong');
+                value.className = 'wcos-split-remaining';
+                value.setAttribute('data-item-id', row.getAttribute('data-item-id') || '');
+                value.textContent = humanDecimal(sourceQuantity);
+                remaining.appendChild(label);
+                remaining.appendChild(value);
+                currentCell.appendChild(remaining);
+            });
+
+            var toolbar = document.createElement('div');
+            toolbar.className = 'wcos-split-child-toolbar';
+            childCountLabel = document.createElement('strong');
+            childCountLabel.className = 'wcos-split-child-count';
+            addChildButton = document.createElement('button');
+            addChildButton.type = 'button';
+            addChildButton.className = 'button button-secondary wcos-split-add-child';
+            addChildButton.textContent = 'Add child order';
+            removeChildButton = document.createElement('button');
+            removeChildButton.type = 'button';
+            removeChildButton.className = 'button wcos-split-remove-child';
+            removeChildButton.textContent = 'Remove last child';
+            toolbar.appendChild(childCountLabel);
+            toolbar.appendChild(addChildButton);
+            toolbar.appendChild(removeChildButton);
+            tableWrap.parentNode.insertBefore(toolbar, tableWrap);
+
+            addChildButton.addEventListener('click', function () {
+                if (busy || completed || state || activeChildren >= maxChildren) {
+                    return;
+                }
+                activeChildren += 1;
+                setChildVisible(activeChildren, true);
+                updateChildToolbar();
+                updateRemaining();
+                updateReviewAvailability();
+                var next = childColumnElements(activeChildren).fields[0];
+                if (next) {
+                    next.focus();
+                }
+            });
+
+            removeChildButton.addEventListener('click', function () {
+                if (busy || completed || state || activeChildren <= 1) {
+                    return;
+                }
+                var column = childColumnElements(activeChildren);
+                column.fields.forEach(function (field) {
                     field.value = '';
-                }
-                field.placeholder = '0';
+                });
+                setChildVisible(activeChildren, false);
+                activeChildren -= 1;
+                updateChildToolbar();
+                updateRemaining();
+                updateReviewAvailability();
             });
-            setChildVisible(childIndex, childIndex === 1);
-        }
 
-        Array.prototype.forEach.call(table.querySelectorAll('tbody tr[data-item-id]'), function (row) {
-            var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
-            var currentCell = row.cells.length > 1 ? row.cells[1] : null;
-            if (!currentCell) {
-                return;
-            }
-            currentCell.textContent = humanDecimal(sourceQuantity);
-            var remaining = document.createElement('span');
-            remaining.className = 'wcos-split-remaining-hint';
-            var label = document.createElement('span');
-            label.textContent = 'Remaining ';
-            var value = document.createElement('strong');
-            value.className = 'wcos-split-remaining';
-            value.setAttribute('data-item-id', row.getAttribute('data-item-id') || '');
-            value.textContent = humanDecimal(sourceQuantity);
-            remaining.appendChild(label);
-            remaining.appendChild(value);
-            currentCell.appendChild(remaining);
-        });
-
-        var toolbar = document.createElement('div');
-        toolbar.className = 'wcos-split-child-toolbar';
-        childCountLabel = document.createElement('strong');
-        childCountLabel.className = 'wcos-split-child-count';
-        addChildButton = document.createElement('button');
-        addChildButton.type = 'button';
-        addChildButton.className = 'button button-secondary wcos-split-add-child';
-        addChildButton.textContent = 'Add child order';
-        removeChildButton = document.createElement('button');
-        removeChildButton.type = 'button';
-        removeChildButton.className = 'button-link-delete wcos-split-remove-child';
-        removeChildButton.textContent = 'Remove last child';
-        toolbar.appendChild(childCountLabel);
-        toolbar.appendChild(addChildButton);
-        toolbar.appendChild(removeChildButton);
-        tableWrap.parentNode.insertBefore(toolbar, tableWrap);
-
-        addChildButton.addEventListener('click', function () {
-            if (busy || completed || state || activeChildren >= maxChildren) {
-                return;
-            }
-            activeChildren += 1;
-            setChildVisible(activeChildren, true);
             updateChildToolbar();
             updateRemaining();
-            updateReviewAvailability();
-            var next = childColumnElements(activeChildren).fields[0];
-            if (next) {
-                next.focus();
-            }
-        });
+        }
 
-        removeChildButton.addEventListener('click', function () {
-            if (busy || completed || state || activeChildren <= 1) {
+        function enhancePolicy() {
+            var list = policyBox.querySelector('ul');
+            if (!list) {
                 return;
             }
-            var column = childColumnElements(activeChildren);
-            column.fields.forEach(function (field) {
-                field.value = '';
+            list.hidden = true;
+            var summary = document.createElement('p');
+            summary.className = 'wcos-split-policy-summary';
+            summary.textContent = 'Child orders are created as Pending payment. Shipping stays on the source order, historical prices and taxes are preserved, and this Split does not change physical product stock.';
+            var toggle = document.createElement('button');
+            toggle.type = 'button';
+            toggle.className = 'button-link wcos-split-policy-toggle';
+            toggle.setAttribute('aria-expanded', 'false');
+            toggle.textContent = 'View safety details';
+            policyBox.insertBefore(summary, list);
+            policyBox.insertBefore(toggle, list);
+            toggle.addEventListener('click', function () {
+                var expanded = toggle.getAttribute('aria-expanded') === 'true';
+                toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+                toggle.textContent = expanded ? 'View safety details' : 'Hide safety details';
+                list.hidden = expanded;
             });
-            setChildVisible(activeChildren, false);
-            activeChildren -= 1;
-            updateChildToolbar();
-            updateRemaining();
-            invalidateReview();
-            updateReviewAvailability();
-        });
-
-        updateChildToolbar();
-        updateRemaining();
-    }
-
-    function enhancePolicy() {
-        if (!policyBox) {
-            return;
         }
-        var list = policyBox.querySelector('ul');
-        if (!list) {
-            return;
-        }
-        list.hidden = true;
-        var summary = document.createElement('p');
-        summary.className = 'wcos-split-policy-summary';
-        summary.textContent = 'Child orders are created as Pending payment. Shipping stays on the source order, historical prices and taxes are preserved, and this Split does not change physical product stock.';
-        var toggle = document.createElement('button');
-        toggle.type = 'button';
-        toggle.className = 'button-link wcos-split-policy-toggle';
-        toggle.setAttribute('aria-expanded', 'false');
-        toggle.textContent = 'View safety details';
-        policyBox.insertBefore(summary, list);
-        policyBox.insertBefore(toggle, list);
-        toggle.addEventListener('click', function () {
-            var expanded = toggle.getAttribute('aria-expanded') === 'true';
-            toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-            toggle.textContent = expanded ? 'View safety details' : 'Hide safety details';
-            list.hidden = expanded;
-        });
-    }
 
-    function createEditButton() {
-        if (!actions || !reviewButton) {
-            return;
-        }
-        editButton = document.createElement('button');
-        editButton.type = 'button';
-        editButton.className = 'button wcos-split-edit-button';
-        editButton.textContent = 'Edit quantities';
-        editButton.hidden = true;
-        actions.insertBefore(editButton, reviewButton);
-        executeButton.hidden = true;
-
-        editButton.addEventListener('click', function () {
-            if (busy || completed) {
-                return;
-            }
-            state = null;
-            reviewBox.hidden = true;
-            reviewSummary.textContent = '';
-            confirmCheckbox.checked = false;
-            executeButton.disabled = true;
+        function createEditButton() {
+            editButton = document.createElement('button');
+            editButton.type = 'button';
+            editButton.className = 'button button-large wcos-split-edit-button';
+            editButton.textContent = 'Edit quantities';
+            editButton.hidden = true;
+            modal.footer.insertBefore(editButton, reviewButton);
             executeButton.hidden = true;
-            editButton.hidden = true;
-            reviewButton.hidden = false;
-            setStatus('');
-            clearError();
-            setBusy(false);
-            updateChildToolbar();
-            updateReviewAvailability();
-            var first = dialog.querySelector('.wcos-split-quantity:not([disabled])');
-            if (first) {
-                first.focus();
+
+            editButton.addEventListener('click', function () {
+                if (busy || completed) {
+                    return;
+                }
+                state = null;
+                reviewBox.hidden = true;
+                reviewSummary.textContent = '';
+                confirmCheckbox.checked = false;
+                executeButton.disabled = true;
+                executeButton.hidden = true;
+                editButton.hidden = true;
+                reviewButton.hidden = false;
+                setStatus('');
+                clearError();
+                setBusy(false);
+                updateChildToolbar();
+                updateReviewAvailability();
+                var first = dialog.querySelector('.wcos-split-quantity:not([disabled])');
+                if (first) {
+                    first.focus();
+                }
+            });
+        }
+
+        function decimalIsPositiveAndLessThan(value, sourceValue) {
+            if (!/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,6})?$/.test(value)) {
+                return false;
             }
-        });
-    }
-
-    function invalidateReview() {
-        if (completed || !state) {
-            return;
+            var valueNumber = Number(value);
+            var sourceNumber = Number(sourceValue);
+            return Number.isFinite(valueNumber) && Number.isFinite(sourceNumber) && valueNumber > 0 && valueNumber < sourceNumber;
         }
-        state = null;
-        reviewBox.hidden = true;
-        reviewSummary.textContent = '';
-        confirmCheckbox.checked = false;
-        executeButton.disabled = true;
-        executeButton.hidden = true;
-        if (editButton) {
-            editButton.hidden = true;
-        }
-        reviewButton.hidden = false;
-        clearResult();
-        updateChildToolbar();
-    }
 
-    function decimalIsPositiveAndLessThan(value, sourceValue) {
-        if (!/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,6})?$/.test(value)) {
-            return false;
-        }
-        var valueNumber = Number(value);
-        var sourceNumber = Number(sourceValue);
-        return Number.isFinite(valueNumber) && Number.isFinite(sourceNumber) && valueNumber > 0 && valueNumber < sourceNumber;
-    }
+        function buildPlan() {
+            var plan = {};
+            var hasQuantity = false;
+            var invalid = false;
 
-    function buildPlan() {
-        var plan = {};
-        var hasQuantity = false;
-        var invalid = false;
+            Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+                var itemId = row.getAttribute('data-item-id');
+                var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
+                var movedForLine = 0;
 
-        Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
-            var itemId = row.getAttribute('data-item-id');
-            var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
-            var movedForLine = 0;
+                Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (quantityInput) {
+                    var cell = quantityInput.closest('td');
+                    if (cell && cell.hidden) {
+                        return;
+                    }
+                    var quantity = quantityInput.value.trim();
+                    if (quantity === '' || Number(quantity) === 0) {
+                        return;
+                    }
+                    if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
+                        invalid = true;
+                        return;
+                    }
+                    var childKey = quantityInput.getAttribute('data-child-key') || '';
+                    if (!/^child-(?:[1-9]|10)$/.test(childKey)) {
+                        invalid = true;
+                        return;
+                    }
+                    if (!plan[childKey]) {
+                        plan[childKey] = {};
+                    }
+                    plan[childKey][itemId] = quantity;
+                    movedForLine += Number(quantity);
+                    hasQuantity = true;
+                });
 
-            Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (quantityInput) {
-                var cell = quantityInput.closest('td');
-                if (cell && cell.hidden) {
-                    return;
-                }
-                var quantity = quantityInput.value.trim();
-                if (quantity === '' || Number(quantity) === 0) {
-                    return;
-                }
-                if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
+                if (movedForLine >= Number(sourceQuantity)) {
                     invalid = true;
-                    return;
-                }
-
-                var childKey = quantityInput.getAttribute('data-child-key') || '';
-                if (!/^child-(?:[1-9]|10)$/.test(childKey)) {
-                    invalid = true;
-                    return;
-                }
-                if (!plan[childKey]) {
-                    plan[childKey] = {};
-                }
-                plan[childKey][itemId] = quantity;
-                movedForLine += Number(quantity);
-                hasQuantity = true;
-            });
-
-            if (movedForLine >= Number(sourceQuantity)) {
-                invalid = true;
-            }
-        });
-
-        Object.keys(plan).forEach(function (childKey) {
-            if (!Object.keys(plan[childKey]).length) {
-                delete plan[childKey];
-            }
-        });
-
-        if (invalid || !hasQuantity) {
-            throw new Error(text('invalidPlan', 'Enter at least one quantity and keep a positive residual quantity on every affected source line.'));
-        }
-        return plan;
-    }
-
-    function updateRemaining() {
-        Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
-            var source = Number(row.getAttribute('data-source-quantity') || 0);
-            var moved = 0;
-            Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (field) {
-                var cell = field.closest('td');
-                if (cell && cell.hidden) {
-                    return;
-                }
-                var value = Number(field.value || 0);
-                if (Number.isFinite(value) && value > 0) {
-                    moved += value;
                 }
             });
-            var remaining = source - moved;
-            var output = row.querySelector('.wcos-split-remaining');
-            if (output) {
-                output.textContent = humanDecimal(String(Math.max(0, remaining).toFixed(6)));
-                output.classList.toggle('is-invalid', remaining <= 0);
-            }
-        });
-    }
 
-    function canBuildPlan() {
-        try {
-            buildPlan();
-            return true;
-        } catch (error) {
-            return false;
-        }
-    }
-
-    function updateReviewAvailability() {
-        if (!reviewButton || reviewButton.hidden) {
-            return;
-        }
-        reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
-    }
-
-    function request(action, data) {
-        var body = new URLSearchParams();
-        body.set('action', action);
-        Object.keys(data).forEach(function (key) {
-            body.set(key, String(data[key]));
-        });
-
-        return window.fetch(dialog.getAttribute('data-ajax-url'), {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            },
-            body: body.toString()
-        }).then(function (response) {
-            return response.json().catch(function () {
-                throw new Error(text('requestFailed', 'The Split request could not be completed.'));
+            Object.keys(plan).forEach(function (childKey) {
+                if (!Object.keys(plan[childKey]).length) {
+                    delete plan[childKey];
+                }
             });
-        }).then(function (payload) {
-            if (!payload || payload.success !== true) {
-                var failure = payload && payload.data ? payload.data : {};
-                var error = new Error(failure.message || text('requestFailed', 'The Split request could not be completed.'));
-                error.code = failure.code || 'request_failed';
-                error.retryable = !!failure.retryable;
+
+            if (invalid || !hasQuantity) {
+                throw new Error(text('invalidPlan', 'Enter at least one quantity and keep a positive residual quantity on every affected source line.'));
+            }
+            return plan;
+        }
+
+        function updateRemaining() {
+            Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
+                var source = Number(row.getAttribute('data-source-quantity') || 0);
+                var moved = 0;
+                Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (field) {
+                    var cell = field.closest('td');
+                    if (cell && cell.hidden) {
+                        return;
+                    }
+                    var value = Number(field.value || 0);
+                    if (Number.isFinite(value) && value > 0) {
+                        moved += value;
+                    }
+                });
+                var remaining = source - moved;
+                var output = row.querySelector('.wcos-split-remaining');
+                if (output) {
+                    output.textContent = humanDecimal(String(Math.max(0, remaining).toFixed(6)));
+                    output.classList.toggle('is-invalid', remaining <= 0);
+                }
+            });
+        }
+
+        function canBuildPlan() {
+            try {
+                buildPlan();
+                return true;
+            } catch (error) {
+                return false;
+            }
+        }
+
+        function updateReviewAvailability() {
+            if (!reviewButton || reviewButton.hidden) {
+                return;
+            }
+            reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
+        }
+
+        function request(action, data) {
+            var body = new URLSearchParams();
+            body.set('action', action);
+            Object.keys(data).forEach(function (key) {
+                body.set(key, String(data[key]));
+            });
+
+            return window.fetch(sourceDialog.getAttribute('data-ajax-url'), {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+                body: body.toString()
+            }).then(function (response) {
+                return response.json().catch(function () {
+                    throw new Error(text('requestFailed', 'The Split request could not be completed.'));
+                });
+            }).then(function (payload) {
+                if (!payload || payload.success !== true) {
+                    var failure = payload && payload.data ? payload.data : {};
+                    var error = new Error(failure.message || text('requestFailed', 'The Split request could not be completed.'));
+                    error.code = failure.code || 'request_failed';
+                    error.retryable = !!failure.retryable;
+                    throw error;
+                }
+                return payload.data || {};
+            }).catch(function (error) {
+                if (typeof error.retryable !== 'boolean') {
+                    error.retryable = true;
+                }
                 throw error;
-            }
-            return payload.data || {};
-        }).catch(function (error) {
-            if (typeof error.retryable !== 'boolean') {
-                error.retryable = true;
-            }
-            throw error;
-        });
-    }
-
-    function setBusy(nextBusy) {
-        busy = !!nextBusy;
-        form.setAttribute('aria-busy', busy ? 'true' : 'false');
-        Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-split-quantity'), function (field) {
-            field.disabled = busy || completed || !!state;
-        });
-        reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
-        confirmCheckbox.disabled = busy || completed || !state;
-        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
-        cancelButton.disabled = busy;
-        closeButton.disabled = busy;
-        if (editButton) {
-            editButton.disabled = busy || completed;
-        }
-        updateChildToolbar();
-    }
-
-    function reviewPlan() {
-        if (busy || completed || state) {
-            return;
-        }
-        clearError();
-        clearResult();
-        var plan;
-        try {
-            plan = buildPlan();
-        } catch (error) {
-            showError(error.message);
-            return;
+            });
         }
 
-        setBusy(true);
-        setStatus(text('reviewing', 'Reviewing Split plan…'));
-        request('wcos_split_review', {
-            order_id: dialog.getAttribute('data-order-id'),
-            nonce: dialog.getAttribute('data-nonce'),
-            plan: JSON.stringify(plan)
-        }).then(function (data) {
-            state = {
-                operationId: data.operation_id,
-                token: data.confirmation_token
-            };
-            var summary = data.summary || {};
-            var childCount = Number(summary.child_count || 0);
-            var lineCount = Number(summary.affected_line_count || 0);
-            reviewSummary.textContent = String(childCount) + (childCount === 1 ? ' child order' : ' child orders') +
-                ' · ' + String(lineCount) + (lineCount === 1 ? ' product line' : ' product lines') +
-                ' · ' + humanDecimal(summary.moved_quantity || '0') + ' quantity moving';
-            reviewBox.hidden = false;
-            confirmCheckbox.checked = false;
-            reviewButton.hidden = true;
+        function setBusy(nextBusy) {
+            busy = !!nextBusy;
+            form.setAttribute('aria-busy', busy ? 'true' : 'false');
+            Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-split-quantity'), function (field) {
+                field.disabled = busy || completed || !!state;
+            });
+            reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
+            confirmCheckbox.disabled = busy || completed || !state;
+            executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+            cancelButton.disabled = busy;
+            closeButton.disabled = busy;
             if (editButton) {
+                editButton.disabled = busy || completed;
+            }
+            updateChildToolbar();
+        }
+
+        function reviewPlan() {
+            if (busy || completed || state) {
+                return;
+            }
+            clearError();
+            clearResult();
+            var plan;
+            try {
+                plan = buildPlan();
+            } catch (error) {
+                showError(error.message);
+                return;
+            }
+
+            setBusy(true);
+            setStatus(text('reviewing', 'Reviewing Split plan…'));
+            request('wcos_split_review', {
+                order_id: sourceDialog.getAttribute('data-order-id'),
+                nonce: sourceDialog.getAttribute('data-nonce'),
+                plan: JSON.stringify(plan)
+            }).then(function (data) {
+                state = { operationId: data.operation_id, token: data.confirmation_token };
+                var summary = data.summary || {};
+                var childCount = Number(summary.child_count || 0);
+                var lineCount = Number(summary.affected_line_count || 0);
+                reviewSummary.textContent = String(childCount) + (childCount === 1 ? ' child order' : ' child orders') +
+                    ' · ' + String(lineCount) + (lineCount === 1 ? ' product line' : ' product lines') +
+                    ' · ' + humanDecimal(summary.moved_quantity || '0') + ' quantity moving';
+                reviewBox.hidden = false;
+                confirmCheckbox.checked = false;
+                reviewButton.hidden = true;
                 editButton.hidden = false;
-            }
-            executeButton.hidden = false;
-            setStatus(text('reviewReady', 'The plan passed server review. Confirm the acknowledgement to execute it.'));
-            setBusy(false);
-            confirmCheckbox.focus();
-        }).catch(function (error) {
-            state = null;
-            reviewBox.hidden = true;
-            executeButton.hidden = true;
-            if (editButton) {
-                editButton.hidden = true;
-            }
-            reviewButton.hidden = false;
-            setStatus('');
-            showError(error.message);
-        }).finally(function () {
-            setBusy(false);
-            updateReviewAvailability();
-        });
-    }
-
-    function renderSuccess(data) {
-        resultBox.textContent = '';
-        var message = document.createElement('p');
-        message.textContent = text('completed', 'Split completed successfully.');
-        resultBox.appendChild(message);
-
-        var children = Array.isArray(data.children) ? data.children : [];
-        if (children.length) {
-            var list = document.createElement('ul');
-            children.forEach(function (child) {
-                var item = document.createElement('li');
-                if (child.edit_url) {
-                    var link = document.createElement('a');
-                    link.href = child.edit_url;
-                    link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
-                    item.appendChild(link);
-                } else {
-                    item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
-                }
-                list.appendChild(item);
-            });
-            resultBox.appendChild(list);
-        }
-
-        var reload = document.createElement('button');
-        reload.type = 'button';
-        reload.className = 'button';
-        reload.textContent = text('reloadOrder', 'Reload source order');
-        reload.addEventListener('click', function () {
-            window.location.reload();
-        });
-        resultBox.appendChild(reload);
-        resultBox.hidden = false;
-        resultBox.focus();
-    }
-
-    function executePlan() {
-        if (busy || completed || !state || !confirmCheckbox.checked) {
-            return;
-        }
-        clearError();
-        clearResult();
-        setBusy(true);
-        setStatus(text('executing', 'Executing Split…'));
-        request('wcos_split_execute', {
-            order_id: dialog.getAttribute('data-order-id'),
-            nonce: dialog.getAttribute('data-nonce'),
-            operation_id: state.operationId,
-            confirmation_token: state.token
-        }).then(function (data) {
-            completed = true;
-            setStatus(text('completed', 'Split completed successfully.'));
-            Array.prototype.forEach.call(dialog.querySelectorAll('input, select, button'), function (field) {
-                if (!field.classList.contains('wcos-split-cancel') && !field.classList.contains('wcos-split-close')) {
-                    field.disabled = true;
-                }
-            });
-            if (editButton) {
-                editButton.hidden = true;
-            }
-            reviewButton.hidden = true;
-            executeButton.hidden = true;
-            renderSuccess(data);
-        }).catch(function (error) {
-            if (!error.retryable) {
+                executeButton.hidden = false;
+                setStatus(text('reviewReady', 'The plan passed server review. Confirm the acknowledgement to execute it.'));
+                confirmCheckbox.focus();
+            }).catch(function (error) {
                 state = null;
                 reviewBox.hidden = true;
                 executeButton.hidden = true;
-                if (editButton) {
-                    editButton.hidden = true;
-                }
+                editButton.hidden = true;
                 reviewButton.hidden = false;
-            }
-            setStatus('');
-            showError(error.message);
-        }).finally(function () {
-            setBusy(false);
-            updateReviewAvailability();
-        });
-    }
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+                updateReviewAvailability();
+            });
+        }
 
-    function trapDialogKeyboard(targetDialog, closeCallback, targetPanel) {
-        targetDialog.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                closeCallback();
+        function renderSuccess(data) {
+            resultBox.textContent = '';
+            var message = document.createElement('p');
+            message.textContent = text('completed', 'Split completed successfully.');
+            resultBox.appendChild(message);
+            var children = Array.isArray(data.children) ? data.children : [];
+            if (children.length) {
+                var list = document.createElement('ul');
+                children.forEach(function (child) {
+                    var item = document.createElement('li');
+                    if (child.edit_url) {
+                        var link = document.createElement('a');
+                        link.href = child.edit_url;
+                        link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                        item.appendChild(link);
+                    } else {
+                        item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                    }
+                    list.appendChild(item);
+                });
+                resultBox.appendChild(list);
+            }
+            var reload = document.createElement('button');
+            reload.type = 'button';
+            reload.className = 'button';
+            reload.textContent = text('reloadOrder', 'Reload source order');
+            reload.addEventListener('click', function () { window.location.reload(); });
+            resultBox.appendChild(reload);
+            resultBox.hidden = false;
+            resultBox.focus();
+        }
+
+        function executePlan() {
+            if (busy || completed || !state || !confirmCheckbox.checked) {
                 return;
             }
-            if (event.key !== 'Tab') {
-                return;
-            }
-            var focusable = quantityFocusableElements(targetDialog);
-            if (!focusable.length) {
-                event.preventDefault();
-                targetPanel.focus();
-                return;
-            }
-            var first = focusable[0];
-            var last = focusable[focusable.length - 1];
-            if (event.shiftKey && document.activeElement === first) {
-                event.preventDefault();
-                last.focus();
-            } else if (!event.shiftKey && document.activeElement === last) {
-                event.preventDefault();
-                first.focus();
+            clearError();
+            clearResult();
+            setBusy(true);
+            setStatus(text('executing', 'Executing Split…'));
+            request('wcos_split_execute', {
+                order_id: sourceDialog.getAttribute('data-order-id'),
+                nonce: sourceDialog.getAttribute('data-nonce'),
+                operation_id: state.operationId,
+                confirmation_token: state.token
+            }).then(function (data) {
+                completed = true;
+                setStatus(text('completed', 'Split completed successfully.'));
+                Array.prototype.forEach.call(dialog.querySelectorAll('input, select, button'), function (field) {
+                    if (!field.classList.contains('wcos-split-cancel') && !field.classList.contains('modal-close')) {
+                        field.disabled = true;
+                    }
+                });
+                editButton.hidden = true;
+                reviewButton.hidden = true;
+                executeButton.hidden = true;
+                renderSuccess(data);
+            }).catch(function (error) {
+                if (!error.retryable) {
+                    state = null;
+                    reviewBox.hidden = true;
+                    executeButton.hidden = true;
+                    editButton.hidden = true;
+                    reviewButton.hidden = false;
+                }
+                setStatus('');
+                showError(error.message);
+            }).finally(function () {
+                setBusy(false);
+                updateReviewAvailability();
+            });
+        }
+
+        modal = window.WCOSBackboneModal.open({
+            trigger: trigger || launcher,
+            title: (sourceDialog.querySelector('.wcos-split-dialog__header h2') || {}).textContent || 'Review quantity split',
+            description: (sourceDialog.querySelector('.wcos-split-dialog__header p') || {}).textContent || launcherDescription,
+            modalClass: 'wcos-split-backbone-modal',
+            isBusy: function () { return busy; },
+            build: function (body, footer, root) {
+                var sourceForm = sourceDialog.querySelector('.wcos-split-form');
+                var sourceActions = sourceDialog.querySelector('.wcos-split-dialog__actions');
+                var clonedForm = sourceForm.cloneNode(true);
+                var clonedActions = clonedForm.querySelector('.wcos-split-dialog__actions');
+                if (clonedActions && clonedActions.parentNode) {
+                    clonedActions.parentNode.removeChild(clonedActions);
+                }
+                body.appendChild(clonedForm);
+                cloneFooterButtons(sourceActions, footer);
+                dialog = root;
+                form = clonedForm;
+                reviewButton = root.querySelector('.wcos-split-review-button');
+                executeButton = root.querySelector('.wcos-split-execute-button');
+                confirmCheckbox = root.querySelector('.wcos-split-confirm-checkbox');
+                reviewBox = root.querySelector('.wcos-split-review');
+                reviewSummary = root.querySelector('.wcos-split-review-summary');
+                statusBox = root.querySelector('.wcos-split-status');
+                errorBox = root.querySelector('.wcos-split-error');
+                resultBox = root.querySelector('.wcos-split-result');
+                table = root.querySelector('.wcos-split-table');
+                tableWrap = root.querySelector('.wcos-split-table-wrap');
+                policyBox = root.querySelector('.wcos-split-policy');
+                cancelButton = root.querySelector('.wcos-split-cancel');
+                closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
+            },
+            onReady: function () {
+                enhanceChildColumns();
+                enhancePolicy();
+                createEditButton();
+                reviewButton.addEventListener('click', reviewPlan);
+                executeButton.addEventListener('click', executePlan);
+                confirmCheckbox.addEventListener('change', function () {
+                    executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
+                });
+                form.addEventListener('input', function (event) {
+                    if (completed || !event.target.classList.contains('wcos-split-quantity')) {
+                        return;
+                    }
+                    clearError();
+                    setStatus('');
+                    updateRemaining();
+                    updateReviewAvailability();
+                });
+                updateReviewAvailability();
+                var first = dialog.querySelector('.wcos-split-quantity:not([disabled])');
+                if (first) {
+                    first.focus();
+                }
             }
         });
     }
@@ -653,135 +627,49 @@
         return button;
     }
 
-    function createMethodDialog() {
-        if (!strategyLaunchers.length) {
-            return null;
-        }
-        var orderId = dialog.getAttribute('data-order-id') || '';
-        var methodId = 'wcos-split-method-dialog-' + orderId;
-        var root = document.createElement('div');
-        root.id = methodId;
-        root.className = 'wcos-split-method-dialog';
-        root.setAttribute('role', 'dialog');
-        root.setAttribute('aria-modal', 'true');
-        root.setAttribute('aria-labelledby', methodId + '-title');
-        root.hidden = true;
-
-        var backdrop = document.createElement('div');
-        backdrop.className = 'wcos-split-method-dialog__backdrop';
-        backdrop.setAttribute('aria-hidden', 'true');
-        var methodPanel = document.createElement('div');
-        methodPanel.className = 'wcos-split-method-dialog__panel';
-        methodPanel.tabIndex = -1;
-        var header = document.createElement('div');
-        header.className = 'wcos-split-method-dialog__header';
-        var heading = document.createElement('h2');
-        heading.id = methodId + '-title';
-        heading.textContent = 'Split order';
-        var close = document.createElement('button');
-        close.type = 'button';
-        close.className = 'button-link wcos-split-method-close';
-        close.setAttribute('aria-label', 'Close split method chooser');
-        var closeGlyph = document.createElement('span');
-        closeGlyph.setAttribute('aria-hidden', 'true');
-        closeGlyph.textContent = '×';
-        close.appendChild(closeGlyph);
-        header.appendChild(heading);
-        header.appendChild(close);
-
-        var intro = document.createElement('p');
-        intro.className = 'description';
-        intro.textContent = 'Choose how this order should be split. You will review the result before anything is changed.';
-        var options = document.createElement('div');
-        options.className = 'wcos-split-method-options';
-        options.appendChild(createMethodOption(
-            'By quantity',
-            'Move exact quantities from one or more product lines into child orders.',
-            openQuantityDialog
-        ));
-
-        strategyLaunchers.forEach(function (strategyLauncher) {
-            var descriptionId = strategyLauncher.getAttribute('aria-describedby');
-            var descriptionElement = descriptionId ? document.getElementById(descriptionId) : null;
-            var description = descriptionElement ? descriptionElement.textContent.trim() : 'Build child orders from the reviewed product classification.';
-            options.appendChild(createMethodOption(
-                methodLabel(strategyLauncher.textContent),
-                description,
-                function () {
-                    strategyLauncher.click();
-                }
-            ));
+    function openMethodChooser() {
+        var handle = null;
+        handle = window.WCOSBackboneModal.open({
+            trigger: launcher,
+            title: 'Split order',
+            description: 'Choose how this order should be split. You will review the result before anything is changed.',
+            modalClass: 'wcos-split-method-backbone-modal',
+            build: function (body, footer) {
+                var options = document.createElement('div');
+                options.className = 'wcos-split-method-options';
+                options.appendChild(createMethodOption(
+                    'By quantity',
+                    'Move exact quantities from one or more product lines into child orders.',
+                    function () {
+                        handle.close(false);
+                        window.setTimeout(function () { openQuantityDialog(launcher); }, 0);
+                    }
+                ));
+                strategyLaunchers.forEach(function (strategyLauncher) {
+                    options.appendChild(createMethodOption(
+                        methodLabel(strategyLauncher.textContent),
+                        strategyLauncher._wcosDescription || 'Build child orders from the reviewed product classification.',
+                        function () {
+                            handle.close(false);
+                            window.setTimeout(function () { strategyLauncher.click(); }, 0);
+                        }
+                    ));
+                });
+                body.appendChild(options);
+                var cancel = document.createElement('button');
+                cancel.type = 'button';
+                cancel.className = 'button button-large modal-close';
+                cancel.textContent = 'Cancel';
+                footer.appendChild(cancel);
+            }
         });
-
-        methodPanel.appendChild(header);
-        methodPanel.appendChild(intro);
-        methodPanel.appendChild(options);
-        root.appendChild(backdrop);
-        root.appendChild(methodPanel);
-        document.body.appendChild(root);
-
-        function openMethodDialog() {
-            methodReturnFocus = document.activeElement;
-            root.hidden = false;
-            syncBodyLock();
-            window.setTimeout(function () {
-                var first = options.querySelector('.wcos-split-method-option');
-                (first || methodPanel).focus();
-            }, 0);
-        }
-
-        function closeMethodDialog() {
-            if (!dialog.hidden) {
-                return;
-            }
-            root.hidden = true;
-            syncBodyLock();
-            if (methodReturnFocus && typeof methodReturnFocus.focus === 'function') {
-                methodReturnFocus.focus();
-            }
-        }
-
-        close.addEventListener('click', closeMethodDialog);
-        backdrop.addEventListener('click', closeMethodDialog);
-        trapDialogKeyboard(root, closeMethodDialog, methodPanel);
-        root.open = openMethodDialog;
-        launcher.setAttribute('aria-controls', methodId);
-        return root;
     }
 
-    enhanceChildColumns();
-    enhancePolicy();
-    createEditButton();
-    methodDialog = createMethodDialog();
-    updateReviewAvailability();
-
     launcher.addEventListener('click', function () {
-        if (methodDialog && typeof methodDialog.open === 'function') {
-            methodDialog.open();
+        if (strategyLaunchers.length) {
+            openMethodChooser();
         } else {
-            openQuantityDialog();
+            openQuantityDialog(launcher);
         }
     });
-    closeButton.addEventListener('click', closeQuantityDialog);
-    cancelButton.addEventListener('click', closeQuantityDialog);
-    reviewButton.addEventListener('click', reviewPlan);
-    executeButton.addEventListener('click', executePlan);
-    confirmCheckbox.addEventListener('change', function () {
-        executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
-    });
-
-    form.addEventListener('input', function (event) {
-        if (completed || !event.target.classList.contains('wcos-split-quantity')) {
-            return;
-        }
-        if (state) {
-            invalidateReview();
-        }
-        clearError();
-        setStatus('');
-        updateRemaining();
-        updateReviewAvailability();
-    });
-
-    trapDialogKeyboard(dialog, closeQuantityDialog, panel);
 })();

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -2,24 +2,36 @@
     'use strict';
 
     var strings = window.wcosSplitStrategyStrings || {};
+    if (!window.WCOSBackboneModal) {
+        return;
+    }
 
     function text(key, fallback) {
         return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
     }
 
-    function request(dialog, action, data) {
+    function removeExternalDescription(button) {
+        var descriptionId = button.getAttribute('aria-describedby');
+        var description = descriptionId ? document.getElementById(descriptionId) : null;
+        var value = description ? description.textContent.trim() : '';
+        if (description && description.parentNode) {
+            description.parentNode.removeChild(description);
+        }
+        button.removeAttribute('aria-describedby');
+        return value;
+    }
+
+    function request(sourceDialog, action, data) {
         var body = new URLSearchParams();
         body.set('action', action);
         Object.keys(data).forEach(function (key) {
             body.set(key, String(data[key]));
         });
 
-        return window.fetch(dialog.getAttribute('data-ajax-url'), {
+        return window.fetch(sourceDialog.getAttribute('data-ajax-url'), {
             method: 'POST',
             credentials: 'same-origin',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            },
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
             body: body.toString()
         }).then(function (response) {
             return response.json().catch(function () {
@@ -35,12 +47,6 @@
             }
             return payload.data || {};
         }).catch(function (error) {
-            /*
-             * An unclassified fetch/JSON transport failure may happen after the
-             * server accepted Execute. Preserve operation/token state so the
-             * same idempotent operation can be retried. Structured server errors
-             * already carry an explicit retryable boolean and are not changed.
-             */
             if (typeof error.retryable !== 'boolean') {
                 error.retryable = true;
             }
@@ -48,368 +54,358 @@
         });
     }
 
+    function cloneFooter(sourceActions, footer) {
+        Array.prototype.forEach.call(sourceActions ? sourceActions.children : [], function (sourceButton) {
+            var button = sourceButton.cloneNode(true);
+            if (button.classList.contains('wcos-strategy-cancel')) {
+                button.classList.add('modal-close');
+                button.classList.add('button-large');
+            }
+            footer.appendChild(button);
+        });
+    }
+
     function setupLauncher(launcher) {
-        var dialogId = launcher.getAttribute('aria-controls');
-        var dialog = dialogId ? document.getElementById(dialogId) : null;
-        if (!dialog) {
+        var sourceDialogId = launcher.getAttribute('aria-controls');
+        var sourceDialog = sourceDialogId ? document.getElementById(sourceDialogId) : null;
+        if (!sourceDialog) {
             return;
         }
 
-        var panel = dialog.querySelector('.wcos-strategy-dialog__panel');
-        var form = dialog.querySelector('.wcos-strategy-form');
-        var closeButton = dialog.querySelector('.wcos-strategy-close');
-        var cancelButton = dialog.querySelector('.wcos-strategy-cancel');
-        var reviewButton = dialog.querySelector('.wcos-strategy-review-button');
-        var reviewSection = dialog.querySelector('.wcos-strategy-review');
-        var reviewSummary = dialog.querySelector('.wcos-strategy-review-summary');
-        var bucketOptions = dialog.querySelector('.wcos-strategy-bucket-options');
-        var confirmButton = dialog.querySelector('.wcos-strategy-confirm-button');
-        var confirmationSection = dialog.querySelector('.wcos-strategy-confirmation');
-        var confirmationSummary = dialog.querySelector('.wcos-strategy-confirmation-summary');
-        var confirmCheckbox = dialog.querySelector('.wcos-strategy-confirm-checkbox');
-        var executeButton = dialog.querySelector('.wcos-strategy-execute-button');
-        var statusBox = dialog.querySelector('.wcos-strategy-status');
-        var errorBox = dialog.querySelector('.wcos-strategy-error');
-        var resultBox = dialog.querySelector('.wcos-strategy-result');
-        var reviewState = null;
-        var confirmationState = null;
-        var selectedBucket = '';
-        var busy = false;
-        var completed = false;
-        var returnFocus = null;
-
-        function focusableElements() {
-            return Array.prototype.slice.call(dialog.querySelectorAll(
-                'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-            )).filter(function (element) {
-                return !element.hidden && element.offsetParent !== null;
-            });
+        if (!launcher._wcosDescription) {
+            launcher._wcosDescription = removeExternalDescription(launcher);
+        } else {
+            removeExternalDescription(launcher);
         }
+        launcher.hidden = true;
 
-        function clearError() {
-            errorBox.hidden = true;
-            errorBox.textContent = '';
-        }
+        function openStrategyModal() {
+            var reviewState = null;
+            var confirmationState = null;
+            var selectedBucket = '';
+            var busy = false;
+            var completed = false;
+            var dialog = null;
+            var form = null;
+            var closeButton = null;
+            var cancelButton = null;
+            var reviewButton = null;
+            var reviewSection = null;
+            var reviewSummary = null;
+            var bucketOptions = null;
+            var confirmButton = null;
+            var confirmationSection = null;
+            var confirmationSummary = null;
+            var confirmCheckbox = null;
+            var executeButton = null;
+            var statusBox = null;
+            var errorBox = null;
+            var resultBox = null;
 
-        function showError(message) {
-            errorBox.textContent = message || text('requestFailed', 'The strategy Split request could not be completed.');
-            errorBox.hidden = false;
-            errorBox.focus();
-        }
-
-        function setStatus(message) {
-            statusBox.textContent = message || '';
-        }
-
-        function clearResult() {
-            resultBox.hidden = true;
-            resultBox.textContent = '';
-        }
-
-        function clearBucketOptions() {
-            bucketOptions.textContent = '';
-            selectedBucket = '';
-        }
-
-        function invalidateConfirmation() {
-            if (completed) {
-                return;
+            function clearError() {
+                errorBox.hidden = true;
+                errorBox.textContent = '';
             }
-            confirmationState = null;
-            confirmationSection.hidden = true;
-            confirmationSummary.textContent = '';
-            confirmCheckbox.checked = false;
-            executeButton.disabled = true;
-        }
 
-        function invalidateReview() {
-            if (completed) {
-                return;
+            function showError(message) {
+                errorBox.textContent = message || text('requestFailed', 'The strategy Split request could not be completed.');
+                errorBox.hidden = false;
+                errorBox.focus();
             }
-            reviewState = null;
-            invalidateConfirmation();
-            reviewSection.hidden = true;
-            reviewSummary.textContent = '';
-            clearBucketOptions();
-            confirmButton.disabled = true;
-        }
 
-        function setBusy(nextBusy) {
-            busy = !!nextBusy;
-            form.setAttribute('aria-busy', busy ? 'true' : 'false');
-            reviewButton.disabled = busy || completed || !!confirmationState;
-            Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-strategy-bucket-radio'), function (field) {
-                field.disabled = busy || completed || !!confirmationState;
-            });
-            confirmButton.disabled = busy || completed || !!confirmationState || !reviewState || !selectedBucket;
-            confirmCheckbox.disabled = busy || completed || !confirmationState;
-            executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
-            closeButton.disabled = busy;
-            cancelButton.disabled = busy;
-        }
-
-        function openDialog() {
-            returnFocus = document.activeElement;
-            dialog.hidden = false;
-            document.body.classList.add('wcos-strategy-modal-open');
-            window.setTimeout(function () {
-                var preferred = completed && !resultBox.hidden ? resultBox : reviewButton;
-                (preferred || panel).focus();
-            }, 0);
-        }
-
-        function closeDialog() {
-            if (busy) {
-                return;
+            function setStatus(message) {
+                statusBox.textContent = message || '';
             }
-            dialog.hidden = true;
-            document.body.classList.remove('wcos-strategy-modal-open');
-            if (returnFocus && typeof returnFocus.focus === 'function') {
-                returnFocus.focus();
-            }
-        }
 
-        function bucketQuantity(items) {
-            var total = 0;
-            Object.keys(items || {}).forEach(function (itemId) {
-                var value = Number(items[itemId]);
-                if (Number.isFinite(value)) {
-                    total += value;
+            function clearResult() {
+                resultBox.hidden = true;
+                resultBox.textContent = '';
+            }
+
+            function clearBucketOptions() {
+                bucketOptions.textContent = '';
+                selectedBucket = '';
+            }
+
+            function invalidateConfirmation() {
+                if (completed) {
+                    return;
                 }
-            });
-            return total;
-        }
-
-        function renderBuckets(review) {
-            clearBucketOptions();
-            var buckets = review && review.buckets ? review.buckets : {};
-            var keys = Object.keys(buckets).sort();
-            if (keys.length < 2) {
-                throw new Error(text('requestFailed', 'The reviewed strategy did not return enough buckets to split.'));
-            }
-
-            keys.forEach(function (bucketKey, index) {
-                var bucket = buckets[bucketKey] || {};
-                var items = bucket.items || {};
-                var option = document.createElement('label');
-                option.className = 'wcos-strategy-bucket-option';
-
-                var radio = document.createElement('input');
-                radio.type = 'radio';
-                radio.name = dialogId + '-source-bucket';
-                radio.value = bucketKey;
-                radio.className = 'wcos-strategy-bucket-radio';
-                radio.id = dialogId + '-bucket-' + String(index + 1);
-
-                var content = document.createElement('span');
-                content.className = 'wcos-strategy-bucket-content';
-                var title = document.createElement('strong');
-                title.textContent = String(bucket.label || bucketKey);
-                var detail = document.createElement('span');
-                detail.className = 'description';
-                detail.textContent = String(Object.keys(items).length) + ' ' + text('bucketLines', 'product lines') +
-                    ' · ' + String(bucketQuantity(items)) + ' ' + text('bucketQuantity', 'total quantity');
-
-                content.appendChild(title);
-                content.appendChild(detail);
-                option.appendChild(radio);
-                option.appendChild(content);
-                bucketOptions.appendChild(option);
-            });
-        }
-
-        function reviewStrategy() {
-            if (busy || completed || confirmationState) {
-                return;
-            }
-            clearError();
-            clearResult();
-            invalidateReview();
-            setBusy(true);
-            setStatus(text('reviewing', 'Reviewing current strategy buckets…'));
-
-            request(dialog, dialog.getAttribute('data-review-action'), {
-                order_id: dialog.getAttribute('data-order-id'),
-                nonce: dialog.getAttribute('data-nonce'),
-                strategy: dialog.getAttribute('data-strategy')
-            }).then(function (data) {
-                reviewState = {
-                    reviewId: data.review_id,
-                    token: data.review_token
-                };
-                renderBuckets(data.review || {});
-                reviewSummary.textContent = data.review && data.review.message ? String(data.review.message) : '';
-                reviewSection.hidden = false;
-                setStatus(text('reviewReady', 'Choose the one bucket that must remain on the source order.'));
-                var firstRadio = bucketOptions.querySelector('.wcos-strategy-bucket-radio');
-                (firstRadio || reviewSection).focus();
-            }).catch(function (error) {
-                invalidateReview();
-                setStatus('');
-                showError(error.message);
-            }).finally(function () {
-                setBusy(false);
-            });
-        }
-
-        function confirmStrategy() {
-            if (busy || completed || !reviewState || !selectedBucket || confirmationState) {
-                if (!selectedBucket) {
-                    showError(text('chooseBucket', 'Choose a source bucket before confirming.'));
-                }
-                return;
-            }
-            clearError();
-            setBusy(true);
-            setStatus(text('confirming', 'Confirming the frozen strategy plan…'));
-
-            request(dialog, dialog.getAttribute('data-confirm-action'), {
-                order_id: dialog.getAttribute('data-order-id'),
-                nonce: dialog.getAttribute('data-nonce'),
-                strategy: dialog.getAttribute('data-strategy'),
-                review_id: reviewState.reviewId,
-                review_token: reviewState.token,
-                source_bucket_key: selectedBucket
-            }).then(function (data) {
-                confirmationState = {
-                    operationId: data.operation_id,
-                    token: data.confirmation_token,
-                    sourceBucket: data.source_bucket_key
-                };
-                reviewState = null;
-                confirmationSummary.textContent = text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.');
-                confirmationSection.hidden = false;
+                confirmationState = null;
+                confirmationSection.hidden = true;
+                confirmationSummary.textContent = '';
                 confirmCheckbox.checked = false;
-                setStatus(text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.'));
-                confirmCheckbox.focus();
-            }).catch(function (error) {
-                if (!error.retryable) {
+                executeButton.disabled = true;
+            }
+
+            function invalidateReview() {
+                if (completed) {
+                    return;
+                }
+                reviewState = null;
+                invalidateConfirmation();
+                reviewSection.hidden = true;
+                reviewSummary.textContent = '';
+                clearBucketOptions();
+                confirmButton.disabled = true;
+            }
+
+            function setBusy(nextBusy) {
+                busy = !!nextBusy;
+                form.setAttribute('aria-busy', busy ? 'true' : 'false');
+                reviewButton.disabled = busy || completed || !!confirmationState;
+                Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-strategy-bucket-radio'), function (field) {
+                    field.disabled = busy || completed || !!confirmationState;
+                });
+                confirmButton.disabled = busy || completed || !!confirmationState || !reviewState || !selectedBucket;
+                confirmCheckbox.disabled = busy || completed || !confirmationState;
+                executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
+                closeButton.disabled = busy;
+                cancelButton.disabled = busy;
+            }
+
+            function bucketQuantity(items) {
+                var total = 0;
+                Object.keys(items || {}).forEach(function (itemId) {
+                    var value = Number(items[itemId]);
+                    if (Number.isFinite(value)) {
+                        total += value;
+                    }
+                });
+                return total;
+            }
+
+            function renderBuckets(review) {
+                clearBucketOptions();
+                var buckets = review && review.buckets ? review.buckets : {};
+                var keys = Object.keys(buckets).sort();
+                if (keys.length < 2) {
+                    throw new Error(text('requestFailed', 'The reviewed strategy did not return enough buckets to split.'));
+                }
+
+                keys.forEach(function (bucketKey, index) {
+                    var bucket = buckets[bucketKey] || {};
+                    var items = bucket.items || {};
+                    var option = document.createElement('label');
+                    option.className = 'wcos-strategy-bucket-option';
+                    var radio = document.createElement('input');
+                    radio.type = 'radio';
+                    radio.name = sourceDialogId + '-source-bucket';
+                    radio.value = bucketKey;
+                    radio.className = 'wcos-strategy-bucket-radio';
+                    radio.id = sourceDialogId + '-bucket-' + String(index + 1);
+                    var content = document.createElement('span');
+                    content.className = 'wcos-strategy-bucket-content';
+                    var title = document.createElement('strong');
+                    title.textContent = String(bucket.label || bucketKey);
+                    var detail = document.createElement('span');
+                    detail.className = 'description';
+                    detail.textContent = String(Object.keys(items).length) + ' ' + text('bucketLines', 'product lines') +
+                        ' · ' + String(bucketQuantity(items)) + ' ' + text('bucketQuantity', 'total quantity');
+                    content.appendChild(title);
+                    content.appendChild(detail);
+                    option.appendChild(radio);
+                    option.appendChild(content);
+                    bucketOptions.appendChild(option);
+                });
+            }
+
+            function reviewStrategy() {
+                if (busy || completed || confirmationState) {
+                    return;
+                }
+                clearError();
+                clearResult();
+                invalidateReview();
+                setBusy(true);
+                setStatus(text('reviewing', 'Reviewing current strategy buckets…'));
+
+                request(sourceDialog, sourceDialog.getAttribute('data-review-action'), {
+                    order_id: sourceDialog.getAttribute('data-order-id'),
+                    nonce: sourceDialog.getAttribute('data-nonce'),
+                    strategy: sourceDialog.getAttribute('data-strategy')
+                }).then(function (data) {
+                    reviewState = { reviewId: data.review_id, token: data.review_token };
+                    renderBuckets(data.review || {});
+                    reviewSummary.textContent = data.review && data.review.message ? String(data.review.message) : '';
+                    reviewSection.hidden = false;
+                    setStatus(text('reviewReady', 'Choose the one bucket that must remain on the source order.'));
+                    var firstRadio = bucketOptions.querySelector('.wcos-strategy-bucket-radio');
+                    (firstRadio || reviewSection).focus();
+                }).catch(function (error) {
                     invalidateReview();
+                    setStatus('');
+                    showError(error.message);
+                }).finally(function () {
+                    setBusy(false);
+                });
+            }
+
+            function confirmStrategy() {
+                if (busy || completed || !reviewState || !selectedBucket || confirmationState) {
+                    if (!selectedBucket) {
+                        showError(text('chooseBucket', 'Choose a source bucket before confirming.'));
+                    }
+                    return;
                 }
-                setStatus('');
-                showError(error.message);
-            }).finally(function () {
-                setBusy(false);
-            });
-        }
+                clearError();
+                setBusy(true);
+                setStatus(text('confirming', 'Confirming the frozen strategy plan…'));
 
-        function renderSuccess(data) {
-            resultBox.textContent = '';
-            var message = document.createElement('p');
-            message.textContent = text('completed', 'Strategy Split completed successfully.');
-            resultBox.appendChild(message);
-
-            var children = Array.isArray(data.children) ? data.children : [];
-            if (children.length) {
-                var list = document.createElement('ul');
-                children.forEach(function (child) {
-                    var item = document.createElement('li');
-                    if (child.edit_url) {
-                        var link = document.createElement('a');
-                        link.href = child.edit_url;
-                        link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
-                        item.appendChild(link);
-                    } else {
-                        item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
-                    }
-                    list.appendChild(item);
-                });
-                resultBox.appendChild(list);
-            }
-
-            var reload = document.createElement('button');
-            reload.type = 'button';
-            reload.className = 'button';
-            reload.textContent = text('reloadOrder', 'Reload source order');
-            reload.addEventListener('click', function () {
-                window.location.reload();
-            });
-            resultBox.appendChild(reload);
-            resultBox.hidden = false;
-            resultBox.focus();
-        }
-
-        function executeStrategy() {
-            if (busy || completed || !confirmationState || !confirmCheckbox.checked) {
-                return;
-            }
-            clearError();
-            clearResult();
-            setBusy(true);
-            setStatus(text('executing', 'Executing strategy Split…'));
-
-            request(dialog, dialog.getAttribute('data-execute-action'), {
-                order_id: dialog.getAttribute('data-order-id'),
-                nonce: dialog.getAttribute('data-nonce'),
-                strategy: dialog.getAttribute('data-strategy'),
-                operation_id: confirmationState.operationId,
-                confirmation_token: confirmationState.token
-            }).then(function (data) {
-                completed = true;
-                setStatus(text('completed', 'Strategy Split completed successfully.'));
-                Array.prototype.forEach.call(dialog.querySelectorAll('input, button'), function (field) {
-                    if (!field.classList.contains('wcos-strategy-cancel') && !field.classList.contains('wcos-strategy-close')) {
-                        field.disabled = true;
-                    }
-                });
-                renderSuccess(data);
-            }).catch(function (error) {
-                if (!error.retryable) {
-                    confirmationState = null;
-                    confirmationSection.hidden = true;
+                request(sourceDialog, sourceDialog.getAttribute('data-confirm-action'), {
+                    order_id: sourceDialog.getAttribute('data-order-id'),
+                    nonce: sourceDialog.getAttribute('data-nonce'),
+                    strategy: sourceDialog.getAttribute('data-strategy'),
+                    review_id: reviewState.reviewId,
+                    review_token: reviewState.token,
+                    source_bucket_key: selectedBucket
+                }).then(function (data) {
+                    confirmationState = {
+                        operationId: data.operation_id,
+                        token: data.confirmation_token,
+                        sourceBucket: data.source_bucket_key
+                    };
+                    reviewState = null;
+                    confirmationSummary.textContent = text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.');
+                    confirmationSection.hidden = false;
                     confirmCheckbox.checked = false;
+                    setStatus(text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.'));
+                    confirmCheckbox.focus();
+                }).catch(function (error) {
+                    if (!error.retryable) {
+                        invalidateReview();
+                    }
+                    setStatus('');
+                    showError(error.message);
+                }).finally(function () {
+                    setBusy(false);
+                });
+            }
+
+            function renderSuccess(data) {
+                resultBox.textContent = '';
+                var message = document.createElement('p');
+                message.textContent = text('completed', 'Strategy Split completed successfully.');
+                resultBox.appendChild(message);
+                var children = Array.isArray(data.children) ? data.children : [];
+                if (children.length) {
+                    var list = document.createElement('ul');
+                    children.forEach(function (child) {
+                        var item = document.createElement('li');
+                        if (child.edit_url) {
+                            var link = document.createElement('a');
+                            link.href = child.edit_url;
+                            link.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                            item.appendChild(link);
+                        } else {
+                            item.textContent = text('childOrder', 'Child order') + ' #' + String(child.number || child.id || '');
+                        }
+                        list.appendChild(item);
+                    });
+                    resultBox.appendChild(list);
                 }
-                setStatus('');
-                showError(error.message);
-            }).finally(function () {
-                setBusy(false);
+                var reload = document.createElement('button');
+                reload.type = 'button';
+                reload.className = 'button';
+                reload.textContent = text('reloadOrder', 'Reload source order');
+                reload.addEventListener('click', function () { window.location.reload(); });
+                resultBox.appendChild(reload);
+                resultBox.hidden = false;
+                resultBox.focus();
+            }
+
+            function executeStrategy() {
+                if (busy || completed || !confirmationState || !confirmCheckbox.checked) {
+                    return;
+                }
+                clearError();
+                clearResult();
+                setBusy(true);
+                setStatus(text('executing', 'Executing strategy Split…'));
+
+                request(sourceDialog, sourceDialog.getAttribute('data-execute-action'), {
+                    order_id: sourceDialog.getAttribute('data-order-id'),
+                    nonce: sourceDialog.getAttribute('data-nonce'),
+                    strategy: sourceDialog.getAttribute('data-strategy'),
+                    operation_id: confirmationState.operationId,
+                    confirmation_token: confirmationState.token
+                }).then(function (data) {
+                    completed = true;
+                    setStatus(text('completed', 'Strategy Split completed successfully.'));
+                    Array.prototype.forEach.call(dialog.querySelectorAll('input, button'), function (field) {
+                        if (!field.classList.contains('wcos-strategy-cancel') && !field.classList.contains('modal-close')) {
+                            field.disabled = true;
+                        }
+                    });
+                    renderSuccess(data);
+                }).catch(function (error) {
+                    if (!error.retryable) {
+                        confirmationState = null;
+                        confirmationSection.hidden = true;
+                        confirmCheckbox.checked = false;
+                    }
+                    setStatus('');
+                    showError(error.message);
+                }).finally(function () {
+                    setBusy(false);
+                });
+            }
+
+            window.WCOSBackboneModal.open({
+                trigger: launcher,
+                title: (sourceDialog.querySelector('.wcos-strategy-dialog__header h2') || {}).textContent || launcher.textContent.trim(),
+                description: (sourceDialog.querySelector('.wcos-strategy-dialog__header p') || {}).textContent || launcher._wcosDescription,
+                modalClass: 'wcos-strategy-backbone-modal',
+                isBusy: function () { return busy; },
+                build: function (body, footer, root) {
+                    var sourceForm = sourceDialog.querySelector('.wcos-strategy-form');
+                    var sourceActions = sourceDialog.querySelector('.wcos-strategy-dialog__actions');
+                    var clonedForm = sourceForm.cloneNode(true);
+                    var clonedActions = clonedForm.querySelector('.wcos-strategy-dialog__actions');
+                    if (clonedActions && clonedActions.parentNode) {
+                        clonedActions.parentNode.removeChild(clonedActions);
+                    }
+                    body.appendChild(clonedForm);
+                    cloneFooter(sourceActions, footer);
+                    dialog = root;
+                    form = clonedForm;
+                    closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
+                    cancelButton = root.querySelector('.wcos-strategy-cancel');
+                    reviewButton = root.querySelector('.wcos-strategy-review-button');
+                    reviewSection = root.querySelector('.wcos-strategy-review');
+                    reviewSummary = root.querySelector('.wcos-strategy-review-summary');
+                    bucketOptions = root.querySelector('.wcos-strategy-bucket-options');
+                    confirmButton = root.querySelector('.wcos-strategy-confirm-button');
+                    confirmationSection = root.querySelector('.wcos-strategy-confirmation');
+                    confirmationSummary = root.querySelector('.wcos-strategy-confirmation-summary');
+                    confirmCheckbox = root.querySelector('.wcos-strategy-confirm-checkbox');
+                    executeButton = root.querySelector('.wcos-strategy-execute-button');
+                    statusBox = root.querySelector('.wcos-strategy-status');
+                    errorBox = root.querySelector('.wcos-strategy-error');
+                    resultBox = root.querySelector('.wcos-strategy-result');
+                },
+                onReady: function () {
+                    reviewButton.addEventListener('click', reviewStrategy);
+                    confirmButton.addEventListener('click', confirmStrategy);
+                    executeButton.addEventListener('click', executeStrategy);
+                    confirmCheckbox.addEventListener('change', function () {
+                        executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
+                    });
+                    bucketOptions.addEventListener('change', function (event) {
+                        if (completed || confirmationState || !event.target.classList.contains('wcos-strategy-bucket-radio')) {
+                            return;
+                        }
+                        selectedBucket = event.target.value || '';
+                        invalidateConfirmation();
+                        clearError();
+                        confirmButton.disabled = busy || !reviewState || !selectedBucket;
+                    });
+                    reviewButton.focus();
+                }
             });
         }
 
-        launcher.addEventListener('click', openDialog);
-        closeButton.addEventListener('click', closeDialog);
-        cancelButton.addEventListener('click', closeDialog);
-        reviewButton.addEventListener('click', reviewStrategy);
-        confirmButton.addEventListener('click', confirmStrategy);
-        executeButton.addEventListener('click', executeStrategy);
-        confirmCheckbox.addEventListener('change', function () {
-            executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
-        });
-        bucketOptions.addEventListener('change', function (event) {
-            if (completed || confirmationState || !event.target.classList.contains('wcos-strategy-bucket-radio')) {
-                return;
-            }
-            selectedBucket = event.target.value || '';
-            invalidateConfirmation();
-            clearError();
-            confirmButton.disabled = busy || !reviewState || !selectedBucket;
-        });
-
-        dialog.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                closeDialog();
-                return;
-            }
-            if (event.key !== 'Tab') {
-                return;
-            }
-            var focusable = focusableElements();
-            if (!focusable.length) {
-                event.preventDefault();
-                panel.focus();
-                return;
-            }
-            var first = focusable[0];
-            var last = focusable[focusable.length - 1];
-            if (event.shiftKey && document.activeElement === first) {
-                event.preventDefault();
-                last.focus();
-            } else if (!event.shiftKey && document.activeElement === last) {
-                event.preventDefault();
-                first.focus();
-            }
-        });
+        launcher.addEventListener('click', openStrategyModal);
     }
 
     Array.prototype.forEach.call(document.querySelectorAll('.wcos-strategy-launcher'), setupLauncher);

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -4,7 +4,8 @@ if (!defined('ABSPATH')) {
     exit(1);
 }
 
-$js_path = dirname(__DIR__, 2) . '/js/p2-split-admin.js';
+$root = dirname(__DIR__, 2);
+$js_path = $root . '/js/p2-split-admin.js';
 $js = file_get_contents($js_path);
 wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split admin client script for terminal-state verification.');
 
@@ -20,20 +21,23 @@ foreach (array(
     'activeChildren = 1;',
     'setChildVisible(childIndex, childIndex === 1);',
     "addChildButton.textContent = 'Add child order';",
+    "removeChildButton.className = 'button wcos-split-remove-child';",
     "removeChildButton.textContent = 'Remove last child';",
     "value.className = 'wcos-split-remaining';",
     "toggle.textContent = 'View safety details';",
-    "heading.textContent = 'Split order';",
-    "'By quantity'",
+    "title: 'Split order'",
+    "modalClass: 'wcos-split-backbone-modal'",
+    "modalClass: 'wcos-split-method-backbone-modal'",
+    'window.WCOSBackboneModal.open',
     'strategyLauncher.click();',
     'completed = true;',
-    'completed && !resultBox.hidden',
     "typeof error.retryable !== 'boolean'",
     'error.retryable = true;',
+    'removeExternalDescription',
 ) as $needle) {
     wcos_p2_adapter_assert(
         false !== strpos($js, $needle),
-        'Split admin client is missing streamlined terminal/UX protection: ' . $needle
+        'Split admin client is missing streamlined Backbone-modal/terminal UX protection: ' . $needle
     );
 }
 
@@ -41,9 +45,31 @@ wcos_p2_adapter_assert(
     false !== strpos($js, 'if (!error.retryable) {'),
     'Non-retryable execute failures do not invalidate the reviewed confirmation state.'
 );
-wcos_p2_adapter_assert(
-    false === strpos($js, 'window.alert'),
-    'Split admin client reintroduced blocking alert UI.'
-);
+wcos_p2_adapter_assert(false === strpos($js, 'window.alert'), 'Split admin client reintroduced blocking alert UI.');
+wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Split admin client reintroduced innerHTML rendering.');
+
+$bridge = file_get_contents($root . '/js/p2-backbone-modal.js');
+wcos_p2_adapter_assert(is_string($bridge) && '' !== $bridge, 'WooCommerce Backbone modal bridge is missing.');
+foreach (array(
+    '$.fn.WCBackboneModal',
+    '.WCBackboneModal({',
+    'wc-backbone-modal',
+    'wc-backbone-modal-content',
+    'wc-backbone-modal-main',
+    'wc-backbone-modal-header',
+    'wc-backbone-modal-backdrop modal-close',
+    'wcos-admin-backbone-modal__body',
+    'wcos-admin-backbone-modal__footer',
+    'wc_backbone_modal_removed',
+) as $needle) {
+    wcos_p2_adapter_assert(false !== strpos($bridge, $needle), 'Shared modal bridge is missing WooCommerce Backbone contract: ' . $needle);
+}
+wcos_p2_adapter_assert(false === strpos($bridge, '.innerHTML'), 'Shared Backbone modal bridge uses innerHTML.');
+
+$css = file_get_contents($root . '/css/p2-split-admin.css');
+wcos_p2_adapter_assert(is_string($css) && false !== strpos($css, '.wcos-split-backbone-modal .wc-backbone-modal-content'), 'Split CSS does not target the WooCommerce Backbone shell.');
+wcos_p2_adapter_assert(false !== strpos($css, '.wcos-split-method-backbone-modal .wc-backbone-modal-content'), 'Split method chooser does not use the WooCommerce Backbone shell.');
+wcos_p2_adapter_assert(false !== strpos($css, '.wcos-split-remove-child'), 'Remove-last-child button styling is missing.');
+wcos_p2_adapter_assert(false !== strpos($css, 'color: #b32d2e;'), 'Remove-last-child destructive text color is missing.');
 
 echo "p2-admin-client-terminal-state-ok\n";

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -61,10 +61,20 @@ foreach (array(
     'wcos-admin-backbone-modal__body',
     'wcos-admin-backbone-modal__footer',
     'wc_backbone_modal_removed',
+    'function remapClonedIds',
+    "container.querySelectorAll('[id]')",
+    "container.querySelectorAll('[for]')",
+    "['aria-labelledby', 'aria-describedby', 'aria-controls', 'aria-owns']",
+    'remapClonedIds(body, instanceId);',
 ) as $needle) {
-    wcos_p2_adapter_assert(false !== strpos($bridge, $needle), 'Shared modal bridge is missing WooCommerce Backbone contract: ' . $needle);
+    wcos_p2_adapter_assert(false !== strpos($bridge, $needle), 'Shared modal bridge is missing WooCommerce Backbone/ID-remap contract: ' . $needle);
 }
 wcos_p2_adapter_assert(false === strpos($bridge, '.innerHTML'), 'Shared Backbone modal bridge uses innerHTML.');
+
+$asset_contract = file_get_contents($root . '/inc/backend/class-wcos-admin-backbone-modal-assets.php');
+wcos_p2_adapter_assert(is_string($asset_contract) && false !== strpos($asset_contract, "wp_enqueue_script('wc-backbone-modal')"), 'Backbone modal asset contract does not require the WooCommerce native handle.');
+wcos_p2_adapter_assert(false !== strpos($asset_contract, "array('jquery', 'wc-backbone-modal')"), 'Shared modal bridge does not declare the WooCommerce Backbone dependency.');
+wcos_p2_adapter_assert(false !== strpos($asset_contract, "'wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin'"), 'Workflow modal clients are not dependency-bound to the shared bridge.');
 
 $css = file_get_contents($root . '/css/p2-split-admin.css');
 wcos_p2_adapter_assert(is_string($css) && false !== strpos($css, '.wcos-split-backbone-modal .wc-backbone-modal-content'), 'Split CSS does not target the WooCommerce Backbone shell.');

--- a/tests/integration/p2-admin-transport-smoke.php
+++ b/tests/integration/p2-admin-transport-smoke.php
@@ -275,14 +275,18 @@ try {
     wcos_p2_adapter_assert(false === strpos($html, 'PrivateFirstNameProbe'), 'Billing first name leaked into the Split dialog.');
     wcos_p2_adapter_assert(false === strpos($html, 'private-probe@example.test'), 'Billing email leaked into the Split dialog.');
 
-    /* Client script keeps user-visible values in text nodes and preserves keyboard focus semantics. */
-    $js_path = dirname(__DIR__, 2) . '/js/p2-split-admin.js';
-    $js = file_get_contents($js_path);
+    /* The client delegates keyboard/focus lifecycle to WooCommerce Backbone modal. */
+    $root = dirname(__DIR__, 2);
+    $js = file_get_contents($root . '/js/p2-split-admin.js');
     wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split admin client script.');
     wcos_p2_adapter_assert(false === strpos($js, 'innerHTML'), 'Split admin client uses innerHTML for mutation result/UI content.');
     wcos_p2_adapter_assert(false === strpos($js, 'alert('), 'Split admin client uses blocking alert() UI.');
-    foreach (array('textContent', "event.key === 'Escape'", "event.key !== 'Tab'", 'data-child-key', 'returnFocus.focus()') as $needle) {
-        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Split admin client is missing accessibility/security behavior: ' . $needle);
+    foreach (array('textContent', 'data-child-key', 'window.WCOSBackboneModal.open', "modalClass: 'wcos-split-backbone-modal'", 'removeExternalDescription') as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Split admin client is missing Backbone-modal/security behavior: ' . $needle);
+    }
+    $bridge = file_get_contents($root . '/js/p2-backbone-modal.js');
+    foreach (array('$.fn.WCBackboneModal', '.WCBackboneModal({', 'wc-backbone-modal-content', 'wc-backbone-modal-header', 'wc-backbone-modal-backdrop modal-close', 'wc_backbone_modal_removed') as $needle) {
+        wcos_p2_adapter_assert(is_string($bridge) && false !== strpos($bridge, $needle), 'Split Backbone modal bridge is missing native WooCommerce behavior: ' . $needle);
     }
 
     ob_start();

--- a/tests/integration/p2-duplicate-readiness-smoke.php
+++ b/tests/integration/p2-duplicate-readiness-smoke.php
@@ -92,7 +92,6 @@ try {
     wcos_p2_adapter_assert(false === strpos($preflight_json, 'DuplicatePrivateProbe'), 'Duplicate preflight leaked billing PII.');
     wcos_p2_adapter_assert(false === strpos($preflight_json, 'duplicate-private@example.test'), 'Duplicate preflight leaked billing email.');
 
-    /* Custom order-level meta is deliberately not copied by the service. */
     $duplicate_direct_operation = 'p2-duplicate-adapter-' . wp_generate_uuid4();
     $target = $duplicate_adapter->duplicate($duplicate_source, $duplicate_direct_operation);
     $target = wc_get_order($target->get_id());
@@ -122,7 +121,6 @@ try {
     wcos_p2_adapter_assert((int) WCOS_Duplicate_Preflight::POLICY_VERSION === (int) $journal['context']['policy_version'], 'Duplicate journal lost policy-version authority.');
     wcos_p2_adapter_assert(array_key_exists('price_precision', $journal['context']), 'Duplicate journal lost price precision.');
 
-    /* Unknown private line metadata fails before a mutation journal/target exists. */
     $unknown_product = wcos_p2_adapter_product('WCOS Duplicate unknown meta', '5.00');
     list($unknown_source, $unknown_item_id) = wcos_p2_adapter_order($unknown_product, 2);
     $unknown_item = $unknown_source->get_item($unknown_item_id);
@@ -144,7 +142,6 @@ try {
     $unknown_source->delete(true);
     wp_delete_post($unknown_product->get_id(), true);
 
-    /* Refunded orders fail closed before mutation. */
     $refund_product = wcos_p2_adapter_product('WCOS Duplicate refund reject', '7.00');
     list($refund_source, $refund_item_id) = wcos_p2_adapter_order($refund_product, 2);
     $refund = wc_create_refund(array(
@@ -158,7 +155,6 @@ try {
     wc_get_order($refund_source->get_id())->delete(true);
     wp_delete_post($refund_product->get_id(), true);
 
-    /* Production transport is fully wired but remains hard-off. */
     wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Duplicate_Admin_Controller::REVIEW_ACTION), 'Duplicate review AJAX route was not bootstrapped.');
     wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Duplicate_Admin_Controller::EXECUTE_ACTION), 'Duplicate execute AJAX route was not bootstrapped.');
     $nonce = wp_create_nonce('wcos_duplicate_order_' . $duplicate_source_id);
@@ -233,12 +229,17 @@ try {
     wcos_p2_adapter_assert(false === strpos($dialog_html, 'DuplicatePrivateProbe'), 'Duplicate dialog leaked billing PII.');
     wcos_p2_adapter_assert(false === strpos($dialog_html, 'duplicate-private@example.test'), 'Duplicate dialog leaked billing email.');
 
-    $js = file_get_contents(dirname(__DIR__, 2) . '/js/p2-duplicate-admin.js');
+    $root = dirname(__DIR__, 2);
+    $js = file_get_contents($root . '/js/p2-duplicate-admin.js');
     wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read Duplicate admin client.');
     wcos_p2_adapter_assert(false === strpos($js, 'innerHTML'), 'Duplicate admin client uses innerHTML.');
     wcos_p2_adapter_assert(false === strpos($js, 'alert('), 'Duplicate admin client uses blocking alert().');
-    foreach (array("event.key === 'Escape'", "event.key !== 'Tab'", 'returnFocus.focus()', 'var completed = false;', 'reviewButton.disabled = busy || completed;', 'executeButton.disabled = busy || completed') as $needle) {
-        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Duplicate admin client is missing terminal/accessibility behavior: ' . $needle);
+    foreach (array('var completed = false;', 'reviewButton.disabled = busy || completed;', 'executeButton.disabled = busy || completed', 'window.WCOSBackboneModal.open', "modalClass: 'wcos-duplicate-backbone-modal'", 'removeExternalDescription') as $needle) {
+        wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Duplicate admin client is missing terminal/Backbone-modal behavior: ' . $needle);
+    }
+    $bridge = file_get_contents($root . '/js/p2-backbone-modal.js');
+    foreach (array('$.fn.WCBackboneModal', '.WCBackboneModal({', 'wc-backbone-modal-content', 'wc-backbone-modal-header', 'wc-backbone-modal-backdrop modal-close', 'wc_backbone_modal_removed') as $needle) {
+        wcos_p2_adapter_assert(is_string($bridge) && false !== strpos($bridge, $needle), 'Duplicate Backbone modal bridge is missing native WooCommerce behavior: ' . $needle);
     }
 } finally {
     if ($duplicate_operation) {

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -59,27 +59,27 @@ try {
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by category'), 'Category strategy launcher is missing.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by stock status'), 'Stock-status strategy launcher is missing.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-haspopup="dialog"'), 'Strategy launchers do not expose dialog semantics.');
-	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-category"'), 'Category launcher is not bound to its dialog.');
-	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Stock-status launcher is not bound to its dialog.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-category"'), 'Category launcher is not bound to its source dialog.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Stock-status launcher is not bound to its source dialog.');
 
 	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $ui_strategy) {
 		$dialog_html = $ui_controller->dialog_html(wc_get_order($ui_order_id), $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Strategy dialog is missing role=dialog: ' . $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-modal="true"'), 'Strategy dialog is missing aria-modal: ' . $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-labelledby='), 'Strategy dialog is missing aria-labelledby: ' . $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-describedby='), 'Strategy dialog is missing aria-describedby: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Strategy source dialog is missing role=dialog: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-modal="true"'), 'Strategy source dialog is missing aria-modal: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-labelledby='), 'Strategy source dialog is missing aria-labelledby: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-describedby='), 'Strategy source dialog is missing aria-describedby: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, '<fieldset class="wcos-strategy-buckets"'), 'Strategy dialog is missing semantic source-bucket fieldset: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, '<legend'), 'Strategy dialog is missing bucket legend: ' . $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="status" aria-live="polite"'), 'Strategy dialog is missing live status region: ' . $ui_strategy);
-		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="alert" tabindex="-1"'), 'Strategy dialog is missing focusable alert region: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="status" aria-live="polite"'), 'Strategy dialog is missing modal-local live status region: ' . $ui_strategy);
+		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="alert" tabindex="-1"'), 'Strategy dialog is missing modal-local focusable alert region: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'wcos-strategy-confirm-checkbox'), 'Strategy dialog is missing explicit execution acknowledgement: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-review-action="' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION . '"'), 'Strategy dialog is missing server Review route authority: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-confirm-action="' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION . '"'), 'Strategy dialog is missing server Confirm route authority: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'data-execute-action="' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION . '"'), 'Strategy dialog is missing server Execute route authority: ' . $ui_strategy);
 	}
 
-	$js_path = dirname(__DIR__, 2) . '/js/p2-split-strategy-admin.js';
-	$js = file_get_contents($js_path);
+	$root = dirname(__DIR__, 2);
+	$js = file_get_contents($root . '/js/p2-split-strategy-admin.js');
 	wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read strategy admin client script.');
 	foreach (array(
 		'var reviewState = null;',
@@ -92,25 +92,35 @@ try {
 		'confirmationState = {',
 		'reviewState = null;',
 		'completed = true;',
-		"event.key === 'Escape'",
-		"event.key !== 'Tab'",
-		'returnFocus.focus()',
+		'window.WCOSBackboneModal.open',
+		"modalClass: 'wcos-strategy-backbone-modal'",
+		'removeExternalDescription',
+		'description.parentNode.removeChild(description)',
+		"statusBox = root.querySelector('.wcos-strategy-status')",
+		"errorBox = root.querySelector('.wcos-strategy-error')",
+		"resultBox = root.querySelector('.wcos-strategy-result')",
 		'field.disabled = busy || completed || !!confirmationState;',
 		"dialog.querySelectorAll('input, button')",
 		"typeof error.retryable !== 'boolean'",
 		'error.retryable = true;',
 	) as $needle) {
-		wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy client state/accessibility contract is missing: ' . $needle);
+		wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy client state/Backbone-modal contract is missing: ' . $needle);
 	}
 	wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Strategy client uses innerHTML for server-provided display data.');
 	wcos_p2_adapter_assert(false === strpos($js, 'window.alert'), 'Strategy client uses blocking window.alert().');
 	wcos_p2_adapter_assert(false === strpos($js, 'JSON.stringify(plan'), 'Strategy client constructs or sends a client-authored mutation plan.');
 	wcos_p2_adapter_assert(false === strpos($js, 'classification_fingerprint'), 'Strategy client treats classification fingerprint as client authority.');
 
-	$css_path = dirname(__DIR__, 2) . '/css/p2-split-strategy-admin.css';
-	$css = file_get_contents($css_path);
+	$bridge = file_get_contents($root . '/js/p2-backbone-modal.js');
+	wcos_p2_adapter_assert(is_string($bridge) && false !== strpos($bridge, '$.fn.WCBackboneModal'), 'Strategy UI lost WooCommerce Backbone modal dependency.');
+	wcos_p2_adapter_assert(false !== strpos($bridge, 'wc_backbone_modal_removed'), 'Strategy UI lost Backbone modal focus-return lifecycle.');
+
+	$css = file_get_contents($root . '/css/p2-split-strategy-admin.css');
 	wcos_p2_adapter_assert(is_string($css) && false !== strpos($css, '@media (max-width: 782px)'), 'Strategy UI is missing responsive admin styling.');
 	wcos_p2_adapter_assert(false !== strpos($css, 'min-height: 44px'), 'Strategy UI is missing mobile-sized action targets.');
+	wcos_p2_adapter_assert(false !== strpos($css, '.wcos-strategy-dialog {'), 'Strategy source dialog is not explicitly hidden.');
+	wcos_p2_adapter_assert(false !== strpos($css, 'display: none !important;'), 'Strategy source dialog/launcher is not hidden from the order page.');
+	wcos_p2_adapter_assert(false !== strpos($css, '.wcos-strategy-backbone-modal .wc-backbone-modal-content'), 'Strategy visible modal does not use WooCommerce Backbone shell.');
 } finally {
 	if ($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller) {
 		$ui_controller->unregister_hooks();


### PR DESCRIPTION
## Classification

`ADMIN_UI_BACKBONE_MODAL_REFACTOR`

## User feedback addressed

1. Replace every custom Order Splitter modal shell with WooCommerce's native Backbone modal presentation.
2. Keep `Remove last child` visually as a normal WooCommerce/WordPress button while retaining red destructive text.
3. Remove Category / Stock-status workflow notices/descriptions from the order edit page; strategy Review, validation, error and success feedback stays inside the modal.

## Scope

Admin UI presentation and client orchestration only. Mutation services, parsers, gateways, journals, confirmation authority, feature gates, strategy gates, order semantics, stock semantics and version remain unchanged.

## Implementation

- Adds a shared `WCOSBackboneModal` bridge backed by WooCommerce's registered `wc-backbone-modal` API.
- Quantity Split, Split method chooser, Duplicate, Category Split and Stock-status Split all open through `$.fn.WCBackboneModal`.
- Existing server-rendered dialog markup is retained only as a hidden cloning source, so transport/security markup remains unchanged while user-visible shells are native WooCommerce modals.
- Modal close/backdrop is guarded while async mutation work is busy.
- External launcher description spans are removed from the DOM at client initialization; strategy feedback remains in modal-local status/error/result regions.
- `Remove last child` uses the normal `.button` treatment with red text.

## Production gate state

Unchanged:
- `SPLIT = true`
- `DUPLICATE = true`
- `MERGE = false`
- `RETURN_ORDER = false`
- `BULK_RETURN = false`
- `manual_quantity = true`
- `category = false`
- `stock_status = false`

A new sandbox candidate will be generated only after canonical CI passes and this PR is merged.