### PR TITLE
UI: move strategy actions to modal footer and surface feedback

### DIFF
--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -31,11 +31,7 @@
 }
 
 .wcos-strategy-feedback {
-    margin: 0 0 16px;
-}
-
-.wcos-strategy-feedback:empty {
-    display: none;
+    margin: 0;
 }
 
 .wcos-strategy-feedback .wcos-strategy-status {
@@ -49,7 +45,7 @@
 }
 
 .wcos-strategy-feedback .notice:last-child {
-    margin-bottom: 0;
+    margin-bottom: 12px;
 }
 
 .wcos-strategy-policy {

--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -30,6 +30,28 @@
     color: #50575e;
 }
 
+.wcos-strategy-feedback {
+    margin: 0 0 16px;
+}
+
+.wcos-strategy-feedback:empty {
+    display: none;
+}
+
+.wcos-strategy-feedback .wcos-strategy-status {
+    margin: 0 0 10px;
+    color: #50575e;
+}
+
+.wcos-strategy-feedback .notice {
+    margin: 0 0 12px;
+    padding: 10px 12px;
+}
+
+.wcos-strategy-feedback .notice:last-child {
+    margin-bottom: 0;
+}
+
 .wcos-strategy-policy {
     margin-top: 0;
     padding: 12px 16px;
@@ -44,13 +66,13 @@
     margin-top: 0;
 }
 
-.wcos-strategy-review-controls,
 .wcos-strategy-review,
-.wcos-strategy-confirmation,
-.wcos-strategy-status,
-.wcos-strategy-error,
-.wcos-strategy-result {
+.wcos-strategy-confirmation {
     margin-top: 16px;
+}
+
+.wcos-strategy-review-controls:empty {
+    display: none;
 }
 
 .wcos-strategy-buckets {
@@ -99,13 +121,8 @@
     display: flex;
     align-items: flex-start;
     gap: 8px;
-    margin: 12px 0;
+    margin: 12px 0 0;
     font-weight: 600;
-}
-
-.wcos-strategy-error,
-.wcos-strategy-result {
-    padding: 10px 12px;
 }
 
 .wcos-strategy-result ul {
@@ -121,12 +138,5 @@
         width: calc(100% - 24px);
         max-width: none;
         min-width: 0;
-    }
-
-    .wcos-strategy-review-controls .button,
-    .wcos-strategy-review .button,
-    .wcos-strategy-confirmation .button {
-        width: 100%;
-        min-height: 44px;
     }
 }

--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -135,4 +135,8 @@
         max-width: none;
         min-width: 0;
     }
+
+    .wcos-strategy-backbone-modal footer .inner .button {
+        min-height: 44px;
+    }
 }

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -108,6 +108,31 @@
             var statusBox = null;
             var errorBox = null;
             var resultBox = null;
