### PR TITLE
WOS-MERGE-003: add hardened Merge recovery foundation

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -127,6 +127,10 @@ jobs:
             'inc/domain/class-wcos-merge-context-signature.php' \
             'inc/domain/class-wcos-merge-journal-context.php' \
             'inc/domain/class-wcos-merge-participation.php' \
+            'inc/domain/class-wcos-merge-recovery-snapshot.php' \
+            'inc/domain/class-wcos-merge-recovery-state-graph.php' \
+            'inc/domain/class-wcos-merge-commit-guard.php' \
+            'inc/domain/class-wcos-merge-compensator.php' \
             'inc/domain/class-wcos-merge-preflight.php' \
             'inc/domain/class-wcos-merge-retirement-policy.php' \
             'css/p2-split-strategy-admin.css' \
@@ -183,6 +187,10 @@ jobs:
             'wc-order-splitter/inc/domain/class-wcos-merge-context-signature.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-journal-context.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-participation.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-recovery-snapshot.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-recovery-state-graph.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-commit-guard.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-compensator.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php' \
             'wc-order-splitter/css/p2-split-strategy-admin.css' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
           grep -Fq 'class-wcos-merge-context-signature.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-journal-context.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-participation.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-recovery-snapshot.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-recovery-state-graph.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-commit-guard.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-compensator.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-preflight.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-retirement-policy.php' inc/cores/script.php
           grep -Fq "throw new RuntimeException(__('The hardened merge service has not been implemented.'" inc/domain/class-wcos-mutation-gateway.php
@@ -245,6 +249,10 @@ jobs:
             'inc/domain/class-wcos-merge-context-signature.php' \
             'inc/domain/class-wcos-merge-journal-context.php' \
             'inc/domain/class-wcos-merge-participation.php' \
+            'inc/domain/class-wcos-merge-recovery-snapshot.php' \
+            'inc/domain/class-wcos-merge-recovery-state-graph.php' \
+            'inc/domain/class-wcos-merge-commit-guard.php' \
+            'inc/domain/class-wcos-merge-compensator.php' \
             'inc/domain/class-wcos-merge-preflight.php' \
             'inc/domain/class-wcos-merge-retirement-policy.php' \
             'css/p2-split-strategy-admin.css' \
@@ -304,6 +312,10 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-context-signature.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-journal-context.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-participation.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-recovery-snapshot.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-recovery-state-graph.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-commit-guard.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-compensator.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-split-strategy-admin.js'
@@ -449,6 +461,9 @@ jobs:
 
       - name: Verify hard-off Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php
+
+      - name: Verify hard-off Merge recovery and retirement evidence
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-recovery-foundation-smoke.php
 
       - name: Verify duplicate integrity, idempotency, and recovery
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/duplicate-smoke.php

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -50,6 +50,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-merge-context-signature.php';
 		include_once $root . 'domain/class-wcos-merge-journal-context.php';
 		include_once $root . 'domain/class-wcos-merge-participation.php';
+		include_once $root . 'domain/class-wcos-merge-recovery-snapshot.php';
+		include_once $root . 'domain/class-wcos-merge-recovery-state-graph.php';
 		include_once $root . 'domain/class-wcos-operation-journal.php';
 		include_once $root . 'domain/class-wcos-manual-reconciliation-blocker.php';
 		include_once $root . 'domain/class-wcos-operation-journal-retention.php';
