### PR TITLE
WOS-MERGE-002: add hard-off Merge domain contracts

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -122,6 +122,13 @@ jobs:
             'inc/domain/class-wcos-category-split-planner.php' \
             'inc/domain/class-wcos-stock-status-split-planner.php' \
             'inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-multi-order-lease.php' \
+            'inc/domain/class-wcos-merge-plan.php' \
+            'inc/domain/class-wcos-merge-context-signature.php' \
+            'inc/domain/class-wcos-merge-journal-context.php' \
+            'inc/domain/class-wcos-merge-participation.php' \
+            'inc/domain/class-wcos-merge-preflight.php' \
+            'inc/domain/class-wcos-merge-retirement-policy.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -171,6 +178,13 @@ jobs:
             'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php' \
             'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php' \
             'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'wc-order-splitter/inc/domain/class-wcos-multi-order-lease.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-plan.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-context-signature.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-journal-context.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-participation.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php' \
             'wc-order-splitter/css/p2-split-strategy-admin.css' \
             'wc-order-splitter/js/p2-split-strategy-admin.js'; do
             if ! unzip -Z1 wc-order-splitter.zip | grep -Fxq "$required_archive_path"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,14 @@ jobs:
           grep -Fq 'class-wcos-split-strategy-confirmation-store.php' inc/cores/script.php
           grep -Fq 'class-wcos-split-strategy-admin-controller.php' inc/cores/script.php
           grep -Fq 'WCOS_Split_Strategy_Admin_Controller::bootstrap();' inc/cores/script.php
+          grep -Fq 'class-wcos-multi-order-lease.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-plan.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-context-signature.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-journal-context.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-participation.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-preflight.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-retirement-policy.php' inc/cores/script.php
+          grep -Fq "throw new RuntimeException(__('The hardened merge service has not been implemented.'" inc/domain/class-wcos-mutation-gateway.php
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -232,6 +240,13 @@ jobs:
             'inc/domain/class-wcos-category-split-planner.php' \
             'inc/domain/class-wcos-stock-status-split-planner.php' \
             'inc/domain/class-wcos-split-strategy-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-multi-order-lease.php' \
+            'inc/domain/class-wcos-merge-plan.php' \
+            'inc/domain/class-wcos-merge-context-signature.php' \
+            'inc/domain/class-wcos-merge-journal-context.php' \
+            'inc/domain/class-wcos-merge-participation.php' \
+            'inc/domain/class-wcos-merge-preflight.php' \
+            'inc/domain/class-wcos-merge-retirement-policy.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -284,6 +299,13 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-multi-order-lease.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-plan.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-context-signature.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-journal-context.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-participation.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-split-strategy-admin.js'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-split-strategy-admin.css'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
@@ -424,6 +446,9 @@ jobs:
 
       - name: Verify governance, authorization, and metadata policy
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
+
+      - name: Verify hard-off Merge domain foundation contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php
 
       - name: Verify duplicate integrity, idempotency, and recovery
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/duplicate-smoke.php

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -32,6 +32,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-stock-side-effect-guard.php';
 		include_once $root . 'domain/class-wcos-mutation-contract.php';
 		include_once $root . 'domain/class-wcos-operation-lock.php';
+		include_once $root . 'domain/class-wcos-multi-order-lease.php';
 		include_once $root . 'domain/class-wcos-feature-gates.php';
 		include_once $root . 'domain/class-wcos-split-strategy-gates.php';
 		include_once $root . 'domain/class-wcos-order-mutation-authorizer.php';
@@ -44,6 +45,11 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-contract-snapshot.php';
 		include_once $root . 'domain/class-wcos-order-copy-context.php';
 		include_once $root . 'domain/class-wcos-order-mutation-snapshot.php';
+		include_once $root . 'domain/class-wcos-merge-retirement-policy.php';
+		include_once $root . 'domain/class-wcos-merge-plan.php';
+		include_once $root . 'domain/class-wcos-merge-context-signature.php';
+		include_once $root . 'domain/class-wcos-merge-journal-context.php';
+		include_once $root . 'domain/class-wcos-merge-participation.php';
 		include_once $root . 'domain/class-wcos-operation-journal.php';
 		include_once $root . 'domain/class-wcos-manual-reconciliation-blocker.php';
 		include_once $root . 'domain/class-wcos-operation-journal-retention.php';
@@ -63,6 +69,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-stock-status-split-planner.php';
 		include_once $root . 'domain/class-wcos-split-strategy-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
+		include_once $root . 'domain/class-wcos-merge-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 

--- a/inc/domain/class-wcos-manual-reconciliation-blocker.php
+++ b/inc/domain/class-wcos-manual-reconciliation-blocker.php
@@ -14,7 +14,7 @@ defined('ABSPATH') || exit;
  * revisions. No customer, address, payment, or catalog PII is stored here.
  */
 final class WCOS_Manual_Reconciliation_Blocker {
-    const SCHEMA_VERSION = 2;
+    const SCHEMA_VERSION = 3;
     const KEY_PREFIX = 'wcos_manual_reconcile_block_';
     const FALLBACK_META_PREFIX = '_wcos_manual_reconcile_fallback_';
 
@@ -30,6 +30,72 @@ final class WCOS_Manual_Reconciliation_Blocker {
         }
 
         return self::block_fallback($order, $operation_id, $incident);
+    }
+
+    /**
+     * Persist one participant's blocker while keeping the source-keyed journal
+     * as the only reconciliation authority.
+     */
+    public static function block_participant(WC_Order $participant, WC_Order $journal_source, $operation_id, $role, $peer_order_id, $pair_fingerprint) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $role = sanitize_key((string) $role);
+        $peer_order_id = absint($peer_order_id);
+        $pair_fingerprint = sanitize_key((string) $pair_fingerprint);
+        if (!$participant->get_id() || !$journal_source->get_id() || '' === $operation_id
+            || !in_array($role, array('source', 'target'), true) || !$peer_order_id || '' === $pair_fingerprint) {
+            return false;
+        }
+
+        $journal = class_exists('WCOS_Operation_Journal')
+            ? WCOS_Operation_Journal::get($journal_source, $operation_id)
+            : null;
+        if (!is_array($journal) || !class_exists('WCOS_Merge_Journal_Context')
+            || !WCOS_Merge_Journal_Context::validates_participant(
+                $journal,
+                $participant->get_id(),
+                $role,
+                $peer_order_id,
+                $pair_fingerprint,
+                $operation_id
+            )) {
+            return false;
+        }
+
+        $incident = self::incident(
+            $participant,
+            $operation_id,
+            array(
+                'participant_role' => $role,
+                'peer_order_id' => $peer_order_id,
+                'journal_source_order_id' => $journal_source->get_id(),
+                'pair_fingerprint' => $pair_fingerprint,
+            ),
+            $journal
+        );
+        if (self::block_primary($participant, $operation_id, $incident)) {
+            return true;
+        }
+        return self::block_fallback($participant, $operation_id, $incident);
+    }
+
+    public static function block_pair(WC_Order $source, WC_Order $target, $operation_id, $pair_fingerprint) {
+        $source_blocked = self::block_participant(
+            $source,
+            $source,
+            $operation_id,
+            'source',
+            $target->get_id(),
+            $pair_fingerprint
+        );
+        $target_blocked = self::block_participant(
+            $target,
+            $source,
+            $operation_id,
+            'target',
+            $source->get_id(),
+            $pair_fingerprint
+        );
+        return $source_blocked && $target_blocked;
     }
 
     /**
@@ -52,16 +118,10 @@ final class WCOS_Manual_Reconciliation_Blocker {
         }
 
         $incidents = self::all_incidents($fresh);
-        if (empty($incidents)) {
-            return array();
-        }
-
         $active = array();
         foreach ($incidents as $operation_id => $operation_incidents) {
-            $journal = class_exists('WCOS_Operation_Journal')
-                ? WCOS_Operation_Journal::get($fresh, $operation_id)
-                : null;
             $latest_incident = self::latest_incident($operation_incidents);
+            $journal = self::journal_for_incident($fresh, $operation_id, $latest_incident);
             if (self::journal_resolves_incident($journal, $latest_incident)) {
                 $primary_cleared = self::clear_primary($fresh, $operation_id);
                 $fallback_cleared = self::clear_fallback($fresh, $operation_id);
@@ -71,6 +131,10 @@ final class WCOS_Manual_Reconciliation_Blocker {
             }
 
             $active[] = $operation_id;
+        }
+
+        if (class_exists('WCOS_Merge_Participation')) {
+            $active = array_merge($active, WCOS_Merge_Participation::unresolved_operation_ids($fresh));
         }
 
         $active = array_values(array_unique(array_filter(array_map('sanitize_key', $active))));
@@ -102,10 +166,9 @@ final class WCOS_Manual_Reconciliation_Blocker {
             return true;
         }
 
-        $journal = class_exists('WCOS_Operation_Journal')
-            ? WCOS_Operation_Journal::get($fresh, $operation_id)
-            : null;
-        if (!self::journal_resolves_incident($journal, self::latest_incident($incidents))) {
+        $latest_incident = self::latest_incident($incidents);
+        $journal = self::journal_for_incident($fresh, $operation_id, $latest_incident);
+        if (!self::journal_resolves_incident($journal, $latest_incident)) {
             return false;
         }
 
@@ -118,19 +181,49 @@ final class WCOS_Manual_Reconciliation_Blocker {
      * Retention uses this to avoid deleting the authoritative resolution proof
      * while either blocker store still exists because cleanup failed.
      */