+            var feedbackBox = null;
+
+            function showReviewAction() {
+                reviewButton.hidden = false;
+                confirmButton.hidden = true;
+                executeButton.hidden = true;
+            }
+
+            function showConfirmAction() {
+                reviewButton.hidden = true;
+                confirmButton.hidden = false;
+                executeButton.hidden = true;
+            }
+
+            function showExecuteAction() {
+                reviewButton.hidden = true;
+                confirmButton.hidden = true;
+                executeButton.hidden = false;
+            }
+
+            function hideWorkflowActions() {
+                reviewButton.hidden = true;
+                confirmButton.hidden = true;
+                executeButton.hidden = true;
+            }
 
             function clearError() {
                 errorBox.hidden = true;
@@ -122,6 +147,7 @@
 
             function setStatus(message) {
                 statusBox.textContent = message || '';
+                statusBox.hidden = !message;
             }
 
             function clearResult() {
@@ -143,6 +169,10 @@
                 confirmationSummary.textContent = '';
                 confirmCheckbox.checked = false;
                 executeButton.disabled = true;
+                executeButton.hidden = true;
+                if (reviewState) {
+                    showConfirmAction();
+                }
             }
 
             function invalidateReview() {
@@ -155,6 +185,7 @@
                 reviewSummary.textContent = '';
                 clearBucketOptions();
                 confirmButton.disabled = true;
+                showReviewAction();
             }
 
             function setBusy(nextBusy) {
@@ -236,6 +267,7 @@
                     renderBuckets(data.review || {});
                     reviewSummary.textContent = data.review && data.review.message ? String(data.review.message) : '';
                     reviewSection.hidden = false;
+                    showConfirmAction();
                     setStatus(text('reviewReady', 'Choose the one bucket that must remain on the source order.'));
                     var firstRadio = bucketOptions.querySelector('.wcos-strategy-bucket-radio');
                     (firstRadio || reviewSection).focus();
@@ -276,11 +308,14 @@
                     confirmationSummary.textContent = text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.');
                     confirmationSection.hidden = false;
                     confirmCheckbox.checked = false;
+                    showExecuteAction();
                     setStatus(text('confirmationReady', 'The plan is frozen. Acknowledge the policy and execute when ready.'));
                     confirmCheckbox.focus();
                 }).catch(function (error) {
                     if (!error.retryable) {
                         invalidateReview();
+                    } else {
+                        showConfirmAction();
                     }
                     setStatus('');
                     showError(error.message);
@@ -338,6 +373,7 @@
                     confirmation_token: confirmationState.token
                 }).then(function (data) {
                     completed = true;
+                    hideWorkflowActions();
                     setStatus(text('completed', 'Strategy Split completed successfully.'));
                     Array.prototype.forEach.call(dialog.querySelectorAll('input, button'), function (field) {
                         if (!field.classList.contains('wcos-strategy-cancel') && !field.classList.contains('modal-close')) {
@@ -347,9 +383,9 @@
                     renderSuccess(data);
                 }).catch(function (error) {
                     if (!error.retryable) {
-                        confirmationState = null;
-                        confirmationSection.hidden = true;
-                        confirmCheckbox.checked = false;
+                        invalidateReview();
+                    } else {
+                        showExecuteAction();
                     }
                     setStatus('');
                     showError(error.message);
@@ -391,6 +427,30 @@
                     statusBox = requireRef(clonedForm.querySelector('.wcos-strategy-status'), 'status region');
                     errorBox = requireRef(clonedForm.querySelector('.wcos-strategy-error'), 'error region');
                     resultBox = requireRef(clonedForm.querySelector('.wcos-strategy-result'), 'result region');
+
+                    feedbackBox = document.createElement('div');
+                    feedbackBox.className = 'wcos-strategy-feedback';
+                    clonedForm.insertBefore(feedbackBox, clonedForm.firstChild);
+                    feedbackBox.appendChild(statusBox);
+                    feedbackBox.appendChild(errorBox);
+                    feedbackBox.appendChild(resultBox);
+                    statusBox.hidden = true;
+                    errorBox.classList.add('inline');
+                    resultBox.classList.add('inline');
+
+                    footer.appendChild(reviewButton);
+                    footer.appendChild(confirmButton);
+                    footer.appendChild(executeButton);
+                    reviewButton.classList.add('button-primary', 'button-large');
+                    confirmButton.classList.remove('button-secondary');
+                    confirmButton.classList.add('button-primary', 'button-large');
+                    executeButton.classList.add('button-large');
+                    showReviewAction();
+
+                    var reviewControls = clonedForm.querySelector('.wcos-strategy-review-controls');
+                    if (reviewControls && !reviewControls.children.length && reviewControls.parentNode) {
+                        reviewControls.parentNode.removeChild(reviewControls);
+                    }
                 },
                 onReady: function () {
                     reviewButton.addEventListener('click', reviewStrategy);

--- a/tests/integration/p2-strategy-modal-feedback-smoke.php
+++ b/tests/integration/p2-strategy-modal-feedback-smoke.php
@@ -1,0 +1,62 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$root = dirname(__DIR__, 2);
+$js = file_get_contents($root . '/js/p2-split-strategy-admin.js');
+wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read strategy admin client for modal feedback acceptance.');
+
+foreach (array(
+	'function showReviewAction()',
+	'function showConfirmAction()',
+	'function showExecuteAction()',
+	'function hideWorkflowActions()',
+	"feedbackBox.className = 'wcos-strategy-feedback';",
+	'clonedForm.insertBefore(feedbackBox, clonedForm.firstChild);',
+	'feedbackBox.appendChild(statusBox);',
+	'feedbackBox.appendChild(errorBox);',
+	'feedbackBox.appendChild(resultBox);',
+	"errorBox.classList.add('inline');",
+	"resultBox.classList.add('inline');",
+	'footer.appendChild(reviewButton);',
+	'footer.appendChild(confirmButton);',
+	'footer.appendChild(executeButton);',
+	"reviewButton.classList.add('button-primary', 'button-large');",
+	"confirmButton.classList.add('button-primary', 'button-large');",
+	"executeButton.classList.add('button-large');",
+	'reviewButton.hidden = false;',
+	'confirmButton.hidden = true;',
+	'executeButton.hidden = true;',
+	'showConfirmAction();',
+	'showExecuteAction();',
+	'showError(error.message);',
+) as $needle) {
+	wcos_p2_adapter_assert(false !== strpos($js, $needle), 'Strategy modal footer/feedback contract is missing: ' . $needle);
+}
+
+wcos_p2_adapter_assert(
+	false === strpos($js, "reviewButton = requireRef(footer.querySelector('.wcos-strategy-review-button')"),
+	'Strategy Review button unexpectedly depends on server footer markup rather than the cloned workflow control.'
+);
+wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Strategy modal feedback reintroduced innerHTML rendering.');
+
+$css = file_get_contents($root . '/css/p2-split-strategy-admin.css');
+wcos_p2_adapter_assert(is_string($css) && '' !== $css, 'Unable to read strategy admin CSS for modal feedback acceptance.');
+foreach (array(
+	'.wcos-strategy-feedback {',
+	'.wcos-strategy-feedback .wcos-strategy-status {',
+	'.wcos-strategy-feedback .notice {',
+	'.wcos-strategy-review-controls:empty {',
+) as $needle) {
+	wcos_p2_adapter_assert(false !== strpos($css, $needle), 'Strategy modal feedback CSS contract is missing: ' . $needle);
+}
+
+$shared_css = file_get_contents($root . '/css/p2-backbone-modal.css');
+wcos_p2_adapter_assert(
+	is_string($shared_css) && false !== strpos($shared_css, 'justify-content: flex-end !important;'),
+	'Strategy modal footer no longer inherits the shared right-aligned WooCommerce action group.'
+);
+
+echo "p2-strategy-modal-feedback-ok\n";

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -93,3 +93,4 @@ require __DIR__ . '/p2-strategy-adapter-smoke.php';
 require __DIR__ . '/p2-strategy-confirmation-smoke.php';
 require __DIR__ . '/p2-strategy-transport-smoke.php';
 require __DIR__ . '/p2-strategy-ui-readiness-smoke.php';
+require __DIR__ . '/p2-strategy-modal-feedback-smoke.php';


### PR DESCRIPTION
## Classification

`ADMIN_UI_STRATEGY_MODAL_ACTION_FEEDBACK_FIX`

## Hands-on feedback addressed

- Category / Stock-status `Review current buckets` was presented inside modal body while `Close` lived alone in the footer.
- Unsupported / no-split Review outcomes were not visibly surfaced where users were looking.

## Changes

- Keep all strategy workflow actions in the WooCommerce Backbone modal footer.
- Initial footer: `Close | Review current buckets`.
- After successful Review: `Close | Confirm selected source bucket`.
- After confirmation: `Close | Execute strategy Split`.
- Move modal-local status/error/success regions to a feedback block at the top of modal content, directly below the modal description.
- Keep server Review/Confirm/Execute authority and all mutation semantics unchanged.
- Add canonical regression assertions for footer state transitions and modal-local feedback placement.

## Scope safety

No mutation service, gateway, planner, journal, stock semantics, feature gates, strategy gates, version or release metadata changes. Category and Stock-status remain hard-off on `main`.
