### PR TITLE
Sandbox candidate UI5: strategy footer workflow + modal feedback

### DIFF
--- a/.github/workflows/sandbox-candidate-ui5-handoff.yml
+++ b/.github/workflows/sandbox-candidate-ui5-handoff.yml
@@ -1,0 +1,89 @@
+name: Sandbox candidate UI5 handoff
+
+on:
+  pull_request:
+    branches:
+      - sandbox/order-splitter-strategy-base-ui5
+
+concurrency:
+  group: sandbox-candidate-ui5-handoff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  handoff:
+    name: Verify UI5 candidate run and expose ZIP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for exact-head sandbox candidate UI5 validation
+        id: candidate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            runs="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --commit "$HEAD_SHA" \
+              --event push \
+              --limit 20 \
+              --json databaseId,status,conclusion,headSha,name)"
+            row="$(printf '%s' "$runs" | jq -c --arg sha "$HEAD_SHA" '
+              map(select(.headSha == $sha and .name == "Sandbox strategy candidate UI5")) | first // empty
+            ')"
+            if test -n "$row"; then
+              run_id="$(printf '%s' "$row" | jq -r '.databaseId')"
+              status="$(printf '%s' "$row" | jq -r '.status')"
+              conclusion="$(printf '%s' "$row" | jq -r '.conclusion // ""')"
+              echo "candidate UI5 run=$run_id status=$status conclusion=$conclusion"
+              if test "$status" = completed; then
+                test "$conclusion" = success
+                echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "candidate UI5 push run not visible yet for $HEAD_SHA"
+            fi
+            sleep 20
+          done
+          echo 'Timed out waiting for exact-head sandbox candidate UI5 validation.' >&2
+          exit 1
+
+      - name: Download exact UI5 candidate artifact
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ steps.candidate.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p handoff
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "wc-order-splitter-sandbox-ui5-$HEAD_SHA" \
+            --dir handoff
+          test -f handoff/wc-order-splitter-sandbox-ui5.zip
+          test -f handoff/wc-order-splitter-sandbox-ui5.zip.sha256
+          (cd handoff && sha256sum -c wc-order-splitter-sandbox-ui5.zip.sha256)
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/sandbox-candidate.txt | grep -Fq 'sandbox testing only'
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/sandbox-candidate.txt | grep -Fq 'Review, Confirm and Execute actions in the WooCommerce Backbone modal footer by phase'
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq "feedbackBox.className = 'wcos-strategy-feedback';"
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(reviewButton);'
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(confirmButton);'
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(executeButton);'
+          unzip -p handoff/wc-order-splitter-sandbox-ui5.zip wc-order-splitter/css/p2-backbone-modal.css | grep -Fq 'justify-content: flex-end !important;'
+
+      - name: Upload reviewed sandbox UI5 ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: wc-order-splitter-sandbox-ui5-reviewed-${{ github.event.pull_request.head.sha }}
+          path: |
+            handoff/wc-order-splitter-sandbox-ui5.zip
+            handoff/wc-order-splitter-sandbox-ui5.zip.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/sandbox-candidate-ui5.yml
+++ b/.github/workflows/sandbox-candidate-ui5.yml
@@ -1,0 +1,444 @@
+name: Sandbox strategy candidate UI5
+
+on:
+  push:
+    branches:
+      - sandbox/order-splitter-strategy-candidate-ui5
+  workflow_dispatch:
+
+concurrency:
+  group: sandbox-strategy-candidate-ui5-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  php-syntax:
+    name: Candidate PHP syntax and unit contracts (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.1', '8.3']
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Lint PHP files
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' file; do
+            php -l "$file"
+          done < <(find . -type f -name '*.php' -print0)
+
+      - name: Run mutation-domain unit tests
+        run: php tests/unit/run.php
+
+  candidate-package:
+    name: Candidate package, modal feedback and exact gate contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+
+      - name: Validate exact sandbox candidate state and UI5 contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          plugin_version=$(sed -n 's/^ \* Version: //p' wc-order-splitter.php | head -n 1)
+          stable_tag=$(sed -n 's/^Stable tag: //p' readme.txt | head -n 1)
+          test -n "$plugin_version"
+          test "$plugin_version" = "$stable_tag"
+          test "$plugin_version" = '1.4.14'
+          test -f sandbox-candidate.txt
+          grep -Fq 'sandbox testing only' sandbox-candidate.txt
+          grep -Fq 'sandbox-ui5' wc-order-splitter.php
+          grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
+          grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => true' inc/domain/class-wcos-split-strategy-gates.php
+          test ! -d inc/mutation-v2
+
+          # Native WooCommerce Backbone lifecycle and UI5 feedback/footer contract.
+          grep -Fq "wp_enqueue_script('wc-backbone-modal')" inc/backend/class-wcos-admin-backbone-modal-assets.php
+          grep -Fq "plugins_url('css/p2-backbone-modal.css'" inc/backend/class-wcos-admin-backbone-modal-assets.php
+          grep -Fq "array('jquery', 'wc-backbone-modal')" inc/backend/class-wcos-admin-backbone-modal-assets.php
+          grep -Fq '$.fn.WCBackboneModal' js/p2-backbone-modal.js
+          grep -Fq 'if (!removed && root.isConnected)' js/p2-backbone-modal.js
+          grep -Fq 'options.onReady(root, handle);' js/p2-backbone-modal.js
+          grep -Fq "feedbackBox.className = 'wcos-strategy-feedback';" js/p2-split-strategy-admin.js
+          grep -Fq 'feedbackBox.appendChild(statusBox);' js/p2-split-strategy-admin.js
+          grep -Fq 'feedbackBox.appendChild(errorBox);' js/p2-split-strategy-admin.js
+          grep -Fq 'feedbackBox.appendChild(resultBox);' js/p2-split-strategy-admin.js
+          grep -Fq 'footer.appendChild(reviewButton);' js/p2-split-strategy-admin.js
+          grep -Fq 'footer.appendChild(confirmButton);' js/p2-split-strategy-admin.js
+          grep -Fq 'footer.appendChild(executeButton);' js/p2-split-strategy-admin.js
+          grep -Fq 'function showReviewAction()' js/p2-split-strategy-admin.js
+          grep -Fq 'function showConfirmAction()' js/p2-split-strategy-admin.js
+          grep -Fq 'function showExecuteAction()' js/p2-split-strategy-admin.js
+          grep -Fq "errorBox = requireRef(clonedForm.querySelector('.wcos-strategy-error'), 'error region')" js/p2-split-strategy-admin.js
+          grep -Fq 'justify-content: flex-end !important;' css/p2-backbone-modal.css
+          grep -Fq '.wcos-strategy-feedback .notice {' css/p2-split-strategy-admin.css
+          grep -Fq 'min-height: 44px;' css/p2-split-strategy-admin.css
+          grep -Fq "removeChildButton.className = 'button wcos-split-remove-child';" js/p2-split-admin.js
+          grep -Fq 'color: #b32d2e;' css/p2-split-admin.css
+
+          telemetry_host='yoexpress''.''top'
+          if grep -R --line-number --fixed-strings "$telemetry_host" \
+            wc-order-splitter.php readme.txt changelog.txt inc js \
+            --include='*.php' --include='*.js' --include='*.txt'; then
+            echo 'Removed telemetry endpoint must not be present in candidate source.' >&2
+            exit 1
+          fi
+
+          if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
+            wc-order-splitter.php inc/cores inc/domain; then
+            echo 'Externally overrideable mutation gates must not return.' >&2
+            exit 1
+          fi
+
+      - name: Build sandbox candidate package tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_root="$RUNNER_TEMP/package/wc-order-splitter"
+          mkdir -p "$package_root"
+          rsync -a ./ "$package_root/" --exclude-from='.distignore'
+
+          find "$package_root" -type f -name '*.php' -print0 | while IFS= read -r -d '' file; do
+            php -l "$file" >/dev/null
+          done
+
+          for forbidden_path in \
+            'inc/backend/actions' \
+            'inc/backend/orders-bulk-return.php' \
+            'inc/backend/order-split-button.php' \
+            'inc/backend/order-return-option.php' \
+            'inc/backend/order-duplicate-option.php' \
+            'inc/backend/order-merge-option.php' \
+            'js/bulk-return-action.js' \
+            'js/merge-action.js' \
+            'js/post-action-tip.js' \
+            'js/split-table.js' \
+            'inc/mutation-v2' \
+            'tests' \
+            'docs' \
+            'AGENTS.md'; do
+            if test -e "$package_root/$forbidden_path"; then
+              echo "Unsafe or development-only path entered candidate package: $forbidden_path" >&2
+              exit 1
+            fi
+          done
+
+          for required_path in \
+            'sandbox-candidate.txt' \
+            'inc/backend/class-wcos-admin-backbone-modal-assets.php' \
+            'js/p2-backbone-modal.js' \
+            'css/p2-backbone-modal.css' \
+            'inc/backend/class-wcos-split-admin-controller.php' \
+            'inc/backend/class-wcos-split-confirmation-store.php' \
+            'inc/domain/class-wcos-split-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-split-order-service.php' \
+            'js/p2-split-admin.js' \
+            'css/p2-split-admin.css' \
+            'inc/backend/class-wcos-duplicate-admin-controller.php' \
+            'inc/backend/class-wcos-duplicate-confirmation-store.php' \
+            'inc/domain/class-wcos-duplicate-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-duplicate-order-service.php' \
+            'js/p2-duplicate-admin.js' \
+            'css/p2-duplicate-admin.css' \
+            'inc/backend/class-wcos-split-strategy-review-store.php' \
+            'inc/backend/class-wcos-split-strategy-confirmation-store.php' \
+            'inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'inc/domain/class-wcos-split-strategy-gates.php' \
+            'inc/domain/class-wcos-category-split-planner.php' \
+            'inc/domain/class-wcos-stock-status-split-planner.php' \
+            'inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'js/p2-split-strategy-admin.js' \
+            'css/p2-split-strategy-admin.css'; do
+            if test ! -e "$package_root/$required_path"; then
+              echo "Required sandbox runtime asset is missing: $required_path" >&2
+              exit 1
+            fi
+          done
+
+          if find "$package_root" -type l | grep -q .; then
+            echo 'Sandbox candidate package must not contain symbolic links.' >&2
+            exit 1
+          fi
+          if grep -R --line-number -E 'yoexpress\.top|WC_Order_Splitter_Push_Subscription' "$package_root"; then
+            echo 'Removed telemetry code entered the candidate package.' >&2
+            exit 1
+          fi
+
+          touch -t 200001010000 "$package_root"
+          find "$package_root" -exec touch -t 200001010000 {} +
+          cd "$RUNNER_TEMP/package"
+          find wc-order-splitter -type f -print | LC_ALL=C sort | zip -X -q "$GITHUB_WORKSPACE/wc-order-splitter-sandbox-ui5.zip" -@
+
+      - name: Inspect candidate ZIP and checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          unzip -t wc-order-splitter-sandbox-ui5.zip
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/sandbox-candidate.txt | grep -Fq 'sandbox testing only'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/wc-order-splitter.php | grep -Fq 'sandbox-ui5'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => true'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::SPLIT => true'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::DUPLICATE => true'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-backbone-modal.js | grep -Fq 'if (!removed && root.isConnected)'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq "feedbackBox.className = 'wcos-strategy-feedback';"
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(reviewButton);'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(confirmButton);'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/js/p2-split-strategy-admin.js | grep -Fq 'footer.appendChild(executeButton);'
+          unzip -p wc-order-splitter-sandbox-ui5.zip wc-order-splitter/css/p2-backbone-modal.css | grep -Fq 'justify-content: flex-end !important;'
+
+          for required_archive_path in \
+            'wc-order-splitter/inc/backend/class-wcos-admin-backbone-modal-assets.php' \
+            'wc-order-splitter/js/p2-backbone-modal.js' \
+            'wc-order-splitter/css/p2-backbone-modal.css' \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-review-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-confirmation-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php' \
+            'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php' \
+            'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'wc-order-splitter/js/p2-split-strategy-admin.js' \
+            'wc-order-splitter/css/p2-split-strategy-admin.css'; do
+            unzip -Z1 wc-order-splitter-sandbox-ui5.zip | grep -Fxq "$required_archive_path"
+          done
+
+          if unzip -Z1 wc-order-splitter-sandbox-ui5.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
+            echo 'Development-only content entered the candidate ZIP.' >&2
+            exit 1
+          fi
+          sha256sum wc-order-splitter-sandbox-ui5.zip > wc-order-splitter-sandbox-ui5.zip.sha256
+          cat wc-order-splitter-sandbox-ui5.zip.sha256
+
+      - name: Upload sandbox candidate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wc-order-splitter-sandbox-ui5-${{ github.sha }}
+          path: |
+            wc-order-splitter-sandbox-ui5.zip
+            wc-order-splitter-sandbox-ui5.zip.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  integration:
+    name: Candidate WooCommerce 11.0.1 / ${{ matrix.storage }} storage
+    needs: [php-syntax]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        storage: [legacy, hpos, hpos-sync]
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Install wp-env
+        run: npm install --no-audit --no-fund
+
+      - name: Start WordPress
+        run: npx wp-env start
+
+      - name: Install and activate WooCommerce 11.0.1
+        run: npx wp-env run cli wp plugin install https://downloads.wordpress.org/plugin/woocommerce.11.0.1.zip --activate
+
+      - name: Install early-translation monitor
+        run: |
+          npx wp-env run cli wp eval '
+            wp_mkdir_p(WPMU_PLUGIN_DIR);
+            @unlink(WP_CONTENT_DIR . "/wcos-early-translation.jsonl");
+            $source = WP_PLUGIN_DIR . "/wc-order-splitter/tests/integration/early-translation-monitor.php";
+            $target = WPMU_PLUGIN_DIR . "/wcos-early-translation-monitor.php";
+            if (!copy($source, $target)) { exit(1); }
+          '
+
+      - name: Activate sandbox candidate
+        run: npx wp-env run cli wp plugin activate wc-order-splitter
+
+      - name: Reject early WooCommerce translation loading
+        run: |
+          npx wp-env run cli wp eval '
+            $log = WP_CONTENT_DIR . "/wcos-early-translation.jsonl";
+            if (file_exists($log) && filesize($log) > 0) {
+              fwrite(STDERR, file_get_contents($log));
+              exit(1);
+            }
+            echo "candidate-early-translation-loading-ok\n";
+          '
+
+      - name: Configure legacy order storage
+        if: matrix.storage == 'legacy'
+        run: |
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_enabled no
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_data_sync_enabled no
+
+      - name: Configure HPOS-only order storage
+        if: matrix.storage == 'hpos'
+        run: |
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_enabled yes
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_data_sync_enabled no
+
+      - name: Configure HPOS compatibility mode
+        if: matrix.storage == 'hpos-sync'
+        run: |
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_enabled yes
+          npx wp-env run cli wp option update woocommerce_custom_orders_table_data_sync_enabled yes
+
+      - name: Verify exact enabled sandbox state and routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx wp-env run cli wp plugin is-active woocommerce
+          npx wp-env run cli wp plugin is-active wc-order-splitter
+          npx wp-env run cli wp eval '
+            $expected = "${{ matrix.storage }}";
+            $hpos = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+            if (("legacy" === $expected && $hpos) || ("legacy" !== $expected && !$hpos)) { exit(1); }
+            if ("1.4.14-sandbox-ui5" !== WC_ORDER_SPLITTER_VERSION) { exit(1); }
+            if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) { exit(1); }
+            if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE)) { exit(1); }
+            foreach (array(WCOS_Feature_Gates::MERGE, WCOS_Feature_Gates::RETURN_ORDER, WCOS_Feature_Gates::BULK_RETURN) as $disabled) {
+              if (WCOS_Feature_Gates::enabled($disabled)) { exit(1); }
+            }
+            foreach (array(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY, WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $enabled_strategy) {
+              if (!WCOS_Split_Strategy_Gates::enabled($enabled_strategy)) { exit(1); }
+            }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            echo "candidate-ui5-enabled-strategy-state-ok\n";
+          '
+
+      - name: Verify mutation lease, hard-off regressions, modal feedback and candidate E2E
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/operation-control-smoke.php
+
+      - name: Verify mutation leases stay bound to operation IDs
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/lease-operation-binding-smoke.php
+
+      - name: Verify governance, authorization, and metadata policy
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
+
+      - name: Verify Duplicate integrity, idempotency, and recovery
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/duplicate-smoke.php
+
+      - name: Verify manual Split conservation, idempotency, and recovery
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/split-smoke.php
+
+      - name: Verify variation identity and historical tax conservation
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/tax-variation-smoke.php
+
+      - name: Verify mutation side effects remain idempotent
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/side-effects-smoke.php
+
+      - name: Verify compensating rollback and crash resume
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/compensation-smoke.php
+
+      - name: Verify retry idempotency at every persistence boundary
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/failure-matrix-smoke.php
+
+      - name: Verify source-save crash recovery contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/source-save-crash-smoke.php
+
+      - name: Verify authoritative journal durability
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/journal-durability-smoke.php
+
+      - name: Reject corrupted reduced-stock source markers
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/stock-marker-validation-smoke.php
+
+      - name: Verify real concurrent operation lease exclusion
+        if: matrix.storage == 'hpos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw="$(npx wp-env run cli wp eval '$o = wc_create_order(); $o->set_status("pending"); $o->save(); echo "WCOS_ORDER_ID=" . $o->get_id() . "\n";')"
+          order_id="$(printf '%s\n' "$raw" | sed -n 's/.*WCOS_ORDER_ID=\([0-9][0-9]*\).*/\1/p' | tail -n 1)"
+          test -n "$order_id"
+          worker='wp-content/plugins/wc-order-splitter/tests/integration/concurrency-lock-worker.php'
+          npx wp-env run cli wp eval-file "$worker" "$order_id" worker-a 4 > /tmp/wcos-worker-a.log 2>&1 &
+          worker_a_pid=$!
+          sleep 1
+          npx wp-env run cli wp eval-file "$worker" "$order_id" worker-b 0 > /tmp/wcos-worker-b.log 2>&1
+          wait "$worker_a_pid"
+          grep -Fq 'ACQUIRED worker-a' /tmp/wcos-worker-a.log
+          grep -Fq 'BLOCKED worker-b' /tmp/wcos-worker-b.log
+          npx wp-env run cli wp eval '$o = wc_get_order('"$order_id"'); if ($o) { $o->delete(true); }'
+
+      - name: Verify real concurrent strategy Confirm remains single-success
+        if: matrix.storage == 'hpos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-fixture.php'
+          worker='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-worker.php'
+          cleanup='wp-content/plugins/wc-order-splitter/tests/integration/strategy-confirm-race-cleanup.php'
+          cleanup_race() { npx wp-env run cli wp eval-file "$cleanup" || true; }
+          trap cleanup_race EXIT
+          npx wp-env run cli wp eval-file "$fixture"
+          npx wp-env run cli wp eval-file "$worker" worker-a > /tmp/wcos-confirm-worker-a.log 2>&1 &
+          a=$!
+          npx wp-env run cli wp eval-file "$worker" worker-b > /tmp/wcos-confirm-worker-b.log 2>&1 &
+          b=$!
+          wait "$a"
+          wait "$b"
+          success_count="$(awk '/^CONFIRMED / { count++ } END { print count + 0 }' /tmp/wcos-confirm-worker-a.log /tmp/wcos-confirm-worker-b.log)"
+          rejected_count="$(awk '/^REJECTED / { count++ } END { print count + 0 }' /tmp/wcos-confirm-worker-a.log /tmp/wcos-confirm-worker-b.log)"
+          test "$success_count" -eq 1
+          test "$rejected_count" -eq 1
+          cleanup_race
+          trap - EXIT
+
+      - name: Stop WordPress
+        if: always()
+        run: npx wp-env stop
+
+  required:
+    name: Required Sandbox Candidate UI5
+    if: always()
+    needs:
+      - php-syntax
+      - candidate-package
+      - integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every sandbox candidate gate passed
+        env:
+          PHP_RESULT: ${{ needs['php-syntax'].result }}
+          PACKAGE_RESULT: ${{ needs['candidate-package'].result }}
+          INTEGRATION_RESULT: ${{ needs['integration'].result }}
+        run: |
+          set -euo pipefail
+          test "$PHP_RESULT" = success
+          test "$PACKAGE_RESULT" = success
+          test "$INTEGRATION_RESULT" = success
+          echo "required-sandbox-candidate-ui5-ok"

--- a/inc/domain/class-wcos-split-strategy-gates.php
+++ b/inc/domain/class-wcos-split-strategy-gates.php
@@ -17,8 +17,8 @@ final class WCOS_Split_Strategy_Gates {
 
 	private static $states = array(
 		self::MANUAL_QUANTITY => true,
-		self::CATEGORY => false,
-		self::STOCK_STATUS => false,
+		self::CATEGORY => true, // Sandbox candidate only. Do not merge to production.
+		self::STOCK_STATUS => true, // Sandbox candidate only. Do not merge to production.
 	);
 
 	public static function enabled($strategy) {

--- a/sandbox-candidate.txt
+++ b/sandbox-candidate.txt
@@ -1,0 +1,15 @@
+Order Splitter sandbox testing only
+
+Candidate: UI5
+Source baseline: main after PR #35 (f0e553a2140c126a6b9eb6577271c7f179bed02e)
+Plugin header: 1.4.14
+Runtime asset suffix: 1.4.14-sandbox-ui5
+
+Sandbox strategy state:
+- manual quantity: enabled
+- category: enabled
+- stock status: enabled
+
+UI5 specifically keeps Category / Stock-status Review, Confirm and Execute actions in the WooCommerce Backbone modal footer by phase, and surfaces server status/error/success feedback directly below the modal description.
+
+Do not deploy this sandbox candidate to production.

--- a/tests/integration/p2-strategy-sandbox-candidate-smoke.php
+++ b/tests/integration/p2-strategy-sandbox-candidate-smoke.php
@@ -1,0 +1,202 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Sandbox candidate lost global Split enablement.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Sandbox candidate lost Duplicate enablement.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Sandbox candidate Category gate is not enabled.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Sandbox candidate Stock-status gate is not enabled.');
+
+$candidate_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
+wcos_p2_adapter_assert($candidate_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Sandbox candidate strategy controller did not bootstrap.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Sandbox candidate Review route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Sandbox candidate Confirm route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Sandbox candidate Execute route is not registered.');
+
+$candidate_previous_user = get_current_user_id();
+$candidate_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$candidate_admin_id = wp_insert_user(array(
+	'user_login' => 'wcos_sandbox_ui5_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-sandbox-ui5-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+wcos_p2_adapter_assert(!is_wp_error($candidate_admin_id), 'Unable to create sandbox UI5 administrator.');
+
+$category_order_id = 0;
+$category_operation_id = '';
+$category_keep = null;
+$category_move = null;
+$category_keep_term = null;
+$category_move_term = null;
+$stock_order_id = 0;
+$stock_operation_id = '';
+$stock_keep = null;
+$stock_move = null;
+
+try {
+	update_option('order_splitter_status_allowed', array('wc-pending'));
+	wp_set_current_user($candidate_admin_id);
+
+	/* Category: enabled Review -> Confirm -> Execute, frozen taxonomy and durable replay. */
+	$suffix = strtolower(wp_generate_password(6, false, false));
+	$category_keep_term = wp_insert_term('WCOS UI5 Keep ' . $suffix, 'product_cat');
+	$category_move_term = wp_insert_term('WCOS UI5 Move ' . $suffix, 'product_cat');
+	wcos_p2_adapter_assert(!is_wp_error($category_keep_term) && !is_wp_error($category_move_term), 'Unable to create UI5 Category terms.');
+	$category_keep = wcos_p2_adapter_product('WCOS UI5 Category Keep', '12.00', 30);
+	$category_move = wcos_p2_adapter_product('WCOS UI5 Category Move', '8.00', 40);
+	wp_set_object_terms($category_keep->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+	wp_set_object_terms($category_move->get_id(), array(absint($category_move_term['term_id'])), 'product_cat');
+
+	$category_order = wc_create_order();
+	$category_order->set_status('pending');
+	$category_order->set_currency('USD');
+	$category_keep_item = $category_order->add_product($category_keep, 2);
+	$category_move_item = $category_order->add_product($category_move, 2);
+	$category_order->calculate_totals(false);
+	$category_order->save();
+	$category_order_id = $category_order->get_id();
+	$category_keep_stock = wc_get_product($category_keep->get_id())->get_stock_quantity();
+	$category_move_stock = wc_get_product($category_move->get_id())->get_stock_quantity();
+	$category_nonce = wp_create_nonce('wcos_split_strategy_order_' . $category_order_id);
+
+	$category_review = $candidate_controller->review_request(array(
+		'order_id' => $category_order_id,
+		'nonce' => $category_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+	));
+	$category_keep_bucket = 'category-' . absint($category_keep_term['term_id']);
+	$category_confirmation = $candidate_controller->confirm_request(array(
+		'order_id' => $category_order_id,
+		'nonce' => $category_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'review_id' => $category_review['review_id'],
+		'review_token' => $category_review['review_token'],
+		'source_bucket_key' => $category_keep_bucket,
+	));
+	$category_operation_id = sanitize_key($category_confirmation['operation_id']);
+
+	wp_set_object_terms($category_move->get_id(), array(absint($category_keep_term['term_id'])), 'product_cat');
+	$category_result = $candidate_controller->execute_request(array(
+		'order_id' => $category_order_id,
+		'nonce' => $category_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'operation_id' => $category_operation_id,
+		'confirmation_token' => $category_confirmation['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $category_result['status'] && 1 === count($category_result['children']), 'UI5 Category Split did not create exactly one child.');
+	$category_child_id = absint($category_result['children'][0]['id']);
+	$category_source = wc_get_order($category_order_id);
+	wcos_p2_adapter_assert($category_source->get_item($category_keep_item) instanceof WC_Order_Item_Product, 'UI5 Category Split lost the retained source bucket.');
+	wcos_p2_adapter_assert(!$category_source->get_item($category_move_item), 'UI5 Category Split ignored frozen Review classification.');
+	wcos_p2_adapter_assert($category_keep_stock == wc_get_product($category_keep->get_id())->get_stock_quantity(), 'UI5 Category Split changed retained-product stock.');
+	wcos_p2_adapter_assert($category_move_stock == wc_get_product($category_move->get_id())->get_stock_quantity(), 'UI5 Category Split changed moved-product stock.');
+	$category_journal = WCOS_Operation_Journal::get($category_source, $category_operation_id);
+	wcos_p2_adapter_assert(is_array($category_journal) && 'completed' === $category_journal['status'], 'UI5 Category journal did not complete.');
+	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::CATEGORY === $category_journal['context']['strategy_authority']['strategy'], 'UI5 Category journal lost semantic strategy authority.');
+
+	WCOS_Split_Strategy_Confirmation_Store::delete($category_operation_id);
+	$category_retry = $candidate_controller->execute_request(array(
+		'order_id' => $category_order_id,
+		'nonce' => $category_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::CATEGORY,
+		'operation_id' => $category_operation_id,
+		'confirmation_token' => '',
+	));
+	wcos_p2_adapter_assert(1 === count($category_retry['children']) && $category_child_id === absint($category_retry['children'][0]['id']), 'UI5 Category durable retry returned a different child.');
+	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($category_order_id, $category_operation_id)), 'UI5 Category durable retry created duplicate children.');
+
+	/* Stock status: enabled Review -> Confirm -> Execute uses frozen volatile status. */
+	$stock_keep = wcos_p2_adapter_product('WCOS UI5 Stock Keep', '11.00');
+	$stock_move = wcos_p2_adapter_product('WCOS UI5 Stock Move', '6.00');
+	$stock_keep->set_stock_status('instock');
+	$stock_keep->save();
+	$stock_move->set_stock_status('outofstock');
+	$stock_move->save();
+	$stock_order = wc_create_order();
+	$stock_order->set_status('pending');
+	$stock_order->set_currency('USD');
+	$stock_keep_item = $stock_order->add_product($stock_keep, 1);
+	$stock_move_item = $stock_order->add_product($stock_move, 2);
+	$stock_order->calculate_totals(false);
+	$stock_order->save();
+	$stock_order_id = $stock_order->get_id();
+	$stock_nonce = wp_create_nonce('wcos_split_strategy_order_' . $stock_order_id);
+
+	$stock_review = $candidate_controller->review_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+	));
+	$stock_confirmation = $candidate_controller->confirm_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+		'review_id' => $stock_review['review_id'],
+		'review_token' => $stock_review['review_token'],
+		'source_bucket_key' => 'stock-instock',
+	));
+	$stock_operation_id = sanitize_key($stock_confirmation['operation_id']);
+	$stock_move = wc_get_product($stock_move->get_id());
+	$stock_move->set_stock_status('instock');
+	$stock_move->save();
+
+	$stock_result = $candidate_controller->execute_request(array(
+		'order_id' => $stock_order_id,
+		'nonce' => $stock_nonce,
+		'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+		'operation_id' => $stock_operation_id,
+		'confirmation_token' => $stock_confirmation['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $stock_result['status'] && 1 === count($stock_result['children']), 'UI5 Stock-status Split did not create exactly one child.');
+	$stock_source = wc_get_order($stock_order_id);
+	wcos_p2_adapter_assert($stock_source->get_item($stock_keep_item) instanceof WC_Order_Item_Product, 'UI5 Stock-status Split lost selected source bucket.');
+	wcos_p2_adapter_assert(!$stock_source->get_item($stock_move_item), 'UI5 Stock-status Split reclassified catalog state after Review.');
+	$stock_journal = WCOS_Operation_Journal::get($stock_source, $stock_operation_id);
+	wcos_p2_adapter_assert(is_array($stock_journal) && 'completed' === $stock_journal['status'], 'UI5 Stock-status journal did not complete.');
+	wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::STOCK_STATUS === $stock_journal['context']['strategy_authority']['strategy'], 'UI5 Stock-status journal lost semantic strategy authority.');
+} finally {
+	wp_set_current_user($candidate_previous_user);
+	update_option('order_splitter_status_allowed', $candidate_allowed_statuses);
+	if ($category_order_id) {
+		$source = wc_get_order($category_order_id);
+		if ($source instanceof WC_Order && '' !== $category_operation_id) {
+			WCOS_Split_Strategy_Confirmation_Store::delete($category_operation_id);
+			wcos_p2_adapter_cleanup($category_order_id, $category_operation_id);
+		} elseif ($source instanceof WC_Order) {
+			$source->delete(true);
+		}
+	}
+	if ($stock_order_id) {
+		$source = wc_get_order($stock_order_id);
+		if ($source instanceof WC_Order && '' !== $stock_operation_id) {
+			WCOS_Split_Strategy_Confirmation_Store::delete($stock_operation_id);
+			wcos_p2_adapter_cleanup($stock_order_id, $stock_operation_id);
+		} elseif ($source instanceof WC_Order) {
+			$source->delete(true);
+		}
+	}
+	foreach (array($category_keep, $category_move, $stock_keep, $stock_move) as $product) {
+		if ($product instanceof WC_Product && $product->get_id()) {
+			wp_delete_post($product->get_id(), true);
+		}
+	}
+	foreach (array($category_keep_term, $category_move_term) as $term) {
+		if (is_array($term) && !empty($term['term_id'])) {
+			wp_delete_term(absint($term['term_id']), 'product_cat');
+		}
+	}
+	if (function_exists('wp_delete_user')) {
+		wp_delete_user($candidate_admin_id);
+	}
+}
+
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Sandbox Category gate changed during UI5 E2E.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Sandbox Stock-status gate changed during UI5 E2E.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Sandbox Review route disappeared after UI5 E2E.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Sandbox Confirm route disappeared after UI5 E2E.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Sandbox Execute route disappeared after UI5 E2E.');
+
+echo "p2-strategy-sandbox-ui5-ok\n";

--- a/tests/integration/p2-whole-line-plan-smoke.php
+++ b/tests/integration/p2-whole-line-plan-smoke.php
@@ -88,9 +88,31 @@ echo "p2-whole-line-plan-ok\n";
 require __DIR__ . '/p2-whole-line-runtime-smoke.php';
 require __DIR__ . '/p2-whole-line-blocker-fallback-smoke.php';
 require __DIR__ . '/p2-whole-line-stock-ownership-smoke.php';
-require __DIR__ . '/p2-strategy-planners-smoke.php';
-require __DIR__ . '/p2-strategy-adapter-smoke.php';
-require __DIR__ . '/p2-strategy-confirmation-smoke.php';
-require __DIR__ . '/p2-strategy-transport-smoke.php';
-require __DIR__ . '/p2-strategy-ui-readiness-smoke.php';
-require __DIR__ . '/p2-strategy-modal-feedback-smoke.php';
+
+/* Preserve the complete pre-enablement strategy regression suite unchanged. */
+$strategy_gate_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
+$strategy_gate_states = $strategy_gate_reflection->getProperty('states');
+$strategy_gate_states->setAccessible(true);
+$candidate_strategy_states = $strategy_gate_states->getValue();
+$candidate_strategy_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
+if ($candidate_strategy_controller instanceof WCOS_Split_Strategy_Admin_Controller) {
+	$candidate_strategy_controller->unregister_hooks();
+}
+$hard_off_strategy_states = $candidate_strategy_states;
+$hard_off_strategy_states[WCOS_Split_Strategy_Gates::CATEGORY] = false;
+$hard_off_strategy_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = false;
+$strategy_gate_states->setValue(null, $hard_off_strategy_states);
+
+try {
+	require __DIR__ . '/p2-strategy-planners-smoke.php';
+	require __DIR__ . '/p2-strategy-adapter-smoke.php';
+	require __DIR__ . '/p2-strategy-confirmation-smoke.php';
+	require __DIR__ . '/p2-strategy-transport-smoke.php';
+	require __DIR__ . '/p2-strategy-ui-readiness-smoke.php';
+	require __DIR__ . '/p2-strategy-modal-feedback-smoke.php';
+} finally {
+	$strategy_gate_states->setValue(null, $candidate_strategy_states);
+	WCOS_Split_Strategy_Admin_Controller::bootstrap();
+}
+
+require __DIR__ . '/p2-strategy-sandbox-candidate-smoke.php';

--- a/wc-order-splitter.php
+++ b/wc-order-splitter.php
@@ -31,7 +31,8 @@ class WooCommerce_Order_Splitter {
 		$wcos_plugin_version = isset($wcos_plugin_data['Version']) ? $wcos_plugin_data['Version'] : '';
 
 		if (!defined('WC_ORDER_SPLITTER_VERSION')) {
-			define('WC_ORDER_SPLITTER_VERSION', $wcos_plugin_version);
+			/* Candidate-only suffix forces refreshed admin JS/CSS while header stays 1.4.14. */
+			define('WC_ORDER_SPLITTER_VERSION', $wcos_plugin_version . '-sandbox-ui5');
 		}
 
 		add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'add_action_links'));


### PR DESCRIPTION
## Classification

`SANDBOX_STRATEGY_CANDIDATE_UI5`

**DO NOT MERGE TO PRODUCTION.** This PR targets a dedicated sandbox base created from post-#35 `main` (`f0e553a2140c126a6b9eb6577271c7f179bed02e`).

## Hands-on feedback covered

UI4 was superseded because Category / Stock-status actions and unsupported Review feedback were still not presented correctly.

UI5 inherits the accepted #35 fix:
- initial footer: `Close | Review current buckets`;
- after successful Review: `Close | Confirm selected source bucket`;
- after successful Confirm: `Close | Execute strategy Split`;
- server status/error/success feedback appears in a modal-local feedback block directly below the modal description;
- unsupported / no-split Review results keep the Review phase active and display the planner message in the visible modal.

## Candidate state

- plugin header: `1.4.14`
- runtime asset suffix: `1.4.14-sandbox-ui5`
- Split: true
- Duplicate: true
- Merge / Return / Bulk Return: false
- manual quantity: true
- Category: true (sandbox only)
- Stock status: true (sandbox only)

## Acceptance

The exact-head UI5 workflow must pass PHP 7.4/8.1/8.3, package/modal-feedback assertions, legacy/HPOS-only/HPOS-sync, bounded hard-off strategy regressions, enabled Category + Stock-status Review→Confirm→Execute E2E, durable replay, stock safety, failure recovery, real operation lease concurrency and real strategy Confirm single-success.

The exact-head handoff must then download the same run artifact, verify SHA-256, sandbox markers, modal-local feedback code, phase footer actions and right-aligned Backbone footer before re-uploading the reviewed ZIP.

No UI5 ZIP is eligible for installation until both `Required Sandbox Candidate UI5` and the exact-head handoff succeed.