-    public static function contains_operation($source_order_id, $operation_id) {
+    public static function contains_operation($source_order_id, $operation_id, $journal_source_order_id = 0) {
         $source_order_id = absint($source_order_id);
         $operation_id = sanitize_key((string) $operation_id);
+        $journal_source_order_id = absint($journal_source_order_id);
         if (!$source_order_id || '' === $operation_id) {
             return false;
         }
 
-        if (self::contains_primary($source_order_id, $operation_id)) {
+        $primary = self::primary_incident($source_order_id, $operation_id);
+        if (is_array($primary) && self::matches_journal_source($primary, $journal_source_order_id, $source_order_id)) {
             return true;
         }
 
         $order = wc_get_order($source_order_id);
-        return $order instanceof WC_Order && self::contains_fallback($order, $operation_id);
+        if (!$order instanceof WC_Order) {
+            return false;
+        }
+        $fallback = $order->get_meta(self::fallback_key($operation_id), true);
+        return is_array($fallback)
+            && self::contains_fallback($order, $operation_id)
+            && self::matches_journal_source($fallback, $journal_source_order_id, $source_order_id);
+    }
+
+    public static function resolve_pair_if_reconciled(WC_Order $journal_source, $operation_id) {
+        $operation_id = sanitize_key((string) $operation_id);
+        $journal = class_exists('WCOS_Operation_Journal')
+            ? WCOS_Operation_Journal::get($journal_source, $operation_id)
+            : null;
+        $pair = is_array($journal) && class_exists('WCOS_Merge_Journal_Context')
+            ? WCOS_Merge_Journal_Context::pair_from_record($journal)
+            : null;
+        if (!is_array($pair)) {
+            return self::resolve_if_reconciled($journal_source, $operation_id);
+        }
+
+        $resolved = true;
+        foreach (array(absint($pair['source_order_id']), absint($pair['target_order_id'])) as $participant_id) {
+            $participant = wc_get_order($participant_id);
+            if (!$participant instanceof WC_Order || !self::resolve_if_reconciled($participant, $operation_id)) {
+                $resolved = false;
+            }
+        }
+        return $resolved;
     }
 
     private static function block_primary(WC_Order $order, $operation_id, array $incident) {
@@ -141,6 +234,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
                 $record = array(
                     'schema_version' => self::SCHEMA_VERSION,
                     'source_order_id' => $order->get_id(),
+                    'participant_order_id' => $order->get_id(),
                     'revision' => 1,
                     'operations' => array(
                         $operation_id => $incident,
@@ -156,6 +250,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
             $replacement = $current;
             $replacement['schema_version'] = self::SCHEMA_VERSION;
             $replacement['source_order_id'] = $order->get_id();
+            $replacement['participant_order_id'] = $order->get_id();
             $replacement['revision'] = isset($current['revision']) ? ((int) $current['revision'] + 1) : 2;
             $replacement['operations'] = isset($current['operations']) && is_array($current['operations'])
                 ? $current['operations']
@@ -189,17 +284,24 @@ final class WCOS_Manual_Reconciliation_Blocker {
         }
     }
 
-    private static function incident(WC_Order $order, $operation_id) {
-        $journal = class_exists('WCOS_Operation_Journal')
-            ? WCOS_Operation_Journal::get($order, $operation_id)
-            : null;
-        return array(
+    private static function incident(WC_Order $order, $operation_id, array $authority = array(), $journal = null) {
+        if (!is_array($journal)) {
+            $journal = class_exists('WCOS_Operation_Journal')
+                ? WCOS_Operation_Journal::get($order, $operation_id)
+                : null;
+        }
+        return array_merge(array(
             'operation_id' => sanitize_key((string) $operation_id),
+            'participant_order_id' => $order->get_id(),
+            'participant_role' => 'source',
+            'peer_order_id' => 0,
+            'journal_source_order_id' => $order->get_id(),
+            'pair_fingerprint' => '',
             'blocked_at' => gmdate('c'),
             'journal_revision_at_block' => is_array($journal) && isset($journal['revision'])
                 ? (int) $journal['revision']
                 : 0,
-        );
+        ), $authority);
     }
 
     private static function all_incidents(WC_Order $order) {
@@ -276,6 +378,36 @@ final class WCOS_Manual_Reconciliation_Blocker {
         if (!is_array($journal) || !isset($journal['status']) || !isset($journal['revision'])) {
             return false;
         }
+
+        $journal_source_id = is_array($incident) && isset($incident['journal_source_order_id'])
+            ? absint($incident['journal_source_order_id'])
+            : 0;
+        $participant_id = is_array($incident) && isset($incident['participant_order_id'])
+            ? absint($incident['participant_order_id'])
+            : $journal_source_id;
+        $role = is_array($incident) && isset($incident['participant_role'])
+            ? sanitize_key((string) $incident['participant_role'])
+            : 'source';
+        $peer_id = is_array($incident) && isset($incident['peer_order_id'])
+            ? absint($incident['peer_order_id'])
+            : 0;
+        $pair_fingerprint = is_array($incident) && isset($incident['pair_fingerprint'])
+            ? sanitize_key((string) $incident['pair_fingerprint'])
+            : '';
+        if ('' !== $pair_fingerprint) {
+            if (!class_exists('WCOS_Merge_Journal_Context')
+                || $journal_source_id !== absint(isset($journal['source_order_id']) ? $journal['source_order_id'] : 0)
+                || !WCOS_Merge_Journal_Context::validates_participant(
+                    $journal,
+                    $participant_id,
+                    $role,
+                    $peer_id,
+                    $pair_fingerprint,
+                    isset($incident['operation_id']) ? $incident['operation_id'] : ''
+                )) {
+                return false;
+            }
+        }
         $status = sanitize_key((string) $journal['status']);
         $journal_revision = (int) $journal['revision'];
         $blocked_revision = is_array($incident) && isset($incident['journal_revision_at_block'])
@@ -304,9 +436,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
              * incident B between the caller's resolution check and this clear.
              * An older reconciliation must never delete that newer blocker.
              */
-            $journal = class_exists('WCOS_Operation_Journal')
-                ? WCOS_Operation_Journal::get($order, $operation_id)
-                : null;
+            $journal = self::journal_for_incident($order, $operation_id, $current['operations'][$operation_id]);
             if (!self::journal_resolves_incident($journal, $current['operations'][$operation_id])) {
                 return false;
             }
@@ -356,9 +486,7 @@ final class WCOS_Manual_Reconciliation_Blocker {
                 return true;
             }
 
-            $journal = class_exists('WCOS_Operation_Journal')
-                ? WCOS_Operation_Journal::get($fresh, $operation_id)
-                : null;
+            $journal = self::journal_for_incident($fresh, $operation_id, $incident);
             if (!self::journal_resolves_incident($journal, $incident)) {
                 return false;
             }
@@ -373,11 +501,18 @@ final class WCOS_Manual_Reconciliation_Blocker {
     }
 
     private static function contains_primary($order_id, $operation_id) {
+        return is_array(self::primary_incident($order_id, $operation_id));
+    }
+
+    private static function primary_incident($order_id, $operation_id) {
         $record = get_option(self::key($order_id), null);
         return is_array($record)
             && isset($record['operations'])
             && is_array($record['operations'])
-            && isset($record['operations'][$operation_id]);
+            && isset($record['operations'][$operation_id])
+            && is_array($record['operations'][$operation_id])
+                ? $record['operations'][$operation_id]
+                : null;
     }
 
     private static function contains_fallback(WC_Order $order, $operation_id) {
@@ -386,6 +521,29 @@ final class WCOS_Manual_Reconciliation_Blocker {
             && !empty($incident)
             && isset($incident['operation_id'])
             && sanitize_key((string) $incident['operation_id']) === sanitize_key((string) $operation_id);
+    }
+
+    private static function journal_for_incident(WC_Order $participant, $operation_id, $incident) {
+        if (!class_exists('WCOS_Operation_Journal')) {
+            return null;
+        }
+        $journal_source_id = is_array($incident) && isset($incident['journal_source_order_id'])
+            ? absint($incident['journal_source_order_id'])
+            : $participant->get_id();
+        $journal_source = wc_get_order($journal_source_id);
+        return $journal_source instanceof WC_Order
+            ? WCOS_Operation_Journal::get($journal_source, $operation_id)
+            : null;
+    }
+
+    private static function matches_journal_source(array $incident, $expected_source_id, $participant_id) {
+        if (!$expected_source_id) {
+            return true;
+        }
+        $actual = isset($incident['journal_source_order_id'])
+            ? absint($incident['journal_source_order_id'])
+            : absint($participant_id);
+        return $actual === $expected_source_id;
     }
 
     private static function compare_and_swap($key, array $current, array $replacement) {

--- a/inc/domain/class-wcos-merge-context-signature.php
+++ b/inc/domain/class-wcos-merge-context-signature.php
@@ -1,0 +1,173 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Versioned, domain-separated keyed compatibility signatures for Merge pairs.
+ *
+ * Normalized email/address values exist only in request memory. Returned records
+ * contain HMAC digests and non-PII control fields only.
+ */
+final class WCOS_Merge_Context_Signature {
+
+	const SCHEMA_VERSION = 1;
+	const ALGORITHM = 'hmac-sha256';
+	const PURPOSE_REGISTERED_IDENTITY = 'merge_registered_identity_v1';
+	const PURPOSE_GUEST_IDENTITY = 'merge_guest_identity_v1';
+	const PURPOSE_BILLING_CONTEXT = 'merge_billing_context_v1';
+	const PURPOSE_SHIPPING_CONTEXT = 'merge_shipping_context_v1';
+	const PURPOSE_PAYMENT_CONTEXT = 'merge_payment_context_v1';
+
+	public static function compatibility(WC_Order $source, WC_Order $target) {
+		$source_customer_id = absint($source->get_customer_id());
+		$target_customer_id = absint($target->get_customer_id());
+		$identity_type = '';
+		$identity_digest = '';
+
+		if ($source_customer_id || $target_customer_id) {
+			if (!$source_customer_id || $source_customer_id !== $target_customer_id) {
+				throw new RuntimeException(__('Merge requires both orders to belong to the same registered customer.', 'wc-order-splitter'));
+			}
+			$identity_type = 'registered';
+			$identity_digest = self::digest(self::PURPOSE_REGISTERED_IDENTITY, array('customer_id' => $source_customer_id));
+		} else {
+			$source_email = self::normalized_guest_email($source);
+			$target_email = self::normalized_guest_email($target);
+			$source_guest = self::digest(self::PURPOSE_GUEST_IDENTITY, array('billing_email' => $source_email));
+			$target_guest = self::digest(self::PURPOSE_GUEST_IDENTITY, array('billing_email' => $target_email));
+			if (!hash_equals($source_guest, $target_guest)) {
+				throw new RuntimeException(__('Merge requires guest orders to have the same nonblank billing identity.', 'wc-order-splitter'));
+			}
+			$identity_type = 'guest';
+			$identity_digest = $source_guest;
+		}
+
+		$source_billing = self::address_digest($source, 'billing');
+		$target_billing = self::address_digest($target, 'billing');
+		$source_shipping = self::address_digest($source, 'shipping');
+		$target_shipping = self::address_digest($target, 'shipping');
+		$source_payment = self::payment_digest($source);
+		$target_payment = self::payment_digest($target);
+
+		foreach (array(
+			'billing' => array($source_billing, $target_billing),
+			'shipping' => array($source_shipping, $target_shipping),
+			'payment' => array($source_payment, $target_payment),
+		) as $context => $digests) {
+			if (!hash_equals($digests[0], $digests[1])) {
+				throw new RuntimeException(
+					sprintf(
+						/* translators: %s: incompatible order context type. */
+						__('Merge requires matching keyed %s context on both orders.', 'wc-order-splitter'),
+						$context
+					)
+				);
+			}
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'algorithm' => self::ALGORITHM,
+			'identity_type' => $identity_type,
+			'customer_id' => 'registered' === $identity_type ? $source_customer_id : 0,
+			'identity_digest' => $identity_digest,
+			'billing_context_digest' => $source_billing,
+			'shipping_context_digest' => $source_shipping,
+			'payment_context_digest' => $source_payment,
+		);
+	}
+
+	public static function assert_current(WC_Order $order, array $record) {
+		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| self::ALGORITHM !== (isset($record['algorithm']) ? (string) $record['algorithm'] : '')) {
+			throw new RuntimeException(__('The Merge keyed-signature scheme no longer matches durable authority.', 'wc-order-splitter'));
+		}
+
+		$identity_type = isset($record['identity_type']) ? sanitize_key((string) $record['identity_type']) : '';
+		if ('registered' === $identity_type) {
+			$customer_id = absint($order->get_customer_id());
+			$digest = self::digest(self::PURPOSE_REGISTERED_IDENTITY, array('customer_id' => $customer_id));
+		} elseif ('guest' === $identity_type && 0 === absint($order->get_customer_id())) {
+			$digest = self::digest(self::PURPOSE_GUEST_IDENTITY, array('billing_email' => self::normalized_guest_email($order)));
+		} else {
+			throw new RuntimeException(__('The Merge customer identity type changed after compatibility review.', 'wc-order-splitter'));
+		}
+
+		$expected = isset($record['identity_digest']) ? (string) $record['identity_digest'] : '';
+		$billing_digest = isset($record['billing_context_digest']) ? (string) $record['billing_context_digest'] : '';
+		$shipping_digest = isset($record['shipping_context_digest']) ? (string) $record['shipping_context_digest'] : '';
+		$payment_digest = isset($record['payment_context_digest']) ? (string) $record['payment_context_digest'] : '';
+		if ('' === $expected || !hash_equals($expected, $digest)
+			|| '' === $billing_digest || !hash_equals($billing_digest, self::address_digest($order, 'billing'))
+			|| '' === $shipping_digest || !hash_equals($shipping_digest, self::address_digest($order, 'shipping'))
+			|| '' === $payment_digest || !hash_equals($payment_digest, self::payment_digest($order))) {
+			throw new RuntimeException(__('The Merge customer, address, or payment context signature changed.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function normalized_guest_email(WC_Order $order) {
+		$email = strtolower(trim((string) $order->get_billing_email()));
+		$email = sanitize_email($email);
+		if ('' === $email || !is_email($email)) {
+			throw new RuntimeException(__('Guest Merge requires a valid nonblank billing email on both orders.', 'wc-order-splitter'));
+		}
+		return $email;
+	}
+
+	private static function address_digest(WC_Order $order, $type) {
+		$type = 'shipping' === $type ? 'shipping' : 'billing';
+		$purpose = 'shipping' === $type ? self::PURPOSE_SHIPPING_CONTEXT : self::PURPOSE_BILLING_CONTEXT;
+		$address = $order->get_address($type);
+		$normalized = array();
+		foreach ((array) $address as $field => $value) {
+			$field = sanitize_key((string) $field);
+			$value = preg_replace('/\s+/u', ' ', trim((string) $value));
+			if ('email' === $field) {
+				$value = strtolower(sanitize_email($value));
+			}
+			if (in_array($field, array('country', 'state', 'postcode'), true)) {
+				$value = strtoupper($value);
+			}
+			$normalized[$field] = array('present' => '' !== $value, 'value' => $value);
+		}
+		ksort($normalized, SORT_STRING);
+		return self::digest($purpose, $normalized);
+	}
+
+	private static function payment_digest(WC_Order $order) {
+		return self::digest(
+			self::PURPOSE_PAYMENT_CONTEXT,
+			array(
+				'payment_method' => sanitize_key((string) $order->get_payment_method()),
+				'payment_method_title' => trim((string) $order->get_payment_method_title()),
+			)
+		);
+	}
+
+	private static function digest($purpose, array $payload) {
+		$secret = (string) wp_salt('auth');
+		if ('' === $secret) {
+			throw new RuntimeException(__('A site-owned secret is required for Merge context signatures.', 'wc-order-splitter'));
+		}
+		$document = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'purpose' => sanitize_key((string) $purpose),
+			'payload' => self::canonicalize($payload),
+		);
+		$json = wp_json_encode($document, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+		if (!is_string($json) || '' === $json) {
+			throw new RuntimeException(__('Merge context could not be encoded for keyed signing.', 'wc-order-splitter'));
+		}
+		return hash_hmac('sha256', $json, $secret);
+	}
+
+	private static function canonicalize(array $value) {
+		ksort($value, SORT_STRING);
+		foreach ($value as $key => $item) {
+			if (is_array($item)) {
+				$value[$key] = self::canonicalize($item);
+			}
+		}
+		return $value;
+	}
+}

--- a/inc/domain/class-wcos-merge-context-signature.php
+++ b/inc/domain/class-wcos-merge-context-signature.php
@@ -17,6 +17,7 @@ final class WCOS_Merge_Context_Signature {
 	const PURPOSE_BILLING_CONTEXT = 'merge_billing_context_v1';
 	const PURPOSE_SHIPPING_CONTEXT = 'merge_shipping_context_v1';
 	const PURPOSE_PAYMENT_CONTEXT = 'merge_payment_context_v1';
+	const PURPOSE_CONTEXT_AUTHORITY = 'merge_context_authority_v1';
 
 	public static function compatibility(WC_Order $source, WC_Order $target) {
 		$source_customer_id = absint($source->get_customer_id());
@@ -103,6 +104,10 @@ final class WCOS_Merge_Context_Signature {
 			|| '' === $payment_digest || !hash_equals($payment_digest, self::payment_digest($order))) {
 			throw new RuntimeException(__('The Merge customer, address, or payment context signature changed.', 'wc-order-splitter'));
 		}
+	}
+
+	public static function authority_fingerprint(array $authority) {
+		return self::digest(self::PURPOSE_CONTEXT_AUTHORITY, $authority);
 	}
 
 	private static function normalized_guest_email(WC_Order $order) {

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -1,0 +1,117 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * PII-free pair vocabulary for the single authoritative source Merge journal.
+ */
+final class WCOS_Merge_Journal_Context {
+
+	const SCHEMA_VERSION = 1;
+	const POLICY_VERSION = 1;
+
+	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, array $evidence = array()) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		if (!$source_id || !$target_id || $source_id === $target_id) {
+			throw new InvalidArgumentException(__('A Merge journal context requires two distinct persisted orders.', 'wc-order-splitter'));
+		}
+
+		$source_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+		$target_signature = WCOS_Order_Contract_Snapshot::source_signature($target);
+		$plan_fingerprint = WCOS_Merge_Plan::fingerprint($plan);
+		$pair_fingerprint = WCOS_Mutation_Fingerprint::create(
+			'merge_pair',
+			$source_id,
+			array(
+				'target_order_id' => $target_id,
+				'source_signature' => $source_signature,
+				'target_signature' => $target_signature,
+				'plan_fingerprint' => $plan_fingerprint,
+				'policy_version' => self::POLICY_VERSION,
+				'context_signature_version' => isset($context_authority['schema_version']) ? (int) $context_authority['schema_version'] : 0,
+			)
+		);
+
+		return array(
+			'merge_pair' => array(
+				'schema_version' => self::SCHEMA_VERSION,
+				'policy_version' => self::POLICY_VERSION,
+				'source_order_id' => $source_id,
+				'target_order_id' => $target_id,
+				'source_signature' => $source_signature,
+				'target_signature' => $target_signature,
+				'pair_fingerprint' => $pair_fingerprint,
+				'plan_fingerprint' => $plan_fingerprint,
+				'context_signature_version' => isset($context_authority['schema_version']) ? (int) $context_authority['schema_version'] : 0,
+				'context_authority' => $context_authority,
+				'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+				'retirement_policy_selected' => false,
+				'archive_source_signature_before' => isset($evidence['archive_source_signature_before'])
+					? sanitize_key((string) $evidence['archive_source_signature_before'])
+					: $source_signature,
+				'active_ownership_before_signature' => isset($evidence['active_ownership_before_signature'])
+					? sanitize_key((string) $evidence['active_ownership_before_signature'])
+					: '',
+				'participation_schema_version' => class_exists('WCOS_Merge_Participation') ? WCOS_Merge_Participation::SCHEMA_VERSION : 1,
+			),
+		);
+	}
+
+	public static function pair_from_record(array $record) {
+		if ('merge' !== sanitize_key(isset($record['type']) ? (string) $record['type'] : '')) {
+			return null;
+		}
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$pair = isset($context['merge_pair']) && is_array($context['merge_pair']) ? $context['merge_pair'] : array();
+		if ((int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0) !== self::SCHEMA_VERSION) {
+			return null;
+		}
+		$source_id = absint(isset($pair['source_order_id']) ? $pair['source_order_id'] : 0);
+		$target_id = absint(isset($pair['target_order_id']) ? $pair['target_order_id'] : 0);
+		$fingerprint = sanitize_key(isset($pair['pair_fingerprint']) ? (string) $pair['pair_fingerprint'] : '');
+		$journal_fingerprint = sanitize_key(isset($record['fingerprint']) ? (string) $record['fingerprint'] : '');
+		$source_signature = sanitize_key(isset($pair['source_signature']) ? (string) $pair['source_signature'] : '');
+		$target_signature = sanitize_key(isset($pair['target_signature']) ? (string) $pair['target_signature'] : '');
+		$plan_fingerprint = sanitize_key(isset($pair['plan_fingerprint']) ? (string) $pair['plan_fingerprint'] : '');
+		if (!$source_id || !$target_id || $source_id === $target_id || '' === $fingerprint
+			|| '' === $source_signature || '' === $target_signature || '' === $plan_fingerprint
+			|| (int) (isset($pair['policy_version']) ? $pair['policy_version'] : 0) !== self::POLICY_VERSION
+			|| (int) (isset($pair['context_signature_version']) ? $pair['context_signature_version'] : 0) < 1
+			|| $source_id !== absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0)
+			|| '' === $journal_fingerprint || !hash_equals($fingerprint, $journal_fingerprint)) {
+			return null;
+		}
+		return $pair;
+	}
+
+	public static function validates_participant(array $record, $participant_order_id, $role, $peer_order_id = 0, $pair_fingerprint = '', $operation_id = '') {
+		$pair = self::pair_from_record($record);
+		if (!is_array($pair)) {
+			return false;
+		}
+		$participant_order_id = absint($participant_order_id);
+		$peer_order_id = absint($peer_order_id);
+		$role = sanitize_key((string) $role);
+		$expected_participant = 'source' === $role ? absint($pair['source_order_id']) : absint($pair['target_order_id']);
+		$expected_peer = 'source' === $role ? absint($pair['target_order_id']) : absint($pair['source_order_id']);
+		if (!in_array($role, array('source', 'target'), true)
+			|| $participant_order_id !== $expected_participant
+			|| ($peer_order_id && $peer_order_id !== $expected_peer)) {
+			return false;
+		}
+		$pair_fingerprint = sanitize_key((string) $pair_fingerprint);
+		$operation_id = sanitize_key((string) $operation_id);
+		$record_operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
+		return ('' === $pair_fingerprint || hash_equals((string) $pair['pair_fingerprint'], $pair_fingerprint))
+			&& ('' === $operation_id || hash_equals($operation_id, $record_operation_id));
+	}
+
+	public static function is_unsafe_record(array $record) {
+		if (!is_array(self::pair_from_record($record))) {
+			return false;
+		}
+		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
+		return !in_array($status, array('completed', 'compensated', 'manual_reconciled'), true);
+	}
+}

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -3,57 +3,55 @@
 defined('ABSPATH') || exit;
 
 /**
- * PII-free pair vocabulary for the single authoritative source Merge journal.
+ * Self-verifying PII-free authority for the single source Merge journal.
  */
 final class WCOS_Merge_Journal_Context {
 
-	const SCHEMA_VERSION = 1;
-	const POLICY_VERSION = 1;
+	const SCHEMA_VERSION = 2;
 
-	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, array $evidence = array()) {
+	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array()) {
 		$source_id = absint($source->get_id());
 		$target_id = absint($target->get_id());
+		$price_precision = WCOS_Price_Precision_Scope::validate($price_precision);
 		if (!$source_id || !$target_id || $source_id === $target_id) {
 			throw new InvalidArgumentException(__('A Merge journal context requires two distinct persisted orders.', 'wc-order-splitter'));
 		}
 
 		$source_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
-		$target_signature = WCOS_Order_Contract_Snapshot::source_signature($target);
-		$plan_fingerprint = WCOS_Merge_Plan::fingerprint($plan);
-		$pair_fingerprint = WCOS_Mutation_Fingerprint::create(
-			'merge_pair',
-			$source_id,
-			array(
-				'target_order_id' => $target_id,
-				'source_signature' => $source_signature,
-				'target_signature' => $target_signature,
-				'plan_fingerprint' => $plan_fingerprint,
-				'policy_version' => self::POLICY_VERSION,
-				'context_signature_version' => isset($context_authority['schema_version']) ? (int) $context_authority['schema_version'] : 0,
-			)
+		$authority = array(
+			'source_order_id' => $source_id,
+			'target_order_id' => $target_id,
+			'source_signature' => $source_signature,
+			'target_signature' => WCOS_Order_Contract_Snapshot::source_signature($target),
+			'plan_schema_version' => WCOS_Merge_Plan::SCHEMA_VERSION,
+			'plan_fingerprint' => WCOS_Merge_Plan::fingerprint($plan),
+			'price_precision' => $price_precision,
+			'preflight_policy_version' => WCOS_Merge_Preflight::POLICY_VERSION,
+			'context_signature_version' => WCOS_Merge_Context_Signature::SCHEMA_VERSION,
+			'context_authority' => $context_authority,
+			'context_authority_fingerprint' => WCOS_Merge_Context_Signature::authority_fingerprint($context_authority),
+			'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
+			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'retirement_policy_selected' => false,
+			'archive_source_signature_before' => isset($evidence['archive_source_signature_before'])
+				? sanitize_key((string) $evidence['archive_source_signature_before'])
+				: $source_signature,
+			'active_ownership_before_signature' => isset($evidence['active_ownership_before_signature'])
+				? sanitize_key((string) $evidence['active_ownership_before_signature'])
+				: '',
+			'participation_schema_version' => WCOS_Merge_Participation::SCHEMA_VERSION,
 		);
+		$authority = self::canonical_authority($authority);
+		if (!is_array($authority)) {
+			throw new RuntimeException(__('The canonical Merge pair authority could not be constructed.', 'wc-order-splitter'));
+		}
+		$pair_fingerprint = self::authority_fingerprint($authority);
 
 		return array(
 			'merge_pair' => array(
 				'schema_version' => self::SCHEMA_VERSION,
-				'policy_version' => self::POLICY_VERSION,
-				'source_order_id' => $source_id,
-				'target_order_id' => $target_id,
-				'source_signature' => $source_signature,
-				'target_signature' => $target_signature,
+				'authority' => $authority,
 				'pair_fingerprint' => $pair_fingerprint,
-				'plan_fingerprint' => $plan_fingerprint,
-				'context_signature_version' => isset($context_authority['schema_version']) ? (int) $context_authority['schema_version'] : 0,
-				'context_authority' => $context_authority,
-				'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
-				'retirement_policy_selected' => false,
-				'archive_source_signature_before' => isset($evidence['archive_source_signature_before'])
-					? sanitize_key((string) $evidence['archive_source_signature_before'])
-					: $source_signature,
-				'active_ownership_before_signature' => isset($evidence['active_ownership_before_signature'])
-					? sanitize_key((string) $evidence['active_ownership_before_signature'])
-					: '',
-				'participation_schema_version' => class_exists('WCOS_Merge_Participation') ? WCOS_Merge_Participation::SCHEMA_VERSION : 1,
 			),
 		);
 	}
@@ -64,25 +62,40 @@ final class WCOS_Merge_Journal_Context {
 		}
 		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
 		$pair = isset($context['merge_pair']) && is_array($context['merge_pair']) ? $context['merge_pair'] : array();
-		if ((int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0) !== self::SCHEMA_VERSION) {
+		if ((int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| !isset($pair['authority']) || !is_array($pair['authority'])) {
 			return null;
 		}
-		$source_id = absint(isset($pair['source_order_id']) ? $pair['source_order_id'] : 0);
-		$target_id = absint(isset($pair['target_order_id']) ? $pair['target_order_id'] : 0);
-		$fingerprint = sanitize_key(isset($pair['pair_fingerprint']) ? (string) $pair['pair_fingerprint'] : '');
-		$journal_fingerprint = sanitize_key(isset($record['fingerprint']) ? (string) $record['fingerprint'] : '');
-		$source_signature = sanitize_key(isset($pair['source_signature']) ? (string) $pair['source_signature'] : '');
-		$target_signature = sanitize_key(isset($pair['target_signature']) ? (string) $pair['target_signature'] : '');
-		$plan_fingerprint = sanitize_key(isset($pair['plan_fingerprint']) ? (string) $pair['plan_fingerprint'] : '');
-		if (!$source_id || !$target_id || $source_id === $target_id || '' === $fingerprint
-			|| '' === $source_signature || '' === $target_signature || '' === $plan_fingerprint
-			|| (int) (isset($pair['policy_version']) ? $pair['policy_version'] : 0) !== self::POLICY_VERSION
-			|| (int) (isset($pair['context_signature_version']) ? $pair['context_signature_version'] : 0) < 1
-			|| $source_id !== absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0)
-			|| '' === $journal_fingerprint || !hash_equals($fingerprint, $journal_fingerprint)) {
+
+		try {
+			$authority = self::canonical_authority($pair['authority']);
+			$context_fingerprint = is_array($authority)
+				? WCOS_Merge_Context_Signature::authority_fingerprint($authority['context_authority'])
+				: '';
+		} catch (Throwable $throwable) {
 			return null;
 		}
-		return $pair;
+		if (!is_array($authority) || $authority !== $pair['authority']) {
+			return null;
+		}
+		if (!hash_equals($authority['context_authority_fingerprint'], $context_fingerprint)) {
+			return null;
+		}
+
+		$computed_fingerprint = self::authority_fingerprint($authority);
+		$pair_fingerprint = self::normalized_fingerprint(isset($pair['pair_fingerprint']) ? $pair['pair_fingerprint'] : '');
+		$journal_fingerprint = self::normalized_fingerprint(isset($record['fingerprint']) ? $record['fingerprint'] : '');
+		$record_precision = isset($context['price_precision']) ? (int) $context['price_precision'] : -1;
+		if ('' === $pair_fingerprint || '' === $journal_fingerprint
+			|| !hash_equals($computed_fingerprint, $pair_fingerprint)
+			|| !hash_equals($computed_fingerprint, $journal_fingerprint)
+			|| $authority['source_order_id'] !== absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0)
+			|| $authority['price_precision'] !== $record_precision) {
+			return null;
+		}
+
+		$authority['pair_fingerprint'] = $computed_fingerprint;
+		return $authority;
 	}
 
 	public static function validates_participant(array $record, $participant_order_id, $role, $peer_order_id = 0, $pair_fingerprint = '', $operation_id = '') {
@@ -93,25 +106,134 @@ final class WCOS_Merge_Journal_Context {
 		$participant_order_id = absint($participant_order_id);
 		$peer_order_id = absint($peer_order_id);
 		$role = sanitize_key((string) $role);
-		$expected_participant = 'source' === $role ? absint($pair['source_order_id']) : absint($pair['target_order_id']);
-		$expected_peer = 'source' === $role ? absint($pair['target_order_id']) : absint($pair['source_order_id']);
+		$expected_participant = 'source' === $role ? $pair['source_order_id'] : $pair['target_order_id'];
+		$expected_peer = 'source' === $role ? $pair['target_order_id'] : $pair['source_order_id'];
 		if (!in_array($role, array('source', 'target'), true)
 			|| $participant_order_id !== $expected_participant
 			|| ($peer_order_id && $peer_order_id !== $expected_peer)) {
 			return false;
 		}
-		$pair_fingerprint = sanitize_key((string) $pair_fingerprint);
+		$pair_fingerprint = self::normalized_fingerprint($pair_fingerprint);
 		$operation_id = sanitize_key((string) $operation_id);
 		$record_operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
-		return ('' === $pair_fingerprint || hash_equals((string) $pair['pair_fingerprint'], $pair_fingerprint))
+		return ('' === $pair_fingerprint || hash_equals($pair['pair_fingerprint'], $pair_fingerprint))
 			&& ('' === $operation_id || hash_equals($operation_id, $record_operation_id));
 	}
 
 	public static function is_unsafe_record(array $record) {
 		if (!is_array(self::pair_from_record($record))) {
-			return false;
+			return true;
 		}
 		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		return !in_array($status, array('completed', 'compensated', 'manual_reconciled'), true);
+	}
+
+	private static function authority_fingerprint(array $authority) {
+		return WCOS_Mutation_Fingerprint::create('merge_pair_authority_v2', $authority['source_order_id'], $authority);
+	}
+
+	private static function canonical_authority(array $authority) {
+		$expected_keys = array(
+			'active_ownership_before_signature', 'archive_source_signature_before', 'context_authority',
+			'context_authority_fingerprint', 'context_signature_version', 'participation_schema_version',
+			'plan_fingerprint', 'plan_schema_version', 'preflight_policy_version', 'price_precision',
+			'retirement_candidates', 'retirement_policy_schema_version', 'retirement_policy_selected',
+			'source_order_id', 'source_signature', 'target_order_id', 'target_signature',
+		);
+		$actual_keys = array_keys($authority);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		if ($actual_keys !== $expected_keys || !is_array($authority['retirement_candidates'])) {
+			return null;
+		}
+
+		$context_authority = self::canonical_context_authority($authority['context_authority']);
+		$source_id = absint($authority['source_order_id']);
+		$target_id = absint($authority['target_order_id']);
+		$source_signature = self::normalized_fingerprint($authority['source_signature']);
+		$target_signature = self::normalized_fingerprint($authority['target_signature']);
+		$plan_fingerprint = self::normalized_fingerprint($authority['plan_fingerprint']);
+		$context_fingerprint = self::normalized_fingerprint($authority['context_authority_fingerprint']);
+		$archive_signature = self::normalized_fingerprint($authority['archive_source_signature_before']);
+		$active_signature = '' === (string) $authority['active_ownership_before_signature']
+			? ''
+			: self::normalized_fingerprint($authority['active_ownership_before_signature']);
+		$price_precision = (int) $authority['price_precision'];
+		if (!$source_id || !$target_id || $source_id === $target_id || !is_array($context_authority)
+			|| '' === $source_signature || '' === $target_signature || '' === $plan_fingerprint
+			|| '' === $context_fingerprint || '' === $archive_signature
+			|| ('' !== (string) $authority['active_ownership_before_signature'] && '' === $active_signature)
+			|| $price_precision !== WCOS_Price_Precision_Scope::validate($price_precision)
+			|| (int) $authority['plan_schema_version'] !== WCOS_Merge_Plan::SCHEMA_VERSION
+			|| (int) $authority['preflight_policy_version'] !== WCOS_Merge_Preflight::POLICY_VERSION
+			|| (int) $authority['context_signature_version'] !== WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (int) $authority['retirement_policy_schema_version'] !== WCOS_Merge_Retirement_Policy::SCHEMA_VERSION
+			|| (int) $authority['participation_schema_version'] !== WCOS_Merge_Participation::SCHEMA_VERSION
+			|| false !== (bool) $authority['retirement_policy_selected']
+			|| WCOS_Merge_Retirement_Policy::identifiers() !== array_values($authority['retirement_candidates'])) {
+			return null;
+		}
+
+		return array(
+			'source_order_id' => $source_id,
+			'target_order_id' => $target_id,
+			'source_signature' => $source_signature,
+			'target_signature' => $target_signature,
+			'plan_schema_version' => WCOS_Merge_Plan::SCHEMA_VERSION,
+			'plan_fingerprint' => $plan_fingerprint,
+			'price_precision' => $price_precision,
+			'preflight_policy_version' => WCOS_Merge_Preflight::POLICY_VERSION,
+			'context_signature_version' => WCOS_Merge_Context_Signature::SCHEMA_VERSION,
+			'context_authority' => $context_authority,
+			'context_authority_fingerprint' => $context_fingerprint,
+			'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
+			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'retirement_policy_selected' => false,
+			'archive_source_signature_before' => $archive_signature,
+			'active_ownership_before_signature' => $active_signature,
+			'participation_schema_version' => WCOS_Merge_Participation::SCHEMA_VERSION,
+		);
+	}
+
+	private static function canonical_context_authority($authority) {
+		if (!is_array($authority)) {
+			return null;
+		}
+		$expected_keys = array(
+			'algorithm', 'billing_context_digest', 'customer_id', 'identity_digest', 'identity_type',
+			'payment_context_digest', 'schema_version', 'shipping_context_digest',
+		);
+		$actual_keys = array_keys($authority);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		$identity_type = isset($authority['identity_type']) ? sanitize_key((string) $authority['identity_type']) : '';
+		$customer_id = absint(isset($authority['customer_id']) ? $authority['customer_id'] : 0);
+		if ($actual_keys !== $expected_keys
+			|| (int) $authority['schema_version'] !== WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (string) $authority['algorithm'] !== WCOS_Merge_Context_Signature::ALGORITHM
+			|| !in_array($identity_type, array('registered', 'guest'), true)
+			|| ('registered' === $identity_type && !$customer_id)
+			|| ('guest' === $identity_type && $customer_id)
+			|| '' === self::normalized_fingerprint($authority['identity_digest'])
+			|| '' === self::normalized_fingerprint($authority['billing_context_digest'])
+			|| '' === self::normalized_fingerprint($authority['shipping_context_digest'])
+			|| '' === self::normalized_fingerprint($authority['payment_context_digest'])) {
+			return null;
+		}
+		return array(
+			'schema_version' => WCOS_Merge_Context_Signature::SCHEMA_VERSION,
+			'algorithm' => WCOS_Merge_Context_Signature::ALGORITHM,
+			'identity_type' => $identity_type,
+			'customer_id' => $customer_id,
+			'identity_digest' => self::normalized_fingerprint($authority['identity_digest']),
+			'billing_context_digest' => self::normalized_fingerprint($authority['billing_context_digest']),
+			'shipping_context_digest' => self::normalized_fingerprint($authority['shipping_context_digest']),
+			'payment_context_digest' => self::normalized_fingerprint($authority['payment_context_digest']),
+		);
+	}
+
+	private static function normalized_fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
 	}
 }

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -11,6 +11,7 @@ defined('ABSPATH') || exit;
 final class WCOS_Merge_Participation {
 
 	const SCHEMA_VERSION = 1;
+	const CORRUPT_OPERATION_ID = 'merge_participation_corrupt';
 	const SOURCE_TARGET_META = '_wcos_merged_into_order_id';
 	const SOURCE_OPERATION_META = '_wcos_merge_operation_id';
 	const SOURCE_PAIR_FINGERPRINT_META = '_wcos_merge_pair_fingerprint';
@@ -69,21 +70,25 @@ final class WCOS_Merge_Participation {
 		}
 		WCOS_Operation_Lock::assert_current_owned_for($source_id, $operation_id);
 		WCOS_Operation_Lock::assert_current_owned_for($target_id, $operation_id);
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		$pair = is_array($record) ? WCOS_Merge_Journal_Context::pair_from_record($record) : null;
+		if (!is_array($pair)
+			|| $source_id !== $pair['source_order_id']
+			|| $target_id !== $pair['target_order_id']
+			|| $operation_id !== sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '')) {
+			return false;
+		}
+		$pair_fingerprint = $pair['pair_fingerprint'];
 
 		$fresh_source = wc_get_order($source_id);
 		$fresh_target = wc_get_order($target_id);
 		if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
 			return false;
 		}
-		$pair_fingerprint = sanitize_key((string) $fresh_source->get_meta(self::SOURCE_PAIR_FINGERPRINT_META, true));
-		if ((int) $fresh_source->get_meta(self::SOURCE_TARGET_META, true) === $target_id
-			&& (string) $fresh_source->get_meta(self::SOURCE_OPERATION_META, true) === $operation_id
-			&& '' !== $pair_fingerprint) {
-			$fresh_source->delete_meta_data(self::SOURCE_TARGET_META);
-			$fresh_source->delete_meta_data(self::SOURCE_OPERATION_META);
-			$fresh_source->delete_meta_data(self::SOURCE_PAIR_FINGERPRINT_META);
-			$fresh_source->save_meta_data();
-		}
+		$fresh_source->delete_meta_data_value(self::SOURCE_TARGET_META, $target_id);
+		$fresh_source->delete_meta_data_value(self::SOURCE_OPERATION_META, $operation_id);
+		$fresh_source->delete_meta_data_value(self::SOURCE_PAIR_FINGERPRINT_META, $pair_fingerprint);
+		$fresh_source->save_meta_data();
 
 		$remaining_authorities = array();
 		if ('' !== $pair_fingerprint) {
@@ -108,6 +113,29 @@ final class WCOS_Merge_Participation {
 			$fresh_target->delete_meta_data_value(self::TARGET_OPERATION_META, $operation_id);
 		}
 		$fresh_target->save_meta_data();
+
+		$source_after = wc_get_order($source_id);
+		$target_after = wc_get_order($target_id);
+		if (!$source_after instanceof WC_Order || !$target_after instanceof WC_Order) {
+			return false;
+		}
+		$owned_pointer = self::authority_pointer($source_id, $operation_id, $pair_fingerprint);
+		if (in_array((string) $target_id, array_map('strval', self::meta_values($source_after, self::SOURCE_TARGET_META)), true)
+			|| in_array($operation_id, array_map('strval', self::meta_values($source_after, self::SOURCE_OPERATION_META)), true)
+			|| in_array($pair_fingerprint, array_map('strval', self::meta_values($source_after, self::SOURCE_PAIR_FINGERPRINT_META)), true)
+			|| in_array($owned_pointer, array_map('strval', self::meta_values($target_after, self::TARGET_AUTHORITY_META)), true)) {
+			return false;
+		}
+
+		$remaining = self::parsed_target_authorities($target_after);
+		if (empty($remaining['source_ids'][$source_id])
+			&& in_array((string) $source_id, array_map('strval', self::meta_values($target_after, self::TARGET_SOURCE_META)), true)) {
+			return false;
+		}
+		if (empty($remaining['operation_ids'][$operation_id])
+			&& in_array($operation_id, array_map('strval', self::meta_values($target_after, self::TARGET_OPERATION_META)), true)) {
+			return false;
+		}
 		return true;
 	}
 
@@ -117,10 +145,18 @@ final class WCOS_Merge_Participation {
 			return array();
 		}
 		$authorities = array();
-		$target_id = absint($participant->get_meta(self::SOURCE_TARGET_META, true));
-		$source_operation = sanitize_key((string) $participant->get_meta(self::SOURCE_OPERATION_META, true));
-		$source_pair_fingerprint = sanitize_key((string) $participant->get_meta(self::SOURCE_PAIR_FINGERPRINT_META, true));
-		if ($target_id && '' !== $source_operation && '' !== $source_pair_fingerprint) {
+		$source_target_values = self::meta_values($participant, self::SOURCE_TARGET_META);
+		$source_operation_values = self::meta_values($participant, self::SOURCE_OPERATION_META);
+		$source_fingerprint_values = self::meta_values($participant, self::SOURCE_PAIR_FINGERPRINT_META);
+		$has_source_evidence = !empty($source_target_values) || !empty($source_operation_values) || !empty($source_fingerprint_values);
+		$target_id = 1 === count($source_target_values) ? absint(reset($source_target_values)) : 0;
+		$source_operation = 1 === count($source_operation_values) ? sanitize_key((string) reset($source_operation_values)) : '';
+		$source_pair_fingerprint = 1 === count($source_fingerprint_values) ? self::normalized_fingerprint(reset($source_fingerprint_values)) : '';
+		if ($has_source_evidence && $target_id && '' !== $source_operation && '' !== $source_pair_fingerprint
+			&& 1 === count($source_target_values) && 1 === count($source_operation_values) && 1 === count($source_fingerprint_values)
+			&& (string) reset($source_target_values) === (string) $target_id
+			&& (string) reset($source_operation_values) === $source_operation
+			&& (string) reset($source_fingerprint_values) === $source_pair_fingerprint) {
 			$authorities[] = array(
 				'participant_order_id' => $participant_id,
 				'participant_role' => 'source',
@@ -129,13 +165,29 @@ final class WCOS_Merge_Participation {
 				'operation_id' => $source_operation,
 				'pair_fingerprint' => $source_pair_fingerprint,
 			);
+		} elseif ($has_source_evidence) {
+			$authorities = array_merge($authorities, self::corrupt_authorities($participant_id, $source_operation_values));
 		}
 
-		foreach (self::meta_values($participant, self::TARGET_AUTHORITY_META) as $pointer) {
+		$target_source_values = self::meta_values($participant, self::TARGET_SOURCE_META);
+		$target_operation_values = self::meta_values($participant, self::TARGET_OPERATION_META);
+		$target_pointer_values = self::meta_values($participant, self::TARGET_AUTHORITY_META);
+		$parsed_targets = array();
+		$target_pointer_keys = array();
+		foreach ($target_pointer_values as $pointer) {
 			$parts = self::parse_authority_pointer($pointer);
 			if (empty($parts)) {
+				$pointer_parts = explode('|', (string) $pointer);
+				$operation_values = isset($pointer_parts[1]) ? array($pointer_parts[1]) : array();
+				$authorities = array_merge($authorities, self::corrupt_authorities($participant_id, $operation_values));
 				continue;
 			}
+			$key = $parts['source_order_id'] . '|' . $parts['operation_id'];
+			if (isset($target_pointer_keys[$key]) && $target_pointer_keys[$key] !== $parts['pair_fingerprint']) {
+				$authorities = array_merge($authorities, self::corrupt_authorities($participant_id, array($parts['operation_id'])));
+			}
+			$target_pointer_keys[$key] = $parts['pair_fingerprint'];
+			$parsed_targets[] = $parts;
 			$authorities[] = array(
 				'participant_order_id' => $participant_id,
 				'participant_role' => 'target',
@@ -145,6 +197,24 @@ final class WCOS_Merge_Participation {
 				'pair_fingerprint' => $parts['pair_fingerprint'],
 			);
 		}
+		$indexed_source_ids = self::normalized_scalar_set($target_source_values, 'absint');
+		$indexed_operation_ids = self::normalized_scalar_set($target_operation_values, 'sanitize_key');
+		$pointer_source_ids = array();
+		$pointer_operation_ids = array();
+		foreach ($parsed_targets as $parts) {
+			$pointer_source_ids[] = $parts['source_order_id'];
+			$pointer_operation_ids[] = $parts['operation_id'];
+		}
+		$pointer_source_ids = self::normalized_scalar_set($pointer_source_ids, 'absint');
+		$pointer_operation_ids = self::normalized_scalar_set($pointer_operation_ids, 'sanitize_key');
+		if ($indexed_source_ids !== $pointer_source_ids || $indexed_operation_ids !== $pointer_operation_ids
+			|| count($target_source_values) !== count($indexed_source_ids)
+			|| count($target_operation_values) !== count($indexed_operation_ids)
+			|| !self::scalar_values_are_canonical($target_source_values, 'absint')
+			|| !self::scalar_values_are_canonical($target_operation_values, 'sanitize_key')
+			|| count($target_pointer_values) !== count(array_unique(array_map('strval', $target_pointer_values)))) {
+			$authorities = array_merge($authorities, self::corrupt_authorities($participant_id, $target_operation_values));
+		}
 
 		return self::unique_authorities($authorities);
 	}
@@ -152,6 +222,10 @@ final class WCOS_Merge_Participation {
 	public static function unresolved_operation_ids(WC_Order $participant) {
 		$active = array();
 		foreach (self::authorities($participant) as $authority) {
+			if ('corrupt' === $authority['participant_role']) {
+				$active[] = $authority['operation_id'];
+				continue;
+			}
 			$source = wc_get_order($authority['journal_source_order_id']);
 			if (!$source instanceof WC_Order) {
 				$active[] = $authority['operation_id'];
@@ -162,14 +236,14 @@ final class WCOS_Merge_Participation {
 				$active[] = $authority['operation_id'];
 				continue;
 			}
-			if (WCOS_Merge_Journal_Context::validates_participant(
+			if (!WCOS_Merge_Journal_Context::validates_participant(
 				$record,
 				$authority['participant_order_id'],
 				$authority['participant_role'],
 				$authority['peer_order_id'],
 				$authority['pair_fingerprint'],
 				$authority['operation_id']
-			) && WCOS_Merge_Journal_Context::is_unsafe_record($record)) {
+			) || WCOS_Merge_Journal_Context::is_unsafe_record($record)) {
 				$active[] = $authority['operation_id'];
 			}
 		}
@@ -265,6 +339,67 @@ final class WCOS_Merge_Participation {
 			return array();
 		}
 		return compact('source_order_id', 'operation_id', 'pair_fingerprint');
+	}
+
+	private static function parsed_target_authorities(WC_Order $target) {
+		$source_ids = array();
+		$operation_ids = array();
+		foreach (self::meta_values($target, self::TARGET_AUTHORITY_META) as $pointer) {
+			$authority = self::parse_authority_pointer($pointer);
+			if (empty($authority)) {
+				continue;
+			}
+			$source_ids[$authority['source_order_id']] = true;
+			$operation_ids[$authority['operation_id']] = true;
+		}
+		return array('source_ids' => $source_ids, 'operation_ids' => $operation_ids);
+	}
+
+	private static function corrupt_authorities($participant_id, array $operation_values) {
+		$operation_ids = self::normalized_scalar_set($operation_values, 'sanitize_key');
+		if (empty($operation_ids)) {
+			$operation_ids = array(self::CORRUPT_OPERATION_ID);
+		}
+		$authorities = array();
+		foreach ($operation_ids as $operation_id) {
+			$authorities[] = array(
+				'participant_order_id' => absint($participant_id),
+				'participant_role' => 'corrupt',
+				'peer_order_id' => 0,
+				'journal_source_order_id' => 0,
+				'operation_id' => $operation_id,
+				'pair_fingerprint' => '',
+			);
+		}
+		return $authorities;
+	}
+
+	private static function normalized_scalar_set(array $values, $normalizer) {
+		$normalized = array();
+		foreach ($values as $value) {
+			$value = call_user_func($normalizer, $value);
+			if (0 === $value || '' === $value) {
+				continue;
+			}
+			$normalized[] = $value;
+		}
+		$normalized = array_values(array_unique($normalized));
+		sort($normalized, SORT_STRING);
+		return $normalized;
+	}
+
+	private static function scalar_values_are_canonical(array $values, $normalizer) {
+		foreach ($values as $value) {
+			if ((string) $value !== (string) call_user_func($normalizer, $value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static function normalized_fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
 	}
 
 	private static function meta_values(WC_Order $order, $key) {

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -1,0 +1,298 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Queryable scalar participation metadata for a journal-authoritative Merge pair.
+ *
+ * These records are discovery indexes, never pair authority. Every candidate is
+ * verified against the single source-keyed journal and its pair fingerprint.
+ */
+final class WCOS_Merge_Participation {
+
+	const SCHEMA_VERSION = 1;
+	const SOURCE_TARGET_META = '_wcos_merged_into_order_id';
+	const SOURCE_OPERATION_META = '_wcos_merge_operation_id';
+	const SOURCE_PAIR_FINGERPRINT_META = '_wcos_merge_pair_fingerprint';
+	const TARGET_SOURCE_META = '_wcos_merged_source_order_id';
+	const TARGET_OPERATION_META = '_wcos_merge_source_operation_id';
+	const TARGET_AUTHORITY_META = '_wcos_merge_authority_pointer';
+
+	public static function persist(WC_Order $source, WC_Order $target, $operation_id, $pair_fingerprint) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$operation_id = sanitize_key((string) $operation_id);
+		$pair_fingerprint = sanitize_key((string) $pair_fingerprint);
+		if (!$source_id || !$target_id || $source_id === $target_id || '' === $operation_id || '' === $pair_fingerprint) {
+			throw new InvalidArgumentException(__('Complete Merge participation authority is required.', 'wc-order-splitter'));
+		}
+		WCOS_Operation_Lock::assert_current_owned_for($source_id, $operation_id);
+		WCOS_Operation_Lock::assert_current_owned_for($target_id, $operation_id);
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		if (!is_array($record)
+			|| !WCOS_Merge_Journal_Context::validates_participant($record, $source_id, 'source', $target_id, $pair_fingerprint, $operation_id)) {
+			throw new RuntimeException(__('Merge participation does not match the authoritative source journal.', 'wc-order-splitter'));
+		}
+
+		$fresh_source = wc_get_order($source_id);
+		$fresh_target = wc_get_order($target_id);
+		if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
+			throw new RuntimeException(__('A Merge participant disappeared before participation could be persisted.', 'wc-order-splitter'));
+		}
+
+		self::set_exact_scalar($fresh_source, self::SOURCE_TARGET_META, $target_id);
+		self::set_exact_scalar($fresh_source, self::SOURCE_OPERATION_META, $operation_id);
+		self::set_exact_scalar($fresh_source, self::SOURCE_PAIR_FINGERPRINT_META, $pair_fingerprint);
+		$fresh_source->save_meta_data();
+
+		self::add_exact_repeatable($fresh_target, self::TARGET_SOURCE_META, $source_id);
+		self::add_exact_repeatable($fresh_target, self::TARGET_OPERATION_META, $operation_id);
+		self::add_exact_repeatable($fresh_target, self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
+		$fresh_target->save_meta_data();
+
+		$source_after = wc_get_order($source_id);
+		$target_after = wc_get_order($target_id);
+		if (!$source_after instanceof WC_Order || !$target_after instanceof WC_Order
+			|| !self::source_values_match($source_after, $target_id, $operation_id, $pair_fingerprint)
+			|| !self::target_values_contain($target_after, $source_id, $operation_id, $pair_fingerprint)) {
+			throw new RuntimeException(__('Merge participation metadata could not be verified after persistence.', 'wc-order-splitter'));
+		}
+		return true;
+	}
+
+	public static function cleanup(WC_Order $source, WC_Order $target, $operation_id) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$operation_id = sanitize_key((string) $operation_id);
+		if (!$source_id || !$target_id || '' === $operation_id) {
+			return false;
+		}
+		WCOS_Operation_Lock::assert_current_owned_for($source_id, $operation_id);
+		WCOS_Operation_Lock::assert_current_owned_for($target_id, $operation_id);
+
+		$fresh_source = wc_get_order($source_id);
+		$fresh_target = wc_get_order($target_id);
+		if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
+			return false;
+		}
+		$pair_fingerprint = sanitize_key((string) $fresh_source->get_meta(self::SOURCE_PAIR_FINGERPRINT_META, true));
+		if ((int) $fresh_source->get_meta(self::SOURCE_TARGET_META, true) === $target_id
+			&& (string) $fresh_source->get_meta(self::SOURCE_OPERATION_META, true) === $operation_id
+			&& '' !== $pair_fingerprint) {
+			$fresh_source->delete_meta_data(self::SOURCE_TARGET_META);
+			$fresh_source->delete_meta_data(self::SOURCE_OPERATION_META);
+			$fresh_source->delete_meta_data(self::SOURCE_PAIR_FINGERPRINT_META);
+			$fresh_source->save_meta_data();
+		}
+
+		$remaining_authorities = array();
+		if ('' !== $pair_fingerprint) {
+			$fresh_target->delete_meta_data_value(self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
+		}
+		foreach ((array) $fresh_target->get_meta(self::TARGET_AUTHORITY_META, false) as $pointer) {
+			$authority = self::parse_authority_pointer($pointer);
+			if (!empty($authority)) {
+				$remaining_authorities[] = $authority;
+			}
+		}
+		$source_still_referenced = false;
+		$operation_still_referenced = false;
+		foreach ($remaining_authorities as $authority) {
+			$source_still_referenced = $source_still_referenced || $source_id === $authority['source_order_id'];
+			$operation_still_referenced = $operation_still_referenced || $operation_id === $authority['operation_id'];
+		}
+		if (!$source_still_referenced) {
+			$fresh_target->delete_meta_data_value(self::TARGET_SOURCE_META, $source_id);
+		}
+		if (!$operation_still_referenced) {
+			$fresh_target->delete_meta_data_value(self::TARGET_OPERATION_META, $operation_id);
+		}
+		$fresh_target->save_meta_data();
+		return true;
+	}
+
+	public static function authorities(WC_Order $participant) {
+		$participant_id = absint($participant->get_id());
+		if (!$participant_id) {
+			return array();
+		}
+		$authorities = array();
+		$target_id = absint($participant->get_meta(self::SOURCE_TARGET_META, true));
+		$source_operation = sanitize_key((string) $participant->get_meta(self::SOURCE_OPERATION_META, true));
+		$source_pair_fingerprint = sanitize_key((string) $participant->get_meta(self::SOURCE_PAIR_FINGERPRINT_META, true));
+		if ($target_id && '' !== $source_operation && '' !== $source_pair_fingerprint) {
+			$authorities[] = array(
+				'participant_order_id' => $participant_id,
+				'participant_role' => 'source',
+				'peer_order_id' => $target_id,
+				'journal_source_order_id' => $participant_id,
+				'operation_id' => $source_operation,
+				'pair_fingerprint' => $source_pair_fingerprint,
+			);
+		}
+
+		foreach ((array) $participant->get_meta(self::TARGET_AUTHORITY_META, false) as $pointer) {
+			$parts = self::parse_authority_pointer($pointer);
+			if (empty($parts)) {
+				continue;
+			}
+			$authorities[] = array(
+				'participant_order_id' => $participant_id,
+				'participant_role' => 'target',
+				'peer_order_id' => $parts['source_order_id'],
+				'journal_source_order_id' => $parts['source_order_id'],
+				'operation_id' => $parts['operation_id'],
+				'pair_fingerprint' => $parts['pair_fingerprint'],
+			);
+		}
+
+		return self::unique_authorities($authorities);
+	}
+
+	public static function unresolved_operation_ids(WC_Order $participant) {
+		$active = array();
+		foreach (self::authorities($participant) as $authority) {
+			$source = wc_get_order($authority['journal_source_order_id']);
+			if (!$source instanceof WC_Order) {
+				$active[] = $authority['operation_id'];
+				continue;
+			}
+			$record = WCOS_Operation_Journal::get($source, $authority['operation_id']);
+			if (!is_array($record)) {
+				$active[] = $authority['operation_id'];
+				continue;
+			}
+			if (WCOS_Merge_Journal_Context::validates_participant(
+				$record,
+				$authority['participant_order_id'],
+				$authority['participant_role'],
+				$authority['peer_order_id'],
+				$authority['pair_fingerprint'],
+				$authority['operation_id']
+			) && WCOS_Merge_Journal_Context::is_unsafe_record($record)) {
+				$active[] = $authority['operation_id'];
+			}
+		}
+		$active = array_values(array_unique(array_filter(array_map('sanitize_key', $active))));
+		sort($active, SORT_STRING);
+		return $active;
+	}
+
+	public static function find_targets($source_order_id, $operation_id) {
+		$source_order_id = absint($source_order_id);
+		$operation_id = sanitize_key((string) $operation_id);
+		if (!$source_order_id || '' === $operation_id) {
+			return array();
+		}
+		$candidates = WCOS_Order_Relation_Repository::find(
+			array(
+				array('key' => self::TARGET_SOURCE_META, 'value' => $source_order_id, 'type' => 'NUMERIC'),
+				array('key' => self::TARGET_OPERATION_META, 'value' => $operation_id),
+			),
+			-1
+		);
+		$source = wc_get_order($source_order_id);
+		$record = $source instanceof WC_Order ? WCOS_Operation_Journal::get($source, $operation_id) : null;
+		if (!is_array($record)) {
+			return array();
+		}
+		return array_values(array_filter($candidates, static function($candidate) use ($record, $source_order_id, $operation_id) {
+			if (!$candidate instanceof WC_Order) {
+				return false;
+			}
+			foreach (self::authorities($candidate) as $authority) {
+				if ('target' === $authority['participant_role']
+					&& $source_order_id === $authority['journal_source_order_id']
+					&& $operation_id === $authority['operation_id']
+					&& WCOS_Merge_Journal_Context::validates_participant(
+						$record,
+						$candidate->get_id(),
+						'target',
+						$source_order_id,
+						$authority['pair_fingerprint'],
+						$operation_id
+					)) {
+					return true;
+				}
+			}
+			return false;
+		}));
+	}
+
+	private static function set_exact_scalar(WC_Order $order, $key, $value) {
+		$current = $order->get_meta($key, false);
+		if (count($current) > 1 || (!empty($current) && (string) reset($current) !== (string) $value)) {
+			throw new RuntimeException(__('Conflicting Merge scalar participation metadata already exists.', 'wc-order-splitter'));
+		}
+		$order->update_meta_data($key, $value);
+	}
+
+	private static function add_exact_repeatable(WC_Order $order, $key, $value) {
+		foreach ((array) $order->get_meta($key, false) as $current) {
+			if ((string) $current === (string) $value) {
+				return;
+			}
+		}
+		$order->add_meta_data($key, $value, false);
+	}
+
+	private static function source_values_match(WC_Order $source, $target_id, $operation_id, $pair_fingerprint) {
+		return (int) $source->get_meta(self::SOURCE_TARGET_META, true) === (int) $target_id
+			&& (string) $source->get_meta(self::SOURCE_OPERATION_META, true) === (string) $operation_id
+			&& (string) $source->get_meta(self::SOURCE_PAIR_FINGERPRINT_META, true) === (string) $pair_fingerprint;
+	}
+
+	private static function target_values_contain(WC_Order $target, $source_id, $operation_id, $pair_fingerprint) {
+		return in_array((string) $source_id, array_map('strval', (array) $target->get_meta(self::TARGET_SOURCE_META, false)), true)
+			&& in_array((string) $operation_id, array_map('strval', (array) $target->get_meta(self::TARGET_OPERATION_META, false)), true)
+			&& in_array(self::authority_pointer($source_id, $operation_id, $pair_fingerprint), array_map('strval', (array) $target->get_meta(self::TARGET_AUTHORITY_META, false)), true);
+	}
+
+	private static function authority_pointer($source_order_id, $operation_id, $pair_fingerprint) {
+		return absint($source_order_id) . '|' . sanitize_key((string) $operation_id) . '|' . sanitize_key((string) $pair_fingerprint);
+	}
+
+	private static function parse_authority_pointer($pointer) {
+		$parts = explode('|', (string) $pointer);
+		if (3 !== count($parts)) {
+			return array();
+		}
+		$source_order_id = absint($parts[0]);
+		$operation_id = sanitize_key($parts[1]);
+		$pair_fingerprint = sanitize_key($parts[2]);
+		if (!$source_order_id || '' === $operation_id || '' === $pair_fingerprint
+			|| self::authority_pointer($source_order_id, $operation_id, $pair_fingerprint) !== (string) $pointer) {
+			return array();
+		}
+		return compact('source_order_id', 'operation_id', 'pair_fingerprint');
+	}
+
+	private static function normalized_values(WC_Order $order, $key, $normalizer) {
+		$values = array();
+		foreach ((array) $order->get_meta($key, false) as $value) {
+			$value = call_user_func($normalizer, $value);
+			if (0 === $value || '' === $value) {
+				continue;
+			}
+			$values[] = $value;
+		}
+		$values = array_values(array_unique($values));
+		sort($values, SORT_STRING);
+		return $values;
+	}
+
+	private static function unique_authorities(array $authorities) {
+		$unique = array();
+		foreach ($authorities as $authority) {
+			$key = implode(':', array(
+				$authority['participant_order_id'],
+				$authority['participant_role'],
+				$authority['journal_source_order_id'],
+				$authority['operation_id'],
+			));
+			$unique[$key] = $authority;
+		}
+		ksort($unique, SORT_STRING);
+		return array_values($unique);
+	}
+}

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -89,7 +89,7 @@ final class WCOS_Merge_Participation {
 		if ('' !== $pair_fingerprint) {
 			$fresh_target->delete_meta_data_value(self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
 		}
-		foreach ((array) $fresh_target->get_meta(self::TARGET_AUTHORITY_META, false) as $pointer) {
+		foreach (self::meta_values($fresh_target, self::TARGET_AUTHORITY_META) as $pointer) {
 			$authority = self::parse_authority_pointer($pointer);
 			if (!empty($authority)) {
 				$remaining_authorities[] = $authority;
@@ -131,7 +131,7 @@ final class WCOS_Merge_Participation {
 			);
 		}
 
-		foreach ((array) $participant->get_meta(self::TARGET_AUTHORITY_META, false) as $pointer) {
+		foreach (self::meta_values($participant, self::TARGET_AUTHORITY_META) as $pointer) {
 			$parts = self::parse_authority_pointer($pointer);
 			if (empty($parts)) {
 				continue;
@@ -220,7 +220,7 @@ final class WCOS_Merge_Participation {
 	}
 
 	private static function set_exact_scalar(WC_Order $order, $key, $value) {
-		$current = $order->get_meta($key, false);
+		$current = self::meta_values($order, $key);
 		if (count($current) > 1 || (!empty($current) && (string) reset($current) !== (string) $value)) {
 			throw new RuntimeException(__('Conflicting Merge scalar participation metadata already exists.', 'wc-order-splitter'));
 		}
@@ -228,7 +228,7 @@ final class WCOS_Merge_Participation {
 	}
 
 	private static function add_exact_repeatable(WC_Order $order, $key, $value) {
-		foreach ((array) $order->get_meta($key, false) as $current) {
+		foreach (self::meta_values($order, $key) as $current) {
 			if ((string) $current === (string) $value) {
 				return;
 			}
@@ -243,9 +243,9 @@ final class WCOS_Merge_Participation {
 	}
 
 	private static function target_values_contain(WC_Order $target, $source_id, $operation_id, $pair_fingerprint) {
-		return in_array((string) $source_id, array_map('strval', (array) $target->get_meta(self::TARGET_SOURCE_META, false)), true)
-			&& in_array((string) $operation_id, array_map('strval', (array) $target->get_meta(self::TARGET_OPERATION_META, false)), true)
-			&& in_array(self::authority_pointer($source_id, $operation_id, $pair_fingerprint), array_map('strval', (array) $target->get_meta(self::TARGET_AUTHORITY_META, false)), true);
+		return in_array((string) $source_id, array_map('strval', self::meta_values($target, self::TARGET_SOURCE_META)), true)
+			&& in_array((string) $operation_id, array_map('strval', self::meta_values($target, self::TARGET_OPERATION_META)), true)
+			&& in_array(self::authority_pointer($source_id, $operation_id, $pair_fingerprint), array_map('strval', self::meta_values($target, self::TARGET_AUTHORITY_META)), true);
 	}
 
 	private static function authority_pointer($source_order_id, $operation_id, $pair_fingerprint) {
@@ -267,17 +267,19 @@ final class WCOS_Merge_Participation {
 		return compact('source_order_id', 'operation_id', 'pair_fingerprint');
 	}
 
-	private static function normalized_values(WC_Order $order, $key, $normalizer) {
+	private static function meta_values(WC_Order $order, $key) {
 		$values = array();
-		foreach ((array) $order->get_meta($key, false) as $value) {
-			$value = call_user_func($normalizer, $value);
-			if (0 === $value || '' === $value) {
+		$key = (string) $key;
+		foreach ($order->get_meta_data() as $meta) {
+			if (!is_object($meta) || !method_exists($meta, 'get_data')) {
 				continue;
 			}
-			$values[] = $value;
+			$data = $meta->get_data();
+			if (!isset($data['key']) || (string) $data['key'] !== $key || !array_key_exists('value', $data)) {
+				continue;
+			}
+			$values[] = $data['value'];
 		}
-		$values = array_values(array_unique($values));
-		sort($values, SORT_STRING);
 		return $values;
 	}
 

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -85,14 +85,14 @@ final class WCOS_Merge_Participation {
 		if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
 			return false;
 		}
-		$fresh_source->delete_meta_data_value(self::SOURCE_TARGET_META, $target_id);
-		$fresh_source->delete_meta_data_value(self::SOURCE_OPERATION_META, $operation_id);
-		$fresh_source->delete_meta_data_value(self::SOURCE_PAIR_FINGERPRINT_META, $pair_fingerprint);
+		self::delete_exact_value($fresh_source, self::SOURCE_TARGET_META, $target_id);
+		self::delete_exact_value($fresh_source, self::SOURCE_OPERATION_META, $operation_id);
+		self::delete_exact_value($fresh_source, self::SOURCE_PAIR_FINGERPRINT_META, $pair_fingerprint);
 		$fresh_source->save_meta_data();
 
 		$remaining_authorities = array();
 		if ('' !== $pair_fingerprint) {
-			$fresh_target->delete_meta_data_value(self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
+			self::delete_exact_value($fresh_target, self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
 		}
 		foreach (self::meta_values($fresh_target, self::TARGET_AUTHORITY_META) as $pointer) {
 			$authority = self::parse_authority_pointer($pointer);
@@ -107,10 +107,10 @@ final class WCOS_Merge_Participation {
 			$operation_still_referenced = $operation_still_referenced || $operation_id === $authority['operation_id'];
 		}
 		if (!$source_still_referenced) {
-			$fresh_target->delete_meta_data_value(self::TARGET_SOURCE_META, $source_id);
+			self::delete_exact_value($fresh_target, self::TARGET_SOURCE_META, $source_id);
 		}
 		if (!$operation_still_referenced) {
-			$fresh_target->delete_meta_data_value(self::TARGET_OPERATION_META, $operation_id);
+			self::delete_exact_value($fresh_target, self::TARGET_OPERATION_META, $operation_id);
 		}
 		$fresh_target->save_meta_data();
 
@@ -308,6 +308,21 @@ final class WCOS_Merge_Participation {
 			}
 		}
 		$order->add_meta_data($key, $value, false);
+	}
+
+	private static function delete_exact_value(WC_Order $order, $key, $value) {
+		$key = (string) $key;
+		$value = (string) $value;
+		foreach ($order->get_meta_data() as $meta) {
+			if (!is_object($meta) || !method_exists($meta, 'get_data')) {
+				continue;
+			}
+			$data = $meta->get_data();
+			if (isset($data['key']) && $key === (string) $data['key']
+				&& array_key_exists('value', $data) && $value === (string) $data['value']) {
+				$order->delete_meta_data_value($key, $data['value']);
+			}
+		}
 	}
 
 	private static function source_values_match(WC_Order $source, $target_id, $operation_id, $pair_fingerprint) {

--- a/inc/domain/class-wcos-merge-plan.php
+++ b/inc/domain/class-wcos-merge-plan.php
@@ -1,0 +1,125 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Canonical server-built whole-line Merge plan for the first safety tranche.
+ */
+final class WCOS_Merge_Plan {
+
+	const SCHEMA_VERSION = 1;
+
+	public static function build(WC_Order $source, WC_Order $target) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$lines = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				throw new RuntimeException(__('Merge encountered an unsupported source product-line object.', 'wc-order-splitter'));
+			}
+			$lines[(int) $item_id] = array(
+				'source_item_id' => (int) $item_id,
+				'line_identity' => WCOS_Line_Identity::from_item($item),
+				'product_id' => (int) $item->get_product_id(),
+				'variation_id' => (int) $item->get_variation_id(),
+				'tax_class' => (string) $item->get_tax_class(),
+				'quantity' => WCOS_Decimal::normalize($item->get_quantity(), 6),
+				'subtotal' => (string) $item->get_subtotal(),
+				'subtotal_tax' => (string) $item->get_subtotal_tax(),
+				'total' => (string) $item->get_total(),
+				'total_tax' => (string) $item->get_total_tax(),
+				'taxes' => $item->get_taxes(),
+				'reduced_stock' => self::normalize_reduced_stock($item->get_meta('_reduced_stock', true)),
+			);
+		}
+
+		return self::canonicalize($source_id, $target_id, $lines);
+	}
+
+	public static function canonicalize($source_order_id, $target_order_id, array $lines) {
+		$source_order_id = absint($source_order_id);
+		$target_order_id = absint($target_order_id);
+		if (!$source_order_id || !$target_order_id) {
+			throw new InvalidArgumentException(__('Persisted source and target order IDs are required for a Merge plan.', 'wc-order-splitter'));
+		}
+		if ($source_order_id === $target_order_id) {
+			throw new InvalidArgumentException(__('An order cannot be merged into itself.', 'wc-order-splitter'));
+		}
+		if (empty($lines)) {
+			throw new InvalidArgumentException(__('A Merge plan requires at least one source product line.', 'wc-order-splitter'));
+		}
+
+		$canonical_lines = array();
+		foreach ($lines as $key => $line) {
+			if (!is_array($line)) {
+				throw new InvalidArgumentException(__('Every Merge plan line must be a canonical array.', 'wc-order-splitter'));
+			}
+			$item_id = absint(isset($line['source_item_id']) ? $line['source_item_id'] : $key);
+			$identity = sanitize_key(isset($line['line_identity']) ? (string) $line['line_identity'] : '');
+			if (!$item_id || '' === $identity || isset($canonical_lines[$item_id])) {
+				throw new InvalidArgumentException(__('Merge plan source lines require unique persisted item IDs and exact identities.', 'wc-order-splitter'));
+			}
+			$line['source_item_id'] = $item_id;
+			$line['line_identity'] = $identity;
+			$canonical_lines[$item_id] = self::canonicalize_value($line);
+		}
+		ksort($canonical_lines, SORT_NUMERIC);
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'source_order_id' => $source_order_id,
+			'target_order_id' => $target_order_id,
+			'line_policy' => 'fresh_target_line_per_source_line',
+			'coalesce_lines' => false,
+			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'lines' => $canonical_lines,
+		);
+	}
+
+	public static function fingerprint(array $plan) {
+		$plan = self::canonicalize(
+			isset($plan['source_order_id']) ? $plan['source_order_id'] : 0,
+			isset($plan['target_order_id']) ? $plan['target_order_id'] : 0,
+			isset($plan['lines']) && is_array($plan['lines']) ? $plan['lines'] : array()
+		);
+		return WCOS_Mutation_Fingerprint::create('merge_plan', $plan['source_order_id'], $plan);
+	}
+
+	private static function normalize_reduced_stock($value) {
+		if ('' === $value || null === $value) {
+			return null;
+		}
+		if (!is_numeric($value)) {
+			throw new RuntimeException(__('A Merge source line contains a non-numeric reduced-stock marker.', 'wc-order-splitter'));
+		}
+		return WCOS_Decimal::normalize($value, 6);
+	}
+
+	private static function canonicalize_value($value) {
+		if (!is_array($value)) {
+			return $value;
+		}
+		if (self::is_list($value)) {
+			$result = array();
+			foreach ($value as $item) {
+				$result[] = self::canonicalize_value($item);
+			}
+			return $result;
+		}
+		ksort($value, SORT_STRING);
+		foreach ($value as $key => $item) {
+			$value[$key] = self::canonicalize_value($item);
+		}
+		return $value;
+	}
+
+	private static function is_list(array $value) {
+		$expected = 0;
+		foreach (array_keys($value) as $key) {
+			if ($key !== $expected++) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/inc/domain/class-wcos-merge-preflight.php
+++ b/inc/domain/class-wcos-merge-preflight.php
@@ -1,0 +1,200 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Merge_Preflight_Exception extends RuntimeException {
+	private $reason;
+	private $report;
+
+	public function __construct($reason, $message, array $report = array()) {
+		$this->reason = sanitize_key((string) $reason);
+		$this->report = $report;
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+
+	public function get_report() {
+		return $this->report;
+	}
+}
+
+/**
+ * Read-only pair compatibility contract for the first technical Merge tranche.
+ * Reports and failure evidence are intentionally PII-free.
+ */
+final class WCOS_Merge_Preflight {
+
+	const POLICY_VERSION = 1;
+
+	public static function policy() {
+		return array(
+			'policy_version' => self::POLICY_VERSION,
+			'commercial_scope' => 'initial_safety_tranche_only',
+			'paid_orders' => 'reject',
+			'refunds' => 'reject',
+			'coupons' => 'reject',
+			'fees' => 'reject',
+			'source_shipping' => 'reject',
+			'line_coalescing' => 'never',
+			'historical_tax' => 'preserve_exact',
+			'catalog_recalculation' => 'never',
+			'retirement_policy' => 'unselected_candidates',
+		);
+	}
+
+	public static function assert_supported(WC_Order $source, WC_Order $target, $precision = null) {
+		$report = self::report($source, $target, $precision);
+		if (empty($report['supported'])) {
+			throw new WCOS_Merge_Preflight_Exception(
+				isset($report['reason']) ? $report['reason'] : 'unsupported',
+				isset($report['message']) ? $report['message'] : __('This order pair is not supported by the hardened Merge foundation.', 'wc-order-splitter'),
+				$report
+			);
+		}
+		return $report;
+	}
+
+	public static function report(WC_Order $source, WC_Order $target, $precision = null) {
+		$precision = null === $precision
+			? WCOS_Price_Precision_Scope::store_precision()
+			: WCOS_Price_Precision_Scope::validate($precision);
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'source_order_id' => absint($source->get_id()),
+			'target_order_id' => absint($target->get_id()),
+			'price_precision' => $precision,
+			'policy' => self::policy(),
+			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'context_authority' => array(),
+			'source_signature' => '',
+			'target_signature' => '',
+			'pair_fingerprint' => '',
+			'plan' => array(),
+		);
+
+		$source_id = $report['source_order_id'];
+		$target_id = $report['target_order_id'];
+		if (!$source_id || !$target_id || 'shop_order' !== $source->get_type() || 'shop_order' !== $target->get_type()) {
+			return self::reject($report, 'unsupported_order_type', __('Merge requires two persisted WooCommerce shop orders.', 'wc-order-splitter'));
+		}
+		if ($source_id === $target_id) {
+			return self::reject($report, 'same_order', __('An order cannot be merged into itself.', 'wc-order-splitter'));
+		}
+
+		$blocked = array_values(array_unique(array_merge(
+			WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source),
+			WCOS_Manual_Reconciliation_Blocker::active_operation_ids($target)
+		)));
+		if (!empty($blocked)) {
+			return self::reject($report, 'manual_reconciliation_required', __('One or both Merge participants have unresolved mutation authority.', 'wc-order-splitter'));
+		}
+
+		$source_status = sanitize_key((string) $source->get_status());
+		$target_status = sanitize_key((string) $target->get_status());
+		$unsupported_statuses = array('trash', 'cancelled', 'refunded', 'failed', 'checkout-draft');
+		if ($source_status !== $target_status
+			|| in_array($source_status, $unsupported_statuses, true)
+			|| in_array($target_status, $unsupported_statuses, true)) {
+			return self::reject($report, 'incompatible_status', __('The initial Merge tranche requires matching compatible order statuses.', 'wc-order-splitter'));
+		}
+
+		$source_currency = (string) $source->get_currency();
+		$target_currency = (string) $target->get_currency();
+		if ('' === $source_currency || $source_currency !== $target_currency) {
+			return self::reject($report, 'incompatible_currency', __('Merge requires the same non-empty currency on both orders.', 'wc-order-splitter'));
+		}
+		if ((bool) $source->get_prices_include_tax() !== (bool) $target->get_prices_include_tax()) {
+			return self::reject($report, 'incompatible_pricing_mode', __('Merge requires matching historical tax-inclusion modes.', 'wc-order-splitter'));
+		}
+
+		if (self::has_paid_evidence($source) || self::has_paid_evidence($target)) {
+			return self::reject($report, 'paid_order_unsupported', __('Paid or transaction-bearing orders are outside the initial Merge tranche.', 'wc-order-splitter'));
+		}
+		if (self::has_refund_evidence($source) || self::has_refund_evidence($target)) {
+			return self::reject($report, 'refund_policy_missing', __('Refunded orders are outside the initial Merge tranche.', 'wc-order-splitter'));
+		}
+		if (!empty($source->get_items('coupon')) || !empty($target->get_items('coupon'))) {
+			return self::reject($report, 'coupon_policy_missing', __('Coupon ownership is outside the initial Merge tranche.', 'wc-order-splitter'));
+		}
+		if (!empty($source->get_items('fee')) || !empty($target->get_items('fee'))) {
+			return self::reject($report, 'fee_policy_missing', __('Fee ownership is outside the initial Merge tranche.', 'wc-order-splitter'));
+		}
+		if (!empty($source->get_items('shipping'))
+			|| 0 !== WCOS_Decimal::to_units($source->get_shipping_total(), $precision)
+			|| 0 !== WCOS_Decimal::to_units($source->get_shipping_tax(), $precision)) {
+			return self::reject($report, 'source_shipping_policy_missing', __('Source shipping ownership is outside the initial Merge tranche.', 'wc-order-splitter'));
+		}
+		if (empty($source->get_items('line_item'))) {
+			return self::reject($report, 'no_source_lines', __('Merge requires at least one source product line.', 'wc-order-splitter'));
+		}
+
+		try {
+			$context_authority = WCOS_Merge_Context_Signature::compatibility($source, $target);
+			self::assert_item_metadata_supported($source);
+			self::assert_item_metadata_supported($target);
+			WCOS_Order_Totals_Rebuilder::assert_consistent($source, $precision);
+			WCOS_Order_Totals_Rebuilder::assert_consistent($target, $precision);
+			$plan = WCOS_Merge_Plan::build($source, $target);
+			$journal_context = WCOS_Merge_Journal_Context::create($source, $target, $plan, $context_authority);
+		} catch (Throwable $throwable) {
+			return self::reject($report, 'incompatible_pair_context', $throwable->getMessage());
+		}
+
+		$pair = $journal_context['merge_pair'];
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('This pair is compatible with the initial hard-off Merge safety tranche.', 'wc-order-splitter');
+		$report['context_authority'] = $context_authority;
+		$report['source_signature'] = $pair['source_signature'];
+		$report['target_signature'] = $pair['target_signature'];
+		$report['pair_fingerprint'] = $pair['pair_fingerprint'];
+		$report['plan'] = $plan;
+		return $report;
+	}
+
+	private static function has_paid_evidence(WC_Order $order) {
+		return $order->is_paid()
+			|| null !== $order->get_date_paid()
+			|| '' !== (string) $order->get_transaction_id();
+	}
+
+	private static function has_refund_evidence(WC_Order $order) {
+		return $order->get_total_refunded() != 0 || !empty($order->get_refunds());
+	}
+
+	private static function assert_item_metadata_supported(WC_Order $order) {
+		$unknown = array();
+		$inconsistent = array();
+		foreach (array('line_item', 'shipping', 'fee', 'tax', 'coupon') as $item_type) {
+			foreach ($order->get_items($item_type) as $item) {
+				WCOS_Order_Item_Meta_Policy::business_metadata($item);
+				$unknown = array_merge(
+					$unknown,
+					WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE)
+				);
+				$inconsistent = array_merge(
+					$inconsistent,
+					WCOS_Order_Item_Meta_Policy::inconsistent_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE)
+				);
+			}
+		}
+		if (!empty($inconsistent)) {
+			throw new RuntimeException(__('Private item metadata classification is inconsistent between Merge copying and line identity.', 'wc-order-splitter'));
+		}
+		if (!empty($unknown)) {
+			throw new RuntimeException(__('Private order-item metadata is not classified for Merge compatibility.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/inc/domain/class-wcos-merge-preflight.php
+++ b/inc/domain/class-wcos-merge-preflight.php
@@ -140,19 +140,23 @@ final class WCOS_Merge_Preflight {
 			WCOS_Order_Totals_Rebuilder::assert_consistent($source, $precision);
 			WCOS_Order_Totals_Rebuilder::assert_consistent($target, $precision);
 			$plan = WCOS_Merge_Plan::build($source, $target);
-			$journal_context = WCOS_Merge_Journal_Context::create($source, $target, $plan, $context_authority);
+			$journal_context = WCOS_Merge_Journal_Context::create($source, $target, $plan, $context_authority, $precision);
 		} catch (Throwable $throwable) {
-			return self::reject($report, 'incompatible_pair_context', $throwable->getMessage());
+			return self::reject(
+				$report,
+				'incompatible_pair_context',
+				__('The order pair failed a hardened Merge compatibility check.', 'wc-order-splitter')
+			);
 		}
 
-		$pair = $journal_context['merge_pair'];
+		$pair = $journal_context['merge_pair']['authority'];
 		$report['supported'] = true;
 		$report['reason'] = 'supported';
 		$report['message'] = __('This pair is compatible with the initial hard-off Merge safety tranche.', 'wc-order-splitter');
 		$report['context_authority'] = $context_authority;
 		$report['source_signature'] = $pair['source_signature'];
 		$report['target_signature'] = $pair['target_signature'];
-		$report['pair_fingerprint'] = $pair['pair_fingerprint'];
+		$report['pair_fingerprint'] = $journal_context['merge_pair']['pair_fingerprint'];
 		$report['plan'] = $plan;
 		return $report;
 	}

--- a/inc/domain/class-wcos-merge-retirement-policy.php
+++ b/inc/domain/class-wcos-merge-retirement-policy.php
@@ -1,0 +1,68 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Unselected source-retirement candidates and their domain evidence model.
+ *
+ * This foundation registers no WooCommerce status and performs no lifecycle
+ * transition. A later boundary decision must select an evidenced candidate.
+ */
+final class WCOS_Merge_Retirement_Policy {
+
+	const SCHEMA_VERSION = 1;
+	const NON_FORCE_TRASH_ARCHIVE = 'non_force_trash_archive';
+	const DEDICATED_MERGED_ARCHIVE = 'dedicated_merged_archive';
+
+	public static function candidates() {
+		return array(
+			self::NON_FORCE_TRASH_ARCHIVE => array(
+				'identifier' => self::NON_FORCE_TRASH_ARCHIVE,
+				'preserve_commercial_record' => true,
+				'active_economic_owner_after' => false,
+				'normal_active_status_after' => false,
+				'hard_delete' => false,
+				'production_selected' => false,
+			),
+			self::DEDICATED_MERGED_ARCHIVE => array(
+				'identifier' => self::DEDICATED_MERGED_ARCHIVE,
+				'preserve_commercial_record' => true,
+				'active_economic_owner_after' => false,
+				'normal_active_status_after' => false,
+				'hard_delete' => false,
+				'production_selected' => false,
+			),
+		);
+	}
+
+	public static function identifiers() {
+		$identifiers = array_keys(self::candidates());
+		sort($identifiers, SORT_STRING);
+		return $identifiers;
+	}
+
+	public static function assert_candidate($identifier) {
+		$identifier = sanitize_key((string) $identifier);
+		$candidates = self::candidates();
+		if (!isset($candidates[$identifier])) {
+			throw new InvalidArgumentException(__('Unknown Merge source-retirement candidate.', 'wc-order-splitter'));
+		}
+		return $candidates[$identifier];
+	}
+
+	public static function assert_archive_preserved($before_signature, $after_signature) {
+		$before_signature = sanitize_key((string) $before_signature);
+		$after_signature = sanitize_key((string) $after_signature);
+		if ('' === $before_signature || !hash_equals($before_signature, $after_signature)) {
+			throw new RuntimeException(__('The retired source commercial archive no longer matches its pre-Merge evidence.', 'wc-order-splitter'));
+		}
+	}
+
+	public static function assert_active_ownership_conserved($before_active_signature, $after_target_signature) {
+		$before_active_signature = sanitize_key((string) $before_active_signature);
+		$after_target_signature = sanitize_key((string) $after_target_signature);
+		if ('' === $before_active_signature || !hash_equals($before_active_signature, $after_target_signature)) {
+			throw new RuntimeException(__('The active target does not conserve the pre-Merge active economic ownership contract.', 'wc-order-splitter'));
+		}
+	}
+}

--- a/inc/domain/class-wcos-multi-order-lease.php
+++ b/inc/domain/class-wcos-multi-order-lease.php
@@ -1,0 +1,100 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Deterministic all-or-nothing composition of existing order-operation leases.
+ *
+ * This class owns no lock storage. Every participant is acquired, refreshed,
+ * asserted, and released exclusively through WCOS_Operation_Lock.
+ */
+final class WCOS_Multi_Order_Lease {
+
+	private $operation_id;
+	private $leases;
+	private $released = false;
+
+	private function __construct($operation_id, array $leases) {
+		$this->operation_id = sanitize_key((string) $operation_id);
+		$this->leases = $leases;
+	}
+
+	public static function acquire(array $order_ids, $operation_id, $ttl = WCOS_Operation_Lock::DEFAULT_TTL) {
+		$order_ids = self::normalize_order_ids($order_ids);
+		$operation_id = sanitize_key((string) $operation_id);
+		if (empty($order_ids) || '' === $operation_id) {
+			throw new InvalidArgumentException(__('Persisted participant order IDs and an operation ID are required.', 'wc-order-splitter'));
+		}
+
+		$leases = array();
+		foreach ($order_ids as $order_id) {
+			$token = WCOS_Operation_Lock::acquire($order_id, $operation_id, $ttl);
+			if (false === $token) {
+				self::release_tokens($leases);
+				return false;
+			}
+			$leases[$order_id] = $token;
+		}
+
+		return new self($operation_id, $leases);
+	}
+
+	public static function normalize_order_ids(array $order_ids) {
+		$normalized = array_values(array_unique(array_filter(array_map('absint', $order_ids))));
+		sort($normalized, SORT_NUMERIC);
+		return $normalized;
+	}
+
+	public function order_ids() {
+		return array_map('intval', array_keys($this->leases));
+	}
+
+	public function operation_id() {
+		return $this->operation_id;
+	}
+
+	public function refresh($ttl = WCOS_Operation_Lock::DEFAULT_TTL) {
+		if ($this->released) {
+			return false;
+		}
+		foreach ($this->leases as $order_id => $token) {
+			if (!WCOS_Operation_Lock::refresh($order_id, $token, $ttl, $this->operation_id)) {
+				return false;
+			}
+		}
+		$this->assert_owned();
+		return true;
+	}
+
+	public function assert_owned() {
+		if ($this->released) {
+			throw new RuntimeException(__('The multi-order mutation lease has already been released.', 'wc-order-splitter'));
+		}
+		foreach ($this->leases as $order_id => $token) {
+			if (!WCOS_Operation_Lock::is_owned($order_id, $token, $this->operation_id)) {
+				throw new RuntimeException(__('A participant order lease is no longer owned by this operation.', 'wc-order-splitter'));
+			}
+		}
+	}
+
+	public function release() {
+		if ($this->released) {
+			return true;
+		}
+		$released = self::release_tokens($this->leases);
+		$this->released = true;
+		return $released;
+	}
+
+	private static function release_tokens(array $leases) {
+		$order_ids = array_keys($leases);
+		rsort($order_ids, SORT_NUMERIC);
+		$released = true;
+		foreach ($order_ids as $order_id) {
+			if (!WCOS_Operation_Lock::release($order_id, $leases[$order_id])) {
+				$released = false;
+			}
+		}
+		return $released;
+	}
+}

--- a/inc/domain/class-wcos-operation-journal-retention.php
+++ b/inc/domain/class-wcos-operation-journal-retention.php
@@ -113,12 +113,25 @@ final class WCOS_Operation_Journal_Retention {
          */
         if ('manual_reconciled' === $status
             && class_exists('WCOS_Manual_Reconciliation_Blocker')
-            && isset($record['source_order_id'], $record['operation_id'])
-            && WCOS_Manual_Reconciliation_Blocker::contains_operation(
-                absint($record['source_order_id']),
-                sanitize_key((string) $record['operation_id'])
-            )) {
-            return false;
+            && isset($record['source_order_id'], $record['operation_id'])) {
+            $journal_source_id = absint($record['source_order_id']);
+            $operation_id = sanitize_key((string) $record['operation_id']);
+            $participant_ids = array($journal_source_id);
+            if (class_exists('WCOS_Merge_Journal_Context')) {
+                $pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+                if (is_array($pair)) {
+                    $participant_ids = array(absint($pair['source_order_id']), absint($pair['target_order_id']));
+                }
+            }
+            foreach (array_values(array_unique(array_filter($participant_ids))) as $participant_id) {
+                if (WCOS_Manual_Reconciliation_Blocker::contains_operation(
+                    $participant_id,
+                    $operation_id,
+                    $journal_source_id
+                )) {
+                    return false;
+                }
+            }
         }
 
         $completed_at = isset($record['completed_at']) ? (string) $record['completed_at'] : '';

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -245,7 +245,7 @@ final class WCOS_Operation_Journal {
             if (class_exists('WCOS_Manual_Reconciliation_Blocker')) {
                 $fresh = wc_get_order($order->get_id());
                 if ($fresh instanceof WC_Order
-                    && !WCOS_Manual_Reconciliation_Blocker::resolve_if_reconciled($fresh, $operation_id)) {
+                    && !WCOS_Manual_Reconciliation_Blocker::resolve_pair_if_reconciled($fresh, $operation_id)) {
                     do_action('wcos_manual_reconciliation_blocker_clear_error', $fresh, $operation_id);
                 }
             }

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -15,6 +15,7 @@ final class WCOS_Order_Item_Meta_Policy {
 
 	const CONTEXT_DUPLICATE = 'duplicate';
 	const CONTEXT_SPLIT = 'split';
+	const CONTEXT_MERGE = 'merge';
 	const CONTEXT_IDENTITY = 'identity';
 
 	const CLASS_BUSINESS = 'business';
@@ -105,14 +106,15 @@ final class WCOS_Order_Item_Meta_Policy {
 	 * otherwise copy configuration that is absent from identity, making distinct
 	 * configured lines indistinguishable to conservation/recovery contracts.
 	 */
-	public static function inconsistent_private_keys(WC_Order_Item $item) {
+	public static function inconsistent_private_keys(WC_Order_Item $item, $copy_context = self::CONTEXT_SPLIT) {
+		$copy_context = sanitize_key((string) $copy_context);
 		$inconsistent = array();
 		foreach ($item->get_meta_data() as $meta) {
 			$key = (string) $meta->key;
 			if (0 !== strpos($key, '_') || self::is_protected($key)) {
 				continue;
 			}
-			$split = self::classify($key, $meta->value, self::CONTEXT_SPLIT, $item);
+			$split = self::classify($key, $meta->value, $copy_context, $item);
 			$identity = self::classify($key, $meta->value, self::CONTEXT_IDENTITY, $item);
 			if ($split !== $identity) {
 				$inconsistent[] = $key;

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -11,6 +11,13 @@ function wcos_merge_foundation_assert($condition, $message) {
 }
 
 function wcos_merge_foundation_order($email, $line_count = 1) {
+	$product = new WC_Product_Simple();
+	$product->set_name('Merge foundation deleted-product fixture');
+	$product->set_regular_price('10.00');
+	$product->set_price('10.00');
+	$product_id = $product->save();
+	wcos_merge_foundation_assert($product_id > 0, 'Unable to create historical product fixture.');
+
 	$order = wc_create_order();
 	$order->set_status('pending');
 	$order->set_currency('USD');
@@ -37,8 +44,7 @@ function wcos_merge_foundation_order($email, $line_count = 1) {
 	for ($index = 0; $index < $line_count; $index++) {
 		$item = new WC_Order_Item_Product();
 		$item->set_name('Persisted configured line');
-		$item->set_product_id(999999);
-		$item->set_variation_id(888888);
+		$item->set_product_id($product_id);
 		$item->set_quantity(1);
 		$item->set_subtotal('10.00');
 		$item->set_total('10.00');
@@ -50,6 +56,7 @@ function wcos_merge_foundation_order($email, $line_count = 1) {
 	}
 	$order->calculate_totals(false);
 	$order->save();
+	$product->delete(true);
 	return wc_get_order($order->get_id());
 }
 

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -1,0 +1,335 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_merge_foundation_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_merge_foundation_order($email, $line_count = 1) {
+	$order = wc_create_order();
+	$order->set_status('pending');
+	$order->set_currency('USD');
+	$order->set_customer_id(0);
+	$order->set_billing_email($email);
+	$order->set_billing_first_name('Merge');
+	$order->set_billing_last_name('Contract');
+	$order->set_billing_address_1('37 Foundation Way');
+	$order->set_billing_city('Testville');
+	$order->set_billing_state('CA');
+	$order->set_billing_postcode('90001');
+	$order->set_billing_country('US');
+	$order->set_billing_phone('+1 555 0100');
+	$order->set_shipping_first_name('Merge');
+	$order->set_shipping_last_name('Contract');
+	$order->set_shipping_address_1('37 Foundation Way');
+	$order->set_shipping_city('Testville');
+	$order->set_shipping_state('CA');
+	$order->set_shipping_postcode('90001');
+	$order->set_shipping_country('US');
+	$order->set_payment_method('cod');
+	$order->set_payment_method_title('Cash on delivery');
+
+	for ($index = 0; $index < $line_count; $index++) {
+		$item = new WC_Order_Item_Product();
+		$item->set_name('Persisted configured line');
+		$item->set_product_id(999999);
+		$item->set_variation_id(888888);
+		$item->set_quantity(1);
+		$item->set_subtotal('10.00');
+		$item->set_total('10.00');
+		$item->set_subtotal_tax('0.00');
+		$item->set_total_tax('0.00');
+		$item->set_taxes(array('subtotal' => array(), 'total' => array()));
+		$item->add_meta_data('Configuration', array('finish' => 'matte', 'slot' => 'A'), true);
+		$order->add_item($item);
+	}
+	$order->calculate_totals(false);
+	$order->save();
+	return wc_get_order($order->get_id());
+}
+
+function wcos_merge_foundation_reason(WC_Order $source, WC_Order $target) {
+	return WCOS_Merge_Preflight::report($source, $target)['reason'];
+}
+
+function wcos_merge_foundation_expect_reason(WC_Order $source, WC_Order $target, $reason, $message) {
+	wcos_merge_foundation_assert($reason === wcos_merge_foundation_reason($source, $target), $message);
+}
+
+$email = 'merge-' . wp_generate_uuid4() . '@example.test';
+$source = wcos_merge_foundation_order($email, 2);
+$target = wcos_merge_foundation_order($email, 1);
+$source_id = $source->get_id();
+$target_id = $target->get_id();
+
+/* Production enablement and routing remain intentionally absent. */
+wcos_merge_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'MERGE gate became enabled.');
+wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual strategy gate changed.');
+wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate changed.');
+wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock strategy gate changed.');
+$gateway = new WCOS_Mutation_Gateway();
+try {
+	$gateway->merge($source, $target, 'merge-foundation-disabled');
+	throw new RuntimeException('Gateway unexpectedly exposed Merge execution.');
+} catch (RuntimeException $exception) {
+	wcos_merge_foundation_assert(false !== strpos($exception->getMessage(), 'disabled'), 'Gateway no longer fails at the hard-off Merge boundary.');
+}
+
+/* Canonical historical-state planning is read-only and never coalesces lines. */
+$report = WCOS_Merge_Preflight::assert_supported($source, $target);
+wcos_merge_foundation_assert(2 === count($report['plan']['lines']), 'Plan did not preserve one target line per source item.');
+wcos_merge_foundation_assert(false === $report['plan']['coalesce_lines'], 'Plan enabled line coalescing.');
+$source_line_ids = array_column($report['plan']['lines'], 'source_item_id');
+wcos_merge_foundation_assert(2 === count(array_unique($source_line_ids)), 'Configured variation lines collided by source item ID.');
+wcos_merge_foundation_assert(
+	WCOS_Merge_Plan::fingerprint($report['plan']) === WCOS_Merge_Plan::fingerprint(WCOS_Merge_Plan::build(wc_get_order($source_id), wc_get_order($target_id))),
+	'Canonical plan fingerprint was not stable.'
+);
+wcos_merge_foundation_assert(
+	WCOS_Merge_Retirement_Policy::identifiers() === $report['retirement_candidates'],
+	'Retirement candidates changed or became selected.'
+);
+
+/* Keyed compatibility proof contains no durable raw customer context. */
+$durable_json = wp_json_encode(array($report['context_authority'], $report['plan']));
+foreach (array($email, '37 Foundation Way', '+1 555 0100') as $pii) {
+	wcos_merge_foundation_assert(false === strpos($durable_json, $pii), 'Raw PII entered a durable Merge proof.');
+}
+$tampered_context = $report['context_authority'];
+$tampered_context['billing_context_digest'] = str_repeat('0', 64);
+try {
+	WCOS_Merge_Context_Signature::assert_current($source, $tampered_context);
+	throw new RuntimeException('Tampered keyed context was accepted.');
+} catch (RuntimeException $exception) {
+	wcos_merge_foundation_assert(false !== strpos($exception->getMessage(), 'signature'), 'Unexpected keyed-signature failure.');
+}
+
+$registered_source = wcos_merge_foundation_order('registered@example.test', 1);
+$registered_target = wcos_merge_foundation_order('registered@example.test', 1);
+$registered_source->set_customer_id(707);
+$registered_target->set_customer_id(707);
+$registered_source->save();
+$registered_target->save();
+$registered_context = WCOS_Merge_Context_Signature::compatibility($registered_source, $registered_target);
+wcos_merge_foundation_assert('registered' === $registered_context['identity_type'], 'Equal registered customer IDs did not form keyed identity authority.');
+$registered_target->set_customer_id(708);
+$registered_target->save();
+wcos_merge_foundation_expect_reason($registered_source, $registered_target, 'incompatible_pair_context', 'Different registered customer IDs passed preflight.');
+$registered_source->delete(true);
+$registered_target->delete(true);
+
+/* Narrow policy rejection matrix. */
+wcos_merge_foundation_expect_reason($source, $source, 'same_order', 'Self Merge passed preflight.');
+$target->set_currency('EUR');
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_currency', 'Currency mismatch passed preflight.');
+$target->set_currency('USD');
+$target->set_status('on-hold');
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_status', 'Status mismatch passed preflight.');
+$target->set_status('pending');
+$target->set_payment_method('bacs');
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_pair_context', 'Payment mismatch passed preflight.');
+$target->set_payment_method('cod');
+$target->set_customer_id(77);
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_pair_context', 'Customer mismatch passed preflight.');
+$target->set_customer_id(0);
+$target->set_billing_phone('+1 555 9999');
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_pair_context', 'Billing-context mismatch passed preflight.');
+$failure_json = wp_json_encode(WCOS_Merge_Preflight::report($source, $target));
+foreach (array($email, '37 Foundation Way', '+1 555 9999') as $pii) {
+	wcos_merge_foundation_assert(false === strpos($failure_json, $pii), 'Raw PII entered preflight failure evidence.');
+}
+$target->set_billing_phone('+1 555 0100');
+$target->set_transaction_id('txn_foundation_reject');
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'paid_order_unsupported', 'Transaction-bearing order passed preflight.');
+$target->set_transaction_id('');
+$target->save();
+
+$coupon = new WC_Order_Item_Coupon();
+$coupon->set_code('foundation');
+$coupon->set_discount('1.00');
+$coupon->set_discount_tax('0.00');
+$target->add_item($coupon);
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'coupon_policy_missing', 'Coupon ownership passed preflight.');
+$target->remove_item($coupon->get_id());
+$fee = new WC_Order_Item_Fee();
+$fee->set_name('Foundation fee');
+$fee->set_amount('1.00');
+$fee->set_total('1.00');
+$target->add_item($fee);
+$target->save();
+wcos_merge_foundation_expect_reason($source, $target, 'fee_policy_missing', 'Fee ownership passed preflight.');
+$target->remove_item($fee->get_id());
+$target->save();
+
+$shipping = new WC_Order_Item_Shipping();
+$shipping->set_method_title('Foundation shipping');
+$shipping->set_method_id('flat_rate');
+$shipping->set_total('1.00');
+$source->add_item($shipping);
+$source->save();
+wcos_merge_foundation_expect_reason($source, $target, 'source_shipping_policy_missing', 'Source shipping ownership passed preflight.');
+$source->remove_item($shipping->get_id());
+$source->save();
+
+$source_items = $source->get_items('line_item');
+$first_source_item = reset($source_items);
+$first_source_item->add_meta_data('_unclassified_merge_state', 'unsafe', true);
+$first_source_item->save();
+wcos_merge_foundation_expect_reason($source, $target, 'incompatible_pair_context', 'Unknown private item metadata passed preflight.');
+$first_source_item->delete_meta_data('_unclassified_merge_state');
+$first_source_item->save();
+
+$blank_guest = wcos_merge_foundation_order('', 1);
+wcos_merge_foundation_expect_reason($source, $blank_guest, 'incompatible_pair_context', 'Blank guest identity passed preflight.');
+$blank_guest->delete(true);
+
+$refund_source = wcos_merge_foundation_order($email, 1);
+$refund_target = wcos_merge_foundation_order($email, 1);
+$refund = wc_create_refund(array(
+	'amount' => '1.00',
+	'reason' => 'Merge foundation rejection fixture',
+	'order_id' => $refund_target->get_id(),
+	'refund_payment' => false,
+	'restock_items' => false,
+));
+wcos_merge_foundation_assert($refund instanceof WC_Order_Refund, 'Unable to establish refund policy fixture.');
+wcos_merge_foundation_expect_reason($refund_source, wc_get_order($refund_target->get_id()), 'refund_policy_missing', 'Refund ownership passed preflight.');
+$refund->delete(true);
+$refund_source->delete(true);
+$refund_target->delete(true);
+
+/* Deterministic multi-order lease: reverse inputs, partial rollback, crossed attempts. */
+$partial_operation = 'merge-partial-' . wp_generate_uuid4();
+$competing_token = WCOS_Operation_Lock::acquire($target_id, 'merge-competitor', 60);
+wcos_merge_foundation_assert(false !== $competing_token, 'Unable to establish competing lease fixture.');
+wcos_merge_foundation_assert(false === WCOS_Multi_Order_Lease::acquire(array($target_id, $source_id), $partial_operation, 60), 'Partial lease acquisition did not fail atomically.');
+$rollback_token = WCOS_Operation_Lock::acquire($source_id, 'merge-rollback-proof', 60);
+wcos_merge_foundation_assert(false !== $rollback_token, 'Partial lease acquisition leaked its first lease.');
+wcos_merge_foundation_assert(WCOS_Operation_Lock::release($source_id, $rollback_token), 'Rollback proof lease did not release.');
+wcos_merge_foundation_assert(WCOS_Operation_Lock::release($target_id, $competing_token), 'Competing lease did not release.');
+
+$stale_source = wcos_merge_foundation_order($email, 1);
+$stale_target = wcos_merge_foundation_order($email, 1);
+$stale_operation = 'merge-stale-' . wp_generate_uuid4();
+$stale_lease = WCOS_Multi_Order_Lease::acquire(array($stale_target->get_id(), $stale_source->get_id()), $stale_operation, 60);
+wcos_merge_foundation_assert($stale_lease instanceof WCOS_Multi_Order_Lease, 'Unable to establish stale lease fixture.');
+$stale_lock_key = 'wcos_mutation_lock_' . $stale_source->get_id();
+$stale_value = get_option($stale_lock_key);
+$stale_value['expires_at'] = time() - 1;
+update_option($stale_lock_key, $stale_value, false);
+$successor_token = WCOS_Operation_Lock::acquire($stale_source->get_id(), 'merge-successor', 60);
+wcos_merge_foundation_assert(false !== $successor_token, 'Expired participant lease could not be taken over.');
+wcos_merge_foundation_assert(false === $stale_lease->release(), 'Stale multi-order release reported full ownership.');
+wcos_merge_foundation_assert(WCOS_Operation_Lock::is_owned($stale_source->get_id(), $successor_token, 'merge-successor'), 'Stale release removed a successor lease.');
+wcos_merge_foundation_assert(WCOS_Operation_Lock::release($stale_source->get_id(), $successor_token), 'Successor lease did not release.');
+$stale_source->delete(true);
+$stale_target->delete(true);
+
+$operation_id = 'merge-foundation-' . wp_generate_uuid4();
+$lease = WCOS_Multi_Order_Lease::acquire(array($target_id, $source_id, $target_id), $operation_id, 60);
+wcos_merge_foundation_assert($lease instanceof WCOS_Multi_Order_Lease, 'Pair lease could not be acquired.');
+wcos_merge_foundation_assert(array($source_id, $target_id) === $lease->order_ids(), 'Pair lease did not normalize ascending unique IDs.');
+wcos_merge_foundation_assert(false === WCOS_Multi_Order_Lease::acquire(array($source_id, $target_id), 'merge-crossed', 60), 'Crossed acquisition bypassed an owned pair lease.');
+wcos_merge_foundation_assert($lease->refresh(60), 'Pair lease refresh failed.');
+$lease->assert_owned();
+
+/* One source journal is authority; scalar participation closes the blocker crash window. */
+$report = WCOS_Merge_Preflight::assert_supported(wc_get_order($source_id), wc_get_order($target_id));
+$context = WCOS_Merge_Journal_Context::create($source, $target, $report['plan'], $report['context_authority']);
+wcos_merge_foundation_assert(WCOS_Operation_Journal::start($source, $operation_id, 'merge', $context, $report['pair_fingerprint']), 'Source Merge journal did not start.');
+$target->add_meta_data(WCOS_Merge_Participation::TARGET_SOURCE_META, 424242, false);
+$target->add_meta_data(WCOS_Merge_Participation::TARGET_OPERATION_META, 'unrelated-operation', false);
+$target->save_meta_data();
+wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation did not persist.');
+wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation was not idempotent.');
+$fresh_target = wc_get_order($target_id);
+wcos_merge_foundation_assert(1 === count(array_filter(array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_AUTHORITY_META, false)), static function($value) use ($operation_id) {
+	return false !== strpos($value, '|' . $operation_id . '|');
+})), 'Idempotent persistence duplicated the atomic target authority pointer.');
+wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source), true), 'Source crash window did not fail closed.');
+wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_target), true), 'Target crash window did not dereference the source journal.');
+$discovered_target_ids = array_map(static function($order) { return $order->get_id(); }, WCOS_Merge_Participation::find_targets($source_id, $operation_id));
+wcos_merge_foundation_assert(in_array($target_id, $discovered_target_ids, true), 'Relation discovery did not find the target in the active storage mode.');
+
+wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($source, $source, $operation_id, 'source', $target_id, $report['pair_fingerprint']), 'Source participant blocker did not persist.');
+wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_target), true), 'Missing target blocker after source persistence did not fail closed through participation.');
+wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($target, $source, $operation_id, 'target', $source_id, $report['pair_fingerprint']), 'Target participant blocker did not persist.');
+$journal = WCOS_Operation_Journal::get($source, $operation_id);
+$durable_json = wp_json_encode(array($journal, get_option('wcos_manual_reconcile_block_' . $source_id), get_option('wcos_manual_reconcile_block_' . $target_id)));
+foreach (array($email, '37 Foundation Way', '+1 555 0100') as $pii) {
+	wcos_merge_foundation_assert(false === strpos($durable_json, $pii), 'Raw PII entered journal or blocker evidence.');
+}
+
+/* Target fallback alone remains authoritative and resolves only from the newer source journal. */
+$target_blocker_key = 'wcos_manual_reconcile_block_' . $target_id;
+$target_primary = get_option($target_blocker_key);
+$target_incident = $target_primary['operations'][$operation_id];
+$fresh_target->update_meta_data(WCOS_Manual_Reconciliation_Blocker::FALLBACK_META_PREFIX . $operation_id, $target_incident);
+$fresh_target->save_meta_data();
+delete_option($target_blocker_key);
+wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_target), true), 'Target-only fallback blocker did not fail closed.');
+$source_blocker_key = 'wcos_manual_reconcile_block_' . $source_id;
+$source_primary = get_option($source_blocker_key);
+$source_incident = $source_primary['operations'][$operation_id];
+$fresh_source = wc_get_order($source_id);
+$fresh_source->update_meta_data(WCOS_Manual_Reconciliation_Blocker::FALLBACK_META_PREFIX . $operation_id, $source_incident);
+$fresh_source->save_meta_data();
+delete_option($source_blocker_key);
+wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_source), true), 'Source-only fallback blocker did not fail closed.');
+wcos_merge_foundation_assert(WCOS_Operation_Journal::mark_manual_reconciliation($source, $operation_id, array('reason' => 'foundation_test')), 'Manual-reconciliation transition failed.');
+wcos_merge_foundation_assert(WCOS_Operation_Journal::mark_manual_reconciled($source, $operation_id, array('resolution' => 'verified')), 'Manual-reconciled transition failed.');
+wcos_merge_foundation_assert(!in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids(wc_get_order($source_id)), true), 'Source blocker survived authoritative reconciliation.');
+wcos_merge_foundation_assert(!in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids(wc_get_order($target_id)), true), 'Target fallback survived authoritative reconciliation.');
+
+/* A newer incident cannot be cleared by the older reconciliation, and either participant preserves retention proof. */
+wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_pair($source, $target, $operation_id, $report['pair_fingerprint']), 'Unable to establish newer pair incidents.');
+wcos_merge_foundation_assert(!WCOS_Manual_Reconciliation_Blocker::resolve_if_reconciled($source, $operation_id), 'Older reconciliation cleared a newer source incident.');
+wcos_merge_foundation_assert(!WCOS_Manual_Reconciliation_Blocker::resolve_if_reconciled($target, $operation_id), 'Older reconciliation cleared a newer target incident.');
+$old_record = WCOS_Operation_Journal::get($source, $operation_id);
+$old_record['completed_at'] = '2000-01-01T00:00:00+00:00';
+wcos_merge_foundation_assert(!WCOS_Operation_Journal_Retention::is_expired_terminal_record($old_record, time()), 'Retention discarded proof while pair blockers remained.');
+delete_option('wcos_manual_reconcile_block_' . $target_id);
+wcos_merge_foundation_assert(!WCOS_Operation_Journal_Retention::is_expired_terminal_record($old_record, time()), 'Retention discarded proof after only one participant blocker cleared.');
+delete_option('wcos_manual_reconcile_block_' . $source_id);
+wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($target, $source, $operation_id, 'target', $source_id, $report['pair_fingerprint']), 'Unable to restore target-only retention fixture.');
+wcos_merge_foundation_assert(!WCOS_Operation_Journal_Retention::is_expired_terminal_record($old_record, time()), 'Retention discarded proof while only the target blocker remained.');
+delete_option('wcos_manual_reconcile_block_' . $target_id);
+
+wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup failed.');
+$fresh_target = wc_get_order($target_id);
+wcos_merge_foundation_assert(in_array('424242', array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_SOURCE_META, false)), true), 'Cleanup removed an unrelated source relation.');
+wcos_merge_foundation_assert(in_array('unrelated-operation', array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_OPERATION_META, false)), true), 'Cleanup removed an unrelated operation relation.');
+wcos_merge_foundation_assert($lease->release(), 'Pair lease did not release safely.');
+
+/* Cleanup test records after terminal journal proof is no longer referenced. */
+WCOS_Operation_Journal::delete($source, $operation_id);
+$source->delete(true);
+$target->delete(true);
+
+/* A surviving participant remains blocked when its peer disappears. */
+$orphan_source = wcos_merge_foundation_order($email, 1);
+$orphan_target = wcos_merge_foundation_order($email, 1);
+$orphan_report = WCOS_Merge_Preflight::assert_supported($orphan_source, $orphan_target);
+$orphan_operation = 'merge-orphan-' . wp_generate_uuid4();
+$orphan_context = WCOS_Merge_Journal_Context::create($orphan_source, $orphan_target, $orphan_report['plan'], $orphan_report['context_authority']);
+wcos_merge_foundation_assert(WCOS_Operation_Journal::start($orphan_source, $orphan_operation, 'merge', $orphan_context, $orphan_report['pair_fingerprint']), 'Orphan journal fixture did not start.');
+wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($orphan_source, $orphan_source, $orphan_operation, 'source', $orphan_target->get_id(), $orphan_report['pair_fingerprint']), 'Orphan source blocker did not persist.');
+$orphan_target->delete(true);
+wcos_merge_foundation_assert(in_array($orphan_operation, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($orphan_source), true), 'Deleted peer made the surviving participant appear safe.');
+delete_option('wcos_manual_reconcile_block_' . $orphan_source->get_id());
+WCOS_Operation_Journal::delete($orphan_source, $orphan_operation);
+$orphan_source->delete(true);
+
+echo "merge-domain-foundation-ok\n";

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -68,6 +68,17 @@ function wcos_merge_foundation_expect_reason(WC_Order $source, WC_Order $target,
 	wcos_merge_foundation_assert($reason === wcos_merge_foundation_reason($source, $target), $message);
 }
 
+function wcos_merge_foundation_meta_values(WC_Order $order, $key) {
+	$values = array();
+	foreach ($order->get_meta_data() as $meta) {
+		$data = $meta->get_data();
+		if (isset($data['key']) && (string) $data['key'] === (string) $key && array_key_exists('value', $data)) {
+			$values[] = $data['value'];
+		}
+	}
+	return $values;
+}
+
 $email = 'merge-' . wp_generate_uuid4() . '@example.test';
 $source = wcos_merge_foundation_order($email, 2);
 $target = wcos_merge_foundation_order($email, 1);
@@ -264,7 +275,7 @@ $target->save_meta_data();
 wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation did not persist.');
 wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation was not idempotent.');
 $fresh_target = wc_get_order($target_id);
-wcos_merge_foundation_assert(1 === count(array_filter(array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_AUTHORITY_META, false)), static function($value) use ($operation_id) {
+wcos_merge_foundation_assert(1 === count(array_filter(array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_AUTHORITY_META)), static function($value) use ($operation_id) {
 	return false !== strpos($value, '|' . $operation_id . '|');
 })), 'Idempotent persistence duplicated the atomic target authority pointer.');
 wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source), true), 'Source crash window did not fail closed.');
@@ -318,8 +329,8 @@ delete_option('wcos_manual_reconcile_block_' . $target_id);
 
 wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup failed.');
 $fresh_target = wc_get_order($target_id);
-wcos_merge_foundation_assert(in_array('424242', array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_SOURCE_META, false)), true), 'Cleanup removed an unrelated source relation.');
-wcos_merge_foundation_assert(in_array('unrelated-operation', array_map('strval', $fresh_target->get_meta(WCOS_Merge_Participation::TARGET_OPERATION_META, false)), true), 'Cleanup removed an unrelated operation relation.');
+wcos_merge_foundation_assert(in_array('424242', array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_SOURCE_META)), true), 'Cleanup removed an unrelated source relation.');
+wcos_merge_foundation_assert(in_array('unrelated-operation', array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_OPERATION_META)), true), 'Cleanup removed an unrelated operation relation.');
 wcos_merge_foundation_assert($lease->release(), 'Pair lease did not release safely.');
 
 /* Cleanup test records after terminal journal proof is no longer referenced. */

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -129,6 +129,20 @@ try {
 	wcos_merge_foundation_assert(false !== strpos($exception->getMessage(), 'signature'), 'Unexpected keyed-signature failure.');
 }
 
+/* Preflight never publishes arbitrary extension exception text or PII. */
+$pii_exception_filter = static function() use ($email) {
+	throw new RuntimeException('Extension failure for ' . $email . ' at 37 Foundation Way, +1 555 0100');
+};
+add_filter('wcos_order_item_meta_classification', $pii_exception_filter, PHP_INT_MAX, 6);
+$pii_exception_report = WCOS_Merge_Preflight::report($source, $target);
+remove_filter('wcos_order_item_meta_classification', $pii_exception_filter, PHP_INT_MAX);
+wcos_merge_foundation_assert('incompatible_pair_context' === $pii_exception_report['reason'], 'Extension exception used an unstable preflight reason.');
+wcos_merge_foundation_assert('The order pair failed a hardened Merge compatibility check.' === $pii_exception_report['message'], 'Extension exception used an unstable preflight message.');
+$pii_exception_json = wp_json_encode($pii_exception_report);
+foreach (array($email, '37 Foundation Way', '+1 555 0100') as $pii) {
+	wcos_merge_foundation_assert(false === strpos($pii_exception_json, $pii), 'Extension exception PII entered preflight evidence.');
+}
+
 $registered_source = wcos_merge_foundation_order('registered@example.test', 1);
 $registered_target = wcos_merge_foundation_order('registered@example.test', 1);
 $registered_source->set_customer_id(707);
@@ -267,10 +281,49 @@ $lease->assert_owned();
 
 /* One source journal is authority; scalar participation closes the blocker crash window. */
 $report = WCOS_Merge_Preflight::assert_supported(wc_get_order($source_id), wc_get_order($target_id));
-$context = WCOS_Merge_Journal_Context::create($source, $target, $report['plan'], $report['context_authority']);
+$context = WCOS_Merge_Journal_Context::create($source, $target, $report['plan'], $report['context_authority'], $report['price_precision']);
 wcos_merge_foundation_assert(WCOS_Operation_Journal::start($source, $operation_id, 'merge', $context, $report['pair_fingerprint']), 'Source Merge journal did not start.');
+$journal = WCOS_Operation_Journal::get($source, $operation_id);
+$verified_pair = WCOS_Merge_Journal_Context::pair_from_record($journal);
+wcos_merge_foundation_assert(is_array($verified_pair), 'Canonical Merge pair authority did not self-verify.');
+wcos_merge_foundation_assert($report['price_precision'] === $verified_pair['price_precision'], 'Pair authority lost price-precision authority.');
+wcos_merge_foundation_assert(WCOS_Merge_Preflight::POLICY_VERSION === $verified_pair['preflight_policy_version'], 'Pair authority lost preflight-policy authority.');
+
+/* Every durable pair-authority field is independently tamper-evident. */
+$authority_tamper_cases = array(
+	'source_order_id' => static function(&$record) { $record['context']['merge_pair']['authority']['source_order_id']++; },
+	'target_order_id' => static function(&$record) { $record['context']['merge_pair']['authority']['target_order_id']++; },
+	'source_signature' => static function(&$record) { $record['context']['merge_pair']['authority']['source_signature'] = str_repeat('1', 64); },
+	'target_signature' => static function(&$record) { $record['context']['merge_pair']['authority']['target_signature'] = str_repeat('2', 64); },
+	'plan_schema_version' => static function(&$record) { $record['context']['merge_pair']['authority']['plan_schema_version']++; },
+	'plan_fingerprint' => static function(&$record) { $record['context']['merge_pair']['authority']['plan_fingerprint'] = str_repeat('3', 64); },
+	'price_precision' => static function(&$record) { $record['context']['merge_pair']['authority']['price_precision']++; },
+	'preflight_policy_version' => static function(&$record) { $record['context']['merge_pair']['authority']['preflight_policy_version']++; },
+	'context_signature_version' => static function(&$record) { $record['context']['merge_pair']['authority']['context_signature_version']++; },
+	'context_authority' => static function(&$record) { $record['context']['merge_pair']['authority']['context_authority']['billing_context_digest'] = str_repeat('4', 64); },
+	'context_authority_fingerprint' => static function(&$record) { $record['context']['merge_pair']['authority']['context_authority_fingerprint'] = str_repeat('5', 64); },
+	'retirement_policy_schema_version' => static function(&$record) { $record['context']['merge_pair']['authority']['retirement_policy_schema_version']++; },
+	'retirement_candidates' => static function(&$record) { $record['context']['merge_pair']['authority']['retirement_candidates'][] = 'unreviewed'; },
+	'retirement_policy_selected' => static function(&$record) { $record['context']['merge_pair']['authority']['retirement_policy_selected'] = true; },
+	'archive_source_signature_before' => static function(&$record) { $record['context']['merge_pair']['authority']['archive_source_signature_before'] = str_repeat('6', 64); },
+	'active_ownership_before_signature' => static function(&$record) { $record['context']['merge_pair']['authority']['active_ownership_before_signature'] = str_repeat('7', 64); },
+	'participation_schema_version' => static function(&$record) { $record['context']['merge_pair']['authority']['participation_schema_version']++; },
+	'pair_schema_version' => static function(&$record) { $record['context']['merge_pair']['schema_version']++; },
+	'pair_fingerprint' => static function(&$record) { $record['context']['merge_pair']['pair_fingerprint'] = str_repeat('8', 64); },
+	'journal_fingerprint' => static function(&$record) { $record['fingerprint'] = str_repeat('9', 64); },
+	'journal_source_order_id' => static function(&$record) { $record['source_order_id']++; },
+	'journal_price_precision' => static function(&$record) { $record['context']['price_precision']++; },
+);
+foreach ($authority_tamper_cases as $field => $tamper) {
+	$tampered_record = $journal;
+	$tamper($tampered_record);
+	wcos_merge_foundation_assert(null === WCOS_Merge_Journal_Context::pair_from_record($tampered_record), 'Tampered pair authority field was accepted: ' . $field);
+}
+
+$unrelated_pointer = '424242|unrelated-operation|' . str_repeat('f', 64);
 $target->add_meta_data(WCOS_Merge_Participation::TARGET_SOURCE_META, 424242, false);
 $target->add_meta_data(WCOS_Merge_Participation::TARGET_OPERATION_META, 'unrelated-operation', false);
+$target->add_meta_data(WCOS_Merge_Participation::TARGET_AUTHORITY_META, $unrelated_pointer, false);
 $target->save_meta_data();
 wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation did not persist.');
 wcos_merge_foundation_assert(WCOS_Merge_Participation::persist($source, $target, $operation_id, $report['pair_fingerprint']), 'Pair participation was not idempotent.');
@@ -282,6 +335,50 @@ wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_
 wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_target), true), 'Target crash window did not dereference the source journal.');
 $discovered_target_ids = array_map(static function($order) { return $order->get_id(); }, WCOS_Merge_Participation::find_targets($source_id, $operation_id));
 wcos_merge_foundation_assert(in_array($target_id, $discovered_target_ids, true), 'Relation discovery did not find the target in the active storage mode.');
+
+/* Invalid journal identity and corrupt participation remain blocking authority. */
+$journal_option_key = 'wcos_mutation_op_' . hash('sha256', $source_id . '|' . sanitize_key($operation_id));
+$journal_mismatch_cases = array(
+	'type' => static function(&$record) { $record['type'] = 'split'; },
+	'source' => static function(&$record) { $record['source_order_id']++; },
+	'target' => static function(&$record) { $record['context']['merge_pair']['authority']['target_order_id']++; },
+	'pair' => static function(&$record) { $record['context']['merge_pair']['pair_fingerprint'] = str_repeat('a', 64); },
+	'fingerprint' => static function(&$record) { $record['fingerprint'] = str_repeat('b', 64); },
+	'operation' => static function(&$record) { $record['operation_id'] = 'different-operation'; },
+);
+foreach ($journal_mismatch_cases as $field => $tamper) {
+	$tampered_record = $journal;
+	$tamper($tampered_record);
+	update_option($journal_option_key, $tampered_record, false);
+	wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids(wc_get_order($source_id)), true), 'Source failed open for journal mismatch: ' . $field);
+	wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids(wc_get_order($target_id)), true), 'Target failed open for journal mismatch: ' . $field);
+	wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Merge_Preflight::report(wc_get_order($source_id), wc_get_order($target_id))['reason'], 'Merge preflight failed open for journal mismatch: ' . $field);
+	wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Duplicate_Preflight::report(wc_get_order($source_id))['reason'], 'Duplicate preflight failed open for journal mismatch: ' . $field);
+	wcos_merge_foundation_assert('manual_reconciliation_required' === (new WCOS_Split_WooCommerce_Adapter())->preflight(wc_get_order($source_id))['reason'], 'Split preflight failed open for journal mismatch: ' . $field);
+}
+update_option($journal_option_key, $journal, false);
+
+$malformed_pointer = $source_id . '|' . $operation_id . '|malformed';
+$fresh_target->add_meta_data(WCOS_Merge_Participation::TARGET_AUTHORITY_META, $malformed_pointer, false);
+$fresh_target->save_meta_data();
+wcos_merge_foundation_assert(!empty(WCOS_Merge_Participation::unresolved_operation_ids(wc_get_order($target_id))), 'Malformed target participation failed open.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Merge_Preflight::report(wc_get_order($source_id), wc_get_order($target_id))['reason'], 'Merge preflight ignored malformed participation.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Duplicate_Preflight::report(wc_get_order($target_id))['reason'], 'Duplicate preflight ignored malformed participation.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === (new WCOS_Split_WooCommerce_Adapter())->preflight(wc_get_order($target_id))['reason'], 'Split preflight ignored malformed participation.');
+$fresh_target = wc_get_order($target_id);
+$fresh_target->delete_meta_data_value(WCOS_Merge_Participation::TARGET_AUTHORITY_META, $malformed_pointer);
+$fresh_target->save_meta_data();
+$conflicting_operation = 'merge-conflict-' . wp_generate_uuid4();
+$fresh_source = wc_get_order($source_id);
+$fresh_source->add_meta_data(WCOS_Merge_Participation::SOURCE_OPERATION_META, $conflicting_operation, false);
+$fresh_source->save_meta_data();
+wcos_merge_foundation_assert(!empty(WCOS_Merge_Participation::unresolved_operation_ids(wc_get_order($source_id))), 'Conflicting source participation failed open.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Merge_Preflight::report(wc_get_order($source_id), wc_get_order($target_id))['reason'], 'Merge preflight ignored conflicting participation.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === WCOS_Duplicate_Preflight::report(wc_get_order($source_id))['reason'], 'Duplicate preflight ignored conflicting participation.');
+wcos_merge_foundation_assert('manual_reconciliation_required' === (new WCOS_Split_WooCommerce_Adapter())->preflight(wc_get_order($source_id))['reason'], 'Split preflight ignored conflicting participation.');
+$fresh_source = wc_get_order($source_id);
+$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_OPERATION_META, $conflicting_operation);
+$fresh_source->save_meta_data();
 
 wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($source, $source, $operation_id, 'source', $target_id, $report['pair_fingerprint']), 'Source participant blocker did not persist.');
 wcos_merge_foundation_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($fresh_target), true), 'Missing target blocker after source persistence did not fail closed through participation.');
