### PR TITLE
UI: fix Backbone modal runtime binding and footer actions

### DIFF
--- a/css/p2-backbone-modal.css
+++ b/css/p2-backbone-modal.css
@@ -1,0 +1,33 @@
+/* Shared presentation rules for Order Splitter workflows inside WooCommerce Backbone modals. */
+
+#wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer {
+    display: flex !important;
+    align-items: center;
+    justify-content: flex-end !important;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+#wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer .button,
+#wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer .button-primary,
+#wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer .button-secondary {
+    float: none !important;
+    margin: 0 !important;
+}
+
+#wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer .wcos-split-remove-child {
+    color: #b32d2e;
+}
+
+@media (max-width: 782px) {
+    #wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer {
+        align-items: stretch;
+        flex-direction: column-reverse;
+    }
+
+    #wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer .button {
+        width: 100%;
+        min-height: 44px;
+        text-align: center;
+    }
+}

--- a/inc/backend/class-wcos-admin-backbone-modal-assets.php
+++ b/inc/backend/class-wcos-admin-backbone-modal-assets.php
@@ -22,6 +22,12 @@ final class WCOS_Admin_Backbone_Modal_Assets {
 
 		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
 		wp_enqueue_script('wc-backbone-modal');
+		wp_enqueue_style(
+			'wcos-admin-backbone-modal',
+			plugins_url('css/p2-backbone-modal.css', $plugin_file),
+			array(),
+			WC_ORDER_SPLITTER_VERSION
+		);
 		wp_enqueue_script(
 			'wcos-admin-backbone-modal',
 			plugins_url('js/p2-backbone-modal.js', $plugin_file),

--- a/js/p2-backbone-modal.js
+++ b/js/p2-backbone-modal.js
@@ -95,6 +95,7 @@
         var namespace = '.wcosBackboneModal' + String(instanceId);
         var restoreFocus = options.restoreFocus !== false;
         var removed = false;
+        var afterRemoved = null;
 
         $(trigger).WCBackboneModal({
             template: templateName,
@@ -134,8 +135,9 @@
             shell: shell,
             body: body,
             footer: footer,
-            close: function (shouldRestoreFocus) {
+            close: function (shouldRestoreFocus, callback) {
                 restoreFocus = shouldRestoreFocus !== false;
+                afterRemoved = typeof callback === 'function' ? callback : null;
                 var close = root.querySelector('.wc-backbone-modal-header .modal-close') || root.querySelector('.modal-close');
                 if (close) {
                     close.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -176,10 +178,24 @@
             if (restoreFocus && previousFocus && previousFocus.isConnected && typeof previousFocus.focus === 'function') {
                 previousFocus.focus();
             }
+            if (typeof afterRemoved === 'function') {
+                var callback = afterRemoved;
+                afterRemoved = null;
+                window.setTimeout(callback, 0);
+            }
         });
 
+        /*
+         * Call onReady after open() has returned its handle to the workflow.
+         * This avoids the synchronous RHS-assignment race that left callers
+         * observing a null modal handle while the modal was already visible.
+         */
         if (typeof options.onReady === 'function') {
-            options.onReady(root, handle);
+            window.setTimeout(function () {
+                if (!removed && root.isConnected) {
+                    options.onReady(root, handle);
+                }
+            }, 0);
         }
 
         return handle;

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -21,6 +21,13 @@
         return value;
     }
 
+    function requireRef(element, label) {
+        if (!element) {
+            throw new Error('Strategy Split modal failed to bind ' + label + '.');
+        }
+        return element;
+    }
+
     function request(sourceDialog, action, data) {
         var body = new URLSearchParams();
         body.set('action', action);
@@ -360,29 +367,30 @@
                 build: function (body, footer, root) {
                     var sourceForm = sourceDialog.querySelector('.wcos-strategy-form');
                     var sourceActions = sourceDialog.querySelector('.wcos-strategy-dialog__actions');
-                    var clonedForm = sourceForm.cloneNode(true);
+                    var clonedForm = requireRef(sourceForm, 'source form').cloneNode(true);
                     var clonedActions = clonedForm.querySelector('.wcos-strategy-dialog__actions');
                     if (clonedActions && clonedActions.parentNode) {
                         clonedActions.parentNode.removeChild(clonedActions);
                     }
                     body.appendChild(clonedForm);
                     cloneFooter(sourceActions, footer);
+
                     dialog = root;
                     form = clonedForm;
-                    closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
-                    cancelButton = root.querySelector('.wcos-strategy-cancel');
-                    reviewButton = root.querySelector('.wcos-strategy-review-button');
-                    reviewSection = root.querySelector('.wcos-strategy-review');
-                    reviewSummary = root.querySelector('.wcos-strategy-review-summary');
-                    bucketOptions = root.querySelector('.wcos-strategy-bucket-options');
-                    confirmButton = root.querySelector('.wcos-strategy-confirm-button');
-                    confirmationSection = root.querySelector('.wcos-strategy-confirmation');
-                    confirmationSummary = root.querySelector('.wcos-strategy-confirmation-summary');
-                    confirmCheckbox = root.querySelector('.wcos-strategy-confirm-checkbox');
-                    executeButton = root.querySelector('.wcos-strategy-execute-button');
-                    statusBox = root.querySelector('.wcos-strategy-status');
-                    errorBox = root.querySelector('.wcos-strategy-error');
-                    resultBox = root.querySelector('.wcos-strategy-result');
+                    closeButton = requireRef(root.querySelector('.wc-backbone-modal-header .modal-close'), 'close button');
+                    cancelButton = requireRef(footer.querySelector('.wcos-strategy-cancel'), 'cancel button');
+                    reviewButton = requireRef(clonedForm.querySelector('.wcos-strategy-review-button'), 'Review button');
+                    reviewSection = requireRef(clonedForm.querySelector('.wcos-strategy-review'), 'Review section');
+                    reviewSummary = requireRef(clonedForm.querySelector('.wcos-strategy-review-summary'), 'Review summary');
+                    bucketOptions = requireRef(clonedForm.querySelector('.wcos-strategy-bucket-options'), 'bucket options');
+                    confirmButton = requireRef(clonedForm.querySelector('.wcos-strategy-confirm-button'), 'Confirm button');
+                    confirmationSection = requireRef(clonedForm.querySelector('.wcos-strategy-confirmation'), 'confirmation section');
+                    confirmationSummary = requireRef(clonedForm.querySelector('.wcos-strategy-confirmation-summary'), 'confirmation summary');
+                    confirmCheckbox = requireRef(clonedForm.querySelector('.wcos-strategy-confirm-checkbox'), 'confirmation checkbox');
+                    executeButton = requireRef(clonedForm.querySelector('.wcos-strategy-execute-button'), 'Execute button');
+                    statusBox = requireRef(clonedForm.querySelector('.wcos-strategy-status'), 'status region');
+                    errorBox = requireRef(clonedForm.querySelector('.wcos-strategy-error'), 'error region');
+                    resultBox = requireRef(clonedForm.querySelector('.wcos-strategy-result'), 'result region');
                 },
                 onReady: function () {
                     reviewButton.addEventListener('click', reviewStrategy);

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -66,14 +66,23 @@ foreach (array(
     "container.querySelectorAll('[for]')",
     "['aria-labelledby', 'aria-describedby', 'aria-controls', 'aria-owns']",
     'remapClonedIds(body, instanceId);',
+    'var afterRemoved = null;',
+    "afterRemoved = typeof callback === 'function' ? callback : null;",
+    'window.setTimeout(callback, 0);',
+    'options.onReady(root, handle);',
 ) as $needle) {
-    wcos_p2_adapter_assert(false !== strpos($bridge, $needle), 'Shared modal bridge is missing WooCommerce Backbone/ID-remap contract: ' . $needle);
+    wcos_p2_adapter_assert(false !== strpos($bridge, $needle), 'Shared modal bridge is missing WooCommerce Backbone/readiness contract: ' . $needle);
 }
+wcos_p2_adapter_assert(
+    false !== strpos($bridge, "if (!removed && root.isConnected) {\n                    options.onReady(root, handle);"),
+    'Backbone modal onReady is not deferred until the rendered modal handle is stable.'
+);
 wcos_p2_adapter_assert(false === strpos($bridge, '.innerHTML'), 'Shared Backbone modal bridge uses innerHTML.');
 
 $asset_contract = file_get_contents($root . '/inc/backend/class-wcos-admin-backbone-modal-assets.php');
 wcos_p2_adapter_assert(is_string($asset_contract) && false !== strpos($asset_contract, "wp_enqueue_script('wc-backbone-modal')"), 'Backbone modal asset contract does not require the WooCommerce native handle.');
 wcos_p2_adapter_assert(false !== strpos($asset_contract, "array('jquery', 'wc-backbone-modal')"), 'Shared modal bridge does not declare the WooCommerce Backbone dependency.');
+wcos_p2_adapter_assert(false !== strpos($asset_contract, "plugins_url('css/p2-backbone-modal.css'"), 'Shared Backbone modal footer stylesheet is not enqueued.');
 wcos_p2_adapter_assert(false !== strpos($asset_contract, "'wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin'"), 'Workflow modal clients are not dependency-bound to the shared bridge.');
 
 $css = file_get_contents($root . '/css/p2-split-admin.css');
@@ -81,5 +90,9 @@ wcos_p2_adapter_assert(is_string($css) && false !== strpos($css, '.wcos-split-ba
 wcos_p2_adapter_assert(false !== strpos($css, '.wcos-split-method-backbone-modal .wc-backbone-modal-content'), 'Split method chooser does not use the WooCommerce Backbone shell.');
 wcos_p2_adapter_assert(false !== strpos($css, '.wcos-split-remove-child'), 'Remove-last-child button styling is missing.');
 wcos_p2_adapter_assert(false !== strpos($css, 'color: #b32d2e;'), 'Remove-last-child destructive text color is missing.');
+
+$shared_css = file_get_contents($root . '/css/p2-backbone-modal.css');
+wcos_p2_adapter_assert(is_string($shared_css) && false !== strpos($shared_css, 'justify-content: flex-end !important;'), 'Backbone modal footer actions are not grouped at the standard right edge.');
+wcos_p2_adapter_assert(false !== strpos($shared_css, '.wcos-admin-backbone-modal__footer'), 'Shared Backbone modal footer selector is missing.');
 
 echo "p2-admin-client-terminal-state-ok\n";

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -96,9 +96,11 @@ try {
 		"modalClass: 'wcos-strategy-backbone-modal'",
 		'removeExternalDescription',
 		'description.parentNode.removeChild(description)',
-		"statusBox = root.querySelector('.wcos-strategy-status')",
-		"errorBox = root.querySelector('.wcos-strategy-error')",
-		"resultBox = root.querySelector('.wcos-strategy-result')",
+		'function requireRef(element, label)',
+		"statusBox = requireRef(clonedForm.querySelector('.wcos-strategy-status'), 'status region')",
+		"errorBox = requireRef(clonedForm.querySelector('.wcos-strategy-error'), 'error region')",
+		"resultBox = requireRef(clonedForm.querySelector('.wcos-strategy-result'), 'result region')",
+		"cancelButton = requireRef(footer.querySelector('.wcos-strategy-cancel'), 'cancel button')",
 		'field.disabled = busy || completed || !!confirmationState;',
 		"dialog.querySelectorAll('input, button')",
 		"typeof error.retryable !== 'boolean'",
@@ -106,6 +108,7 @@ try {
 	) as $needle) {
 		wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy client state/Backbone-modal contract is missing: ' . $needle);
 	}
+	wcos_p2_adapter_assert(false === strpos($js, "errorBox = root.querySelector('.wcos-strategy-error')"), 'Strategy error region regressed to ambiguous modal-root binding.');
 	wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Strategy client uses innerHTML for server-provided display data.');
 	wcos_p2_adapter_assert(false === strpos($js, 'window.alert'), 'Strategy client uses blocking window.alert().');
 	wcos_p2_adapter_assert(false === strpos($js, 'JSON.stringify(plan'), 'Strategy client constructs or sends a client-authored mutation plan.');


### PR DESCRIPTION
## Classification

`ADMIN_UI_BACKBONE_MODAL_RUNTIME_FIX`

## Hands-on failures fixed

- Quantity Split threw `Cannot read properties of null (reading 'footer')` during modal readiness, preventing Review.
- Strategy Split could throw `Cannot set properties of null (setting 'hidden')` from `clearError()`, preventing Review/validation feedback.
- WooCommerce modal footer actions were distributed across the full footer instead of using a standard right-aligned action group.

## Root causes

1. The shared bridge invoked `onReady` synchronously from inside `open()`, before the caller's `modal = open(...)` assignment completed.
2. Strategy controls/status/error/result were queried from the broad modal root rather than being bound to the exact cloned form/footer that owns the workflow state.
3. Native WooCommerce footer flex rules were not normalized for the plugin's multi-button action set.

## Changes

- Defer bridge `onReady` until after `open()` returns and the rendered root is still connected.
- Add close-completion callback support using `wc_backbone_modal_removed` for safe modal transitions.
- Bind Strategy Split references directly from the cloned form/footer and fail fast if required modal-local controls are missing.
- Add shared Backbone modal footer CSS: right-aligned action group, normalized gaps/margins, responsive mobile stacking.
- Preserve `Remove last child` as a normal button with destructive red text when active.
- Add regression assertions for readiness ordering, strategy reference ownership and footer layout.

## Scope safety

No mutation engine, gateway, journal, confirmation authority, planner, stock semantics, feature gate, strategy gate, version or release metadata changes.

Production strategy gates remain hard-off (`category=false`, `stock_status=false`). A new sandbox candidate will be generated only after this PR passes canonical CI and is merged.