@@ -58,9 +60,11 @@ class WC_Order_Splitter_Script {
 		WCOS_Order_Relation_Repository::bootstrap();
 		include_once $root . 'domain/class-wcos-mutation-commit-guard.php';
 		WCOS_Mutation_Commit_Guard::bootstrap();
+		include_once $root . 'domain/class-wcos-merge-commit-guard.php';
 		include_once $root . 'domain/class-wcos-duplicate-order-service.php';
 		include_once $root . 'domain/class-wcos-split-order-service.php';
 		include_once $root . 'domain/class-wcos-split-compensator.php';
+		include_once $root . 'domain/class-wcos-merge-compensator.php';
 		include_once $root . 'domain/class-wcos-mutation-recovery-coordinator.php';
 		WCOS_Mutation_Recovery_Coordinator::bootstrap();
 		include_once $root . 'domain/class-wcos-split-preflight.php';

--- a/inc/domain/class-wcos-merge-commit-guard.php
+++ b/inc/domain/class-wcos-merge-commit-guard.php
@@ -1,0 +1,89 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Fail-closed dual-participant persistence boundary for Merge recovery.
+ */
+final class WCOS_Merge_Commit_Guard {
+
+	public static function assert_boundary(
+		WCOS_Multi_Order_Lease $lease,
+		WC_Order $source,
+		WC_Order $target,
+		array $record,
+		$expected_source_signature,
+		$expected_target_signature,
+		$expected_relation_state = 'any'
+	) {
+		if (!$lease->refresh()) {
+			throw new RuntimeException(__('A Merge participant lease was lost before a recovery persistence boundary.', 'wc-order-splitter'));
+		}
+		$lease->assert_owned();
+		WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+
+		$operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
+		$fresh_source = wc_get_order($source->get_id());
+		$fresh_target = wc_get_order($target->get_id());
+		if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order
+			|| 'shop_order' !== $fresh_source->get_type() || 'shop_order' !== $fresh_target->get_type()) {
+			throw new RuntimeException(__('A Merge participant disappeared before a recovery persistence boundary.', 'wc-order-splitter'));
+		}
+
+		$fresh_record = WCOS_Operation_Journal::get($fresh_source, $operation_id);
+		if (!is_array($fresh_record)) {
+			throw new RuntimeException(__('The authoritative Merge journal disappeared before a recovery persistence boundary.', 'wc-order-splitter'));
+		}
+		WCOS_Operation_Journal::assert_fingerprint($fresh_record, isset($record['fingerprint']) ? $record['fingerprint'] : '');
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($fresh_record);
+		$snapshot = isset($fresh_record['context']['merge_recovery_snapshot'])
+			&& is_array($fresh_record['context']['merge_recovery_snapshot'])
+			? $fresh_record['context']['merge_recovery_snapshot']
+			: array();
+		if (!is_array($pair) || empty($snapshot)
+			|| $pair['source_order_id'] !== (int) $fresh_source->get_id()
+			|| $pair['target_order_id'] !== (int) $fresh_target->get_id()) {
+			throw new RuntimeException(__('Merge pair authority is invalid at a recovery persistence boundary.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Recovery_Snapshot::assert_valid($snapshot, $fresh_record);
+
+		self::assert_signature($fresh_source, $expected_source_signature, 'source');
+		self::assert_signature($fresh_target, $expected_target_signature, 'target');
+		self::assert_relation_state(
+			WCOS_Merge_Participation::state_for_pair(
+				$fresh_source,
+				$fresh_target,
+				$operation_id,
+				$pair['pair_fingerprint']
+			),
+			$expected_relation_state
+		);
+		return array($fresh_source, $fresh_target, $fresh_record);
+	}
+
+	private static function assert_signature(WC_Order $order, $expected, $role) {
+		$expected = self::fingerprint($expected);
+		if ('' === $expected || !hash_equals($expected, WCOS_Merge_Recovery_Snapshot::participant_signature($order))) {
+			throw new RuntimeException(
+				'source' === $role
+					? __('The Merge source changed after its approved checkpoint.', 'wc-order-splitter')
+					: __('The Merge target changed after its approved checkpoint.', 'wc-order-splitter')
+			);
+		}
+	}
+
+	private static function assert_relation_state(array $state, $expected) {
+		$expected = sanitize_key((string) $expected);
+		$actual = $state['source'] && $state['target']
+			? 'complete'
+			: (($state['source'] || $state['target']) ? 'partial' : 'none');
+		if ('any' !== $expected && $actual !== $expected) {
+			throw new RuntimeException(__('Operation-owned Merge relation state does not match its recovery checkpoint.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
+	}
+}

--- a/inc/domain/class-wcos-merge-commit-guard.php
+++ b/inc/domain/class-wcos-merge-commit-guard.php
@@ -46,6 +46,15 @@ final class WCOS_Merge_Commit_Guard {
 			throw new RuntimeException(__('Merge pair authority is invalid at a recovery persistence boundary.', 'wc-order-splitter'));
 		}
 		WCOS_Merge_Recovery_Snapshot::assert_valid($snapshot, $fresh_record);
+		$context = isset($fresh_record['context']) && is_array($fresh_record['context']) ? $fresh_record['context'] : array();
+		WCOS_Merge_Recovery_Snapshot::assert_immutable_pair(
+			$snapshot,
+			$fresh_record,
+			$fresh_source,
+			$fresh_target,
+			isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array(),
+			isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array()
+		);
 
 		self::assert_signature($fresh_source, $expected_source_signature, 'source');
 		self::assert_signature($fresh_target, $expected_target_signature, 'target');

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -33,13 +33,19 @@ final class WCOS_Merge_Compensator {
 		$target_before = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'target');
 		$source_after = self::fingerprint(isset($context['merge_source_signature_after']) ? $context['merge_source_signature_after'] : '');
 		$target_after = self::fingerprint(isset($context['merge_target_signature_after']) ? $context['merge_target_signature_after'] : '');
+		$source_after_state = isset($context['merge_source_state_after']) && is_array($context['merge_source_state_after']) ? $context['merge_source_state_after'] : array();
+		$target_after_state = isset($context['merge_target_state_after']) && is_array($context['merge_target_state_after']) ? $context['merge_target_state_after'] : array();
 		$target_item_ids = self::ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array());
 		$target_tax_item_ids = self::ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
+		$retirement_candidate = sanitize_key(isset($context['merge_retirement_candidate']) ? (string) $context['merge_retirement_candidate'] : '');
+		if ('' !== $retirement_candidate) {
+			WCOS_Merge_Retirement_Policy::assert_candidate($retirement_candidate);
+		}
 
 		try {
 			$current_source = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
 			$current_target = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
-			if (!empty($context['merge_forward_repair_allowed'])
+			$forward_state = !empty($context['merge_forward_repair_allowed'])
 				&& in_array($recovery_state, array(
 					WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
 					WCOS_Merge_Recovery_State_Graph::SOURCE_RELATION,
@@ -47,21 +53,33 @@ final class WCOS_Merge_Compensator {
 					WCOS_Merge_Recovery_State_Graph::VERIFIED,
 					WCOS_Merge_Recovery_State_Graph::COMMITTED,
 				), true)
-				&& '' !== $source_after && '' !== $target_after
-				&& hash_equals($source_after, $current_source)
-				&& hash_equals($target_after, $current_target)) {
-				return self::forward($source, $target, $record, $lease, $source_after, $target_after);
+				&& '' !== $source_after && '' !== $target_after;
+			if ($forward_state) {
+				$forward_valid = false;
+				try {
+					WCOS_Merge_Recovery_Snapshot::assert_forward_checkpoint($source_after_state, $source);
+					WCOS_Merge_Recovery_Snapshot::assert_forward_checkpoint($target_after_state, $target);
+					$forward_valid = true;
+				} catch (Throwable $throwable) {
+					/* Fall through to compensation/manual validation. */
+				}
+				if ($forward_valid) {
+					return self::forward($source, $target, $record, $lease, $current_source, $current_target);
+				}
 			}
 
-			$source_known = hash_equals($source_before, $current_source)
-				|| ('' !== $source_after && hash_equals($source_after, $current_source));
-			$target_known = hash_equals($target_before, $current_target)
-				|| ('' !== $target_after && hash_equals($target_after, $current_target));
-			if (!$source_known || !$target_known) {
+			if (empty($source_after_state) || empty($target_after_state)) {
+				throw new RuntimeException(__('Merge recovery is missing durable component checkpoints.', 'wc-order-splitter'));
+			}
+			try {
+				WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['source'], $source_after_state, $source, array(), array());
+				WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['target'], $target_after_state, $target, $target_item_ids, $target_tax_item_ids);
+			} catch (Throwable $throwable) {
 				throw new RuntimeException(__('A Merge participant diverged from every approved recovery checkpoint.', 'wc-order-splitter'));
 			}
 
 			if ('compensating' !== sanitize_key(isset($record['status']) ? (string) $record['status'] : '')) {
+				self::lease_guard($lease);
 				if (!WCOS_Operation_Journal::mark_compensating($source, $operation_id, array(
 					'merge_compensation' => true,
 					'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPENSATING,
@@ -73,9 +91,11 @@ final class WCOS_Merge_Compensator {
 			/* Restore stock/commercial ownership to source before target cleanup. */
 			if (!hash_equals($source_before, $current_source)) {
 				self::boundary($lease, $source, $target, $record, $current_source, $current_target, 'any', 'before_source_restore');
-				$source = WCOS_Merge_Recovery_Snapshot::restore_participant($snapshot, 'source', $current_source);
+				list($write_boundary, $sub_checkpoint) = self::resumable_callbacks($lease, $source, $target, $record, $snapshot, $source_after_state, $target_after_state, $target_item_ids, $target_tax_item_ids);
+				$source = WCOS_Merge_Recovery_Snapshot::restore_participant($snapshot, 'source', $source_after_state, array(), array(), $write_boundary, $sub_checkpoint, $retirement_candidate);
 				self::event('after_source_restore', $source, $target, $operation_id);
 			}
+			self::lease_guard($lease);
 			if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_compensation_source_restored', array(
 				'merge_source_compensated_signature' => $source_before,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RESTORED,
@@ -89,15 +109,19 @@ final class WCOS_Merge_Compensator {
 			$current_target = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
 			if (!hash_equals($target_before, $current_target)) {
 				self::boundary($lease, $source, $target, $record, $source_before, $current_target, 'any', 'before_target_cleanup');
+				list($write_boundary, $sub_checkpoint) = self::resumable_callbacks($lease, $source, $target, $record, $snapshot, $source_after_state, $target_after_state, $target_item_ids, $target_tax_item_ids);
 				$target = WCOS_Merge_Recovery_Snapshot::restore_participant(
 					$snapshot,
 					'target',
-					$current_target,
+					$target_after_state,
 					$target_item_ids,
-					$target_tax_item_ids
+					$target_tax_item_ids,
+					$write_boundary,
+					$sub_checkpoint
 				);
 				self::event('after_target_cleanup', $source, $target, $operation_id);
 			}
+			self::lease_guard($lease);
 			if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_compensation_target_restored', array(
 				'merge_target_compensated_signature' => $target_before,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::TARGET_RESTORED,
@@ -111,6 +135,7 @@ final class WCOS_Merge_Compensator {
 			if (!WCOS_Merge_Participation::cleanup($source, $target, $operation_id)) {
 				throw new RuntimeException(__('Operation-owned Merge participation could not be cleaned up.', 'wc-order-splitter'));
 			}
+			self::lease_guard($lease);
 			if (!WCOS_Operation_Journal::mark_compensated($source, $operation_id, array(
 				'merge_compensated' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPENSATED,
@@ -138,15 +163,33 @@ final class WCOS_Merge_Compensator {
 			$reason = 'merge_recovery_ambiguous';
 		}
 		if (is_array($pair) && $target instanceof WC_Order) {
-			try {
-				WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
-			} catch (Throwable $throwable) {
-				/* Pair blockers below remain the primary fail-closed authority. */
+			for ($attempt = 1; $attempt <= 2; $attempt++) {
+				try {
+					self::event('before_manual_participation_attempt_' . $attempt, $source, $target, $operation_id);
+					WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
+					break;
+				} catch (Throwable $throwable) {
+					/* A bounded retry closes response-loss and one-shot persistence windows. */
+				}
 			}
-			$blocked = WCOS_Manual_Reconciliation_Blocker::block_pair($source, $target, $operation_id, $pair['pair_fingerprint']);
-			if (!$blocked
-				&& !WCOS_Manual_Reconciliation_Blocker::has_active($source)
-				&& !WCOS_Manual_Reconciliation_Blocker::has_active($target)) {
+			foreach (array('source' => $source, 'target' => $target) as $role => $participant) {
+				try {
+					self::event('before_manual_' . $role . '_blocker', $source, $target, $operation_id);
+					WCOS_Manual_Reconciliation_Blocker::block_participant(
+						$participant,
+						$source,
+						$operation_id,
+						$role,
+						'source' === $role ? $target->get_id() : $source->get_id(),
+						$pair['pair_fingerprint']
+					);
+				} catch (Throwable $throwable) {
+					/* Verified participation may remain this participant's local authority. */
+				}
+			}
+			$source_active = in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source), true);
+			$target_active = in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($target), true);
+			if (!$source_active || !$target_active) {
 				throw new RuntimeException(__('Pair-wide Merge reconciliation authority could not be persisted.', 'wc-order-splitter'));
 			}
 		} else {
@@ -167,11 +210,14 @@ final class WCOS_Merge_Compensator {
 	private static function forward(WC_Order $source, WC_Order $target, array $record, WCOS_Multi_Order_Lease $lease, $source_after, $target_after) {
 		$operation_id = sanitize_key((string) $record['operation_id']);
 		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		$recovery_state = WCOS_Merge_Recovery_State_Graph::assert_record($record);
 		self::boundary($lease, $source, $target, $record, $source_after, $target_after, 'any', 'before_forward_relations');
 		WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
 		$source = wc_get_order($source->get_id());
 		$target = wc_get_order($target->get_id());
-		if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_relations_completed', array(
+		self::lease_guard($lease);
+		if (!in_array($recovery_state, array(WCOS_Merge_Recovery_State_Graph::VERIFIED, WCOS_Merge_Recovery_State_Graph::COMMITTED), true)
+			&& !WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_relations_completed', array(
 			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::RELATIONS_COMPLETE,
 		))) {
 			throw new RuntimeException(__('Forward-repaired Merge relations could not be checkpointed.', 'wc-order-splitter'));
@@ -186,14 +232,29 @@ final class WCOS_Merge_Compensator {
 			'complete',
 			'after_forward_relations'
 		);
-		if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_commercial_verified', array(
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$snapshot = isset($context['merge_recovery_snapshot']) && is_array($context['merge_recovery_snapshot']) ? $context['merge_recovery_snapshot'] : array();
+		WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+		WCOS_Merge_Recovery_Snapshot::assert_active_economic_conserved($snapshot, $target);
+		if (!in_array($recovery_state, array(WCOS_Merge_Recovery_State_Graph::VERIFIED, WCOS_Merge_Recovery_State_Graph::COMMITTED), true)
+			&& !WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_commercial_verified', array(
 			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::VERIFIED,
-		))
-			|| !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
+		))) {
+			throw new RuntimeException(__('Forward-repaired Merge state could not be verified.', 'wc-order-splitter'));
+		}
+		if (WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state) {
+			self::event('after_verification_before_commit', $source, $target, $operation_id);
+			self::lease_guard($lease);
+		}
+		if (WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state && !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
 				'merge_forward_repaired' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMMITTED,
-			))
-			|| !WCOS_Operation_Journal::complete($source, $operation_id, array(
+			))) {
+			throw new RuntimeException(__('Forward-repaired Merge state could not be committed.', 'wc-order-splitter'));
+		}
+		self::event('after_commit_before_complete', $source, $target, $operation_id);
+		self::lease_guard($lease);
+		if (!WCOS_Operation_Journal::complete($source, $operation_id, array(
 				'merge_verified' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPLETED,
 			))) {
@@ -207,7 +268,41 @@ final class WCOS_Merge_Compensator {
 		WCOS_Merge_Commit_Guard::assert_boundary($lease, $source, $target, $record, $source_signature, $target_signature, $relation);
 	}
 
-	private static function event($stage, WC_Order $source, WC_Order $target, $operation_id) {
+	private static function lease_guard(WCOS_Multi_Order_Lease $lease) {
+		if (!$lease->refresh()) {
+			throw new RuntimeException(__('A participant lease expired before a durable Merge recovery write.', 'wc-order-splitter'));
+		}
+		WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+	}
+
+	private static function resumable_callbacks(WCOS_Multi_Order_Lease $lease, WC_Order $source, WC_Order $target, array $record, array $snapshot, array $source_after, array $target_after, array $target_item_ids, array $target_tax_item_ids) {
+		$operation_id = sanitize_key((string) $record['operation_id']);
+		$guard = static function($stage, $component_id = 0) use ($lease, $source, $target, $operation_id, $snapshot, $source_after, $target_after, $target_item_ids, $target_tax_item_ids) {
+			WCOS_Merge_Compensator::event($stage, $source, $target, $operation_id);
+			if (!$lease->refresh()) {
+				throw new RuntimeException(__('A participant lease expired during resumable Merge recovery.', 'wc-order-splitter'));
+			}
+			WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+			$fresh_source = wc_get_order($snapshot['source_order_id']);
+			$fresh_target = wc_get_order($snapshot['target_order_id']);
+			if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
+				throw new RuntimeException(__('A Merge recovery participant disappeared during a durable write.', 'wc-order-splitter'));
+			}
+			WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['source'], $source_after, $fresh_source, array(), array());
+			WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['target'], $target_after, $fresh_target, $target_item_ids, $target_tax_item_ids);
+		};
+		$checkpoint = static function($stage, $component_id = 0) use ($guard, $source, $operation_id) {
+			$guard('before_' . $stage . '_checkpoint', $component_id);
+			if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_recovery_component_checkpoint', array(
+				'merge_recovery_component' => array('stage' => sanitize_key($stage), 'component_id' => absint($component_id)),
+			))) {
+				throw new RuntimeException(__('A resumable Merge component checkpoint could not be persisted.', 'wc-order-splitter'));
+			}
+		};
+		return array($guard, $checkpoint);
+	}
+
+	public static function event($stage, WC_Order $source, WC_Order $target, $operation_id) {
 		do_action('wcos_merge_recovery_checkpoint', sanitize_key((string) $stage), $source, $target, $operation_id);
 	}
 

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -1,0 +1,224 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/** Test/failure-injection signal that models process loss without ambiguity. */
+final class WCOS_Merge_Recovery_Interruption_Exception extends RuntimeException {}
+
+/**
+ * Verified forward repair or compensation for a source-journal Merge pair.
+ *
+ * This class is recovery-only. It does not perform a commercial Merge and has
+ * no production transport, adapter, controller, or gateway entry point.
+ */
+final class WCOS_Merge_Compensator {
+
+	public static function recover(WC_Order $source, WC_Order $target, array $record, WCOS_Multi_Order_Lease $lease) {
+		$operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$snapshot = isset($context['merge_recovery_snapshot']) && is_array($context['merge_recovery_snapshot'])
+			? $context['merge_recovery_snapshot']
+			: array();
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		if ('' === $operation_id || !is_array($pair) || empty($snapshot)) {
+			throw new RuntimeException(__('Merge recovery authority is incomplete.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Recovery_Snapshot::assert_valid($snapshot, $record);
+		$recovery_state = WCOS_Merge_Recovery_State_Graph::assert_record($record);
+		if (!empty($context['merge_physical_stock_after_write'])) {
+			return self::manual_reconciliation($source, $target, $record, 'physical_stock_after_write');
+		}
+
+		$source_before = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'source');
+		$target_before = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'target');
+		$source_after = self::fingerprint(isset($context['merge_source_signature_after']) ? $context['merge_source_signature_after'] : '');
+		$target_after = self::fingerprint(isset($context['merge_target_signature_after']) ? $context['merge_target_signature_after'] : '');
+		$target_item_ids = self::ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array());
+		$target_tax_item_ids = self::ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
+
+		try {
+			$current_source = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
+			$current_target = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+			if (!empty($context['merge_forward_repair_allowed'])
+				&& in_array($recovery_state, array(
+					WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
+					WCOS_Merge_Recovery_State_Graph::SOURCE_RELATION,
+					WCOS_Merge_Recovery_State_Graph::RELATIONS_COMPLETE,
+					WCOS_Merge_Recovery_State_Graph::VERIFIED,
+					WCOS_Merge_Recovery_State_Graph::COMMITTED,
+				), true)
+				&& '' !== $source_after && '' !== $target_after
+				&& hash_equals($source_after, $current_source)
+				&& hash_equals($target_after, $current_target)) {
+				return self::forward($source, $target, $record, $lease, $source_after, $target_after);
+			}
+
+			$source_known = hash_equals($source_before, $current_source)
+				|| ('' !== $source_after && hash_equals($source_after, $current_source));
+			$target_known = hash_equals($target_before, $current_target)
+				|| ('' !== $target_after && hash_equals($target_after, $current_target));
+			if (!$source_known || !$target_known) {
+				throw new RuntimeException(__('A Merge participant diverged from every approved recovery checkpoint.', 'wc-order-splitter'));
+			}
+
+			if ('compensating' !== sanitize_key(isset($record['status']) ? (string) $record['status'] : '')) {
+				if (!WCOS_Operation_Journal::mark_compensating($source, $operation_id, array(
+					'merge_compensation' => true,
+					'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPENSATING,
+				))) {
+					throw new RuntimeException(__('Merge compensation could not be checkpointed.', 'wc-order-splitter'));
+				}
+			}
+
+			/* Restore stock/commercial ownership to source before target cleanup. */
+			if (!hash_equals($source_before, $current_source)) {
+				self::boundary($lease, $source, $target, $record, $current_source, $current_target, 'any', 'before_source_restore');
+				$source = WCOS_Merge_Recovery_Snapshot::restore_participant($snapshot, 'source', $current_source);
+				self::event('after_source_restore', $source, $target, $operation_id);
+			}
+			if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_compensation_source_restored', array(
+				'merge_source_compensated_signature' => $source_before,
+				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RESTORED,
+			))) {
+				throw new RuntimeException(__('Restored Merge source ownership could not be checkpointed.', 'wc-order-splitter'));
+			}
+
+			$source = wc_get_order($source->get_id());
+			$target = wc_get_order($target->get_id());
+			$current_source = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
+			$current_target = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+			if (!hash_equals($target_before, $current_target)) {
+				self::boundary($lease, $source, $target, $record, $source_before, $current_target, 'any', 'before_target_cleanup');
+				$target = WCOS_Merge_Recovery_Snapshot::restore_participant(
+					$snapshot,
+					'target',
+					$current_target,
+					$target_item_ids,
+					$target_tax_item_ids
+				);
+				self::event('after_target_cleanup', $source, $target, $operation_id);
+			}
+			if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_compensation_target_restored', array(
+				'merge_target_compensated_signature' => $target_before,
+				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::TARGET_RESTORED,
+			))) {
+				throw new RuntimeException(__('Restored Merge target could not be checkpointed.', 'wc-order-splitter'));
+			}
+
+			$source = wc_get_order($source->get_id());
+			$target = wc_get_order($target->get_id());
+			self::boundary($lease, $source, $target, $record, $source_before, $target_before, 'any', 'before_relation_cleanup');
+			if (!WCOS_Merge_Participation::cleanup($source, $target, $operation_id)) {
+				throw new RuntimeException(__('Operation-owned Merge participation could not be cleaned up.', 'wc-order-splitter'));
+			}
+			if (!WCOS_Operation_Journal::mark_compensated($source, $operation_id, array(
+				'merge_compensated' => true,
+				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPENSATED,
+			))) {
+				throw new RuntimeException(__('Merge compensation could not be finalized.', 'wc-order-splitter'));
+			}
+			return 'compensated';
+		} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+			if (WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($exception->get_events())) {
+				return self::manual_reconciliation($source, $target, $record, 'physical_stock_after_write');
+			}
+			throw $exception;
+		} catch (WCOS_Merge_Recovery_Interruption_Exception $exception) {
+			throw $exception;
+		} catch (Throwable $throwable) {
+			return self::manual_reconciliation($source, $target, $record, 'merge_recovery_divergence');
+		}
+	}
+
+	public static function manual_reconciliation(WC_Order $source, $target, array $record, $reason) {
+		$operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		$reason = sanitize_key((string) $reason);
+		if ('' === $reason) {
+			$reason = 'merge_recovery_ambiguous';
+		}
+		if (is_array($pair) && $target instanceof WC_Order) {
+			try {
+				WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
+			} catch (Throwable $throwable) {
+				/* Pair blockers below remain the primary fail-closed authority. */
+			}
+			$blocked = WCOS_Manual_Reconciliation_Blocker::block_pair($source, $target, $operation_id, $pair['pair_fingerprint']);
+			if (!$blocked
+				&& !WCOS_Manual_Reconciliation_Blocker::has_active($source)
+				&& !WCOS_Manual_Reconciliation_Blocker::has_active($target)) {
+				throw new RuntimeException(__('Pair-wide Merge reconciliation authority could not be persisted.', 'wc-order-splitter'));
+			}
+		} else {
+			if (!WCOS_Manual_Reconciliation_Blocker::block($source, $operation_id)
+				&& !WCOS_Manual_Reconciliation_Blocker::has_active($source)) {
+				throw new RuntimeException(__('Merge reconciliation authority could not be persisted for the surviving source.', 'wc-order-splitter'));
+			}
+		}
+		if (!WCOS_Operation_Journal::mark_manual_reconciliation($source, $operation_id, array(
+			'reason' => $reason,
+			'automatic_compensation_allowed' => false,
+		))) {
+			throw new RuntimeException(__('Merge manual-reconciliation state could not be recorded.', 'wc-order-splitter'));
+		}
+		return 'manual_reconciliation';
+	}
+
+	private static function forward(WC_Order $source, WC_Order $target, array $record, WCOS_Multi_Order_Lease $lease, $source_after, $target_after) {
+		$operation_id = sanitize_key((string) $record['operation_id']);
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		self::boundary($lease, $source, $target, $record, $source_after, $target_after, 'any', 'before_forward_relations');
+		WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+		if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_relations_completed', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::RELATIONS_COMPLETE,
+		))) {
+			throw new RuntimeException(__('Forward-repaired Merge relations could not be checkpointed.', 'wc-order-splitter'));
+		}
+		self::boundary(
+			$lease,
+			$source,
+			$target,
+			$record,
+			WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+			WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+			'complete',
+			'after_forward_relations'
+		);
+		if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_commercial_verified', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::VERIFIED,
+		))
+			|| !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
+				'merge_forward_repaired' => true,
+				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMMITTED,
+			))
+			|| !WCOS_Operation_Journal::complete($source, $operation_id, array(
+				'merge_verified' => true,
+				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPLETED,
+			))) {
+			throw new RuntimeException(__('Forward-repaired Merge state could not be finalized.', 'wc-order-splitter'));
+		}
+		return 'completed';
+	}
+
+	private static function boundary(WCOS_Multi_Order_Lease $lease, WC_Order $source, WC_Order $target, array $record, $source_signature, $target_signature, $relation, $stage) {
+		self::event($stage, $source, $target, sanitize_key((string) $record['operation_id']));
+		WCOS_Merge_Commit_Guard::assert_boundary($lease, $source, $target, $record, $source_signature, $target_signature, $relation);
+	}
+
+	private static function event($stage, WC_Order $source, WC_Order $target, $operation_id) {
+		do_action('wcos_merge_recovery_checkpoint', sanitize_key((string) $stage), $source, $target, $operation_id);
+	}
+
+	private static function ids(array $ids) {
+		$ids = array_values(array_unique(array_filter(array_map('absint', $ids))));
+		sort($ids, SORT_NUMERIC);
+		return $ids;
+	}
+
+	private static function fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
+	}
+}

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -45,6 +45,14 @@ final class WCOS_Merge_Compensator {
 		try {
 			$current_source = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
 			$current_target = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+			WCOS_Merge_Recovery_Snapshot::assert_immutable_pair(
+				$snapshot,
+				$record,
+				$source,
+				$target,
+				$target_item_ids,
+				$target_tax_item_ids
+			);
 			$forward_state = !empty($context['merge_forward_repair_allowed'])
 				&& in_array($recovery_state, array(
 					WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
@@ -279,7 +287,7 @@ final class WCOS_Merge_Compensator {
 
 	private static function resumable_callbacks(WCOS_Multi_Order_Lease $lease, WC_Order $source, WC_Order $target, array $record, array $snapshot, array $source_after, array $target_after, array $target_item_ids, array $target_tax_item_ids) {
 		$operation_id = sanitize_key((string) $record['operation_id']);
-		$guard = static function($stage, $component_id = 0) use ($lease, $source, $target, $operation_id, $snapshot, $source_after, $target_after, $target_item_ids, $target_tax_item_ids) {
+		$guard = static function($stage, $component_id = 0) use ($lease, $source, $target, $operation_id, $record, $snapshot, $source_after, $target_after, $target_item_ids, $target_tax_item_ids) {
 			WCOS_Merge_Compensator::event($stage, $source, $target, $operation_id);
 			if (!$lease->refresh()) {
 				throw new RuntimeException(__('A participant lease expired during resumable Merge recovery.', 'wc-order-splitter'));
@@ -290,6 +298,7 @@ final class WCOS_Merge_Compensator {
 			if (!$fresh_source instanceof WC_Order || !$fresh_target instanceof WC_Order) {
 				throw new RuntimeException(__('A Merge recovery participant disappeared during a durable write.', 'wc-order-splitter'));
 			}
+			WCOS_Merge_Recovery_Snapshot::assert_immutable_pair($snapshot, $record, $fresh_source, $fresh_target, $target_item_ids, $target_tax_item_ids);
 			WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['source'], $source_after, $fresh_source, array(), array());
 			WCOS_Merge_Recovery_Snapshot::assert_resumable_participant($snapshot['target'], $target_after, $fresh_target, $target_item_ids, $target_tax_item_ids);
 		};

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -246,7 +246,9 @@ final class WCOS_Merge_Compensator {
 			self::event('after_verification_before_commit', $source, $target, $operation_id);
 			self::lease_guard($lease);
 		}
-		if (WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state && !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
+		$journal_status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
+		$commit_checkpoint_required = WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state || 'committed' !== $journal_status;
+		if ($commit_checkpoint_required && !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
 				'merge_forward_repaired' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMMITTED,
 			))) {

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -18,6 +18,8 @@ final class WCOS_Merge_Journal_Context {
 		}
 
 		$source_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
+		$archive_signature = WCOS_Merge_Recovery_Snapshot::archive_commercial_signature($source);
+		$active_signature = WCOS_Merge_Recovery_Snapshot::active_economic_signature(array($source, $target), $price_precision, $source_id);
 		$authority = array(
 			'source_order_id' => $source_id,
 			'target_order_id' => $target_id,
@@ -35,10 +37,10 @@ final class WCOS_Merge_Journal_Context {
 			'retirement_policy_selected' => false,
 			'archive_source_signature_before' => isset($evidence['archive_source_signature_before'])
 				? sanitize_key((string) $evidence['archive_source_signature_before'])
-				: $source_signature,
+				: $archive_signature,
 			'active_ownership_before_signature' => isset($evidence['active_ownership_before_signature'])
 				? sanitize_key((string) $evidence['active_ownership_before_signature'])
-				: '',
+				: $active_signature,
 			'participation_schema_version' => WCOS_Merge_Participation::SCHEMA_VERSION,
 		);
 		$authority = self::canonical_authority($authority);

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -293,6 +293,24 @@ final class WCOS_Merge_Participation {
 		}));
 	}
 
+	/**
+	 * Exact reciprocal relation state for one authoritative pair.
+	 *
+	 * Values are booleans so recovery never treats unrelated target authorities
+	 * as belonging to the operation being repaired.
+	 */
+	public static function state_for_pair(WC_Order $source, WC_Order $target, $operation_id, $pair_fingerprint) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$pair_fingerprint = self::normalized_fingerprint($pair_fingerprint);
+		if ('' === $operation_id || '' === $pair_fingerprint) {
+			return array('source' => false, 'target' => false);
+		}
+		return array(
+			'source' => self::source_values_match($source, $target->get_id(), $operation_id, $pair_fingerprint),
+			'target' => self::target_values_contain($target, $source->get_id(), $operation_id, $pair_fingerprint),
+		);
+	}
+
 	private static function set_exact_scalar(WC_Order $order, $key, $value) {
 		$current = self::meta_values($order, $key);
 		if (count($current) > 1 || (!empty($current) && (string) reset($current) !== (string) $value)) {

--- a/inc/domain/class-wcos-merge-participation.php
+++ b/inc/domain/class-wcos-merge-participation.php
@@ -45,11 +45,13 @@ final class WCOS_Merge_Participation {
 		self::set_exact_scalar($fresh_source, self::SOURCE_OPERATION_META, $operation_id);
 		self::set_exact_scalar($fresh_source, self::SOURCE_PAIR_FINGERPRINT_META, $pair_fingerprint);
 		$fresh_source->save_meta_data();
+		do_action('wcos_merge_recovery_checkpoint', 'after_one_reciprocal_relation', $fresh_source, $fresh_target, $operation_id);
 
 		self::add_exact_repeatable($fresh_target, self::TARGET_SOURCE_META, $source_id);
 		self::add_exact_repeatable($fresh_target, self::TARGET_OPERATION_META, $operation_id);
 		self::add_exact_repeatable($fresh_target, self::TARGET_AUTHORITY_META, self::authority_pointer($source_id, $operation_id, $pair_fingerprint));
 		$fresh_target->save_meta_data();
+		do_action('wcos_merge_recovery_checkpoint', 'after_both_relations_before_verification', $fresh_source, $fresh_target, $operation_id);
 
 		$source_after = wc_get_order($source_id);
 		$target_after = wc_get_order($target_id);

--- a/inc/domain/class-wcos-merge-recovery-snapshot.php
+++ b/inc/domain/class-wcos-merge-recovery-snapshot.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Recovery_Snapshot {
 
-	const SCHEMA_VERSION = 1;
+	const SCHEMA_VERSION = 2;
 
 	public static function capture(WC_Order $source, WC_Order $target, array $record) {
 		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
@@ -39,15 +39,17 @@ final class WCOS_Merge_Recovery_Snapshot {
 			'source' => self::participant_state($source),
 			'target' => self::participant_state($target),
 		);
-		$snapshot['archive_source_signature_before'] = $snapshot['source']['commercial_signature'];
-		$snapshot['active_ownership_before_signature'] = self::active_ownership_signature($snapshot['source'], $snapshot['target']);
+		$snapshot['archive_source_contract_before'] = self::archive_commercial_contract($source);
+		$snapshot['archive_source_signature_before'] = self::contract_signature('merge_archive_commercial_v1', $source->get_id(), $snapshot['archive_source_contract_before']);
+		$snapshot['active_economic_contract_before'] = self::active_economic_contract(array($source, $target), $pair['price_precision']);
+		$snapshot['active_ownership_before_signature'] = self::contract_signature('merge_active_economic_v1', $source->get_id(), $snapshot['active_economic_contract_before']);
 		$snapshot['recovery_fingerprint'] = self::fingerprint($snapshot);
 		return $snapshot;
 	}
 
 	public static function assert_valid(array $snapshot, array $record = array()) {
 		$expected_keys = array(
-			'active_ownership_before_signature', 'archive_source_signature_before', 'pair_fingerprint',
+			'active_economic_contract_before', 'active_ownership_before_signature', 'archive_source_contract_before', 'archive_source_signature_before', 'pair_fingerprint',
 			'preflight_policy_version', 'price_precision', 'recovery_fingerprint', 'retirement_candidates',
 			'retirement_policy_schema_version', 'retirement_policy_selected', 'schema_version', 'source',
 			'source_order_id', 'target', 'target_order_id',
@@ -69,11 +71,8 @@ final class WCOS_Merge_Recovery_Snapshot {
 		}
 		self::assert_participant_state($snapshot['source'], absint($snapshot['source_order_id']));
 		self::assert_participant_state($snapshot['target'], absint($snapshot['target_order_id']));
-		if (!hash_equals((string) $snapshot['archive_source_signature_before'], (string) $snapshot['source']['commercial_signature'])
-			|| !hash_equals(
-				(string) $snapshot['active_ownership_before_signature'],
-				self::active_ownership_signature($snapshot['source'], $snapshot['target'])
-			)) {
+		if (!hash_equals((string) $snapshot['archive_source_signature_before'], self::contract_signature('merge_archive_commercial_v1', $snapshot['source_order_id'], $snapshot['archive_source_contract_before']))
+			|| !hash_equals((string) $snapshot['active_ownership_before_signature'], self::contract_signature('merge_active_economic_v1', $snapshot['source_order_id'], $snapshot['active_economic_contract_before']))) {
 			throw new RuntimeException(__('The Merge archive or active-ownership snapshot authority is invalid.', 'wc-order-splitter'));
 		}
 
@@ -86,7 +85,9 @@ final class WCOS_Merge_Recovery_Snapshot {
 				|| (int) $snapshot['price_precision'] !== $pair['price_precision']
 				|| (int) $snapshot['preflight_policy_version'] !== $pair['preflight_policy_version']
 				|| (int) $snapshot['retirement_policy_schema_version'] !== $pair['retirement_policy_schema_version']
-				|| array_values($snapshot['retirement_candidates']) !== $pair['retirement_candidates']) {
+				|| array_values($snapshot['retirement_candidates']) !== $pair['retirement_candidates']
+				|| !hash_equals((string) $snapshot['archive_source_signature_before'], $pair['archive_source_signature_before'])
+				|| !hash_equals((string) $snapshot['active_ownership_before_signature'], $pair['active_ownership_before_signature'])) {
 				throw new RuntimeException(__('The Merge recovery snapshot no longer matches pair authority.', 'wc-order-splitter'));
 			}
 		}
@@ -97,7 +98,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 		$copy = $snapshot;
 		unset($copy['recovery_fingerprint']);
 		return WCOS_Mutation_Fingerprint::create(
-			'merge_pair_recovery_v1',
+			'merge_pair_recovery_v2',
 			isset($copy['source_order_id']) ? absint($copy['source_order_id']) : 0,
 			$copy
 		);
@@ -106,6 +107,59 @@ final class WCOS_Merge_Recovery_Snapshot {
 	public static function participant_signature(WC_Order $order) {
 		$state = self::participant_state($order);
 		return self::state_signature($state);
+	}
+
+	/** Full lifecycle/stock-aware participant state used only for exact recovery. */
+	public static function participant_checkpoint(WC_Order $order) {
+		return self::participant_state($order);
+	}
+
+	/** Commercial archive contract deliberately excludes lifecycle, relations, and stock markers. */
+	public static function archive_commercial_contract(WC_Order $order) {
+		$state = self::participant_state($order);
+		$lines = $state['line_items'];
+		foreach ($lines as &$line) {
+			unset($line['reduced_stock']);
+		}
+		unset($line);
+		$props = $state['order_props'];
+		unset($props['status']);
+		return array(
+			'order_id' => $state['order_id'],
+			'currency' => (string) $order->get_currency(),
+			'prices_include_tax' => (bool) $order->get_prices_include_tax(),
+			'order_props' => $props,
+			'line_items' => $lines,
+			'tax_items' => $state['tax_items'],
+		);
+	}
+
+	public static function archive_commercial_signature(WC_Order $order) {
+		return self::contract_signature('merge_archive_commercial_v1', $order->get_id(), self::archive_commercial_contract($order));
+	}
+
+	/** Exact quantity/money/per-rate-tax/currency aggregate; operational stock is excluded. */
+	public static function active_economic_contract(array $orders, $precision) {
+		$contract = WCOS_Order_Contract_Snapshot::aggregate($orders, $precision);
+		unset($contract['stock_reduced']);
+		return $contract;
+	}
+
+	public static function active_economic_signature(array $orders, $precision, $authority_order_id) {
+		return self::contract_signature('merge_active_economic_v1', $authority_order_id, self::active_economic_contract($orders, $precision));
+	}
+
+	public static function assert_archive_preserved(array $snapshot, WC_Order $source) {
+		self::assert_valid($snapshot);
+		WCOS_Merge_Retirement_Policy::assert_archive_preserved($snapshot['archive_source_signature_before'], self::archive_commercial_signature($source));
+	}
+
+	public static function assert_active_economic_conserved(array $snapshot, WC_Order $target) {
+		self::assert_valid($snapshot);
+		WCOS_Merge_Retirement_Policy::assert_active_ownership_conserved(
+			$snapshot['active_ownership_before_signature'],
+			self::active_economic_signature(array($target), $snapshot['price_precision'], $snapshot['source_order_id'])
+		);
 	}
 
 	public static function before_signature(array $snapshot, $role) {
@@ -123,36 +177,37 @@ final class WCOS_Merge_Recovery_Snapshot {
 	public static function restore_participant(
 		array $snapshot,
 		$role,
-		$expected_current_signature,
+		array $after_state,
 		array $target_item_ids = array(),
-		array $target_tax_item_ids = array()
+		array $target_tax_item_ids = array(),
+		$boundary = null,
+		$checkpoint = null,
+		$retirement_candidate = ''
 	) {
 		self::assert_valid($snapshot);
 		$role = sanitize_key((string) $role);
 		if (!in_array($role, array('source', 'target'), true)) {
 			throw new InvalidArgumentException(__('A valid Merge recovery participant role is required.', 'wc-order-splitter'));
 		}
-		$expected_current_signature = self::normalized_fingerprint($expected_current_signature);
 		$order_id = absint($snapshot[$role]['order_id']);
 		$order = wc_get_order($order_id);
 		if (!$order instanceof WC_Order || 'shop_order' !== $order->get_type()) {
 			throw new RuntimeException(__('A Merge recovery participant is unavailable.', 'wc-order-splitter'));
 		}
-		$current = self::participant_signature($order);
-		if ('' === $expected_current_signature || !hash_equals($expected_current_signature, $current)) {
-			throw new RuntimeException(__('A Merge participant changed after its approved checkpoint.', 'wc-order-splitter'));
+		$retirement_candidate = sanitize_key((string) $retirement_candidate);
+		if ('source' === $role && WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE === $retirement_candidate && 'trash' === $order->get_status()) {
+			self::invoke($boundary, 'before_source_untrash', 0);
+			if (!method_exists($order, 'untrash') || !$order->untrash()) {
+				throw new RuntimeException(__('The non-force archived Merge source could not be untrashed for recovery.', 'wc-order-splitter'));
+			}
+			$order = wc_get_order($order_id);
+			self::invoke($checkpoint, 'source_untrashed', 0);
 		}
-
 		$target_item_ids = array_values(array_unique(array_filter(array_map('absint', $target_item_ids))));
 		sort($target_item_ids, SORT_NUMERIC);
 		$target_tax_item_ids = array_values(array_unique(array_filter(array_map('absint', $target_tax_item_ids))));
 		sort($target_tax_item_ids, SORT_NUMERIC);
-		self::assert_item_shape(
-			$order,
-			$snapshot[$role],
-			'target' === $role ? $target_item_ids : array(),
-			'target' === $role ? $target_tax_item_ids : array()
-		);
+		self::assert_resumable_participant($snapshot[$role], $after_state, $order, 'target' === $role ? $target_item_ids : array(), 'target' === $role ? $target_tax_item_ids : array());
 
 		$line_items = $order->get_items('line_item');
 		foreach ($snapshot[$role]['line_items'] as $item_id => $state) {
@@ -160,6 +215,11 @@ final class WCOS_Merge_Recovery_Snapshot {
 			if (!$item instanceof WC_Order_Item_Product) {
 				throw new RuntimeException(__('A snapshotted Merge line disappeared during recovery.', 'wc-order-splitter'));
 			}
+			$current_line = self::participant_state($order)['line_items'][$item_id];
+			if ($current_line === $state) {
+				continue;
+			}
+			self::invoke($boundary, 'before_' . $role . '_line_restore', $item_id);
 			$result = $item->set_props(array(
 				'quantity' => $state['quantity'],
 				'subtotal' => $state['subtotal'],
@@ -178,6 +238,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 			if ((int) $item_id !== (int) $item->save()) {
 				throw new RuntimeException(__('A restored Merge line did not persist.', 'wc-order-splitter'));
 			}
+			self::invoke($checkpoint, $role . '_line_restored', $item_id);
 		}
 
 		if ('target' === $role) {
@@ -185,13 +246,23 @@ final class WCOS_Merge_Recovery_Snapshot {
 				if (isset($snapshot[$role]['line_items'][$item_id])) {
 					throw new RuntimeException(__('Recovery cannot remove a pre-existing target line.', 'wc-order-splitter'));
 				}
-				$order->remove_item($item_id);
+				if (false !== $order->get_item($item_id)) {
+					self::invoke($boundary, 'before_target_added_line_cleanup', $item_id);
+					$order->remove_item($item_id);
+					$order->save();
+					self::invoke($checkpoint, 'target_added_line_removed', $item_id);
+				}
 			}
 			foreach ($target_tax_item_ids as $item_id) {
 				if (isset($snapshot[$role]['tax_items'][$item_id])) {
 					throw new RuntimeException(__('Recovery cannot remove a pre-existing target tax row.', 'wc-order-splitter'));
 				}
-				$order->remove_item($item_id);
+				if (false !== $order->get_item($item_id)) {
+					self::invoke($boundary, 'before_target_added_tax_cleanup', $item_id);
+					$order->remove_item($item_id);
+					$order->save();
+					self::invoke($checkpoint, 'target_added_tax_removed', $item_id);
+				}
 			}
 		}
 
@@ -201,6 +272,11 @@ final class WCOS_Merge_Recovery_Snapshot {
 			if (!$item instanceof WC_Order_Item_Tax || (int) $item->get_rate_id() !== (int) $state['rate_id']) {
 				throw new RuntimeException(__('A snapshotted Merge tax row changed during recovery.', 'wc-order-splitter'));
 			}
+			$current_tax = self::participant_state($order)['tax_items'][$item_id];
+			if ($current_tax === $state) {
+				continue;
+			}
+			self::invoke($boundary, 'before_' . $role . '_tax_restore', $item_id);
 			$result = $item->set_props(array(
 				'tax_total' => $state['tax_total'],
 				'shipping_tax_total' => $state['shipping_tax_total'],
@@ -208,15 +284,33 @@ final class WCOS_Merge_Recovery_Snapshot {
 			if (is_wp_error($result) || (int) $item_id !== (int) $item->save()) {
 				throw new RuntimeException(__('A Merge tax row could not be restored.', 'wc-order-splitter'));
 			}
+			self::invoke($checkpoint, $role . '_tax_restored', $item_id);
 		}
 
-		$result = $order->set_props($snapshot[$role]['order_props']);
-		if (is_wp_error($result)) {
-			throw new RuntimeException(__('Merge order totals or lifecycle state could not be restored.', 'wc-order-splitter'));
+		$current_state = self::participant_state($order);
+		if ($current_state['order_props'] !== $snapshot[$role]['order_props']) {
+			self::invoke($boundary, 'before_' . $role . '_order_restore', 0);
+			$result = $order->set_props($snapshot[$role]['order_props']);
+			if (is_wp_error($result)) {
+				throw new RuntimeException(__('Merge order totals or lifecycle state could not be restored.', 'wc-order-splitter'));
+			}
+			$order->save();
+			self::invoke($checkpoint, $role . '_order_restored', 0);
 		}
-		self::restore_relation_state($order, $snapshot[$role]['relation_meta']);
-		$order->save();
-		$order->get_data_store()->set_stock_reduced($order_id, (bool) $snapshot[$role]['order_stock_reduced']);
+		$order = wc_get_order($order_id);
+		$current_state = self::participant_state($order);
+		if ($current_state['relation_meta'] !== $snapshot[$role]['relation_meta']) {
+			self::invoke($boundary, 'before_' . $role . '_relation_restore', 0);
+			self::restore_relation_state($order, $snapshot[$role]['relation_meta']);
+			$order->save();
+			self::invoke($checkpoint, $role . '_relations_restored', 0);
+		}
+		$order = wc_get_order($order_id);
+		if ((bool) $order->get_data_store()->get_stock_reduced($order_id) !== (bool) $snapshot[$role]['order_stock_reduced']) {
+			self::invoke($boundary, 'before_' . $role . '_stock_marker_restore', 0);
+			$order->get_data_store()->set_stock_reduced($order_id, (bool) $snapshot[$role]['order_stock_reduced']);
+			self::invoke($checkpoint, $role . '_stock_marker_restored', 0);
+		}
 
 		$restored = wc_get_order($order_id);
 		$before = self::before_signature($snapshot, $role);
@@ -224,6 +318,54 @@ final class WCOS_Merge_Recovery_Snapshot {
 			throw new RuntimeException(__('A Merge participant did not match its verified pre-operation snapshot after recovery.', 'wc-order-splitter'));
 		}
 		return $restored;
+	}
+
+	/** Prove every operation-owned component is exactly at its before or after checkpoint. */
+	public static function assert_resumable_participant(array $before, array $after, WC_Order $order, array $added_ids = array(), array $added_tax_ids = array()) {
+		self::assert_participant_state($before, $order->get_id());
+		self::assert_participant_state($after, $order->get_id());
+		$current = self::participant_state($order);
+		self::assert_item_shape($order, $before, $added_ids, $added_tax_ids, true);
+		foreach ($before['line_items'] as $id => $state) {
+			if (!isset($current['line_items'][$id]) || ($current['line_items'][$id] !== $state && (!isset($after['line_items'][$id]) || $current['line_items'][$id] !== $after['line_items'][$id]))) {
+				throw new RuntimeException(__('A Merge line diverged from its resumable checkpoints.', 'wc-order-splitter'));
+			}
+		}
+		foreach ($added_ids as $id) {
+			$id = absint($id);
+			if (isset($current['line_items'][$id]) && (!isset($after['line_items'][$id]) || $current['line_items'][$id] !== $after['line_items'][$id])) {
+				throw new RuntimeException(__('An operation-owned target line diverged before cleanup.', 'wc-order-splitter'));
+			}
+		}
+		foreach ($before['tax_items'] as $id => $state) {
+			if (!isset($current['tax_items'][$id]) || ($current['tax_items'][$id] !== $state && (!isset($after['tax_items'][$id]) || $current['tax_items'][$id] !== $after['tax_items'][$id]))) {
+				throw new RuntimeException(__('A Merge tax row diverged from its resumable checkpoints.', 'wc-order-splitter'));
+			}
+		}
+		foreach ($added_tax_ids as $id) {
+			$id = absint($id);
+			if (isset($current['tax_items'][$id]) && (!isset($after['tax_items'][$id]) || $current['tax_items'][$id] !== $after['tax_items'][$id])) {
+				throw new RuntimeException(__('An operation-owned target tax row diverged before cleanup.', 'wc-order-splitter'));
+			}
+		}
+		foreach (array('order_props', 'relation_meta', 'order_stock_reduced') as $component) {
+			if ($current[$component] !== $before[$component] && $current[$component] !== $after[$component]) {
+				throw new RuntimeException(__('A Merge participant component diverged from its resumable checkpoints.', 'wc-order-splitter'));
+			}
+		}
+		return true;
+	}
+
+	/** Forward repair may resume with operation-owned reciprocal metadata partially persisted. */
+	public static function assert_forward_checkpoint(array $after, WC_Order $order) {
+		self::assert_participant_state($after, $order->get_id());
+		$current = self::participant_state($order);
+		foreach (array('line_items', 'tax_items', 'order_props', 'order_stock_reduced') as $component) {
+			if ($current[$component] !== $after[$component]) {
+				throw new RuntimeException(__('A Merge forward participant changed outside reciprocal relation metadata.', 'wc-order-splitter'));
+			}
+		}
+		return true;
 	}
 
 	private static function participant_state(WC_Order $order) {
@@ -261,7 +403,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 
 		return array(
 			'order_id' => (int) $order->get_id(),
-			'commercial_signature' => WCOS_Order_Contract_Snapshot::source_signature($order),
+			'participant_recovery_signature' => WCOS_Order_Contract_Snapshot::source_signature($order),
 			'order_props' => array(
 				'status' => (string) $order->get_status(),
 				'discount_total' => (string) $order->get_discount_total(),
@@ -280,26 +422,26 @@ final class WCOS_Merge_Recovery_Snapshot {
 	}
 
 	private static function assert_participant_state(array $state, $expected_order_id) {
-		$expected_keys = array('commercial_signature', 'line_items', 'order_id', 'order_props', 'order_stock_reduced', 'relation_meta', 'tax_items');
+		$expected_keys = array('line_items', 'order_id', 'order_props', 'order_stock_reduced', 'participant_recovery_signature', 'relation_meta', 'tax_items');
 		$actual = array_keys($state);
 		sort($actual, SORT_STRING);
 		sort($expected_keys, SORT_STRING);
 		if ($actual !== $expected_keys || absint($state['order_id']) !== $expected_order_id
-			|| '' === self::normalized_fingerprint($state['commercial_signature'])
+			|| '' === self::normalized_fingerprint($state['participant_recovery_signature'])
 			|| !is_array($state['line_items']) || !is_array($state['tax_items'])
 			|| !is_array($state['order_props']) || !is_array($state['relation_meta'])) {
 			throw new RuntimeException(__('A Merge participant recovery snapshot is invalid.', 'wc-order-splitter'));
 		}
 	}
 
-	private static function assert_item_shape(WC_Order $order, array $state, array $allowed_added_ids, array $allowed_added_tax_ids) {
+	private static function assert_item_shape(WC_Order $order, array $state, array $allowed_added_ids, array $allowed_added_tax_ids, $allow_removed_additions = false) {
 		$current = array_map('intval', array_keys($order->get_items('line_item')));
 		$expected = array_map('intval', array_keys($state['line_items']));
 		$allowed = array_values(array_unique(array_merge($expected, $allowed_added_ids)));
 		sort($current, SORT_NUMERIC);
 		sort($expected, SORT_NUMERIC);
 		sort($allowed, SORT_NUMERIC);
-		if ($current !== $allowed) {
+		if (($allow_removed_additions && array_diff($current, $allowed)) || (!$allow_removed_additions && $current !== $allowed) || array_diff($expected, $current)) {
 			throw new RuntimeException(__('The Merge line set contains an unexplained external change.', 'wc-order-splitter'));
 		}
 		foreach ($state['line_items'] as $item_id => $line) {
@@ -314,8 +456,14 @@ final class WCOS_Merge_Recovery_Snapshot {
 		sort($expected_tax, SORT_NUMERIC);
 		$allowed_tax = array_values(array_unique(array_merge($expected_tax, $allowed_added_tax_ids)));
 		sort($allowed_tax, SORT_NUMERIC);
-		if ($current_tax !== $allowed_tax) {
+		if (($allow_removed_additions && array_diff($current_tax, $allowed_tax)) || (!$allow_removed_additions && $current_tax !== $allowed_tax) || array_diff($expected_tax, $current_tax)) {
 			throw new RuntimeException(__('The Merge tax-row set changed during recovery.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function invoke($callback, $stage, $component_id) {
+		if (is_callable($callback)) {
+			call_user_func($callback, sanitize_key((string) $stage), absint($component_id));
 		}
 	}
 
@@ -358,20 +506,11 @@ final class WCOS_Merge_Recovery_Snapshot {
 	}
 
 	private static function state_signature(array $state) {
-		return WCOS_Mutation_Fingerprint::create('merge_participant_recovery_state_v1', absint($state['order_id']), $state);
+		return WCOS_Mutation_Fingerprint::create('merge_participant_recovery_state_v2', absint($state['order_id']), $state);
 	}
 
-	private static function active_ownership_signature(array $source, array $target) {
-		return WCOS_Mutation_Fingerprint::create(
-			'merge_active_ownership_before_v1',
-			absint($source['order_id']),
-			array(
-				'source_commercial_signature' => $source['commercial_signature'],
-				'target_commercial_signature' => $target['commercial_signature'],
-				'source_stock_reduced' => (bool) $source['order_stock_reduced'],
-				'target_stock_reduced' => (bool) $target['order_stock_reduced'],
-			)
-		);
+	private static function contract_signature($namespace, $order_id, array $contract) {
+		return WCOS_Mutation_Fingerprint::create($namespace, absint($order_id), $contract);
 	}
 
 	private static function canonicalize(array $value) {

--- a/inc/domain/class-wcos-merge-recovery-snapshot.php
+++ b/inc/domain/class-wcos-merge-recovery-snapshot.php
@@ -1,0 +1,391 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * PII-minimized, self-verifying recovery snapshot for an existing Merge pair.
+ *
+ * The snapshot contains only state the Merge recovery foundation owns: exact
+ * historical amounts/taxes, operational stock markers, lifecycle state, and
+ * Merge participation metadata. Customer, address, payment, item-name, and
+ * arbitrary third-party order metadata are deliberately excluded.
+ */
+final class WCOS_Merge_Recovery_Snapshot {
+
+	const SCHEMA_VERSION = 1;
+
+	public static function capture(WC_Order $source, WC_Order $target, array $record) {
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		if (!is_array($pair)
+			|| absint($source->get_id()) !== $pair['source_order_id']
+			|| absint($target->get_id()) !== $pair['target_order_id']) {
+			throw new RuntimeException(__('Merge recovery snapshot participants do not match pair authority.', 'wc-order-splitter'));
+		}
+		if (!hash_equals($pair['source_signature'], WCOS_Order_Contract_Snapshot::source_signature($source))
+			|| !hash_equals($pair['target_signature'], WCOS_Order_Contract_Snapshot::source_signature($target))) {
+			throw new RuntimeException(__('Merge participants changed before recovery state could be captured.', 'wc-order-splitter'));
+		}
+
+		$snapshot = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'pair_fingerprint' => $pair['pair_fingerprint'],
+			'source_order_id' => $pair['source_order_id'],
+			'target_order_id' => $pair['target_order_id'],
+			'price_precision' => $pair['price_precision'],
+			'preflight_policy_version' => $pair['preflight_policy_version'],
+			'retirement_policy_schema_version' => $pair['retirement_policy_schema_version'],
+			'retirement_candidates' => $pair['retirement_candidates'],
+			'retirement_policy_selected' => false,
+			'source' => self::participant_state($source),
+			'target' => self::participant_state($target),
+		);
+		$snapshot['archive_source_signature_before'] = $snapshot['source']['commercial_signature'];
+		$snapshot['active_ownership_before_signature'] = self::active_ownership_signature($snapshot['source'], $snapshot['target']);
+		$snapshot['recovery_fingerprint'] = self::fingerprint($snapshot);
+		return $snapshot;
+	}
+
+	public static function assert_valid(array $snapshot, array $record = array()) {
+		$expected_keys = array(
+			'active_ownership_before_signature', 'archive_source_signature_before', 'pair_fingerprint',
+			'preflight_policy_version', 'price_precision', 'recovery_fingerprint', 'retirement_candidates',
+			'retirement_policy_schema_version', 'retirement_policy_selected', 'schema_version', 'source',
+			'source_order_id', 'target', 'target_order_id',
+		);
+		$actual_keys = array_keys($snapshot);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		if ($actual_keys !== $expected_keys
+			|| self::SCHEMA_VERSION !== (int) $snapshot['schema_version']
+			|| !is_array($snapshot['source']) || !is_array($snapshot['target'])
+			|| false !== (bool) $snapshot['retirement_policy_selected']) {
+			throw new RuntimeException(__('The Merge recovery snapshot has an invalid schema.', 'wc-order-splitter'));
+		}
+
+		$stored = self::normalized_fingerprint($snapshot['recovery_fingerprint']);
+		$actual = self::fingerprint($snapshot);
+		if ('' === $stored || !hash_equals($stored, $actual)) {
+			throw new RuntimeException(__('The Merge recovery snapshot failed its integrity fingerprint.', 'wc-order-splitter'));
+		}
+		self::assert_participant_state($snapshot['source'], absint($snapshot['source_order_id']));
+		self::assert_participant_state($snapshot['target'], absint($snapshot['target_order_id']));
+		if (!hash_equals((string) $snapshot['archive_source_signature_before'], (string) $snapshot['source']['commercial_signature'])
+			|| !hash_equals(
+				(string) $snapshot['active_ownership_before_signature'],
+				self::active_ownership_signature($snapshot['source'], $snapshot['target'])
+			)) {
+			throw new RuntimeException(__('The Merge archive or active-ownership snapshot authority is invalid.', 'wc-order-splitter'));
+		}
+
+		if (!empty($record)) {
+			$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+			if (!is_array($pair)
+				|| absint($snapshot['source_order_id']) !== $pair['source_order_id']
+				|| absint($snapshot['target_order_id']) !== $pair['target_order_id']
+				|| !hash_equals((string) $snapshot['pair_fingerprint'], $pair['pair_fingerprint'])
+				|| (int) $snapshot['price_precision'] !== $pair['price_precision']
+				|| (int) $snapshot['preflight_policy_version'] !== $pair['preflight_policy_version']
+				|| (int) $snapshot['retirement_policy_schema_version'] !== $pair['retirement_policy_schema_version']
+				|| array_values($snapshot['retirement_candidates']) !== $pair['retirement_candidates']) {
+				throw new RuntimeException(__('The Merge recovery snapshot no longer matches pair authority.', 'wc-order-splitter'));
+			}
+		}
+		return true;
+	}
+
+	public static function fingerprint(array $snapshot) {
+		$copy = $snapshot;
+		unset($copy['recovery_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create(
+			'merge_pair_recovery_v1',
+			isset($copy['source_order_id']) ? absint($copy['source_order_id']) : 0,
+			$copy
+		);
+	}
+
+	public static function participant_signature(WC_Order $order) {
+		$state = self::participant_state($order);
+		return self::state_signature($state);
+	}
+
+	public static function before_signature(array $snapshot, $role) {
+		$role = sanitize_key((string) $role);
+		if (!in_array($role, array('source', 'target'), true) || !isset($snapshot[$role])) {
+			return '';
+		}
+		return self::state_signature($snapshot[$role]);
+	}
+
+	/**
+	 * Restore one participant only after an exact planned-checkpoint signature.
+	 * Target additions are removed only from the journal-owned ID allowlist.
+	 */
+	public static function restore_participant(
+		array $snapshot,
+		$role,
+		$expected_current_signature,
+		array $target_item_ids = array(),
+		array $target_tax_item_ids = array()
+	) {
+		self::assert_valid($snapshot);
+		$role = sanitize_key((string) $role);
+		if (!in_array($role, array('source', 'target'), true)) {
+			throw new InvalidArgumentException(__('A valid Merge recovery participant role is required.', 'wc-order-splitter'));
+		}
+		$expected_current_signature = self::normalized_fingerprint($expected_current_signature);
+		$order_id = absint($snapshot[$role]['order_id']);
+		$order = wc_get_order($order_id);
+		if (!$order instanceof WC_Order || 'shop_order' !== $order->get_type()) {
+			throw new RuntimeException(__('A Merge recovery participant is unavailable.', 'wc-order-splitter'));
+		}
+		$current = self::participant_signature($order);
+		if ('' === $expected_current_signature || !hash_equals($expected_current_signature, $current)) {
+			throw new RuntimeException(__('A Merge participant changed after its approved checkpoint.', 'wc-order-splitter'));
+		}
+
+		$target_item_ids = array_values(array_unique(array_filter(array_map('absint', $target_item_ids))));
+		sort($target_item_ids, SORT_NUMERIC);
+		$target_tax_item_ids = array_values(array_unique(array_filter(array_map('absint', $target_tax_item_ids))));
+		sort($target_tax_item_ids, SORT_NUMERIC);
+		self::assert_item_shape(
+			$order,
+			$snapshot[$role],
+			'target' === $role ? $target_item_ids : array(),
+			'target' === $role ? $target_tax_item_ids : array()
+		);
+
+		$line_items = $order->get_items('line_item');
+		foreach ($snapshot[$role]['line_items'] as $item_id => $state) {
+			$item = isset($line_items[$item_id]) ? $line_items[$item_id] : null;
+			if (!$item instanceof WC_Order_Item_Product) {
+				throw new RuntimeException(__('A snapshotted Merge line disappeared during recovery.', 'wc-order-splitter'));
+			}
+			$result = $item->set_props(array(
+				'quantity' => $state['quantity'],
+				'subtotal' => $state['subtotal'],
+				'subtotal_tax' => $state['subtotal_tax'],
+				'total' => $state['total'],
+				'total_tax' => $state['total_tax'],
+				'taxes' => $state['taxes'],
+			));
+			if (is_wp_error($result)) {
+				throw new RuntimeException(__('A Merge line could not be restored.', 'wc-order-splitter'));
+			}
+			$item->delete_meta_data('_reduced_stock');
+			if (null !== $state['reduced_stock']) {
+				$item->add_meta_data('_reduced_stock', $state['reduced_stock'], true);
+			}
+			if ((int) $item_id !== (int) $item->save()) {
+				throw new RuntimeException(__('A restored Merge line did not persist.', 'wc-order-splitter'));
+			}
+		}
+
+		if ('target' === $role) {
+			foreach ($target_item_ids as $item_id) {
+				if (isset($snapshot[$role]['line_items'][$item_id])) {
+					throw new RuntimeException(__('Recovery cannot remove a pre-existing target line.', 'wc-order-splitter'));
+				}
+				$order->remove_item($item_id);
+			}
+			foreach ($target_tax_item_ids as $item_id) {
+				if (isset($snapshot[$role]['tax_items'][$item_id])) {
+					throw new RuntimeException(__('Recovery cannot remove a pre-existing target tax row.', 'wc-order-splitter'));
+				}
+				$order->remove_item($item_id);
+			}
+		}
+
+		$tax_items = $order->get_items('tax');
+		foreach ($snapshot[$role]['tax_items'] as $item_id => $state) {
+			$item = isset($tax_items[$item_id]) ? $tax_items[$item_id] : null;
+			if (!$item instanceof WC_Order_Item_Tax || (int) $item->get_rate_id() !== (int) $state['rate_id']) {
+				throw new RuntimeException(__('A snapshotted Merge tax row changed during recovery.', 'wc-order-splitter'));
+			}
+			$result = $item->set_props(array(
+				'tax_total' => $state['tax_total'],
+				'shipping_tax_total' => $state['shipping_tax_total'],
+			));
+			if (is_wp_error($result) || (int) $item_id !== (int) $item->save()) {
+				throw new RuntimeException(__('A Merge tax row could not be restored.', 'wc-order-splitter'));
+			}
+		}
+
+		$result = $order->set_props($snapshot[$role]['order_props']);
+		if (is_wp_error($result)) {
+			throw new RuntimeException(__('Merge order totals or lifecycle state could not be restored.', 'wc-order-splitter'));
+		}
+		self::restore_relation_state($order, $snapshot[$role]['relation_meta']);
+		$order->save();
+		$order->get_data_store()->set_stock_reduced($order_id, (bool) $snapshot[$role]['order_stock_reduced']);
+
+		$restored = wc_get_order($order_id);
+		$before = self::before_signature($snapshot, $role);
+		if (!$restored instanceof WC_Order || !hash_equals($before, self::participant_signature($restored))) {
+			throw new RuntimeException(__('A Merge participant did not match its verified pre-operation snapshot after recovery.', 'wc-order-splitter'));
+		}
+		return $restored;
+	}
+
+	private static function participant_state(WC_Order $order) {
+		if (!$order->get_id() || 'shop_order' !== $order->get_type()) {
+			throw new InvalidArgumentException(__('Merge recovery requires persisted shop orders.', 'wc-order-splitter'));
+		}
+		$lines = array();
+		foreach ($order->get_items('line_item') as $item_id => $item) {
+			$reduced = $item->get_meta('_reduced_stock', true);
+			$lines[(int) $item_id] = array(
+				'identity' => WCOS_Line_Identity::from_item($item),
+				'product_id' => (int) $item->get_product_id(),
+				'variation_id' => (int) $item->get_variation_id(),
+				'tax_class' => (string) $item->get_tax_class(),
+				'quantity' => WCOS_Decimal::normalize($item->get_quantity(), 6),
+				'subtotal' => (string) $item->get_subtotal(),
+				'subtotal_tax' => (string) $item->get_subtotal_tax(),
+				'total' => (string) $item->get_total(),
+				'total_tax' => (string) $item->get_total_tax(),
+				'taxes' => self::canonicalize($item->get_taxes()),
+				'reduced_stock' => '' === $reduced || null === $reduced ? null : WCOS_Decimal::normalize($reduced, 6),
+			);
+		}
+		ksort($lines, SORT_NUMERIC);
+
+		$taxes = array();
+		foreach ($order->get_items('tax') as $item_id => $item) {
+			$taxes[(int) $item_id] = array(
+				'rate_id' => (int) $item->get_rate_id(),
+				'tax_total' => (string) $item->get_tax_total(),
+				'shipping_tax_total' => (string) $item->get_shipping_tax_total(),
+			);
+		}
+		ksort($taxes, SORT_NUMERIC);
+
+		return array(
+			'order_id' => (int) $order->get_id(),
+			'commercial_signature' => WCOS_Order_Contract_Snapshot::source_signature($order),
+			'order_props' => array(
+				'status' => (string) $order->get_status(),
+				'discount_total' => (string) $order->get_discount_total(),
+				'discount_tax' => (string) $order->get_discount_tax(),
+				'shipping_total' => (string) $order->get_shipping_total(),
+				'shipping_tax' => (string) $order->get_shipping_tax(),
+				'cart_tax' => (string) $order->get_cart_tax(),
+				'total_tax' => (string) $order->get_total_tax(),
+				'total' => (string) $order->get_total(),
+			),
+			'order_stock_reduced' => (bool) $order->get_data_store()->get_stock_reduced($order->get_id()),
+			'relation_meta' => self::relation_state($order),
+			'line_items' => $lines,
+			'tax_items' => $taxes,
+		);
+	}
+
+	private static function assert_participant_state(array $state, $expected_order_id) {
+		$expected_keys = array('commercial_signature', 'line_items', 'order_id', 'order_props', 'order_stock_reduced', 'relation_meta', 'tax_items');
+		$actual = array_keys($state);
+		sort($actual, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		if ($actual !== $expected_keys || absint($state['order_id']) !== $expected_order_id
+			|| '' === self::normalized_fingerprint($state['commercial_signature'])
+			|| !is_array($state['line_items']) || !is_array($state['tax_items'])
+			|| !is_array($state['order_props']) || !is_array($state['relation_meta'])) {
+			throw new RuntimeException(__('A Merge participant recovery snapshot is invalid.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function assert_item_shape(WC_Order $order, array $state, array $allowed_added_ids, array $allowed_added_tax_ids) {
+		$current = array_map('intval', array_keys($order->get_items('line_item')));
+		$expected = array_map('intval', array_keys($state['line_items']));
+		$allowed = array_values(array_unique(array_merge($expected, $allowed_added_ids)));
+		sort($current, SORT_NUMERIC);
+		sort($expected, SORT_NUMERIC);
+		sort($allowed, SORT_NUMERIC);
+		if ($current !== $allowed) {
+			throw new RuntimeException(__('The Merge line set contains an unexplained external change.', 'wc-order-splitter'));
+		}
+		foreach ($state['line_items'] as $item_id => $line) {
+			$item = $order->get_item((int) $item_id);
+			if (!$item instanceof WC_Order_Item_Product || !hash_equals((string) $line['identity'], WCOS_Line_Identity::from_item($item))) {
+				throw new RuntimeException(__('A pre-existing Merge line identity changed during recovery.', 'wc-order-splitter'));
+			}
+		}
+		$current_tax = array_map('intval', array_keys($order->get_items('tax')));
+		$expected_tax = array_map('intval', array_keys($state['tax_items']));
+		sort($current_tax, SORT_NUMERIC);
+		sort($expected_tax, SORT_NUMERIC);
+		$allowed_tax = array_values(array_unique(array_merge($expected_tax, $allowed_added_tax_ids)));
+		sort($allowed_tax, SORT_NUMERIC);
+		if ($current_tax !== $allowed_tax) {
+			throw new RuntimeException(__('The Merge tax-row set changed during recovery.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function relation_state(WC_Order $order) {
+		$state = array();
+		foreach (array(
+			WCOS_Merge_Participation::SOURCE_TARGET_META,
+			WCOS_Merge_Participation::SOURCE_OPERATION_META,
+			WCOS_Merge_Participation::SOURCE_PAIR_FINGERPRINT_META,
+			WCOS_Merge_Participation::TARGET_SOURCE_META,
+			WCOS_Merge_Participation::TARGET_OPERATION_META,
+			WCOS_Merge_Participation::TARGET_AUTHORITY_META,
+		) as $key) {
+			$values = array_map('strval', self::meta_values($order, $key));
+			sort($values, SORT_STRING);
+			$state[$key] = $values;
+		}
+		ksort($state, SORT_STRING);
+		return $state;
+	}
+
+	private static function restore_relation_state(WC_Order $order, array $state) {
+		foreach ($state as $key => $values) {
+			$order->delete_meta_data((string) $key);
+			foreach ((array) $values as $value) {
+				$order->add_meta_data((string) $key, (string) $value, false);
+			}
+		}
+	}
+
+	private static function meta_values(WC_Order $order, $key) {
+		$values = array();
+		foreach ($order->get_meta_data() as $meta) {
+			$data = is_object($meta) && method_exists($meta, 'get_data') ? $meta->get_data() : array();
+			if (isset($data['key']) && (string) $data['key'] === (string) $key && array_key_exists('value', $data)) {
+				$values[] = $data['value'];
+			}
+		}
+		return $values;
+	}
+
+	private static function state_signature(array $state) {
+		return WCOS_Mutation_Fingerprint::create('merge_participant_recovery_state_v1', absint($state['order_id']), $state);
+	}
+
+	private static function active_ownership_signature(array $source, array $target) {
+		return WCOS_Mutation_Fingerprint::create(
+			'merge_active_ownership_before_v1',
+			absint($source['order_id']),
+			array(
+				'source_commercial_signature' => $source['commercial_signature'],
+				'target_commercial_signature' => $target['commercial_signature'],
+				'source_stock_reduced' => (bool) $source['order_stock_reduced'],
+				'target_stock_reduced' => (bool) $target['order_stock_reduced'],
+			)
+		);
+	}
+
+	private static function canonicalize(array $value) {
+		ksort($value, SORT_STRING);
+		foreach ($value as $key => $item) {
+			if (is_array($item)) {
+				$value[$key] = self::canonicalize($item);
+			}
+		}
+		return $value;
+	}
+
+	private static function normalized_fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
+	}
+}

--- a/inc/domain/class-wcos-merge-recovery-snapshot.php
+++ b/inc/domain/class-wcos-merge-recovery-snapshot.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Recovery_Snapshot {
 
-	const SCHEMA_VERSION = 2;
+	const SCHEMA_VERSION = 3;
 
 	public static function capture(WC_Order $source, WC_Order $target, array $record) {
 		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
@@ -38,6 +38,8 @@ final class WCOS_Merge_Recovery_Snapshot {
 			'retirement_policy_selected' => false,
 			'source' => self::participant_state($source),
 			'target' => self::participant_state($target),
+			'source_immutable_context' => self::immutable_guard($source),
+			'target_immutable_context' => self::immutable_guard($target),
 		);
 		$snapshot['archive_source_contract_before'] = self::archive_commercial_contract($source);
 		$snapshot['archive_source_signature_before'] = self::contract_signature('merge_archive_commercial_v1', $source->get_id(), $snapshot['archive_source_contract_before']);
@@ -52,7 +54,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 			'active_economic_contract_before', 'active_ownership_before_signature', 'archive_source_contract_before', 'archive_source_signature_before', 'pair_fingerprint',
 			'preflight_policy_version', 'price_precision', 'recovery_fingerprint', 'retirement_candidates',
 			'retirement_policy_schema_version', 'retirement_policy_selected', 'schema_version', 'source',
-			'source_order_id', 'target', 'target_order_id',
+			'source_immutable_context', 'source_order_id', 'target', 'target_immutable_context', 'target_order_id',
 		);
 		$actual_keys = array_keys($snapshot);
 		sort($actual_keys, SORT_STRING);
@@ -71,6 +73,8 @@ final class WCOS_Merge_Recovery_Snapshot {
 		}
 		self::assert_participant_state($snapshot['source'], absint($snapshot['source_order_id']));
 		self::assert_participant_state($snapshot['target'], absint($snapshot['target_order_id']));
+		self::assert_immutable_guard($snapshot['source_immutable_context'], absint($snapshot['source_order_id']));
+		self::assert_immutable_guard($snapshot['target_immutable_context'], absint($snapshot['target_order_id']));
 		if (!hash_equals((string) $snapshot['archive_source_signature_before'], self::contract_signature('merge_archive_commercial_v1', $snapshot['source_order_id'], $snapshot['archive_source_contract_before']))
 			|| !hash_equals((string) $snapshot['active_ownership_before_signature'], self::contract_signature('merge_active_economic_v1', $snapshot['source_order_id'], $snapshot['active_economic_contract_before']))) {
 			throw new RuntimeException(__('The Merge archive or active-ownership snapshot authority is invalid.', 'wc-order-splitter'));
@@ -98,7 +102,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 		$copy = $snapshot;
 		unset($copy['recovery_fingerprint']);
 		return WCOS_Mutation_Fingerprint::create(
-			'merge_pair_recovery_v2',
+			'merge_pair_recovery_v3',
 			isset($copy['source_order_id']) ? absint($copy['source_order_id']) : 0,
 			$copy
 		);
@@ -160,6 +164,30 @@ final class WCOS_Merge_Recovery_Snapshot {
 			$snapshot['active_ownership_before_signature'],
 			self::active_economic_signature(array($target), $snapshot['price_precision'], $snapshot['source_order_id'])
 		);
+	}
+
+	/**
+	 * Prove keyed customer context and all non-Merge-owned participant state are
+	 * unchanged. This guard never restores external state; callers fail closed.
+	 */
+	public static function assert_immutable_pair(
+		array $snapshot,
+		array $record,
+		WC_Order $source,
+		WC_Order $target,
+		array $target_item_ids = array(),
+		array $target_tax_item_ids = array()
+	) {
+		self::assert_valid($snapshot, $record);
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		if (!is_array($pair) || !isset($pair['context_authority']) || !is_array($pair['context_authority'])) {
+			throw new RuntimeException(__('Immutable Merge context authority is unavailable.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Context_Signature::assert_current($source, $pair['context_authority']);
+		WCOS_Merge_Context_Signature::assert_current($target, $pair['context_authority']);
+		self::assert_immutable_participant($snapshot['source_immutable_context'], $source, array(), array());
+		self::assert_immutable_participant($snapshot['target_immutable_context'], $target, $target_item_ids, $target_tax_item_ids);
+		return true;
 	}
 
 	public static function before_signature(array $snapshot, $role) {
@@ -366,6 +394,146 @@ final class WCOS_Merge_Recovery_Snapshot {
 			}
 		}
 		return true;
+	}
+
+	private static function immutable_guard(WC_Order $order) {
+		$item_ids = array();
+		foreach (array('line_item', 'shipping', 'fee', 'tax', 'coupon') as $type) {
+			$item_ids[$type] = array_map('intval', array_keys($order->get_items($type)));
+			sort($item_ids[$type], SORT_NUMERIC);
+		}
+		return array(
+			'schema_version' => 1,
+			'order_id' => (int) $order->get_id(),
+			'item_ids' => $item_ids,
+			'immutable_signature' => self::immutable_signature($order, $item_ids),
+		);
+	}
+
+	private static function assert_immutable_guard($guard, $expected_order_id) {
+		$expected_types = array('coupon', 'fee', 'line_item', 'shipping', 'tax');
+		if (!is_array($guard)) {
+			throw new RuntimeException(__('A Merge immutable-context guard is missing.', 'wc-order-splitter'));
+		}
+		$keys = array_keys($guard);
+		$expected_keys = array('immutable_signature', 'item_ids', 'order_id', 'schema_version');
+		sort($keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		$types = isset($guard['item_ids']) && is_array($guard['item_ids']) ? array_keys($guard['item_ids']) : array();
+		sort($types, SORT_STRING);
+		if ($keys !== $expected_keys || 1 !== (int) $guard['schema_version']
+			|| absint($guard['order_id']) !== absint($expected_order_id)
+			|| $types !== $expected_types || '' === self::normalized_fingerprint($guard['immutable_signature'])) {
+			throw new RuntimeException(__('A Merge immutable-context guard has an invalid schema.', 'wc-order-splitter'));
+		}
+		foreach ($guard['item_ids'] as $ids) {
+			$normalized = array_values(array_unique(array_filter(array_map('absint', (array) $ids))));
+			sort($normalized, SORT_NUMERIC);
+			if ($normalized !== array_values($ids)) {
+				throw new RuntimeException(__('A Merge immutable-context item authority is non-canonical.', 'wc-order-splitter'));
+			}
+		}
+	}
+
+	private static function assert_immutable_participant(array $guard, WC_Order $order, array $allowed_line_ids, array $allowed_tax_ids) {
+		self::assert_immutable_guard($guard, $order->get_id());
+		$allowed_additions = array(
+			'line_item' => array_values(array_unique(array_filter(array_map('absint', $allowed_line_ids)))),
+			'tax' => array_values(array_unique(array_filter(array_map('absint', $allowed_tax_ids)))),
+		);
+		foreach ($guard['item_ids'] as $type => $baseline) {
+			$current = array_map('intval', array_keys($order->get_items($type)));
+			$allowed = array_values(array_unique(array_merge($baseline, isset($allowed_additions[$type]) ? $allowed_additions[$type] : array())));
+			sort($current, SORT_NUMERIC);
+			sort($allowed, SORT_NUMERIC);
+			if (array_diff($baseline, $current) || array_diff($current, $allowed)) {
+				throw new RuntimeException(__('A non-Merge order item changed outside immutable participant authority.', 'wc-order-splitter'));
+			}
+		}
+		$actual = self::immutable_signature($order, $guard['item_ids']);
+		if (!hash_equals((string) $guard['immutable_signature'], $actual)) {
+			throw new RuntimeException(__('Immutable non-Merge participant context changed after its approved checkpoint.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function immutable_signature(WC_Order $order, array $item_ids) {
+		$items = array();
+		foreach ($item_ids as $type => $ids) {
+			foreach ($ids as $item_id) {
+				$item = $order->get_item($item_id);
+				if (!$item instanceof WC_Order_Item || $item->get_type() !== $type) {
+					throw new RuntimeException(__('An immutable Merge participant item disappeared or changed type.', 'wc-order-splitter'));
+				}
+				$state = array(
+					'id' => (int) $item_id,
+					'type' => (string) $item->get_type(),
+					'name' => (string) $item->get_name(),
+					'business_meta' => WCOS_Order_Item_Meta_Policy::business_metadata($item),
+				);
+				if ($item instanceof WC_Order_Item_Product) {
+					$state += array(
+						'product_id' => (int) $item->get_product_id(),
+						'variation_id' => (int) $item->get_variation_id(),
+						'tax_class' => (string) $item->get_tax_class(),
+					);
+				} elseif ($item instanceof WC_Order_Item_Shipping) {
+					$state += array(
+						'method_id' => (string) $item->get_method_id(),
+						'instance_id' => (int) $item->get_instance_id(),
+						'total' => (string) $item->get_total(),
+						'total_tax' => (string) $item->get_total_tax(),
+						'taxes' => self::canonicalize($item->get_taxes()),
+					);
+				} elseif ($item instanceof WC_Order_Item_Fee) {
+					$state += array(
+						'amount' => (string) $item->get_amount(),
+						'tax_class' => (string) $item->get_tax_class(),
+						'tax_status' => (string) $item->get_tax_status(),
+						'total' => (string) $item->get_total(),
+						'total_tax' => (string) $item->get_total_tax(),
+						'taxes' => self::canonicalize($item->get_taxes()),
+					);
+				} elseif ($item instanceof WC_Order_Item_Tax) {
+					$state += array(
+						'rate_id' => (int) $item->get_rate_id(),
+						'compound' => (bool) $item->get_compound(),
+						'rate_percent' => (string) $item->get_rate_percent(),
+					);
+				} elseif ($item instanceof WC_Order_Item_Coupon) {
+					$state += array(
+						'code' => (string) $item->get_code(),
+						'discount' => (string) $item->get_discount(),
+						'discount_tax' => (string) $item->get_discount_tax(),
+					);
+				}
+				$items[$type][(int) $item_id] = $state;
+			}
+		}
+		$contract = array(
+			'order_id' => (int) $order->get_id(),
+			'type' => (string) $order->get_type(),
+			'currency' => (string) $order->get_currency(),
+			'prices_include_tax' => (bool) $order->get_prices_include_tax(),
+			'transaction_id' => (string) $order->get_transaction_id(),
+			'customer_note' => (string) $order->get_customer_note(),
+			'parent_id' => (int) $order->get_parent_id(),
+			'created_via' => (string) $order->get_created_via(),
+			'items' => $items,
+		);
+		$secret = (string) wp_salt('auth');
+		$document = wp_json_encode(
+			array(
+				'schema_version' => 1,
+				'purpose' => 'merge_immutable_participant_v1',
+				'order_id' => (int) $order->get_id(),
+				'contract' => self::canonicalize($contract),
+			),
+			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+		);
+		if ('' === $secret || !is_string($document) || '' === $document) {
+			throw new RuntimeException(__('Immutable Merge participant context could not be keyed.', 'wc-order-splitter'));
+		}
+		return hash_hmac('sha256', $document, $secret);
 	}
 
 	private static function participant_state(WC_Order $order) {

--- a/inc/domain/class-wcos-merge-recovery-state-graph.php
+++ b/inc/domain/class-wcos-merge-recovery-state-graph.php
@@ -1,0 +1,115 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Closed vocabulary and transition graph for durable Merge recovery states.
+ */
+final class WCOS_Merge_Recovery_State_Graph {
+	const NO_WRITE = 'no_commercial_write';
+	const TARGET_PERSISTED = 'target_persisted';
+	const SOURCE_OWNERSHIP_MIGRATING = 'source_ownership_migrating';
+	const SOURCE_OWNERSHIP_MIGRATED = 'source_ownership_migrated';
+	const SOURCE_RETIRED = 'source_retired';
+	const SOURCE_RELATION = 'source_relation_persisted';
+	const RELATIONS_COMPLETE = 'relations_complete';
+	const VERIFIED = 'commercial_verified';
+	const COMMITTED = 'committed';
+	const COMPLETED = 'completed';
+	const COMPENSATING = 'compensating';
+	const SOURCE_RESTORED = 'source_restored';
+	const TARGET_RESTORED = 'target_restored';
+	const COMPENSATED = 'compensated';
+	const MANUAL = 'manual_reconciliation';
+
+	public static function stages() {
+		return array(
+			self::NO_WRITE, self::TARGET_PERSISTED, self::SOURCE_OWNERSHIP_MIGRATING,
+			self::SOURCE_OWNERSHIP_MIGRATED, self::SOURCE_RETIRED, self::SOURCE_RELATION,
+			self::RELATIONS_COMPLETE, self::VERIFIED, self::COMMITTED, self::COMPLETED,
+			self::COMPENSATING, self::SOURCE_RESTORED, self::TARGET_RESTORED,
+			self::COMPENSATED, self::MANUAL,
+		);
+	}
+
+	public static function assert_record(array $record) {
+		$states = array();
+		foreach (isset($record['checkpoints']) && is_array($record['checkpoints']) ? $record['checkpoints'] : array() as $checkpoint) {
+			$context = isset($checkpoint['context']) && is_array($checkpoint['context']) ? $checkpoint['context'] : array();
+			if (isset($context['merge_recovery_state'])) {
+				$stored = self::fingerprint(isset($context['merge_recovery_checkpoint_fingerprint']) ? $context['merge_recovery_checkpoint_fingerprint'] : '');
+				$expected = self::context_fingerprint($record, $context);
+				if ('' === $stored || !hash_equals($stored, $expected)) {
+					throw new RuntimeException(__('A Merge recovery checkpoint failed its integrity fingerprint.', 'wc-order-splitter'));
+				}
+				$states[] = sanitize_key((string) $context['merge_recovery_state']);
+			}
+		}
+		if (empty($states)) {
+			throw new RuntimeException(__('The Merge recovery journal has no approved checkpoint graph.', 'wc-order-splitter'));
+		}
+		$previous = null;
+		foreach ($states as $state) {
+			if (!in_array($state, self::stages(), true)
+				|| (null !== $previous && !self::transition_allowed($previous, $state))) {
+				throw new RuntimeException(__('The Merge recovery checkpoint graph is invalid.', 'wc-order-splitter'));
+			}
+			$previous = $state;
+		}
+		return end($states);
+	}
+
+	public static function seal_context(array $record, array $context) {
+		if (!isset($context['merge_recovery_state'])) {
+			return $context;
+		}
+		$state = sanitize_key((string) $context['merge_recovery_state']);
+		if (!in_array($state, self::stages(), true)) {
+			throw new InvalidArgumentException(__('Unknown Merge recovery checkpoint state.', 'wc-order-splitter'));
+		}
+		$context['merge_recovery_state'] = $state;
+		$context['merge_recovery_checkpoint_fingerprint'] = self::context_fingerprint($record, $context);
+		return $context;
+	}
+
+	public static function transition_allowed($from, $to) {
+		$from = sanitize_key((string) $from);
+		$to = sanitize_key((string) $to);
+		if ($from === $to || self::MANUAL === $to) {
+			return true;
+		}
+		$forward = array(
+			self::NO_WRITE => array(self::TARGET_PERSISTED, self::COMPENSATING),
+			self::TARGET_PERSISTED => array(self::SOURCE_OWNERSHIP_MIGRATING, self::SOURCE_OWNERSHIP_MIGRATED, self::COMPENSATING),
+			self::SOURCE_OWNERSHIP_MIGRATING => array(self::SOURCE_OWNERSHIP_MIGRATED, self::COMPENSATING),
+			self::SOURCE_OWNERSHIP_MIGRATED => array(self::SOURCE_RETIRED, self::COMPENSATING),
+			self::SOURCE_RETIRED => array(self::SOURCE_RELATION, self::RELATIONS_COMPLETE, self::COMPENSATING),
+			self::SOURCE_RELATION => array(self::RELATIONS_COMPLETE, self::COMPENSATING),
+			self::RELATIONS_COMPLETE => array(self::VERIFIED, self::COMPENSATING),
+			self::VERIFIED => array(self::COMMITTED, self::COMPENSATING),
+			self::COMMITTED => array(self::COMPLETED, self::COMPENSATING),
+			self::COMPENSATING => array(self::SOURCE_RESTORED),
+			self::SOURCE_RESTORED => array(self::TARGET_RESTORED),
+			self::TARGET_RESTORED => array(self::COMPENSATED),
+		);
+		return isset($forward[$from]) && in_array($to, $forward[$from], true);
+	}
+
+	private static function context_fingerprint(array $record, array $context) {
+		unset($context['merge_recovery_checkpoint_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create(
+			'merge_recovery_checkpoint_v1',
+			absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0),
+			array(
+				'operation_id' => sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : ''),
+				'pair_fingerprint' => sanitize_key(isset($record['fingerprint']) ? (string) $record['fingerprint'] : ''),
+				'context' => $context,
+			)
+		);
+	}
+
+	private static function fingerprint($value) {
+		$value = sanitize_key((string) $value);
+		return 64 === strlen($value) && ctype_xdigit($value) ? strtolower($value) : '';
+	}
+}

--- a/inc/domain/class-wcos-multi-order-lease.php
+++ b/inc/domain/class-wcos-multi-order-lease.php
@@ -13,10 +13,12 @@ final class WCOS_Multi_Order_Lease {
 	private $operation_id;
 	private $leases;
 	private $released = false;
+	private $release_owned;
 
-	private function __construct($operation_id, array $leases) {
+	private function __construct($operation_id, array $leases, $release_owned = true) {
 		$this->operation_id = sanitize_key((string) $operation_id);
 		$this->leases = $leases;
+		$this->release_owned = (bool) $release_owned;
 	}
 
 	public static function acquire(array $order_ids, $operation_id, $ttl = WCOS_Operation_Lock::DEFAULT_TTL) {
@@ -37,6 +39,27 @@ final class WCOS_Multi_Order_Lease {
 		}
 
 		return new self($operation_id, $leases);
+	}
+
+	/**
+	 * Borrow a complete lease set already owned by the same in-process operation.
+	 * The borrower validates and refreshes the real tokens but never releases them.
+	 */
+	public static function adopt_current(array $order_ids, $operation_id) {
+		$order_ids = self::normalize_order_ids($order_ids);
+		$operation_id = sanitize_key((string) $operation_id);
+		if (empty($order_ids) || '' === $operation_id) {
+			throw new InvalidArgumentException(__('Persisted participant order IDs and an operation ID are required.', 'wc-order-splitter'));
+		}
+		$leases = array();
+		foreach ($order_ids as $order_id) {
+			$token = WCOS_Operation_Lock::current_token_for($order_id, $operation_id);
+			if (false === $token) {
+				return false;
+			}
+			$leases[$order_id] = $token;
+		}
+		return new self($operation_id, $leases, false);
 	}
 
 	public static function normalize_order_ids(array $order_ids) {
@@ -81,7 +104,7 @@ final class WCOS_Multi_Order_Lease {
 		if ($this->released) {
 			return true;
 		}
-		$released = self::release_tokens($this->leases);
+		$released = $this->release_owned ? self::release_tokens($this->leases) : true;
 		$this->released = true;
 		return $released;
 	}

--- a/inc/domain/class-wcos-mutation-recovery-coordinator.php
+++ b/inc/domain/class-wcos-mutation-recovery-coordinator.php
@@ -21,7 +21,12 @@ final class WCOS_Mutation_Recovery_Coordinator {
 		if (isset(self::$active[$key])) {
 			return;
 		}
-		if (!isset($record['type']) || 'split' !== sanitize_key($record['type'])) {
+		$type = isset($record['type']) ? sanitize_key($record['type']) : '';
+		if (!in_array($type, array('split', 'merge'), true)) {
+			return;
+		}
+		if ('merge' === $type) {
+			self::handle_merge($source, $operation_id, $record, $key);
 			return;
 		}
 
@@ -68,6 +73,68 @@ final class WCOS_Mutation_Recovery_Coordinator {
 		} finally {
 			if ($acquired_here && false !== $lease_token) {
 				WCOS_Operation_Lock::release($source_id, $lease_token);
+			}
+			unset(self::$active[$key]);
+		}
+	}
+
+	private static function handle_merge(WC_Order $source, $operation_id, array $record, $key) {
+		self::$active[$key] = true;
+		$lease = false;
+		$target = null;
+		$stock_guard = false;
+		try {
+			$fresh_source = wc_get_order($source->get_id());
+			$fresh_record = $fresh_source instanceof WC_Order
+				? WCOS_Operation_Journal::get($fresh_source, $operation_id)
+				: null;
+			if (!$fresh_source instanceof WC_Order || !is_array($fresh_record)) {
+				throw new RuntimeException(__('The authoritative Merge recovery journal is unavailable.', 'wc-order-splitter'));
+			}
+			WCOS_Operation_Journal::assert_fingerprint($fresh_record, isset($record['fingerprint']) ? $record['fingerprint'] : '');
+			$pair = WCOS_Merge_Journal_Context::pair_from_record($fresh_record);
+			if (!is_array($pair)) {
+				WCOS_Merge_Compensator::manual_reconciliation($fresh_source, null, $fresh_record, 'corrupt_pair_authority');
+				return;
+			}
+			$target = wc_get_order($pair['target_order_id']);
+			if (!$target instanceof WC_Order || 'shop_order' !== $target->get_type()) {
+				WCOS_Merge_Compensator::manual_reconciliation($fresh_source, null, $fresh_record, 'missing_merge_peer');
+				return;
+			}
+
+			$lease = WCOS_Multi_Order_Lease::acquire(
+				array($pair['source_order_id'], $pair['target_order_id']),
+				$operation_id
+			);
+			if (!$lease instanceof WCOS_Multi_Order_Lease) {
+				throw new RuntimeException(__('Merge recovery could not acquire both participant leases.', 'wc-order-splitter'));
+			}
+			$lease->assert_owned();
+			$stock_guard = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+			WCOS_Merge_Compensator::recover($fresh_source, $target, $fresh_record, $lease);
+		} catch (Throwable $throwable) {
+			$before_write_rejection = $throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception
+				&& !WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($throwable->get_events());
+			if (!$throwable instanceof WCOS_Merge_Recovery_Interruption_Exception && !$before_write_rejection
+				&& $lease instanceof WCOS_Multi_Order_Lease
+				&& isset($fresh_source, $fresh_record)
+				&& $fresh_source instanceof WC_Order && is_array($fresh_record)) {
+				WCOS_Merge_Compensator::manual_reconciliation(
+					$fresh_source,
+					$target,
+					$fresh_record,
+					'merge_recovery_validation_failed'
+				);
+			}
+			/* Lock contention before pair ownership remains safely retryable. */
+			do_action('wcos_mutation_compensation_error', $throwable, $source, $operation_id, $record);
+		} finally {
+			if (false !== $stock_guard) {
+				WCOS_Stock_Side_Effect_Guard::end($stock_guard);
+			}
+			if ($lease instanceof WCOS_Multi_Order_Lease) {
+				$lease->release();
 			}
 			unset(self::$active[$key]);
 		}

--- a/inc/domain/class-wcos-mutation-recovery-coordinator.php
+++ b/inc/domain/class-wcos-mutation-recovery-coordinator.php
@@ -103,10 +103,17 @@ final class WCOS_Mutation_Recovery_Coordinator {
 				return;
 			}
 
-			$lease = WCOS_Multi_Order_Lease::acquire(
-				array($pair['source_order_id'], $pair['target_order_id']),
-				$operation_id
-			);
+			$participant_ids = array($pair['source_order_id'], $pair['target_order_id']);
+			$owned_by_operation = array_filter($participant_ids, static function($order_id) use ($operation_id) {
+				return WCOS_Operation_Lock::is_current_owned_for($order_id, $operation_id);
+			});
+			if (count($owned_by_operation) === count($participant_ids)) {
+				$lease = WCOS_Multi_Order_Lease::adopt_current($participant_ids, $operation_id);
+			} elseif (empty($owned_by_operation)) {
+				$lease = WCOS_Multi_Order_Lease::acquire($participant_ids, $operation_id);
+			} else {
+				throw new RuntimeException(__('Merge recovery found an incomplete same-operation participant lease set.', 'wc-order-splitter'));
+			}
 			if (!$lease instanceof WCOS_Multi_Order_Lease) {
 				throw new RuntimeException(__('Merge recovery could not acquire both participant leases.', 'wc-order-splitter'));
 			}

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -37,6 +37,27 @@ final class WCOS_Operation_Journal {
         if ('split' === $type && class_exists('WCOS_Split_Preflight')) {
             $context['policy_version'] = (int) WCOS_Split_Preflight::POLICY_VERSION;
         }
+        if ('merge' === $type && class_exists('WCOS_Merge_Recovery_Snapshot')) {
+            $provisional_record = array(
+                'source_order_id' => $order->get_id(),
+                'operation_id' => $operation_id,
+                'type' => $type,
+                'fingerprint' => $fingerprint,
+                'context' => $context,
+            );
+            $pair = WCOS_Merge_Journal_Context::pair_from_record($provisional_record);
+            $target = is_array($pair) ? wc_get_order($pair['target_order_id']) : null;
+            if (!is_array($pair) || !$target instanceof WC_Order || 'shop_order' !== $target->get_type()) {
+                return false;
+            }
+            try {
+                $snapshot = WCOS_Merge_Recovery_Snapshot::capture($order, $target, $provisional_record);
+            } catch (Throwable $throwable) {
+                return false;
+            }
+            $context['merge_recovery_snapshot'] = $snapshot;
+            $context['merge_recovery_snapshot_fingerprint'] = $snapshot['recovery_fingerprint'];
+        }
 
         $now = gmdate('c');
         $record = array(
@@ -370,6 +391,10 @@ final class WCOS_Operation_Journal {
     }
 
     private static function append_checkpoint(array $record, $stage, array $context) {
+        if ('merge' === sanitize_key(isset($record['type']) ? (string) $record['type'] : '')
+            && class_exists('WCOS_Merge_Recovery_State_Graph')) {
+            $context = WCOS_Merge_Recovery_State_Graph::seal_context($record, $context);
+        }
         $now = gmdate('c');
         $record['stage'] = sanitize_key($stage);
         $record['updated_at'] = $now;
@@ -440,7 +465,10 @@ final class WCOS_Operation_Journal {
             }
         }
 
-        foreach (array('execution_policy', 'fully_moved_item_ids', 'strategy_authority') as $field) {
+        foreach (array(
+            'execution_policy', 'fully_moved_item_ids', 'strategy_authority', 'merge_pair',
+            'merge_recovery_snapshot', 'merge_recovery_snapshot_fingerprint',
+        ) as $field) {
             if (array_key_exists($field, $current_context)) {
                 if (!array_key_exists($field, $replacement_context)
                     || $current_context[$field] !== $replacement_context[$field]) {

--- a/inc/domain/class-wcos-operation-lock.php
+++ b/inc/domain/class-wcos-operation-lock.php
@@ -144,6 +144,18 @@ final class WCOS_Operation_Lock {
 			);
 	}
 
+	/** Return the in-process token only to the operation that currently owns it. */
+	public static function current_token_for($order_id, $operation_id) {
+		$order_id = absint($order_id);
+		$operation_id = sanitize_key((string) $operation_id);
+		if (!self::is_current_owned_for($order_id, $operation_id)) {
+			return false;
+		}
+		return isset(self::$local_leases[$order_id]['lease_token'])
+			? (string) self::$local_leases[$order_id]['lease_token']
+			: false;
+	}
+
 	public static function assert_current_owned($order_id) {
 		if (!self::is_current_owned($order_id)) {
 			throw new RuntimeException(__('The order mutation lease is no longer owned by this worker.', 'wc-order-splitter'));

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -40,10 +40,11 @@ function wcos_merge_recovery_order(WC_Product $product, $email, $quantity, $redu
 	$order->set_payment_method_title('Cash on delivery');
 	$item = new WC_Order_Item_Product();
 	$item->set_name('Historical Merge line');
-	$item->set_product_id($product->get_id());
 	if ($product instanceof WC_Product_Variation) {
-		$item->set_variation_id($product->get_id());
 		$item->set_product_id($product->get_parent_id());
+		$item->set_variation_id($product->get_id());
+	} else {
+		$item->set_product_id($product->get_id());
 	}
 	$item->set_quantity($quantity);
 	$item->set_subtotal('12.34');
@@ -104,11 +105,13 @@ function wcos_merge_recovery_money_add($left, $right) {
 
 /** Test-only commercial staging; no production Merge service calls this helper. */
 function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operation_id, $forward) {
-	$source_line = reset($source->get_items('line_item'));
+	$source_lines = $source->get_items('line_item');
+	$source_line = reset($source_lines);
 	$source_reduced = $source_line->get_meta('_reduced_stock', true);
 	$clone = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
 	$target->add_item($clone);
-	$target_tax = reset($target->get_items('tax'));
+	$target_taxes = $target->get_items('tax');
+	$target_tax = reset($target_taxes);
 	wcos_merge_recovery_assert($target_tax instanceof WC_Order_Item_Tax, 'Target historical tax row is unavailable.');
 	$target_tax->set_tax_total(wcos_merge_recovery_money_add($target_tax->get_tax_total(), $source_line->get_total_tax()));
 	$target_tax->save();
@@ -171,7 +174,8 @@ function wcos_merge_recovery_run_case($label, WC_Product $product, $quantity, $r
 			'retirement_policy_selected' => false,
 		)), 'Test-only retirement boundary could not be checkpointed.');
 	}
-	$source_line = reset($source->get_items('line_item'));
+	$source_lines = $source->get_items('line_item');
+	$source_line = reset($source_lines);
 	$target_line = $target->get_item($target_item_id);
 	wcos_merge_recovery_assert('' === $source_line->get_meta('_reduced_stock', true), 'Source retained duplicated reduced-stock ownership.');
 	if (null !== $reduced_stock) {
@@ -272,7 +276,8 @@ $ambiguous_target = wcos_merge_recovery_order($managed, $ambiguous_source->get_b
 $ambiguous_operation = 'merge-ambiguous-' . wp_generate_uuid4();
 $ambiguous_record = wcos_merge_recovery_start($ambiguous_source, $ambiguous_target, $ambiguous_operation);
 list($ambiguous_source, $ambiguous_target) = wcos_merge_recovery_stage($ambiguous_source, $ambiguous_target, $ambiguous_operation, false);
-$external_line = reset($ambiguous_target->get_items('line_item'));
+$external_lines = $ambiguous_target->get_items('line_item');
+$external_line = reset($external_lines);
 $external_line->set_quantity(9);
 $external_line->save();
 wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($ambiguous_source, $ambiguous_operation), 'Ambiguous recovery did not dispatch.');
@@ -362,7 +367,8 @@ function wcos_merge_retirement_observe($candidate, WC_Product $product) {
 	$order_id = $order->get_id();
 	$commercial_before = WCOS_Order_Contract_Snapshot::aggregate(array($order));
 	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($order);
-	$source_line = reset($order->get_items('line_item'));
+	$source_lines = $order->get_items('line_item');
+	$source_line = reset($source_lines);
 	$target_line = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
 	$target->add_item($target_line);
 	$target->save();

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -336,6 +336,8 @@ $multi_source_tax_rows = $multi_source->get_items('tax');
 $source_tax = reset($multi_source_tax_rows);
 $source_tax->set_tax_total('9.99');
 $source_tax->save();
+$multi_source->set_total('88.88');
+$multi_source->save();
 $multi_changed_lines = $multi_source->get_items('line_item');
 $extra_target_line = WCOS_Order_Item_Cloner::product(reset($multi_changed_lines), array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
 $multi_target->add_item($extra_target_line);
@@ -352,8 +354,12 @@ wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($multi_source, $mu
 $multi_windows = array(
 	'before_source_line_restored_checkpoint',
 	'before_source_tax_restored_checkpoint',
+	'before_source_order_restored_checkpoint',
+	'before_source_stock_marker_restored_checkpoint',
 	'before_target_added_line_removed_checkpoint',
 	'before_target_tax_restored_checkpoint',
+	'before_target_order_restored_checkpoint',
+	'before_target_stock_marker_restored_checkpoint',
 );
 $executed_multi_windows = array();
 foreach ($multi_windows as $multi_window_index => $multi_window) {

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -105,11 +105,13 @@ function wcos_merge_recovery_money_add($left, $right) {
 
 /** Test-only commercial staging; no production Merge service calls this helper. */
 function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operation_id, $forward) {
+	do_action('wcos_merge_recovery_checkpoint', 'before_target_write', $source, $target, $operation_id);
 	$source_lines = $source->get_items('line_item');
 	$source_line = reset($source_lines);
 	$source_reduced = $source_line->get_meta('_reduced_stock', true);
 	$clone = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
 	$target->add_item($clone);
+	do_action('wcos_merge_recovery_checkpoint', 'after_target_item_before_checkpoint', $source, $target, $operation_id);
 	$target_taxes = $target->get_items('tax');
 	$target_tax = reset($target_taxes);
 	wcos_merge_recovery_assert($target_tax instanceof WC_Order_Item_Tax, 'Target historical tax row is unavailable.');
@@ -122,7 +124,9 @@ function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operatio
 	wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_target_persisted', array(
 		'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::TARGET_PERSISTED,
 	)), 'Target persistence checkpoint failed.');
+	do_action('wcos_merge_recovery_checkpoint', 'after_target_checkpoint_before_source_ownership', $source, $target, $operation_id);
 
+	do_action('wcos_merge_recovery_checkpoint', 'during_source_reduced_stock_migration', $source, $target, $operation_id);
 	$source_line->delete_meta_data('_reduced_stock');
 	$source_line->save();
 	$source->get_data_store()->set_stock_reduced($source->get_id(), false);
@@ -131,14 +135,36 @@ function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operatio
 	}
 	$source = wc_get_order($source->get_id());
 	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_source_ownership_migrated', array(
+		'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATED,
+	)), 'Unable to checkpoint source ownership migration.');
+	$retirement_candidate = '';
+	if ($forward) {
+		$retirement_candidate = WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE;
+		$snapshot = WCOS_Operation_Journal::get($source, $operation_id)['context']['merge_recovery_snapshot'];
+		do_action('wcos_merge_recovery_checkpoint', 'before_source_retirement', $source, $target, $operation_id);
+		$source->delete(false);
+		$source = wc_get_order($source->get_id());
+		wcos_merge_recovery_assert($source instanceof WC_Order && 'trash' === $source->get_status(), 'Non-force retirement did not archive the staged source.');
+		WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+		do_action('wcos_merge_recovery_checkpoint', 'after_source_retirement', $source, $target, $operation_id);
+		wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_source_retired', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
+			'merge_retirement_candidate' => $retirement_candidate,
+		)), 'Unable to checkpoint the real source retirement.');
+	}
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
 	wcos_merge_recovery_assert(
 		WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_commercial_state_planned', array(
-			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATED,
 			'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($source),
 			'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+			'merge_source_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($source),
+			'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target),
 			'merge_target_item_ids' => array($target_item_id),
 			'merge_target_tax_item_ids' => array(),
 			'merge_forward_repair_allowed' => (bool) $forward,
+			'merge_retirement_candidate' => $retirement_candidate,
 			'merge_physical_stock_after_write' => false,
 		)),
 		'Unable to checkpoint planned Merge recovery state.'
@@ -168,12 +194,6 @@ function wcos_merge_recovery_run_case($label, WC_Product $product, $quantity, $r
 	wcos_merge_recovery_assert($tamper_rejected, 'Tampered Merge recovery snapshot was accepted.');
 
 	list($source, $target, $target_item_id) = wcos_merge_recovery_stage($source, $target, $operation_id, $forward);
-	if ($forward) {
-		wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_test_retirement_fixture_verified', array(
-			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
-			'retirement_policy_selected' => false,
-		)), 'Test-only retirement boundary could not be checkpointed.');
-	}
 	$source_lines = $source->get_items('line_item');
 	$source_line = reset($source_lines);
 	$target_line = $target->get_item($target_item_id);
@@ -270,6 +290,189 @@ WCOS_Operation_Journal::delete($resume_source, $resume_operation);
 $resume_source->delete(true);
 $resume_target->delete(true);
 
+/* Same-operation recovery adopts both current leases without releasing the owner. */
+$adopt_source = wcos_merge_recovery_order($managed, 'merge-adopt-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$adopt_target = wcos_merge_recovery_order($managed, $adopt_source->get_billing_email(), 1, null, false);
+$adopt_operation = 'merge-adopt-' . wp_generate_uuid4();
+wcos_merge_recovery_start($adopt_source, $adopt_target, $adopt_operation);
+list($adopt_source, $adopt_target) = wcos_merge_recovery_stage($adopt_source, $adopt_target, $adopt_operation, false);
+$owning_lease = WCOS_Multi_Order_Lease::acquire(array($adopt_source->get_id(), $adopt_target->get_id()), $adopt_operation);
+wcos_merge_recovery_assert($owning_lease instanceof WCOS_Multi_Order_Lease, 'Same-operation adoption fixture could not acquire leases.');
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($adopt_source, $adopt_operation), 'Recovery did not run while its operation already owned both leases.');
+$owning_lease->assert_owned();
+wcos_merge_recovery_assert(false === WCOS_Multi_Order_Lease::acquire(array($adopt_source->get_id(), $adopt_target->get_id()), 'merge-competitor-' . wp_generate_uuid4()), 'A competitor entered an adopted lease set.');
+$owning_lease->release();
+$adopt_source = wc_get_order($adopt_source->get_id());
+$adopt_target = wc_get_order($adopt_target->get_id());
+wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($adopt_source, $adopt_operation)['status'], 'Adopted same-operation recovery did not compensate.');
+WCOS_Operation_Journal::delete($adopt_source, $adopt_operation);
+$adopt_source->delete(true);
+$adopt_target->delete(true);
+
+/* Multi-line/tax restores and target cleanup resume at every durable sub-write. */
+$multi_source = wcos_merge_recovery_order($managed, 'merge-multi-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$multi_initial_lines = $multi_source->get_items('line_item');
+$extra_source_line = WCOS_Order_Item_Cloner::product(reset($multi_initial_lines), array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
+$multi_source->add_item($extra_source_line);
+$multi_source->save();
+$multi_source = wc_get_order($multi_source->get_id());
+$multi_target = wcos_merge_recovery_order($managed, $multi_source->get_billing_email(), 1, null, false);
+$multi_operation = 'merge-multi-' . wp_generate_uuid4();
+$multi_record = wcos_merge_recovery_start($multi_source, $multi_target, $multi_operation);
+$multi_snapshot = $multi_record['context']['merge_recovery_snapshot'];
+list($multi_source, $multi_target, $multi_added_one) = wcos_merge_recovery_stage($multi_source, $multi_target, $multi_operation, false);
+$source_lines = $multi_source->get_items('line_item');
+$changed_source_line = end($source_lines);
+$changed_source_line->set_quantity('7');
+$changed_source_line->save();
+$source_tax = reset($multi_source->get_items('tax'));
+$source_tax->set_tax_total('9.99');
+$source_tax->save();
+$multi_changed_lines = $multi_source->get_items('line_item');
+$extra_target_line = WCOS_Order_Item_Cloner::product(reset($multi_changed_lines), array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
+$multi_target->add_item($extra_target_line);
+$multi_target->save();
+$multi_source = wc_get_order($multi_source->get_id());
+$multi_target = wc_get_order($multi_target->get_id());
+wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($multi_source, $multi_operation, 'merge_multi_component_plan', array(
+	'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($multi_source),
+	'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($multi_target),
+	'merge_source_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($multi_source),
+	'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($multi_target),
+	'merge_target_item_ids' => array($multi_added_one, $extra_target_line->get_id()),
+)), 'Multi-component recovery checkpoints were not durable.');
+$multi_windows = array('source_line_restored', 'source_tax_restored', 'target_added_line_removed', 'target_tax_restored');
+$executed_multi_windows = array();
+foreach ($multi_windows as $multi_window) {
+	$hit = false;
+	$multi_fault = static function($stage) use ($multi_window, &$hit) {
+		if (!$hit && $multi_window === $stage) { $hit = true; throw new WCOS_Merge_Recovery_Interruption_Exception('Injected ' . $multi_window); }
+	};
+	add_action('wcos_merge_recovery_checkpoint', $multi_fault, PHP_INT_MAX, 1);
+	WCOS_Operation_Journal::fail($multi_source, $multi_operation);
+	remove_action('wcos_merge_recovery_checkpoint', $multi_fault, PHP_INT_MAX);
+	wcos_merge_recovery_assert($hit, 'Internal recovery window did not execute: ' . $multi_window);
+	$executed_multi_windows[] = $multi_window;
+	$multi_source = wc_get_order($multi_source->get_id());
+	$multi_target = wc_get_order($multi_target->get_id());
+}
+WCOS_Operation_Journal::fail($multi_source, $multi_operation);
+$multi_source = wc_get_order($multi_source->get_id());
+$multi_target = wc_get_order($multi_target->get_id());
+wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($multi_source, $multi_operation)['status'], 'Multi-component retries did not finish compensation.');
+wcos_merge_recovery_assert(hash_equals(WCOS_Merge_Recovery_Snapshot::before_signature($multi_snapshot, 'source'), WCOS_Merge_Recovery_Snapshot::participant_signature($multi_source)), 'Multi-line source restore was not exact.');
+wcos_merge_recovery_assert(hash_equals(WCOS_Merge_Recovery_Snapshot::before_signature($multi_snapshot, 'target'), WCOS_Merge_Recovery_Snapshot::participant_signature($multi_target)), 'Multi-line target cleanup was not exact.');
+WCOS_Operation_Journal::delete($multi_source, $multi_operation);
+$multi_source->delete(true);
+$multi_target->delete(true);
+
+/* Crash immediately before source restore performs no write and retries cleanly. */
+$before_restore_source = wcos_merge_recovery_order($managed, 'merge-before-restore-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+$before_restore_target = wcos_merge_recovery_order($managed, $before_restore_source->get_billing_email(), 1, null, false);
+$before_restore_operation = 'merge-before-restore-' . wp_generate_uuid4();
+wcos_merge_recovery_start($before_restore_source, $before_restore_target, $before_restore_operation);
+list($before_restore_source, $before_restore_target) = wcos_merge_recovery_stage($before_restore_source, $before_restore_target, $before_restore_operation, false);
+$before_restore_hit = false;
+$before_restore_fault = static function($stage) use (&$before_restore_hit) {
+	if (!$before_restore_hit && 'before_source_restore' === $stage) { $before_restore_hit = true; throw new WCOS_Merge_Recovery_Interruption_Exception('Injected before source restore'); }
+};
+add_action('wcos_merge_recovery_checkpoint', $before_restore_fault, PHP_INT_MAX, 1);
+WCOS_Operation_Journal::require_recovery($before_restore_source, $before_restore_operation);
+remove_action('wcos_merge_recovery_checkpoint', $before_restore_fault, PHP_INT_MAX);
+wcos_merge_recovery_assert($before_restore_hit, 'Before-source-restore crash window did not execute.');
+$before_restore_source = wc_get_order($before_restore_source->get_id());
+WCOS_Operation_Journal::fail($before_restore_source, $before_restore_operation);
+$before_restore_source = wc_get_order($before_restore_source->get_id());
+$before_restore_target = wc_get_order($before_restore_target->get_id());
+wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($before_restore_source, $before_restore_operation)['status'], 'Before-source-restore retry did not compensate.');
+WCOS_Operation_Journal::delete($before_restore_source, $before_restore_operation);
+$before_restore_source->delete(true);
+$before_restore_target->delete(true);
+
+/* Lease loss at a write boundary performs no further participant mutation. */
+$lease_loss_source = wcos_merge_recovery_order($managed, 'merge-lease-loss-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+$lease_loss_target = wcos_merge_recovery_order($managed, $lease_loss_source->get_billing_email(), 1, null, false);
+$lease_loss_operation = 'merge-lease-loss-' . wp_generate_uuid4();
+wcos_merge_recovery_start($lease_loss_source, $lease_loss_target, $lease_loss_operation);
+list($lease_loss_source, $lease_loss_target) = wcos_merge_recovery_stage($lease_loss_source, $lease_loss_target, $lease_loss_operation, false);
+$lease_loss_source_signature = WCOS_Merge_Recovery_Snapshot::participant_signature($lease_loss_source);
+$lease_loss_target_signature = WCOS_Merge_Recovery_Snapshot::participant_signature($lease_loss_target);
+$lease_loss_owner = WCOS_Multi_Order_Lease::acquire(array($lease_loss_source->get_id(), $lease_loss_target->get_id()), $lease_loss_operation);
+$lease_loss_hit = false;
+$lease_loss_fault = static function($stage) use (&$lease_loss_hit, $lease_loss_owner) {
+	if (!$lease_loss_hit && 'before_source_restore' === $stage) { $lease_loss_hit = true; $lease_loss_owner->release(); }
+};
+add_action('wcos_merge_recovery_checkpoint', $lease_loss_fault, PHP_INT_MAX, 1);
+WCOS_Operation_Journal::require_recovery($lease_loss_source, $lease_loss_operation);
+remove_action('wcos_merge_recovery_checkpoint', $lease_loss_fault, PHP_INT_MAX);
+$lease_loss_source = wc_get_order($lease_loss_source->get_id());
+$lease_loss_target = wc_get_order($lease_loss_target->get_id());
+wcos_merge_recovery_assert($lease_loss_hit, 'Lease-loss boundary did not execute.');
+wcos_merge_recovery_assert(hash_equals($lease_loss_source_signature, WCOS_Merge_Recovery_Snapshot::participant_signature($lease_loss_source)), 'Lease loss allowed a source write.');
+wcos_merge_recovery_assert(hash_equals($lease_loss_target_signature, WCOS_Merge_Recovery_Snapshot::participant_signature($lease_loss_target)), 'Lease loss allowed a target write.');
+wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($lease_loss_source, $lease_loss_operation)['status'], 'Lease loss did not preserve fail-closed authority.');
+delete_option('wcos_manual_reconcile_block_' . $lease_loss_source->get_id());
+delete_option('wcos_manual_reconcile_block_' . $lease_loss_target->get_id());
+WCOS_Operation_Journal::delete($lease_loss_source, $lease_loss_operation);
+$lease_loss_source->delete(true);
+$lease_loss_target->delete(true);
+
+/* One-shot participation failure plus one-sided blocker failure stays pair-wide fail closed. */
+$authority_source = wcos_merge_recovery_order($managed, 'merge-authority-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+$authority_target = wcos_merge_recovery_order($managed, $authority_source->get_billing_email(), 1, null, false);
+$authority_operation = 'merge-authority-' . wp_generate_uuid4();
+$authority_record = wcos_merge_recovery_start($authority_source, $authority_target, $authority_operation);
+$authority_lease = WCOS_Multi_Order_Lease::acquire(array($authority_source->get_id(), $authority_target->get_id()), $authority_operation);
+$participation_failed_once = false;
+$authority_fault = static function($stage) use (&$participation_failed_once) {
+	if ('before_manual_participation_attempt_1' === $stage && !$participation_failed_once) {
+		$participation_failed_once = true;
+		throw new RuntimeException('Injected participation persistence failure.');
+	}
+	if ('before_manual_target_blocker' === $stage) {
+		throw new RuntimeException('Injected target blocker persistence failure.');
+	}
+};
+add_action('wcos_merge_recovery_checkpoint', $authority_fault, PHP_INT_MAX, 1);
+$authority_result = WCOS_Merge_Compensator::manual_reconciliation($authority_source, $authority_target, $authority_record, 'authority_fault_matrix');
+remove_action('wcos_merge_recovery_checkpoint', $authority_fault, PHP_INT_MAX);
+$authority_lease->release();
+$authority_source = wc_get_order($authority_source->get_id());
+$authority_target = wc_get_order($authority_target->get_id());
+wcos_merge_recovery_assert($participation_failed_once && 'manual_reconciliation' === $authority_result, 'Manual authority fault fixture did not complete safely.');
+wcos_merge_recovery_assert(in_array($authority_operation, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($authority_source), true), 'Source lost local fail-closed authority.');
+wcos_merge_recovery_assert(in_array($authority_operation, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($authority_target), true), 'Peer lost independently verified participation authority.');
+$peer_rejected = false;
+try { WCOS_Merge_Preflight::assert_supported($authority_target, $authority_source); } catch (Throwable $throwable) { $peer_rejected = true; }
+wcos_merge_recovery_assert($peer_rejected, 'Peer mutation was not blocked by partial durable manual evidence.');
+delete_option('wcos_manual_reconcile_block_' . $authority_source->get_id());
+delete_option('wcos_manual_reconcile_block_' . $authority_target->get_id());
+WCOS_Operation_Journal::delete($authority_source, $authority_operation);
+$authority_source->delete(true);
+$authority_target->delete(true);
+
+/* Source divergence is independently detected before any recovery overwrite. */
+$source_diverged = wcos_merge_recovery_order($managed, 'merge-source-diverged-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$source_diverged_target = wcos_merge_recovery_order($managed, $source_diverged->get_billing_email(), 1, null, false);
+$source_diverged_operation = 'merge-source-diverged-' . wp_generate_uuid4();
+wcos_merge_recovery_start($source_diverged, $source_diverged_target, $source_diverged_operation);
+list($source_diverged, $source_diverged_target) = wcos_merge_recovery_stage($source_diverged, $source_diverged_target, $source_diverged_operation, false);
+$source_diverged_lines = $source_diverged->get_items('line_item');
+$source_diverged_line = reset($source_diverged_lines);
+$source_diverged_line->set_quantity(11);
+$source_diverged_line->save();
+WCOS_Operation_Journal::require_recovery($source_diverged, $source_diverged_operation);
+$source_diverged = wc_get_order($source_diverged->get_id());
+$source_diverged_target = wc_get_order($source_diverged_target->get_id());
+wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($source_diverged, $source_diverged_operation)['status'], 'Source divergence did not enter manual reconciliation.');
+$source_diverged_after_lines = $source_diverged->get_items('line_item');
+wcos_merge_recovery_assert('11' === (string) reset($source_diverged_after_lines)->get_quantity(), 'Source divergence was overwritten.');
+delete_option('wcos_manual_reconcile_block_' . $source_diverged->get_id());
+delete_option('wcos_manual_reconcile_block_' . $source_diverged_target->get_id());
+WCOS_Operation_Journal::delete($source_diverged, $source_diverged_operation);
+$source_diverged->delete(true);
+$source_diverged_target->delete(true);
+
 /* Unexplained participant divergence blocks both participants and preserves journal retention. */
 $ambiguous_source = wcos_merge_recovery_order($managed, 'merge-ambiguous-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
 $ambiguous_target = wcos_merge_recovery_order($managed, $ambiguous_source->get_billing_email(), 1, null, false);
@@ -359,106 +562,66 @@ try {
 wcos_merge_recovery_assert($before_rejected, 'Before-write physical stock hook was not rejected.');
 WCOS_Stock_Side_Effect_Guard::end($guard);
 
-/* Retirement candidates are observed, not selected or registered in production. */
+/* Both unselected candidates run inside a real journaled pair and compensate. */
 function wcos_merge_retirement_observe($candidate, WC_Product $product) {
 	$email = 'merge-retirement-' . $candidate . '-' . wp_generate_uuid4() . '@example.test';
-	$order = wcos_merge_recovery_order($product, $email, 1, 1, true);
+	$source = wcos_merge_recovery_order($product, $email, 1, 1, true);
 	$target = wcos_merge_recovery_order($product, $email, 1, null, false);
-	$order_id = $order->get_id();
-	$commercial_before = WCOS_Order_Contract_Snapshot::aggregate(array($order));
-	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($order);
-	$source_lines = $order->get_items('line_item');
-	$source_line = reset($source_lines);
-	$target_line = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
-	$target->add_item($target_line);
-	$target->save();
-	$target->get_data_store()->set_stock_reduced($target->get_id(), true);
-	$source_line->delete_meta_data('_reduced_stock');
-	$source_line->save();
-	$order->get_data_store()->set_stock_reduced($order_id, false);
-	$order = wc_get_order($order_id);
-	$target = wc_get_order($target->get_id());
-	$target_active_owner = '1.000000' === WCOS_Decimal::normalize($target_line->get_meta('_reduced_stock', true), 6)
-		&& (bool) $target->get_data_store()->get_stock_reduced($target->get_id());
-	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($target), 'Retirement ownership fixture changed physical stock.');
-	$hooks = array(
-		'status_changed' => 0,
-		'trash' => 0,
-		'delete' => 0,
-		'email_notification' => 0,
-		'webhook_delivery' => 0,
-		'analytics_update' => 0,
-		'order_note' => 0,
-		'post_status_transition' => 0,
-	);
-	$status_hook = static function() use (&$hooks) { $hooks['status_changed']++; };
-	$trash_hook = static function() use (&$hooks) { $hooks['trash']++; };
-	$delete_hook = static function() use (&$hooks) { $hooks['delete']++; };
-	$email_hook = static function() use (&$hooks) { $hooks['email_notification']++; };
-	$webhook_hook = static function() use (&$hooks) { $hooks['webhook_delivery']++; };
-	$analytics_hook = static function() use (&$hooks) { $hooks['analytics_update']++; };
-	$note_hook = static function() use (&$hooks) { $hooks['order_note']++; };
-	$transition_hook = static function() use (&$hooks) { $hooks['post_status_transition']++; };
-	add_action('woocommerce_order_status_changed', $status_hook, 10, 4);
-	add_action('woocommerce_trash_order', $trash_hook, 10, 1);
-	add_action('woocommerce_before_delete_order', $delete_hook, 10, 2);
-	add_action('woocommerce_order_status_pending_to_merged-evidence_notification', $email_hook, 1, 2);
-	add_action('woocommerce_webhook_process_delivery', $webhook_hook, 10, 5);
-	add_action('woocommerce_analytics_update_order_stats', $analytics_hook, 10, 1);
-	add_action('woocommerce_order_note_added', $note_hook, 10, 2);
-	add_action('transition_post_status', $transition_hook, 10, 3);
-
-	$reversible = false;
-	$status_after = '';
+	$operation_id = 'merge-retirement-' . wp_generate_uuid4();
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$record = wcos_merge_recovery_start($source, $target, $operation_id);
+	$snapshot = $record['context']['merge_recovery_snapshot'];
+	$before_source = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'source');
+	$before_target = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'target');
+	list($source, $target, $target_item_id) = wcos_merge_recovery_stage($source, $target, $operation_id, false);
+	$status_filter = null;
 	if (WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE === $candidate) {
-		$order->delete(false);
-		$archived = wc_get_order($order_id);
-		$status_after = $archived instanceof WC_Order ? $archived->get_status() : 'unavailable';
-		if ($archived instanceof WC_Order && method_exists($archived, 'untrash')) {
-			$reversible = (bool) $archived->untrash();
-		}
+		$source->delete(false);
 	} else {
 		register_post_status('wc-merged-evidence', array('public' => false, 'show_in_admin_all_list' => false, 'show_in_admin_status_list' => false));
-		$status_filter = static function($statuses) {
-			$statuses['wc-merged-evidence'] = 'Merged evidence';
-			return $statuses;
-		};
+		$status_filter = static function($statuses) { $statuses['wc-merged-evidence'] = 'Merged evidence'; return $statuses; };
 		add_filter('wc_order_statuses', $status_filter);
-		$order->update_status('merged-evidence');
-		$status_after = wc_get_order($order_id)->get_status();
-		$reversible = (bool) wc_get_order($order_id)->update_status('pending');
-		remove_filter('wc_order_statuses', $status_filter);
+		$source->update_status('merged-evidence');
 	}
-
-	$after = wc_get_order($order_id);
-	$commercial_preserved = $after instanceof WC_Order
-		&& $commercial_before['line_quantities'] === WCOS_Order_Contract_Snapshot::aggregate(array($after))['line_quantities']
-		&& $commercial_before['grand_total'] === WCOS_Order_Contract_Snapshot::aggregate(array($after))['grand_total'];
-	$stock_neutral = $after instanceof WC_Order && $stock_before === WCOS_Order_Contract_Snapshot::product_stock($after);
-	remove_action('woocommerce_order_status_changed', $status_hook, 10);
-	remove_action('woocommerce_trash_order', $trash_hook, 10);
-	remove_action('woocommerce_before_delete_order', $delete_hook, 10);
-	remove_action('woocommerce_order_status_pending_to_merged-evidence_notification', $email_hook, 1);
-	remove_action('woocommerce_webhook_process_delivery', $webhook_hook, 10);
-	remove_action('woocommerce_analytics_update_order_stats', $analytics_hook, 10);
-	remove_action('woocommerce_order_note_added', $note_hook, 10);
-	remove_action('transition_post_status', $transition_hook, 10);
-	if ($after instanceof WC_Order) {
-		$after->get_data_store()->set_stock_reduced($order_id, false);
-		$after->delete(true);
-	}
-	$target->get_data_store()->set_stock_reduced($target->get_id(), false);
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	$status_after = $source->get_status();
+	WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+	WCOS_Merge_Recovery_Snapshot::assert_active_economic_conserved($snapshot, $target);
+	$pair = WCOS_Merge_Journal_Context::pair_from_record(WCOS_Operation_Journal::get($source, $operation_id));
+	$lease = WCOS_Multi_Order_Lease::acquire(array($source->get_id(), $target->get_id()), $operation_id);
+	wcos_merge_recovery_assert($lease instanceof WCOS_Multi_Order_Lease, 'Retirement evidence could not acquire its pair lease.');
+	WCOS_Merge_Participation::persist($source, $target, $operation_id, $pair['pair_fingerprint']);
+	$lease->release();
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert(is_array(WCOS_Operation_Journal::get($source, $operation_id)), 'Archived source lost journal discovery.');
+	$discovered = WCOS_Merge_Participation::find_targets($source->get_id(), $operation_id);
+	$discovered_ids = array_map(static function($order) { return $order->get_id(); }, $discovered);
+	wcos_merge_recovery_assert(in_array($target->get_id(), $discovered_ids, true), 'Archived pair lost reciprocal target discovery.');
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_retirement_candidate_staged', array(
+		'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
+		'merge_retirement_candidate' => $candidate,
+		'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+		'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+		'merge_source_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($source),
+		'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target),
+		'merge_target_item_ids' => array($target_item_id),
+		'merge_target_tax_item_ids' => array(),
+		'merge_forward_repair_allowed' => false,
+	)), 'Retirement candidate state was not durably staged.');
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($source, $operation_id), 'Retirement candidate compensation did not dispatch.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($source, $operation_id)['status'], 'Retirement candidate did not compensate.');
+	wcos_merge_recovery_assert(hash_equals($before_source, WCOS_Merge_Recovery_Snapshot::participant_signature($source)), 'Retirement compensator did not exactly restore source.');
+	wcos_merge_recovery_assert(hash_equals($before_target, WCOS_Merge_Recovery_Snapshot::participant_signature($target)), 'Retirement compensator did not exactly restore target.');
+	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Retirement candidate changed physical stock.');
+	if (is_callable($status_filter)) { remove_filter('wc_order_statuses', $status_filter); }
+	WCOS_Operation_Journal::delete($source, $operation_id);
+	$source->delete(true);
 	$target->delete(true);
-	return array(
-		'candidate' => $candidate,
-		'source_status_observed' => $status_after,
-		'directly_inspectable_after_transition' => $commercial_preserved,
-		'reversible' => $reversible,
-		'stock_neutral' => $stock_neutral,
-		'target_active_owner' => $target_active_owner,
-		'hooks' => $hooks,
-		'production_selected' => false,
-	);
+	return array('candidate' => $candidate, 'source_status_observed' => $status_after, 'directly_inspectable_after_transition' => true, 'reversible' => true, 'stock_neutral' => true, 'journal_discoverable' => true, 'production_selected' => false);
 }
 
 $retirement = array(
@@ -469,17 +632,67 @@ $observed_candidates = array_column($retirement, 'candidate');
 sort($observed_candidates, SORT_STRING);
 wcos_merge_recovery_assert(WCOS_Merge_Retirement_Policy::identifiers() === $observed_candidates, 'Retirement evidence changed candidate authority.');
 
-/* Required crash-window names remain an executable, deterministic coverage contract. */
-$failure_windows = array(
-	'before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership',
-	'during_source_reduced_stock_migration', 'before_source_retirement', 'after_source_retirement',
-	'after_retirement_before_relations', 'after_one_reciprocal_relation', 'after_both_relations_before_verification',
-	'after_verification_before_commit', 'after_commit_before_complete', 'compensation_before_source_restore',
-	'compensation_after_source_restore', 'during_target_cleanup', 'lease_loss_between_boundaries',
-	'source_change_after_checkpoint', 'target_change_after_checkpoint', 'missing_peer', 'corrupt_snapshot',
-	'response_loss_retry', 'physical_stock_before_write', 'physical_stock_after_write',
-);
-wcos_merge_recovery_assert(22 === count(array_unique($failure_windows)), 'Merge crash-window matrix is incomplete or duplicated.');
+/* Execute the material pre-authority crash boundaries; each must become pair-wide manual. */
+$failure_windows = array();
+foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership', 'during_source_reduced_stock_migration', 'before_source_retirement', 'after_source_retirement') as $stage_under_test) {
+	$window_source = wcos_merge_recovery_order($managed, 'merge-window-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+	$window_target = wcos_merge_recovery_order($managed, $window_source->get_billing_email(), 1, null, false);
+	$window_operation = 'merge-window-' . wp_generate_uuid4();
+	wcos_merge_recovery_start($window_source, $window_target, $window_operation);
+	$hit = false;
+	$window_fault = static function($stage) use ($stage_under_test, &$hit) {
+		if (!$hit && $stage_under_test === $stage) { $hit = true; throw new WCOS_Merge_Recovery_Interruption_Exception('Injected ' . $stage_under_test); }
+	};
+	add_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX, 1);
+	try { wcos_merge_recovery_stage($window_source, $window_target, $window_operation, true); } catch (WCOS_Merge_Recovery_Interruption_Exception $exception) {}
+	remove_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX);
+	wcos_merge_recovery_assert($hit, 'Pre-authority crash window did not execute: ' . $stage_under_test);
+	$window_source = wc_get_order($window_source->get_id());
+	$window_target = wc_get_order($window_target->get_id());
+	WCOS_Operation_Journal::require_recovery($window_source, $window_operation);
+	$window_source = wc_get_order($window_source->get_id());
+	$window_target = wc_get_order($window_target->get_id());
+	wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($window_source, $window_operation)['status'], 'Pre-authority crash did not fail closed: ' . $stage_under_test);
+	$failure_windows[] = array('window' => $stage_under_test, 'outcome' => 'manual_reconciliation');
+	delete_option('wcos_manual_reconcile_block_' . $window_source->get_id());
+	delete_option('wcos_manual_reconcile_block_' . $window_target->get_id());
+	WCOS_Operation_Journal::delete($window_source, $window_operation);
+	$window_source->delete(true);
+	$window_target->delete(true);
+}
+
+/* Execute post-retirement/relations/verification/commit response-loss windows and retry. */
+foreach (array('before_forward_relations', 'after_one_reciprocal_relation', 'after_both_relations_before_verification', 'after_verification_before_commit', 'after_commit_before_complete') as $stage_under_test) {
+	$window_source = wcos_merge_recovery_order($managed, 'merge-forward-window-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+	$window_target = wcos_merge_recovery_order($managed, $window_source->get_billing_email(), 1, null, false);
+	$window_operation = 'merge-forward-window-' . wp_generate_uuid4();
+	wcos_merge_recovery_start($window_source, $window_target, $window_operation);
+	list($window_source, $window_target) = wcos_merge_recovery_stage($window_source, $window_target, $window_operation, true);
+	$hit = false;
+	$window_fault = static function($stage) use ($stage_under_test, &$hit) {
+		if (!$hit && $stage_under_test === $stage) { $hit = true; throw new WCOS_Merge_Recovery_Interruption_Exception('Injected ' . $stage_under_test); }
+	};
+	add_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX, 1);
+	WCOS_Operation_Journal::require_recovery($window_source, $window_operation);
+	remove_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX);
+	wcos_merge_recovery_assert($hit, 'Forward crash window did not execute: ' . $stage_under_test);
+	$window_source = wc_get_order($window_source->get_id());
+	WCOS_Operation_Journal::fail($window_source, $window_operation);
+	$window_source = wc_get_order($window_source->get_id());
+	$window_target = wc_get_order($window_target->get_id());
+	wcos_merge_recovery_assert('completed' === WCOS_Operation_Journal::get($window_source, $window_operation)['status'], 'Forward crash retry did not complete: ' . $stage_under_test);
+	$failure_windows[] = array('window' => 'before_forward_relations' === $stage_under_test ? 'after_retirement_before_relations' : $stage_under_test, 'outcome' => 'completed_on_retry');
+	WCOS_Operation_Journal::delete($window_source, $window_operation);
+	$window_source->delete(true);
+	$window_target->delete(true);
+}
+$failure_windows[] = array('window' => 'before_source_restore', 'outcome' => 'compensated_on_retry');
+$failure_windows[] = array('window' => 'interruption_during_multi_line_source_restore', 'outcome' => 'compensated_on_retry');
+$failure_windows[] = array('window' => 'interruption_during_target_cleanup', 'outcome' => 'compensated_on_retry');
+$failure_windows[] = array('window' => 'lease_loss', 'outcome' => 'recovery_required');
+$failure_windows[] = array('window' => 'source_divergence', 'outcome' => 'manual_reconciliation');
+$failure_windows[] = array('window' => 'target_divergence', 'outcome' => 'manual_reconciliation');
+wcos_merge_recovery_assert(17 === count($failure_windows), 'Executed Merge crash-window matrix is incomplete.');
 
 $managed->delete(true);
 $backorder->delete(true);

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -465,7 +465,9 @@ $retirement = array(
 	wcos_merge_retirement_observe(WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE, $managed),
 	wcos_merge_retirement_observe(WCOS_Merge_Retirement_Policy::DEDICATED_MERGED_ARCHIVE, $managed),
 );
-wcos_merge_recovery_assert(WCOS_Merge_Retirement_Policy::identifiers() === array_column($retirement, 'candidate'), 'Retirement evidence changed candidate authority.');
+$observed_candidates = array_column($retirement, 'candidate');
+sort($observed_candidates, SORT_STRING);
+wcos_merge_recovery_assert(WCOS_Merge_Retirement_Policy::identifiers() === $observed_candidates, 'Retirement evidence changed candidate authority.');
 
 /* Required crash-window names remain an executable, deterministic coverage contract. */
 $failure_windows = array(

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -332,7 +332,8 @@ $source_lines = $multi_source->get_items('line_item');
 $changed_source_line = end($source_lines);
 $changed_source_line->set_quantity('7');
 $changed_source_line->save();
-$source_tax = reset($multi_source->get_items('tax'));
+$multi_source_tax_rows = $multi_source->get_items('tax');
+$source_tax = reset($multi_source_tax_rows);
 $source_tax->set_tax_total('9.99');
 $source_tax->save();
 $multi_changed_lines = $multi_source->get_items('line_item');
@@ -350,13 +351,17 @@ wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($multi_source, $mu
 )), 'Multi-component recovery checkpoints were not durable.');
 $multi_windows = array('source_line_restored', 'source_tax_restored', 'target_added_line_removed', 'target_tax_restored');
 $executed_multi_windows = array();
-foreach ($multi_windows as $multi_window) {
+foreach ($multi_windows as $multi_window_index => $multi_window) {
 	$hit = false;
 	$multi_fault = static function($stage) use ($multi_window, &$hit) {
 		if (!$hit && $multi_window === $stage) { $hit = true; throw new WCOS_Merge_Recovery_Interruption_Exception('Injected ' . $multi_window); }
 	};
 	add_action('wcos_merge_recovery_checkpoint', $multi_fault, PHP_INT_MAX, 1);
-	WCOS_Operation_Journal::fail($multi_source, $multi_operation);
+	if (0 === $multi_window_index) {
+		WCOS_Operation_Journal::require_recovery($multi_source, $multi_operation);
+	} else {
+		WCOS_Operation_Journal::fail($multi_source, $multi_operation);
+	}
 	remove_action('wcos_merge_recovery_checkpoint', $multi_fault, PHP_INT_MAX);
 	wcos_merge_recovery_assert($hit, 'Internal recovery window did not execute: ' . $multi_window);
 	$executed_multi_windows[] = $multi_window;

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -698,7 +698,10 @@ foreach (array('before_forward_relations', 'after_one_reciprocal_relation', 'aft
 	remove_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX);
 	wcos_merge_recovery_assert($hit, 'Forward crash window did not execute: ' . $stage_under_test);
 	$window_source = wc_get_order($window_source->get_id());
-	WCOS_Operation_Journal::fail($window_source, $window_operation);
+	wcos_merge_recovery_assert(
+		WCOS_Operation_Journal::require_recovery($window_source, $window_operation),
+		'Forward crash retry did not dispatch: ' . $stage_under_test
+	);
 	$window_source = wc_get_order($window_source->get_id());
 	$window_target = wc_get_order($window_target->get_id());
 	wcos_merge_recovery_assert('completed' === WCOS_Operation_Journal::get($window_source, $window_operation)['status'], 'Forward crash retry did not complete: ' . $stage_under_test);

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -1,0 +1,488 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_merge_recovery_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_merge_recovery_product($managed = true, $backorders = false) {
+	$product = new WC_Product_Simple();
+	$product->set_name('Merge recovery stock fixture');
+	$product->set_regular_price('12.34');
+	$product->set_price('12.34');
+	$product->set_manage_stock($managed);
+	if ($managed) {
+		$product->set_stock_quantity('40');
+		$product->set_backorders($backorders ? 'yes' : 'no');
+	}
+	wcos_merge_recovery_assert($product->save() > 0, 'Unable to persist Merge recovery product fixture.');
+	return $product;
+}
+
+function wcos_merge_recovery_order(WC_Product $product, $email, $quantity, $reduced_stock = null, $stock_reduced = false) {
+	$order = wc_create_order();
+	$order->set_status('pending');
+	$order->set_currency('USD');
+	$order->set_billing_email($email);
+	$order->set_billing_first_name('Recovery');
+	$order->set_billing_last_name('Fixture');
+	$order->set_billing_address_1('40 Recovery Way');
+	$order->set_billing_city('Testville');
+	$order->set_billing_state('CA');
+	$order->set_billing_postcode('90001');
+	$order->set_billing_country('US');
+	$order->set_payment_method('cod');
+	$order->set_payment_method_title('Cash on delivery');
+	$item = new WC_Order_Item_Product();
+	$item->set_name('Historical Merge line');
+	$item->set_product_id($product->get_id());
+	if ($product instanceof WC_Product_Variation) {
+		$item->set_variation_id($product->get_id());
+		$item->set_product_id($product->get_parent_id());
+	}
+	$item->set_quantity($quantity);
+	$item->set_subtotal('12.34');
+	$item->set_total('12.34');
+	$item->set_subtotal_tax('1.23');
+	$item->set_total_tax('1.23');
+	$item->set_taxes(array('subtotal' => array(1 => '1.23'), 'total' => array(1 => '1.23')));
+	if (null !== $reduced_stock) {
+		$item->add_meta_data('_reduced_stock', WCOS_Decimal::normalize($reduced_stock, 6), true);
+	}
+	$order->add_item($item);
+	$tax = new WC_Order_Item_Tax();
+	$tax->set_rate_id(1);
+	$tax->set_label('Historical tax');
+	$tax->set_compound(false);
+	$tax->set_tax_total('1.23');
+	$tax->set_shipping_tax_total('0.00');
+	$tax->set_rate_percent(10);
+	$order->add_item($tax);
+	$order->set_cart_tax('1.23');
+	$order->set_total('13.57');
+	$order->save();
+	$order->get_data_store()->set_stock_reduced($order->get_id(), $stock_reduced);
+	return wc_get_order($order->get_id());
+}
+
+function wcos_merge_recovery_start(WC_Order $source, WC_Order $target, $operation_id) {
+	$report = WCOS_Merge_Preflight::assert_supported($source, $target);
+	$context = WCOS_Merge_Journal_Context::create(
+		$source,
+		$target,
+		$report['plan'],
+		$report['context_authority'],
+		$report['price_precision']
+	);
+	wcos_merge_recovery_assert(
+		WCOS_Operation_Journal::start($source, $operation_id, 'merge', $context, $report['pair_fingerprint']),
+		'Unable to start authoritative Merge recovery journal.'
+	);
+	wcos_merge_recovery_assert(
+		WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_recovery_initialized', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::NO_WRITE,
+		)),
+		'Unable to initialize Merge recovery checkpoint graph.'
+	);
+	$record = WCOS_Operation_Journal::get($source, $operation_id);
+	wcos_merge_recovery_assert(isset($record['context']['merge_recovery_snapshot']), 'Merge journal omitted its pair recovery snapshot.');
+	return $record;
+}
+
+function wcos_merge_recovery_money_add($left, $right) {
+	$precision = wc_get_price_decimals();
+	return WCOS_Decimal::from_units(
+		WCOS_Decimal::to_units($left, $precision) + WCOS_Decimal::to_units($right, $precision),
+		$precision
+	);
+}
+
+/** Test-only commercial staging; no production Merge service calls this helper. */
+function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operation_id, $forward) {
+	$source_line = reset($source->get_items('line_item'));
+	$source_reduced = $source_line->get_meta('_reduced_stock', true);
+	$clone = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
+	$target->add_item($clone);
+	$target_tax = reset($target->get_items('tax'));
+	wcos_merge_recovery_assert($target_tax instanceof WC_Order_Item_Tax, 'Target historical tax row is unavailable.');
+	$target_tax->set_tax_total(wcos_merge_recovery_money_add($target_tax->get_tax_total(), $source_line->get_total_tax()));
+	$target_tax->save();
+	$target->set_cart_tax(wcos_merge_recovery_money_add($target->get_cart_tax(), $source_line->get_total_tax()));
+	$target->set_total(wcos_merge_recovery_money_add($target->get_total(), wcos_merge_recovery_money_add($source_line->get_total(), $source_line->get_total_tax())));
+	$target->save();
+	$target_item_id = $clone->get_id();
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_target_persisted', array(
+		'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::TARGET_PERSISTED,
+	)), 'Target persistence checkpoint failed.');
+
+	$source_line->delete_meta_data('_reduced_stock');
+	$source_line->save();
+	$source->get_data_store()->set_stock_reduced($source->get_id(), false);
+	if ('' !== $source_reduced) {
+		$target->get_data_store()->set_stock_reduced($target->get_id(), true);
+	}
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert(
+		WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_commercial_state_planned', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATED,
+			'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+			'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+			'merge_target_item_ids' => array($target_item_id),
+			'merge_target_tax_item_ids' => array(),
+			'merge_forward_repair_allowed' => (bool) $forward,
+			'merge_physical_stock_after_write' => false,
+		)),
+		'Unable to checkpoint planned Merge recovery state.'
+	);
+	return array($source, $target, $target_item_id);
+}
+
+function wcos_merge_recovery_run_case($label, WC_Product $product, $quantity, $reduced_stock, $forward, $target_reduced_stock = null) {
+	$email = 'merge-recovery-' . $label . '-' . wp_generate_uuid4() . '@example.test';
+	$source = wcos_merge_recovery_order($product, $email, $quantity, $reduced_stock, null !== $reduced_stock);
+	$target = wcos_merge_recovery_order($product, $email, 1, $target_reduced_stock, null !== $target_reduced_stock);
+	$operation_id = 'merge-recovery-' . $label . '-' . wp_generate_uuid4();
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$record = wcos_merge_recovery_start($source, $target, $operation_id);
+	$snapshot = $record['context']['merge_recovery_snapshot'];
+	$before_source = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'source');
+	$before_target = WCOS_Merge_Recovery_Snapshot::before_signature($snapshot, 'target');
+
+	$tampered = $snapshot;
+	$tampered['source']['order_stock_reduced'] = !$tampered['source']['order_stock_reduced'];
+	$tamper_rejected = false;
+	try {
+		WCOS_Merge_Recovery_Snapshot::assert_valid($tampered, $record);
+	} catch (RuntimeException $exception) {
+		$tamper_rejected = true;
+	}
+	wcos_merge_recovery_assert($tamper_rejected, 'Tampered Merge recovery snapshot was accepted.');
+
+	list($source, $target, $target_item_id) = wcos_merge_recovery_stage($source, $target, $operation_id, $forward);
+	if ($forward) {
+		wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_test_retirement_fixture_verified', array(
+			'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
+			'retirement_policy_selected' => false,
+		)), 'Test-only retirement boundary could not be checkpointed.');
+	}
+	$source_line = reset($source->get_items('line_item'));
+	$target_line = $target->get_item($target_item_id);
+	wcos_merge_recovery_assert('' === $source_line->get_meta('_reduced_stock', true), 'Source retained duplicated reduced-stock ownership.');
+	if (null !== $reduced_stock) {
+		wcos_merge_recovery_assert(
+			WCOS_Decimal::normalize($reduced_stock, 6) === WCOS_Decimal::normalize($target_line->get_meta('_reduced_stock', true), 6),
+			'Target did not receive exact reduced-stock ownership.'
+		);
+	}
+	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Test-only ownership staging changed physical stock.');
+
+	/* Coordinator must acquire both leases itself from a source-only journal. */
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($source, $operation_id, array('reason' => 'integration_recovery')), 'Merge recovery dispatch failed.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	$final = WCOS_Operation_Journal::get($source, $operation_id);
+	if ($forward) {
+		wcos_merge_recovery_assert('completed' === $final['status'], 'Approved exact Merge checkpoint did not forward-repair.');
+		$pair = WCOS_Merge_Journal_Context::pair_from_record($final);
+		wcos_merge_recovery_assert(
+			array('source' => true, 'target' => true) === WCOS_Merge_Participation::state_for_pair($source, $target, $operation_id, $pair['pair_fingerprint']),
+			'Forward repair did not finish reciprocal participation.'
+		);
+		wcos_merge_recovery_assert(false !== $target->get_item($target_item_id), 'Forward repair removed an approved target line.');
+	} else {
+		wcos_merge_recovery_assert('compensated' === $final['status'], 'Verified Merge state did not compensate.');
+		wcos_merge_recovery_assert(hash_equals($before_source, WCOS_Merge_Recovery_Snapshot::participant_signature($source)), 'Compensation did not restore source exactly.');
+		wcos_merge_recovery_assert(hash_equals($before_target, WCOS_Merge_Recovery_Snapshot::participant_signature($target)), 'Compensation did not restore target exactly.');
+		wcos_merge_recovery_assert(false === $target->get_item($target_item_id), 'Compensation retained an operation-owned target line.');
+		/* Response-loss retry is terminal and must not duplicate/remove anything. */
+		wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($source, $operation_id), 'Compensation retry was not idempotent.');
+		wcos_merge_recovery_assert(1 === count($target->get_items('line_item')), 'Compensation retry changed the target line set.');
+	}
+	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Recovery changed physical product stock.');
+
+	WCOS_Operation_Journal::delete($source, $operation_id);
+	$source->delete(true);
+	$target->delete(true);
+	return array('label' => $label, 'forward' => (bool) $forward, 'stock_neutral' => true);
+}
+
+wcos_merge_recovery_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'MERGE gate changed during recovery work.');
+$managed = wcos_merge_recovery_product(true, false);
+$backorder = wcos_merge_recovery_product(true, true);
+$unmanaged = wcos_merge_recovery_product(false, false);
+$variation_parent = new WC_Product_Variable();
+$variation_parent->set_name('Merge parent-managed variation fixture');
+$variation_parent->set_manage_stock(true);
+$variation_parent->set_stock_quantity(30);
+$variation_parent_id = $variation_parent->save();
+$variation = new WC_Product_Variation();
+$variation->set_parent_id($variation_parent_id);
+$variation->set_regular_price('12.34');
+$variation->set_price('12.34');
+$variation->set_manage_stock(false);
+wcos_merge_recovery_assert($variation->save() > 0, 'Unable to persist parent-managed variation fixture.');
+$matrix = array(
+	wcos_merge_recovery_run_case('managed-compensate', $managed, 2, 2, false, 1),
+	wcos_merge_recovery_run_case('managed-forward', $managed, 2, 2, true),
+	wcos_merge_recovery_run_case('parent-managed-variation', $variation, 2, 2, false),
+	wcos_merge_recovery_run_case('fractional', $managed, '0.500000', '0.500000', false),
+	wcos_merge_recovery_run_case('backorder', $backorder, 3, 3, false),
+	wcos_merge_recovery_run_case('unmanaged', $unmanaged, 1, null, false),
+);
+
+/* Crash after source restore but before its checkpoint resumes idempotently. */
+$resume_source = wcos_merge_recovery_order($managed, 'merge-resume-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$resume_target = wcos_merge_recovery_order($managed, $resume_source->get_billing_email(), 1, null, false);
+$resume_operation = 'merge-resume-' . wp_generate_uuid4();
+$resume_record = wcos_merge_recovery_start($resume_source, $resume_target, $resume_operation);
+$resume_snapshot = $resume_record['context']['merge_recovery_snapshot'];
+list($resume_source, $resume_target, $resume_item_id) = wcos_merge_recovery_stage($resume_source, $resume_target, $resume_operation, false);
+$interrupted = false;
+$interrupt_once = static function($stage) use (&$interrupted) {
+	if (!$interrupted && 'after_source_restore' === $stage) {
+		$interrupted = true;
+		throw new WCOS_Merge_Recovery_Interruption_Exception('deterministic_failure_injection');
+	}
+};
+add_action('wcos_merge_recovery_checkpoint', $interrupt_once, PHP_INT_MAX, 1);
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($resume_source, $resume_operation), 'Failure-injected compensation did not dispatch.');
+remove_action('wcos_merge_recovery_checkpoint', $interrupt_once, PHP_INT_MAX);
+$resume_source = wc_get_order($resume_source->get_id());
+$resume_target = wc_get_order($resume_target->get_id());
+wcos_merge_recovery_assert('compensating' === WCOS_Operation_Journal::get($resume_source, $resume_operation)['status'], 'Injected crash did not preserve resumable compensation state.');
+wcos_merge_recovery_assert(hash_equals(WCOS_Merge_Recovery_Snapshot::before_signature($resume_snapshot, 'source'), WCOS_Merge_Recovery_Snapshot::participant_signature($resume_source)), 'Source restore was not durable before injected response loss.');
+wcos_merge_recovery_assert(WCOS_Operation_Journal::fail($resume_source, $resume_operation), 'Partial compensation retry did not dispatch.');
+$resume_source = wc_get_order($resume_source->get_id());
+$resume_target = wc_get_order($resume_target->get_id());
+wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($resume_source, $resume_operation)['status'], 'Partial compensation retry did not finish.');
+wcos_merge_recovery_assert(false === $resume_target->get_item($resume_item_id), 'Partial compensation retry duplicated or retained target state.');
+WCOS_Operation_Journal::delete($resume_source, $resume_operation);
+$resume_source->delete(true);
+$resume_target->delete(true);
+
+/* Unexplained participant divergence blocks both participants and preserves journal retention. */
+$ambiguous_source = wcos_merge_recovery_order($managed, 'merge-ambiguous-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$ambiguous_target = wcos_merge_recovery_order($managed, $ambiguous_source->get_billing_email(), 1, null, false);
+$ambiguous_operation = 'merge-ambiguous-' . wp_generate_uuid4();
+$ambiguous_record = wcos_merge_recovery_start($ambiguous_source, $ambiguous_target, $ambiguous_operation);
+list($ambiguous_source, $ambiguous_target) = wcos_merge_recovery_stage($ambiguous_source, $ambiguous_target, $ambiguous_operation, false);
+$external_line = reset($ambiguous_target->get_items('line_item'));
+$external_line->set_quantity(9);
+$external_line->save();
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($ambiguous_source, $ambiguous_operation), 'Ambiguous recovery did not dispatch.');
+$ambiguous_source = wc_get_order($ambiguous_source->get_id());
+$ambiguous_target = wc_get_order($ambiguous_target->get_id());
+$ambiguous_final = WCOS_Operation_Journal::get($ambiguous_source, $ambiguous_operation);
+wcos_merge_recovery_assert('manual_reconciliation' === $ambiguous_final['status'], 'External target change did not enter manual reconciliation.');
+wcos_merge_recovery_assert(in_array($ambiguous_operation, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($ambiguous_source), true), 'Ambiguous source failed open.');
+wcos_merge_recovery_assert(in_array($ambiguous_operation, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($ambiguous_target), true), 'Ambiguous target failed open.');
+$expired_proof = $ambiguous_final;
+$expired_proof['completed_at'] = '2000-01-01T00:00:00+00:00';
+wcos_merge_recovery_assert(!WCOS_Operation_Journal_Retention::is_expired_terminal_record($expired_proof, time()), 'Retention removed pair-wide reconciliation proof.');
+delete_option('wcos_manual_reconcile_block_' . $ambiguous_source->get_id());
+delete_option('wcos_manual_reconcile_block_' . $ambiguous_target->get_id());
+WCOS_Operation_Journal::delete($ambiguous_source, $ambiguous_operation);
+$ambiguous_source->delete(true);
+$ambiguous_target->delete(true);
+
+/* Durable after-write evidence is never automatically compensated. */
+$physical_source = wcos_merge_recovery_order($managed, 'merge-physical-' . wp_generate_uuid4() . '@example.test', 2, 2, true);
+$physical_target = wcos_merge_recovery_order($managed, $physical_source->get_billing_email(), 1, null, false);
+$physical_operation = 'merge-physical-' . wp_generate_uuid4();
+wcos_merge_recovery_start($physical_source, $physical_target, $physical_operation);
+list($physical_source, $physical_target) = wcos_merge_recovery_stage($physical_source, $physical_target, $physical_operation, false);
+wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($physical_source, $physical_operation, 'merge_physical_stock_observed', array(
+	'merge_physical_stock_after_write' => true,
+)), 'After-write physical-stock evidence was not durable.');
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($physical_source, $physical_operation), 'Physical-stock recovery did not dispatch.');
+$physical_source = wc_get_order($physical_source->get_id());
+$physical_target = wc_get_order($physical_target->get_id());
+wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($physical_source, $physical_operation)['status'], 'After-write evidence did not force manual reconciliation.');
+wcos_merge_recovery_assert(WCOS_Manual_Reconciliation_Blocker::has_active($physical_source) && WCOS_Manual_Reconciliation_Blocker::has_active($physical_target), 'After-write evidence did not block the pair.');
+delete_option('wcos_manual_reconcile_block_' . $physical_source->get_id());
+delete_option('wcos_manual_reconcile_block_' . $physical_target->get_id());
+WCOS_Operation_Journal::delete($physical_source, $physical_operation);
+$physical_source->delete(true);
+$physical_target->delete(true);
+
+/* Missing peer and durable snapshot corruption fail closed. */
+$missing_source = wcos_merge_recovery_order($managed, 'merge-missing-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+$missing_target = wcos_merge_recovery_order($managed, $missing_source->get_billing_email(), 1, null, false);
+$missing_operation = 'merge-missing-' . wp_generate_uuid4();
+wcos_merge_recovery_start($missing_source, $missing_target, $missing_operation);
+$missing_target->delete(true);
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($missing_source, $missing_operation), 'Missing-peer recovery did not dispatch.');
+$missing_source = wc_get_order($missing_source->get_id());
+wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($missing_source, $missing_operation)['status'], 'Missing peer failed open.');
+wcos_merge_recovery_assert(WCOS_Manual_Reconciliation_Blocker::has_active($missing_source), 'Missing peer did not block the survivor.');
+delete_option('wcos_manual_reconcile_block_' . $missing_source->get_id());
+WCOS_Operation_Journal::delete($missing_source, $missing_operation);
+$missing_source->delete(true);
+
+$corrupt_source = wcos_merge_recovery_order($managed, 'merge-corrupt-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
+$corrupt_target = wcos_merge_recovery_order($managed, $corrupt_source->get_billing_email(), 1, null, false);
+$corrupt_operation = 'merge-corrupt-' . wp_generate_uuid4();
+$corrupt_record = wcos_merge_recovery_start($corrupt_source, $corrupt_target, $corrupt_operation);
+$corrupt_record['context']['merge_recovery_snapshot']['source']['order_stock_reduced'] = false;
+$corrupt_key = 'wcos_mutation_op_' . hash('sha256', $corrupt_source->get_id() . '|' . sanitize_key($corrupt_operation));
+update_option($corrupt_key, $corrupt_record, false);
+wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($corrupt_source, $corrupt_operation), 'Corrupt-snapshot recovery did not dispatch.');
+$corrupt_source = wc_get_order($corrupt_source->get_id());
+$corrupt_target = wc_get_order($corrupt_target->get_id());
+wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($corrupt_source, $corrupt_operation)['status'], 'Corrupt snapshot failed open.');
+wcos_merge_recovery_assert(WCOS_Manual_Reconciliation_Blocker::has_active($corrupt_source) && WCOS_Manual_Reconciliation_Blocker::has_active($corrupt_target), 'Corrupt snapshot did not block both participants.');
+delete_option('wcos_manual_reconcile_block_' . $corrupt_source->get_id());
+delete_option('wcos_manual_reconcile_block_' . $corrupt_target->get_id());
+WCOS_Operation_Journal::delete($corrupt_source, $corrupt_operation);
+$corrupt_source->delete(true);
+$corrupt_target->delete(true);
+
+/* Before-write stock hooks are rejected; observed after-write evidence is manual-only. */
+$guard = WCOS_Stock_Side_Effect_Guard::begin('merge-recovery-stock-hook-' . wp_generate_uuid4());
+$before_rejected = false;
+try {
+	do_action('woocommerce_product_before_set_stock', $managed);
+} catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
+	$before_rejected = true;
+}
+wcos_merge_recovery_assert($before_rejected, 'Before-write physical stock hook was not rejected.');
+WCOS_Stock_Side_Effect_Guard::end($guard);
+
+/* Retirement candidates are observed, not selected or registered in production. */
+function wcos_merge_retirement_observe($candidate, WC_Product $product) {
+	$email = 'merge-retirement-' . $candidate . '-' . wp_generate_uuid4() . '@example.test';
+	$order = wcos_merge_recovery_order($product, $email, 1, 1, true);
+	$target = wcos_merge_recovery_order($product, $email, 1, null, false);
+	$order_id = $order->get_id();
+	$commercial_before = WCOS_Order_Contract_Snapshot::aggregate(array($order));
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($order);
+	$source_line = reset($order->get_items('line_item'));
+	$target_line = WCOS_Order_Item_Cloner::product($source_line, array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
+	$target->add_item($target_line);
+	$target->save();
+	$target->get_data_store()->set_stock_reduced($target->get_id(), true);
+	$source_line->delete_meta_data('_reduced_stock');
+	$source_line->save();
+	$order->get_data_store()->set_stock_reduced($order_id, false);
+	$order = wc_get_order($order_id);
+	$target = wc_get_order($target->get_id());
+	$target_active_owner = '1.000000' === WCOS_Decimal::normalize($target_line->get_meta('_reduced_stock', true), 6)
+		&& (bool) $target->get_data_store()->get_stock_reduced($target->get_id());
+	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($target), 'Retirement ownership fixture changed physical stock.');
+	$hooks = array(
+		'status_changed' => 0,
+		'trash' => 0,
+		'delete' => 0,
+		'email_notification' => 0,
+		'webhook_delivery' => 0,
+		'analytics_update' => 0,
+		'order_note' => 0,
+		'post_status_transition' => 0,
+	);
+	$status_hook = static function() use (&$hooks) { $hooks['status_changed']++; };
+	$trash_hook = static function() use (&$hooks) { $hooks['trash']++; };
+	$delete_hook = static function() use (&$hooks) { $hooks['delete']++; };
+	$email_hook = static function() use (&$hooks) { $hooks['email_notification']++; };
+	$webhook_hook = static function() use (&$hooks) { $hooks['webhook_delivery']++; };
+	$analytics_hook = static function() use (&$hooks) { $hooks['analytics_update']++; };
+	$note_hook = static function() use (&$hooks) { $hooks['order_note']++; };
+	$transition_hook = static function() use (&$hooks) { $hooks['post_status_transition']++; };
+	add_action('woocommerce_order_status_changed', $status_hook, 10, 4);
+	add_action('woocommerce_trash_order', $trash_hook, 10, 1);
+	add_action('woocommerce_before_delete_order', $delete_hook, 10, 2);
+	add_action('woocommerce_order_status_pending_to_merged-evidence_notification', $email_hook, 1, 2);
+	add_action('woocommerce_webhook_process_delivery', $webhook_hook, 10, 5);
+	add_action('woocommerce_analytics_update_order_stats', $analytics_hook, 10, 1);
+	add_action('woocommerce_order_note_added', $note_hook, 10, 2);
+	add_action('transition_post_status', $transition_hook, 10, 3);
+
+	$reversible = false;
+	$status_after = '';
+	if (WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE === $candidate) {
+		$order->delete(false);
+		$archived = wc_get_order($order_id);
+		$status_after = $archived instanceof WC_Order ? $archived->get_status() : 'unavailable';
+		if ($archived instanceof WC_Order && method_exists($archived, 'untrash')) {
+			$reversible = (bool) $archived->untrash();
+		}
+	} else {
+		register_post_status('wc-merged-evidence', array('public' => false, 'show_in_admin_all_list' => false, 'show_in_admin_status_list' => false));
+		$status_filter = static function($statuses) {
+			$statuses['wc-merged-evidence'] = 'Merged evidence';
+			return $statuses;
+		};
+		add_filter('wc_order_statuses', $status_filter);
+		$order->update_status('merged-evidence');
+		$status_after = wc_get_order($order_id)->get_status();
+		$reversible = (bool) wc_get_order($order_id)->update_status('pending');
+		remove_filter('wc_order_statuses', $status_filter);
+	}
+
+	$after = wc_get_order($order_id);
+	$commercial_preserved = $after instanceof WC_Order
+		&& $commercial_before['line_quantities'] === WCOS_Order_Contract_Snapshot::aggregate(array($after))['line_quantities']
+		&& $commercial_before['grand_total'] === WCOS_Order_Contract_Snapshot::aggregate(array($after))['grand_total'];
+	$stock_neutral = $after instanceof WC_Order && $stock_before === WCOS_Order_Contract_Snapshot::product_stock($after);
+	remove_action('woocommerce_order_status_changed', $status_hook, 10);
+	remove_action('woocommerce_trash_order', $trash_hook, 10);
+	remove_action('woocommerce_before_delete_order', $delete_hook, 10);
+	remove_action('woocommerce_order_status_pending_to_merged-evidence_notification', $email_hook, 1);
+	remove_action('woocommerce_webhook_process_delivery', $webhook_hook, 10);
+	remove_action('woocommerce_analytics_update_order_stats', $analytics_hook, 10);
+	remove_action('woocommerce_order_note_added', $note_hook, 10);
+	remove_action('transition_post_status', $transition_hook, 10);
+	if ($after instanceof WC_Order) {
+		$after->get_data_store()->set_stock_reduced($order_id, false);
+		$after->delete(true);
+	}
+	$target->get_data_store()->set_stock_reduced($target->get_id(), false);
+	$target->delete(true);
+	return array(
+		'candidate' => $candidate,
+		'source_status_observed' => $status_after,
+		'directly_inspectable_after_transition' => $commercial_preserved,
+		'reversible' => $reversible,
+		'stock_neutral' => $stock_neutral,
+		'target_active_owner' => $target_active_owner,
+		'hooks' => $hooks,
+		'production_selected' => false,
+	);
+}
+
+$retirement = array(
+	wcos_merge_retirement_observe(WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE, $managed),
+	wcos_merge_retirement_observe(WCOS_Merge_Retirement_Policy::DEDICATED_MERGED_ARCHIVE, $managed),
+);
+wcos_merge_recovery_assert(WCOS_Merge_Retirement_Policy::identifiers() === array_column($retirement, 'candidate'), 'Retirement evidence changed candidate authority.');
+
+/* Required crash-window names remain an executable, deterministic coverage contract. */
+$failure_windows = array(
+	'before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership',
+	'during_source_reduced_stock_migration', 'before_source_retirement', 'after_source_retirement',
+	'after_retirement_before_relations', 'after_one_reciprocal_relation', 'after_both_relations_before_verification',
+	'after_verification_before_commit', 'after_commit_before_complete', 'compensation_before_source_restore',
+	'compensation_after_source_restore', 'during_target_cleanup', 'lease_loss_between_boundaries',
+	'source_change_after_checkpoint', 'target_change_after_checkpoint', 'missing_peer', 'corrupt_snapshot',
+	'response_loss_retry', 'physical_stock_before_write', 'physical_stock_after_write',
+);
+wcos_merge_recovery_assert(22 === count(array_unique($failure_windows)), 'Merge crash-window matrix is incomplete or duplicated.');
+
+$managed->delete(true);
+$backorder->delete(true);
+$unmanaged->delete(true);
+$variation->delete(true);
+$variation_parent->delete(true);
+echo 'merge-recovery-evidence=' . wp_json_encode(array(
+	'storage' => \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ? 'hpos' : 'legacy',
+	'stock_matrix' => $matrix,
+	'retirement_candidates' => $retirement,
+	'failure_windows' => $failure_windows,
+	'merge_gate' => false,
+)) . "\n";
+echo "merge-recovery-foundation-ok\n";

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -142,9 +142,10 @@ function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operatio
 	if ($forward) {
 		$retirement_candidate = WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE;
 		$snapshot = WCOS_Operation_Journal::get($source, $operation_id)['context']['merge_recovery_snapshot'];
+		$source_id = $source->get_id();
 		do_action('wcos_merge_recovery_checkpoint', 'before_source_retirement', $source, $target, $operation_id);
 		$source->delete(false);
-		$source = wc_get_order($source->get_id());
+		$source = wc_get_order($source_id);
 		wcos_merge_recovery_assert($source instanceof WC_Order && 'trash' === $source->get_status(), 'Non-force retirement did not archive the staged source.');
 		WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
 		do_action('wcos_merge_recovery_checkpoint', 'after_source_retirement', $source, $target, $operation_id);
@@ -576,7 +577,9 @@ function wcos_merge_retirement_observe($candidate, WC_Product $product) {
 	list($source, $target, $target_item_id) = wcos_merge_recovery_stage($source, $target, $operation_id, false);
 	$status_filter = null;
 	if (WCOS_Merge_Retirement_Policy::NON_FORCE_TRASH_ARCHIVE === $candidate) {
+		$source_id = $source->get_id();
 		$source->delete(false);
+		$source = wc_get_order($source_id);
 	} else {
 		register_post_status('wc-merged-evidence', array('public' => false, 'show_in_admin_all_list' => false, 'show_in_admin_status_list' => false));
 		$status_filter = static function($statuses) { $statuses['wc-merged-evidence'] = 'Merged evidence'; return $statuses; };

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -315,6 +315,12 @@ $multi_source = wcos_merge_recovery_order($managed, 'merge-multi-' . wp_generate
 $multi_initial_lines = $multi_source->get_items('line_item');
 $extra_source_line = WCOS_Order_Item_Cloner::product(reset($multi_initial_lines), array(), true, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE);
 $multi_source->add_item($extra_source_line);
+$multi_source_tax_items = $multi_source->get_items('tax');
+$multi_source_tax = reset($multi_source_tax_items);
+$multi_source_tax->set_tax_total('2.46');
+$multi_source_tax->save();
+$multi_source->set_cart_tax('2.46');
+$multi_source->set_total('27.14');
 $multi_source->save();
 $multi_source = wc_get_order($multi_source->get_id());
 $multi_target = wcos_merge_recovery_order($managed, $multi_source->get_billing_email(), 1, null, false);

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -656,6 +656,8 @@ $failure_windows = array();
 foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership', 'during_source_reduced_stock_migration', 'before_source_retirement', 'after_source_retirement') as $stage_under_test) {
 	$window_source = wcos_merge_recovery_order($managed, 'merge-window-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
 	$window_target = wcos_merge_recovery_order($managed, $window_source->get_billing_email(), 1, null, false);
+	$window_source_id = $window_source->get_id();
+	$window_target_id = $window_target->get_id();
 	$window_operation = 'merge-window-' . wp_generate_uuid4();
 	wcos_merge_recovery_start($window_source, $window_target, $window_operation);
 	$hit = false;
@@ -666,8 +668,8 @@ foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'af
 	try { wcos_merge_recovery_stage($window_source, $window_target, $window_operation, true); } catch (WCOS_Merge_Recovery_Interruption_Exception $exception) {}
 	remove_action('wcos_merge_recovery_checkpoint', $window_fault, PHP_INT_MAX);
 	wcos_merge_recovery_assert($hit, 'Pre-authority crash window did not execute: ' . $stage_under_test);
-	$window_source = wc_get_order($window_source->get_id());
-	$window_target = wc_get_order($window_target->get_id());
+	$window_source = wc_get_order($window_source_id);
+	$window_target = wc_get_order($window_target_id);
 	WCOS_Operation_Journal::require_recovery($window_source, $window_operation);
 	$window_source = wc_get_order($window_source->get_id());
 	$window_target = wc_get_order($window_target->get_id());

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -349,7 +349,12 @@ wcos_merge_recovery_assert(WCOS_Operation_Journal::checkpoint($multi_source, $mu
 	'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($multi_target),
 	'merge_target_item_ids' => array($multi_added_one, $extra_target_line->get_id()),
 )), 'Multi-component recovery checkpoints were not durable.');
-$multi_windows = array('source_line_restored', 'source_tax_restored', 'target_added_line_removed', 'target_tax_restored');
+$multi_windows = array(
+	'before_source_line_restored_checkpoint',
+	'before_source_tax_restored_checkpoint',
+	'before_target_added_line_removed_checkpoint',
+	'before_target_tax_restored_checkpoint',
+);
 $executed_multi_windows = array();
 foreach ($multi_windows as $multi_window_index => $multi_window) {
 	$hit = false;

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -103,6 +103,16 @@ function wcos_merge_recovery_money_add($left, $right) {
 	);
 }
 
+function wcos_merge_recovery_owned_components(WC_Order $order) {
+	$state = WCOS_Merge_Recovery_Snapshot::participant_checkpoint($order);
+	return array(
+		'line_items' => $state['line_items'],
+		'tax_items' => $state['tax_items'],
+		'order_props' => $state['order_props'],
+		'order_stock_reduced' => $state['order_stock_reduced'],
+	);
+}
+
 /** Test-only commercial staging; no production Merge service calls this helper. */
 function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operation_id, $forward) {
 	do_action('wcos_merge_recovery_checkpoint', 'before_target_write', $source, $target, $operation_id);
@@ -129,6 +139,7 @@ function wcos_merge_recovery_stage(WC_Order $source, WC_Order $target, $operatio
 	do_action('wcos_merge_recovery_checkpoint', 'during_source_reduced_stock_migration', $source, $target, $operation_id);
 	$source_line->delete_meta_data('_reduced_stock');
 	$source_line->save();
+	do_action('wcos_merge_recovery_checkpoint', 'after_source_line_ownership_before_order_flags', $source, $target, $operation_id);
 	$source->get_data_store()->set_stock_reduced($source->get_id(), false);
 	if ('' !== $source_reduced) {
 		$target->get_data_store()->set_stock_reduced($target->get_id(), true);
@@ -237,6 +248,78 @@ function wcos_merge_recovery_run_case($label, WC_Product $product, $quantity, $r
 	return array('label' => $label, 'forward' => (bool) $forward, 'stock_neutral' => true);
 }
 
+function wcos_merge_recovery_run_immutable_drift_case($label, WC_Product $product, $forward, $target_shipping) {
+	$email = 'merge-immutable-' . $label . '-' . wp_generate_uuid4() . '@example.test';
+	$source = wcos_merge_recovery_order($product, $email, 2, 2, true);
+	$target = wcos_merge_recovery_order($product, $email, 1, null, false);
+	$shipping_id = 0;
+	if ($target_shipping) {
+		$shipping = new WC_Order_Item_Shipping();
+		$shipping->set_method_title('Immutable target shipping');
+		$shipping->set_method_id('flat_rate');
+		$shipping->set_instance_id(71);
+		$shipping->set_total('0.00');
+		$shipping->set_taxes(array('total' => array()));
+		$target->add_item($shipping);
+		$target->save();
+		$shipping_id = $shipping->get_id();
+	}
+	$operation_id = 'merge-immutable-' . $label . '-' . wp_generate_uuid4();
+	wcos_merge_recovery_start($source, $target, $operation_id);
+	list($source, $target) = wcos_merge_recovery_stage($source, $target, $operation_id, $forward);
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$source_quantity_before = array_map(static function($item) { return (string) $item->get_quantity(); }, $source->get_items('line_item'));
+	$target_quantity_before = array_map(static function($item) { return (string) $item->get_quantity(); }, $target->get_items('line_item'));
+	$source_total_before = (string) $source->get_total();
+	$target_total_before = (string) $target->get_total();
+
+	if ('source-billing-payment' === $label) {
+		$source->set_billing_city('Externally changed city');
+		$source->set_payment_method('bacs');
+		$source->set_payment_method_title('External bank transfer');
+		$source->save();
+	} else {
+		$shipping = $target->get_item($shipping_id);
+		wcos_merge_recovery_assert($shipping instanceof WC_Order_Item_Shipping, 'Target shipping drift fixture is unavailable.');
+		$shipping->set_method_title('Externally changed shipping');
+		$shipping->save();
+		$target_lines = $target->get_items('line_item');
+		$preexisting_target_line = reset($target_lines);
+		$preexisting_target_line->set_name('Externally renamed target line');
+		$preexisting_target_line->save();
+	}
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert($source_quantity_before === array_map(static function($item) { return (string) $item->get_quantity(); }, $source->get_items('line_item')), 'Source immutable drift changed quantity.');
+	wcos_merge_recovery_assert($target_quantity_before === array_map(static function($item) { return (string) $item->get_quantity(); }, $target->get_items('line_item')), 'Target immutable drift changed quantity.');
+	wcos_merge_recovery_assert($source_total_before === (string) $source->get_total() && $target_total_before === (string) $target->get_total(), 'Immutable drift changed participant totals.');
+	$source_owned_before = wcos_merge_recovery_owned_components($source);
+	$target_owned_before = wcos_merge_recovery_owned_components($target);
+
+	wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($source, $operation_id), 'Immutable-context drift did not dispatch recovery.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($source, $operation_id)['status'], 'Immutable-context drift failed open: ' . $label);
+	wcos_merge_recovery_assert($source_owned_before === wcos_merge_recovery_owned_components($source), 'Immutable source drift allowed an automatic recovery write.');
+	wcos_merge_recovery_assert($target_owned_before === wcos_merge_recovery_owned_components($target), 'Immutable target drift allowed an automatic recovery write.');
+	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Immutable-context rejection changed physical stock.');
+	wcos_merge_recovery_assert(WCOS_Manual_Reconciliation_Blocker::has_active($source) && WCOS_Manual_Reconciliation_Blocker::has_active($target), 'Immutable-context drift did not block both participants.');
+	if ('source-billing-payment' === $label) {
+		wcos_merge_recovery_assert('Externally changed city' === $source->get_billing_city() && 'bacs' === $source->get_payment_method(), 'Recovery overwrote external billing/payment drift.');
+	} else {
+		$shipping = $target->get_item($shipping_id);
+		$target_lines = $target->get_items('line_item');
+		wcos_merge_recovery_assert($shipping instanceof WC_Order_Item_Shipping && 'Externally changed shipping' === $shipping->get_method_title(), 'Recovery overwrote external target shipping drift.');
+		wcos_merge_recovery_assert('Externally renamed target line' === reset($target_lines)->get_name(), 'Recovery overwrote external target item drift.');
+	}
+	delete_option('wcos_manual_reconcile_block_' . $source->get_id());
+	delete_option('wcos_manual_reconcile_block_' . $target->get_id());
+	WCOS_Operation_Journal::delete($source, $operation_id);
+	$source->delete(true);
+	$target->delete(true);
+	return array('label' => $label, 'manual_before_recovery_write' => true, 'stock_neutral' => true);
+}
+
 wcos_merge_recovery_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'MERGE gate changed during recovery work.');
 $managed = wcos_merge_recovery_product(true, false);
 $backorder = wcos_merge_recovery_product(true, true);
@@ -259,6 +342,10 @@ $matrix = array(
 	wcos_merge_recovery_run_case('fractional', $managed, '0.500000', '0.500000', false),
 	wcos_merge_recovery_run_case('backorder', $backorder, 3, 3, false),
 	wcos_merge_recovery_run_case('unmanaged', $unmanaged, 1, null, false),
+);
+$immutable_drift_matrix = array(
+	wcos_merge_recovery_run_immutable_drift_case('source-billing-payment', $managed, true, false),
+	wcos_merge_recovery_run_immutable_drift_case('target-shipping-item', $managed, false, true),
 );
 
 /* Crash after source restore but before its checkpoint resumes idempotently. */
@@ -659,9 +746,10 @@ wcos_merge_recovery_assert(WCOS_Merge_Retirement_Policy::identifiers() === $obse
 
 /* Execute the material pre-authority crash boundaries; each must become pair-wide manual. */
 $failure_windows = array();
-foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership', 'during_source_reduced_stock_migration', 'before_source_retirement', 'after_source_retirement') as $stage_under_test) {
+foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'after_target_checkpoint_before_source_ownership', 'during_source_reduced_stock_migration', 'after_source_line_ownership_before_order_flags', 'before_source_retirement', 'after_source_retirement') as $stage_under_test) {
 	$window_source = wcos_merge_recovery_order($managed, 'merge-window-' . wp_generate_uuid4() . '@example.test', 1, 1, true);
 	$window_target = wcos_merge_recovery_order($managed, $window_source->get_billing_email(), 1, null, false);
+	$window_stock_before = WCOS_Order_Contract_Snapshot::product_stock($window_source);
 	$window_source_id = $window_source->get_id();
 	$window_target_id = $window_target->get_id();
 	$window_operation = 'merge-window-' . wp_generate_uuid4();
@@ -676,10 +764,19 @@ foreach (array('before_target_write', 'after_target_item_before_checkpoint', 'af
 	wcos_merge_recovery_assert($hit, 'Pre-authority crash window did not execute: ' . $stage_under_test);
 	$window_source = wc_get_order($window_source_id);
 	$window_target = wc_get_order($window_target_id);
+	if ('after_source_line_ownership_before_order_flags' === $stage_under_test) {
+		$partial_lines = $window_source->get_items('line_item');
+		$partial_line = reset($partial_lines);
+		wcos_merge_recovery_assert('' === $partial_line->get_meta('_reduced_stock', true), 'Partial ownership crash did not persist the source line write.');
+		wcos_merge_recovery_assert((bool) $window_source->get_data_store()->get_stock_reduced($window_source_id), 'Partial ownership crash unexpectedly persisted the source order flag.');
+		wcos_merge_recovery_assert(!(bool) $window_target->get_data_store()->get_stock_reduced($window_target_id), 'Partial ownership crash unexpectedly persisted the target order flag.');
+		wcos_merge_recovery_assert($window_stock_before === WCOS_Order_Contract_Snapshot::product_stock($window_source), 'Partial ownership crash changed physical product stock.');
+	}
 	WCOS_Operation_Journal::require_recovery($window_source, $window_operation);
 	$window_source = wc_get_order($window_source->get_id());
 	$window_target = wc_get_order($window_target->get_id());
 	wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($window_source, $window_operation)['status'], 'Pre-authority crash did not fail closed: ' . $stage_under_test);
+	wcos_merge_recovery_assert($window_stock_before === WCOS_Order_Contract_Snapshot::product_stock($window_source), 'Pre-authority recovery changed physical product stock: ' . $stage_under_test);
 	$failure_windows[] = array('window' => $stage_under_test, 'outcome' => 'manual_reconciliation');
 	delete_option('wcos_manual_reconcile_block_' . $window_source->get_id());
 	delete_option('wcos_manual_reconcile_block_' . $window_target->get_id());
@@ -722,7 +819,7 @@ $failure_windows[] = array('window' => 'interruption_during_target_cleanup', 'ou
 $failure_windows[] = array('window' => 'lease_loss', 'outcome' => 'recovery_required');
 $failure_windows[] = array('window' => 'source_divergence', 'outcome' => 'manual_reconciliation');
 $failure_windows[] = array('window' => 'target_divergence', 'outcome' => 'manual_reconciliation');
-wcos_merge_recovery_assert(17 === count($failure_windows), 'Executed Merge crash-window matrix is incomplete.');
+wcos_merge_recovery_assert(18 === count($failure_windows), 'Executed Merge crash-window matrix is incomplete.');
 
 $managed->delete(true);
 $backorder->delete(true);
@@ -732,6 +829,7 @@ $variation_parent->delete(true);
 echo 'merge-recovery-evidence=' . wp_json_encode(array(
 	'storage' => \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ? 'hpos' : 'legacy',
 	'stock_matrix' => $matrix,
+	'immutable_drift_matrix' => $immutable_drift_matrix,
 	'retirement_candidates' => $retirement,
 	'failure_windows' => $failure_windows,
 	'merge_gate' => false,

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -30,6 +30,7 @@ require_once $root . 'class-wcos-mutation-contract.php';
 require_once $root . 'class-wcos-split-plan.php';
 require_once $root . 'class-wcos-merge-retirement-policy.php';
 require_once $root . 'class-wcos-merge-plan.php';
+require_once $root . 'class-wcos-merge-recovery-state-graph.php';
 
 $tests = array();
 
@@ -263,6 +264,35 @@ $tests['merge retirement candidates preserve archive and remain unselected'] = s
 	}
 	WCOS_Merge_Retirement_Policy::assert_archive_preserved(str_repeat('a', 64), str_repeat('a', 64));
 	WCOS_Merge_Retirement_Policy::assert_active_ownership_conserved(str_repeat('b', 64), str_repeat('b', 64));
+};
+
+$tests['merge recovery graph accepts forward and source-first compensation paths'] = static function() {
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('no_commercial_write', 'target_persisted'), 'Initial target transition was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('source_retired', 'source_relation_persisted'), 'Reciprocal relation transition was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('commercial_verified', 'committed'), 'Verified commit transition was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('compensating', 'source_restored'), 'Source-first compensation was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('source_restored', 'target_restored'), 'Target cleanup after source restore was rejected.');
+	assert_same(false, WCOS_Merge_Recovery_State_Graph::transition_allowed('target_persisted', 'completed'));
+	assert_same(false, WCOS_Merge_Recovery_State_Graph::transition_allowed('compensating', 'target_restored'));
+};
+
+$tests['merge recovery checkpoints are self-verifying'] = static function() {
+	$record = array(
+		'source_order_id' => 40,
+		'operation_id' => 'merge-recovery-unit',
+		'fingerprint' => str_repeat('a', 64),
+		'checkpoints' => array(),
+	);
+	$context = WCOS_Merge_Recovery_State_Graph::seal_context($record, array(
+		'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::NO_WRITE,
+		'merge_source_signature_after' => str_repeat('b', 64),
+	));
+	$record['checkpoints'][] = array('context' => $context);
+	assert_same(WCOS_Merge_Recovery_State_Graph::NO_WRITE, WCOS_Merge_Recovery_State_Graph::assert_record($record));
+	$record['checkpoints'][0]['context']['merge_source_signature_after'] = str_repeat('c', 64);
+	assert_throws(static function() use ($record) {
+		WCOS_Merge_Recovery_State_Graph::assert_record($record);
+	}, RuntimeException::class);
 };
 
 $failures = 0;


### PR DESCRIPTION
## Summary

Implements WOS-MERGE-003 only: the hard-off, dual-order Merge Recovery Foundation.

- adds a PII-minimized, self-verifying source/target recovery snapshot;
- adds a fingerprinted Merge recovery checkpoint graph;
- adds a dual-order commit guard over the existing WCOS_Multi_Order_Lease;
- adds workflow-specific forward-repair/compensation with source-first ownership restore;
- extends the existing recovery coordinator for source-journal Merge dispatch;
- integrates pair-wide blocker/manual-reconciliation behavior;
- adds storage-matrix recovery, stock-ownership, crash-window, and retirement-candidate evidence tests;
- packages the recovery foundation while keeping all production Merge execution surfaces absent.

## Authority and scope

- Issue: #40
- exact base: 39ca2828389c700ccc000e8b30fcdae01a39d576
- branch: codex/wos-merge-003-recovery-foundation
- one authoritative source journal; no target shadow journal
- no production Merge service, adapter, controller, transport, UI, or status registration
- no retirement policy selected
- MERGE remains false
- Split/Duplicate and strategy gates are unchanged

## Local validation

- all PHP files lint clean (existing PHP 8.4 deprecation notices are unchanged)
- mutation-domain unit suite passes, including recovery graph transition and tamper tests
- git diff --check passes
- complete origin/main...HEAD scope/gate self-review passes
- local wp-env integration could not start because Docker is unavailable on this host; the exact-head canonical GitHub matrix is authoritative

## Review gates

- Draft PR; do not merge
- canonical CI and per-storage retirement evidence pending
- final source-retirement policy remains a ChatGPT/human boundary decision

Closes #40 only after independent technical acceptance and owner merge.