@@ -327,10 +424,19 @@ wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participa
 wcos_merge_foundation_assert(!WCOS_Operation_Journal_Retention::is_expired_terminal_record($old_record, time()), 'Retention discarded proof while only the target blocker remained.');
 delete_option('wcos_manual_reconcile_block_' . $target_id);
 
-wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup failed.');
+/* Retry cleanup from the partial state where source metadata is already gone. */
+$fresh_source = wc_get_order($source_id);
+$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_TARGET_META, $target_id);
+$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_OPERATION_META, $operation_id);
+$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_PAIR_FINGERPRINT_META, $report['pair_fingerprint']);
+$fresh_source->save_meta_data();
+wcos_merge_foundation_assert(in_array($source_id . '|' . $operation_id . '|' . $report['pair_fingerprint'], array_map('strval', wcos_merge_foundation_meta_values(wc_get_order($target_id), WCOS_Merge_Participation::TARGET_AUTHORITY_META)), true), 'Partial cleanup fixture lost target authority before retry.');
+wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup retry failed.');
+wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup was not idempotent after retry.');
 $fresh_target = wc_get_order($target_id);
 wcos_merge_foundation_assert(in_array('424242', array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_SOURCE_META)), true), 'Cleanup removed an unrelated source relation.');
 wcos_merge_foundation_assert(in_array('unrelated-operation', array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_OPERATION_META)), true), 'Cleanup removed an unrelated operation relation.');
+wcos_merge_foundation_assert(in_array($unrelated_pointer, array_map('strval', wcos_merge_foundation_meta_values($fresh_target, WCOS_Merge_Participation::TARGET_AUTHORITY_META)), true), 'Cleanup removed an unrelated authority pointer.');
 wcos_merge_foundation_assert($lease->release(), 'Pair lease did not release safely.');
 
 /* Cleanup test records after terminal journal proof is no longer referenced. */
@@ -343,7 +449,7 @@ $orphan_source = wcos_merge_foundation_order($email, 1);
 $orphan_target = wcos_merge_foundation_order($email, 1);
 $orphan_report = WCOS_Merge_Preflight::assert_supported($orphan_source, $orphan_target);
 $orphan_operation = 'merge-orphan-' . wp_generate_uuid4();
-$orphan_context = WCOS_Merge_Journal_Context::create($orphan_source, $orphan_target, $orphan_report['plan'], $orphan_report['context_authority']);
+$orphan_context = WCOS_Merge_Journal_Context::create($orphan_source, $orphan_target, $orphan_report['plan'], $orphan_report['context_authority'], $orphan_report['price_precision']);
 wcos_merge_foundation_assert(WCOS_Operation_Journal::start($orphan_source, $orphan_operation, 'merge', $orphan_context, $orphan_report['pair_fingerprint']), 'Orphan journal fixture did not start.');
 wcos_merge_foundation_assert(WCOS_Manual_Reconciliation_Blocker::block_participant($orphan_source, $orphan_source, $orphan_operation, 'source', $orphan_target->get_id(), $orphan_report['pair_fingerprint']), 'Orphan source blocker did not persist.');
 $orphan_target->delete(true);

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -426,10 +426,13 @@ delete_option('wcos_manual_reconcile_block_' . $target_id);
 
 /* Retry cleanup from the partial state where source metadata is already gone. */
 $fresh_source = wc_get_order($source_id);
-$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_TARGET_META, $target_id);
-$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_OPERATION_META, $operation_id);
-$fresh_source->delete_meta_data_value(WCOS_Merge_Participation::SOURCE_PAIR_FINGERPRINT_META, $report['pair_fingerprint']);
+$fresh_source->delete_meta_data(WCOS_Merge_Participation::SOURCE_TARGET_META);
+$fresh_source->delete_meta_data(WCOS_Merge_Participation::SOURCE_OPERATION_META);
+$fresh_source->delete_meta_data(WCOS_Merge_Participation::SOURCE_PAIR_FINGERPRINT_META);
 $fresh_source->save_meta_data();
+wcos_merge_foundation_assert(empty(wcos_merge_foundation_meta_values(wc_get_order($source_id), WCOS_Merge_Participation::SOURCE_TARGET_META)), 'Partial cleanup fixture retained source target metadata.');
+wcos_merge_foundation_assert(empty(wcos_merge_foundation_meta_values(wc_get_order($source_id), WCOS_Merge_Participation::SOURCE_OPERATION_META)), 'Partial cleanup fixture retained source operation metadata.');
+wcos_merge_foundation_assert(empty(wcos_merge_foundation_meta_values(wc_get_order($source_id), WCOS_Merge_Participation::SOURCE_PAIR_FINGERPRINT_META)), 'Partial cleanup fixture retained source fingerprint metadata.');
 wcos_merge_foundation_assert(in_array($source_id . '|' . $operation_id . '|' . $report['pair_fingerprint'], array_map('strval', wcos_merge_foundation_meta_values(wc_get_order($target_id), WCOS_Merge_Participation::TARGET_AUTHORITY_META)), true), 'Partial cleanup fixture lost target authority before retry.');
 wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup retry failed.');
 wcos_merge_foundation_assert(WCOS_Merge_Participation::cleanup($source, $target, $operation_id), 'Participation cleanup was not idempotent after retry.');

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -80,12 +80,14 @@ wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strat
 wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate changed.');
 wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock strategy gate changed.');
 $gateway = new WCOS_Mutation_Gateway();
+$merge_rejected_at_gate = false;
 try {
 	$gateway->merge($source, $target, 'merge-foundation-disabled');
-	throw new RuntimeException('Gateway unexpectedly exposed Merge execution.');
 } catch (RuntimeException $exception) {
-	wcos_merge_foundation_assert(false !== strpos($exception->getMessage(), 'disabled'), 'Gateway no longer fails at the hard-off Merge boundary.');
+	$merge_rejected_at_gate = true;
+	wcos_merge_foundation_assert(false === strpos($exception->getMessage(), 'has not been implemented'), 'Gateway reached the Merge implementation placeholder instead of the hard-off gate.');
 }
+wcos_merge_foundation_assert($merge_rejected_at_gate, 'Gateway unexpectedly exposed Merge execution.');
 
 /* Canonical historical-state planning is read-only and never coalesces lines. */
 $report = WCOS_Merge_Preflight::assert_supported($source, $target);

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -28,6 +28,8 @@ require_once $root . 'class-wcos-line-identity.php';
 require_once $root . 'class-wcos-mutation-fingerprint.php';
 require_once $root . 'class-wcos-mutation-contract.php';
 require_once $root . 'class-wcos-split-plan.php';
+require_once $root . 'class-wcos-merge-retirement-policy.php';
+require_once $root . 'class-wcos-merge-plan.php';
 
 $tests = array();
 
@@ -219,6 +221,48 @@ $tests['duplicate service and preflight policy versions stay aligned'] = static 
 	assert_true(1 === preg_match('/const POLICY_VERSION = ([0-9]+);/', $service, $service_match), 'Duplicate service policy version is missing.');
 	assert_true(1 === preg_match('/const POLICY_VERSION = ([0-9]+);/', $preflight, $preflight_match), 'Duplicate preflight policy version is missing.');
 	assert_same($service_match[1], $preflight_match[1]);
+};
+
+$tests['merge plan fingerprint is canonical and keeps identical lines distinct'] = static function() {
+	$identity = WCOS_Line_Identity::from_values(10, 20, 'reduced-rate', array('engraving' => 'A'));
+	$first = WCOS_Merge_Plan::canonicalize(101, 202, array(
+		22 => array('source_item_id' => 22, 'line_identity' => $identity, 'quantity' => '1.000000', 'taxes' => array('total' => array(2 => '1.00'))),
+		11 => array('taxes' => array('total' => array(2 => '1.00')), 'quantity' => '1.000000', 'line_identity' => $identity, 'source_item_id' => 11),
+	));
+	$second = WCOS_Merge_Plan::canonicalize(101, 202, array(
+		11 => array('source_item_id' => 11, 'line_identity' => $identity, 'quantity' => '1.000000', 'taxes' => array('total' => array(2 => '1.00'))),
+		22 => array('taxes' => array('total' => array(2 => '1.00')), 'quantity' => '1.000000', 'line_identity' => $identity, 'source_item_id' => 22),
+	));
+	assert_same(WCOS_Merge_Plan::fingerprint($first), WCOS_Merge_Plan::fingerprint($second));
+	assert_same(array(11, 22), array_keys($first['lines']));
+	assert_same(false, $first['coalesce_lines']);
+	assert_same('fresh_target_line_per_source_line', $first['line_policy']);
+};
+
+$tests['merge plan rejects self merge and normalized item collisions'] = static function() {
+	assert_throws(static function() {
+		WCOS_Merge_Plan::canonicalize(10, 10, array(1 => array('source_item_id' => 1, 'line_identity' => str_repeat('a', 64))));
+	}, InvalidArgumentException::class);
+	assert_throws(static function() {
+		WCOS_Merge_Plan::canonicalize(10, 11, array(
+			'01' => array('source_item_id' => 1, 'line_identity' => str_repeat('a', 64)),
+			1 => array('source_item_id' => 1, 'line_identity' => str_repeat('b', 64)),
+		));
+	}, InvalidArgumentException::class);
+};
+
+$tests['merge retirement candidates preserve archive and remain unselected'] = static function() {
+	$candidates = WCOS_Merge_Retirement_Policy::candidates();
+	assert_same(array('dedicated_merged_archive', 'non_force_trash_archive'), WCOS_Merge_Retirement_Policy::identifiers());
+	foreach ($candidates as $candidate) {
+		assert_same(true, $candidate['preserve_commercial_record']);
+		assert_same(false, $candidate['active_economic_owner_after']);
+		assert_same(false, $candidate['normal_active_status_after']);
+		assert_same(false, $candidate['hard_delete']);
+		assert_same(false, $candidate['production_selected']);
+	}
+	WCOS_Merge_Retirement_Policy::assert_archive_preserved(str_repeat('a', 64), str_repeat('a', 64));
+	WCOS_Merge_Retirement_Policy::assert_active_ownership_conserved(str_repeat('b', 64), str_repeat('b', 64));
 };
 
 $failures = 0;


### PR DESCRIPTION
## Scope

Implements WOS-MERGE-002 only: the hard-off Merge domain contract foundation approved in #37 and specified by #38.

Base SHA: `f0e553a2140c126a6b9eb6577271c7f179bed02e`

- composes `WCOS_Operation_Lock` into a deterministic all-or-nothing multi-order lease
- extends the existing source-journal blocker/retention model to pair participants
- adds atomic scalar participation authority and storage-aware relation discovery
- adds versioned, domain-separated HMAC context signatures with PII-free durable evidence
- adds canonical Merge plan/read-only preflight contracts
- models both unselected retirement candidates and minimal pair journal vocabulary
- adds focused unit/integration contracts to canonical CI and package assertions

## Hard-off boundary

- `MERGE=false` remains unchanged
- `WCOS_Mutation_Gateway::merge()` remains the non-executable placeholder
- no Merge service, adapter, controller, transport, UI, status registration, commercial write, or legacy handler restoration
- Split/Duplicate and strategy gates remain unchanged

## Local evidence

- all PHP files lint successfully (only pre-existing PHP 8.4 deprecation notices)
- `php tests/unit/run.php`: pass
- `git diff --check origin/main...HEAD`: pass
- workflow YAML parsing: pass
- release-tree/ZIP safety smoke: pass; legacy Merge handlers excluded and foundation classes packaged
- local wp-env integration execution was unavailable because this host has no Docker; canonical GitHub CI provided the required storage-mode authority

## Canonical CI

Final run: https://github.com/yoohwz/wc-order-splitter/actions/runs/32551587126

- architecture/gates: pass
- PHP 7.4 / 8.1 / 8.3 syntax and unit contracts: pass
- package safety: pass
- WooCommerce 11.0.1 legacy / HPOS-only / HPOS-sync: pass
- aggregate Required CI: pass

## Commits

1. `e90fb25` Add hard-off Merge domain contracts
2. `7afbf1e` Test Merge foundation across storage modes
3. `9c31f35` Fix deleted-product integration fixture
4. `605890f` Assert Merge gateway hard-off boundary
5. `d187f78` Read repeatable WooCommerce metadata scalars

Refs #38
