### PR TITLE
WOS-MERGE-004: hardened Merge service and adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,13 @@ jobs:
           grep -Fq 'class-wcos-merge-compensator.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-preflight.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-retirement-policy.php' inc/cores/script.php
-          grep -Fq "throw new RuntimeException(__('The hardened merge service has not been implemented.'" inc/domain/class-wcos-mutation-gateway.php
+          grep -Fq 'class-wcos-merge-order-service.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-woocommerce-adapter.php' inc/cores/script.php
+          grep -Fq 'new WCOS_Merge_WooCommerce_Adapter' inc/domain/class-wcos-mutation-gateway.php
+          grep -Fq 'const APPROVED = self::NON_FORCE_TRASH_ARCHIVE;' inc/domain/class-wcos-merge-retirement-policy.php
+          test ! -e inc/backend/class-wcos-merge-admin-controller.php
+          test ! -e inc/backend/class-wcos-merge-confirmation-store.php
+          test ! -e inc/backend/class-wcos-merge-review-store.php
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -255,6 +261,8 @@ jobs:
             'inc/domain/class-wcos-merge-compensator.php' \
             'inc/domain/class-wcos-merge-preflight.php' \
             'inc/domain/class-wcos-merge-retirement-policy.php' \
+            'inc/domain/class-wcos-merge-order-service.php' \
+            'inc/domain/class-wcos-merge-woocommerce-adapter.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -318,6 +326,8 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-compensator.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-order-service.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-woocommerce-adapter.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-split-strategy-admin.js'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-split-strategy-admin.css'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
@@ -464,6 +474,9 @@ jobs:
 
       - name: Verify hard-off Merge recovery and retirement evidence
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-recovery-foundation-smoke.php
+
+      - name: Verify hardened Merge service, adapter, recovery, and stock contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php
 
       - name: Verify duplicate integrity, idempotency, and recovery
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/duplicate-smoke.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,8 +496,17 @@ jobs:
       - name: Verify hardened Merge pre-complete crash contract
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_after_commit_before_complete
 
-      - name: Verify hardened Merge response-loss, lease-loss, and stock-guard contracts
-        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_post_aux
+      - name: Verify hardened Merge response-loss contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php response_loss
+
+      - name: Verify hardened Merge lease-loss contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php lease_loss
+
+      - name: Verify hardened Merge blocked stock-write contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php stock_guard_before
+
+      - name: Verify hardened Merge observed stock-write contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php stock_guard_after
 
       - name: Verify hardened Merge immutable-context and stock contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php drift_stock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,8 +475,17 @@ jobs:
       - name: Verify hard-off Merge recovery and retirement evidence
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-recovery-foundation-smoke.php
 
-      - name: Verify hardened Merge service, adapter, recovery, and stock contracts
-        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php
+      - name: Verify hardened Merge service and adapter core contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php core
+
+      - name: Verify hardened Merge pre-retirement crash contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_pre
+
+      - name: Verify hardened Merge post-retirement crash contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_post
+
+      - name: Verify hardened Merge immutable-context and stock contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php drift_stock
 
       - name: Verify duplicate integrity, idempotency, and recovery
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/duplicate-smoke.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,8 +481,23 @@ jobs:
       - name: Verify hardened Merge pre-retirement crash contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_pre
 
-      - name: Verify hardened Merge post-retirement crash contracts
-        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_post
+      - name: Verify hardened Merge before-relations crash contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_before_forward_relations
+
+      - name: Verify hardened Merge partial-relations crash contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_after_one_reciprocal_relation
+
+      - name: Verify hardened Merge post-relations crash contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_after_both_relations_before_verification
+
+      - name: Verify hardened Merge pre-commit crash contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_after_verification_before_commit
+
+      - name: Verify hardened Merge pre-complete crash contract
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php forward_after_commit_before_complete
+
+      - name: Verify hardened Merge response-loss, lease-loss, and stock-guard contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_post_aux
 
       - name: Verify hardened Merge immutable-context and stock contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php drift_stock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,17 @@ php tests/unit/run.php
 
 WooCommerce/WordPress integration contracts run through `.github/workflows/ci.yml` across legacy, HPOS, and HPOS-sync storage. The GitHub Actions workflows are the merge authority. Local success is necessary but not sufficient.
 
+## Local-runtime worktree contract
+
+When a task brief designates Local-runtime mode:
+
+- Implementation and hands-on runtime validation must use the exact active Git worktree loaded by WordPress Local.
+- Do not use a detached temporary implementation worktree for that task.
+- Isolated worktrees remain allowed for independent review, experiments, and explicitly parallel non-runtime work.
+- File copying or `rsync` between worktrees is not accepted as runtime evidence.
+- Before changing worktree topology or switching the active Local-runtime branch, prove every affected worktree is clean and safe to switch. If that cannot be proven, stop with `LOCAL_RUNTIME_WORKTREE_SYNC_REQUIRED` without discarding uncommitted state.
+- Canonical GitHub CI remains the merge authority.
+
 ## Review rules
 
 - Review the complete diff, not only the newest commit.

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -61,6 +61,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-mutation-commit-guard.php';
 		WCOS_Mutation_Commit_Guard::bootstrap();
 		include_once $root . 'domain/class-wcos-merge-commit-guard.php';
+		include_once $root . 'domain/class-wcos-merge-order-service.php';
 		include_once $root . 'domain/class-wcos-duplicate-order-service.php';
 		include_once $root . 'domain/class-wcos-split-order-service.php';
 		include_once $root . 'domain/class-wcos-split-compensator.php';
@@ -75,6 +76,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
 		include_once $root . 'domain/class-wcos-merge-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';
+		include_once $root . 'domain/class-wcos-merge-woocommerce-adapter.php';
 		include_once $root . 'domain/class-wcos-mutation-gateway.php';
 
 		include_once $root . 'backend/class-wcos-admin-backbone-modal-assets.php';

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -19,7 +19,7 @@ final class WCOS_Merge_Compensator {
 		$snapshot = isset($context['merge_recovery_snapshot']) && is_array($context['merge_recovery_snapshot'])
 			? $context['merge_recovery_snapshot']
 			: array();
-		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
+		$pair = WCOS_Merge_Journal_Context::assert_executable_policy($record);
 		if ('' === $operation_id || !is_array($pair) || empty($snapshot)) {
 			throw new RuntimeException(__('Merge recovery authority is incomplete.', 'wc-order-splitter'));
 		}
@@ -39,7 +39,7 @@ final class WCOS_Merge_Compensator {
 		$target_tax_item_ids = self::ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
 		$retirement_candidate = sanitize_key(isset($context['merge_retirement_candidate']) ? (string) $context['merge_retirement_candidate'] : '');
 		if ('' !== $retirement_candidate) {
-			WCOS_Merge_Retirement_Policy::assert_candidate($retirement_candidate);
+			WCOS_Merge_Retirement_Policy::assert_approved($retirement_candidate);
 		}
 
 		try {
@@ -251,19 +251,39 @@ final class WCOS_Merge_Compensator {
 			throw new RuntimeException(__('Forward-repaired Merge state could not be verified.', 'wc-order-splitter'));
 		}
 		if (WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state) {
-			self::event('after_verification_before_commit', $source, $target, $operation_id);
-			self::lease_guard($lease);
+			self::boundary(
+					$lease,
+					$source,
+					$target,
+					$record,
+					WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+					WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+					'complete',
+					'after_verification_before_commit'
+			);
 		}
 		$journal_status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		$commit_checkpoint_required = WCOS_Merge_Recovery_State_Graph::COMMITTED !== $recovery_state || 'committed' !== $journal_status;
 		if ($commit_checkpoint_required && !WCOS_Operation_Journal::mark_committed($source, $operation_id, array(
-				'merge_forward_repaired' => true,
-				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMMITTED,
+					'merge_forward_repaired' => true,
+					'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMMITTED,
+					'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+					'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+					'merge_source_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($source),
+					'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target),
 			))) {
 			throw new RuntimeException(__('Forward-repaired Merge state could not be committed.', 'wc-order-splitter'));
 		}
-		self::event('after_commit_before_complete', $source, $target, $operation_id);
-		self::lease_guard($lease);
+		self::boundary(
+				$lease,
+				$source,
+				$target,
+				$record,
+				WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+				WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+				'complete',
+				'after_commit_before_complete'
+		);
 		if (!WCOS_Operation_Journal::complete($source, $operation_id, array(
 				'merge_verified' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPLETED,

--- a/inc/domain/class-wcos-merge-compensator.php
+++ b/inc/domain/class-wcos-merge-compensator.php
@@ -284,9 +284,14 @@ final class WCOS_Merge_Compensator {
 				'complete',
 				'after_commit_before_complete'
 		);
+		$terminal_record = WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $operation_id);
+		if (!is_array($terminal_record)) {
+			throw new RuntimeException(__('Forward-repaired Merge terminal authority could not be reloaded.', 'wc-order-splitter'));
+		}
 		if (!WCOS_Operation_Journal::complete($source, $operation_id, array(
 				'merge_verified' => true,
 				'merge_recovery_state' => WCOS_Merge_Recovery_State_Graph::COMPLETED,
+				'merge_terminal_result' => WCOS_Merge_Journal_Context::create_terminal_result($terminal_record),
 			))) {
 			throw new RuntimeException(__('Forward-repaired Merge state could not be finalized.', 'wc-order-splitter'));
 		}

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -7,9 +7,9 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Journal_Context {
 
-	const SCHEMA_VERSION = 2;
+	const SCHEMA_VERSION = 3;
 
-	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array()) {
+	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array(), $selected_retirement_policy = '') {
 		$source_id = absint($source->get_id());
 		$target_id = absint($target->get_id());
 		$price_precision = WCOS_Price_Precision_Scope::validate($price_precision);
@@ -17,6 +17,10 @@ final class WCOS_Merge_Journal_Context {
 			throw new InvalidArgumentException(__('A Merge journal context requires two distinct persisted orders.', 'wc-order-splitter'));
 		}
 
+		$selected_retirement_policy = sanitize_key((string) $selected_retirement_policy);
+		if ('' !== $selected_retirement_policy) {
+			WCOS_Merge_Retirement_Policy::assert_approved($selected_retirement_policy);
+		}
 		$source_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
 		$archive_signature = WCOS_Merge_Recovery_Snapshot::archive_commercial_signature($source);
 		$active_signature = WCOS_Merge_Recovery_Snapshot::active_economic_signature(array($source, $target), $price_precision, $source_id);
@@ -34,7 +38,8 @@ final class WCOS_Merge_Journal_Context {
 			'context_authority_fingerprint' => WCOS_Merge_Context_Signature::authority_fingerprint($context_authority),
 			'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
 			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
-			'retirement_policy_selected' => false,
+			'retirement_policy_selected' => '' !== $selected_retirement_policy,
+			'retirement_policy_identifier' => $selected_retirement_policy,
 			'archive_source_signature_before' => isset($evidence['archive_source_signature_before'])
 				? sanitize_key((string) $evidence['archive_source_signature_before'])
 				: $archive_signature,
@@ -55,6 +60,18 @@ final class WCOS_Merge_Journal_Context {
 				'authority' => $authority,
 				'pair_fingerprint' => $pair_fingerprint,
 			),
+		);
+	}
+
+	public static function create_executable(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array()) {
+		return self::create(
+			$source,
+			$target,
+			$plan,
+			$context_authority,
+			$price_precision,
+			$evidence,
+			WCOS_Merge_Retirement_Policy::approved_identifier()
 		);
 	}
 
@@ -122,6 +139,17 @@ final class WCOS_Merge_Journal_Context {
 			&& ('' === $operation_id || hash_equals($operation_id, $record_operation_id));
 	}
 
+	public static function assert_executable_policy(array $record) {
+		$pair = self::pair_from_record($record);
+		if (!is_array($pair)
+			|| true !== $pair['retirement_policy_selected']
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== $pair['retirement_policy_identifier']) {
+			throw new RuntimeException(__('The Merge journal does not contain executable approved retirement-policy authority.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Retirement_Policy::assert_approved($pair['retirement_policy_identifier']);
+		return $pair;
+	}
+
 	public static function is_unsafe_record(array $record) {
 		if (!is_array(self::pair_from_record($record))) {
 			return true;
@@ -131,7 +159,7 @@ final class WCOS_Merge_Journal_Context {
 	}
 
 	private static function authority_fingerprint(array $authority) {
-		return WCOS_Mutation_Fingerprint::create('merge_pair_authority_v2', $authority['source_order_id'], $authority);
+		return WCOS_Mutation_Fingerprint::create('merge_pair_authority_v3', $authority['source_order_id'], $authority);
 	}
 
 	private static function canonical_authority(array $authority) {
@@ -139,7 +167,7 @@ final class WCOS_Merge_Journal_Context {
 			'active_ownership_before_signature', 'archive_source_signature_before', 'context_authority',
 			'context_authority_fingerprint', 'context_signature_version', 'participation_schema_version',
 			'plan_fingerprint', 'plan_schema_version', 'preflight_policy_version', 'price_precision',
-			'retirement_candidates', 'retirement_policy_schema_version', 'retirement_policy_selected',
+			'retirement_candidates', 'retirement_policy_identifier', 'retirement_policy_schema_version', 'retirement_policy_selected',
 			'source_order_id', 'source_signature', 'target_order_id', 'target_signature',
 		);
 		$actual_keys = array_keys($authority);
@@ -161,6 +189,8 @@ final class WCOS_Merge_Journal_Context {
 			? ''
 			: self::normalized_fingerprint($authority['active_ownership_before_signature']);
 		$price_precision = (int) $authority['price_precision'];
+		$policy_selected = true === $authority['retirement_policy_selected'];
+		$policy_identifier = sanitize_key((string) $authority['retirement_policy_identifier']);
 		if (!$source_id || !$target_id || $source_id === $target_id || !is_array($context_authority)
 			|| '' === $source_signature || '' === $target_signature || '' === $plan_fingerprint
 			|| '' === $context_fingerprint || '' === $archive_signature
@@ -171,7 +201,9 @@ final class WCOS_Merge_Journal_Context {
 			|| (int) $authority['context_signature_version'] !== WCOS_Merge_Context_Signature::SCHEMA_VERSION
 			|| (int) $authority['retirement_policy_schema_version'] !== WCOS_Merge_Retirement_Policy::SCHEMA_VERSION
 			|| (int) $authority['participation_schema_version'] !== WCOS_Merge_Participation::SCHEMA_VERSION
-			|| false !== (bool) $authority['retirement_policy_selected']
+			|| (!in_array($authority['retirement_policy_selected'], array(true, false), true))
+			|| ($policy_selected && WCOS_Merge_Retirement_Policy::approved_identifier() !== $policy_identifier)
+			|| (!$policy_selected && '' !== $policy_identifier)
 			|| WCOS_Merge_Retirement_Policy::identifiers() !== array_values($authority['retirement_candidates'])) {
 			return null;
 		}
@@ -190,7 +222,8 @@ final class WCOS_Merge_Journal_Context {
 			'context_authority_fingerprint' => $context_fingerprint,
 			'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
 			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
-			'retirement_policy_selected' => false,
+			'retirement_policy_selected' => $policy_selected,
+			'retirement_policy_identifier' => $policy_identifier,
 			'archive_source_signature_before' => $archive_signature,
 			'active_ownership_before_signature' => $active_signature,
 			'participation_schema_version' => WCOS_Merge_Participation::SCHEMA_VERSION,

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -8,6 +8,7 @@ defined('ABSPATH') || exit;
 final class WCOS_Merge_Journal_Context {
 
 	const SCHEMA_VERSION = 3;
+	const TERMINAL_RESULT_SCHEMA_VERSION = 1;
 
 	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array(), $selected_retirement_policy = '') {
 		$source_id = absint($source->get_id());
@@ -156,6 +157,87 @@ final class WCOS_Merge_Journal_Context {
 		}
 		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		return !in_array($status, array('completed', 'compensated', 'manual_reconciled'), true);
+	}
+
+	public static function create_terminal_result(array $record) {
+		$pair = self::assert_executable_policy($record);
+		if ('committed' !== sanitize_key(isset($record['status']) ? (string) $record['status'] : '')
+			|| WCOS_Merge_Recovery_State_Graph::COMMITTED !== WCOS_Merge_Recovery_State_Graph::assert_record($record)) {
+			throw new RuntimeException(__('The Merge terminal result requires durable committed authority.', 'wc-order-splitter'));
+		}
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$result = array(
+			'schema_version' => self::TERMINAL_RESULT_SCHEMA_VERSION,
+			'status' => 'completed',
+			'operation_id' => sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : ''),
+			'source_order_id' => (int) $pair['source_order_id'],
+			'target_order_id' => (int) $pair['target_order_id'],
+			'retirement_policy' => (string) $pair['retirement_policy_identifier'],
+			'target_item_ids' => self::canonical_ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array()),
+			'target_tax_item_ids' => self::canonical_ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array()),
+		);
+		if ('' === $result['operation_id']) {
+			throw new RuntimeException(__('The Merge terminal result is missing its operation authority.', 'wc-order-splitter'));
+		}
+		$result['result_fingerprint'] = self::terminal_result_fingerprint($result);
+		return $result;
+	}
+
+	public static function terminal_result_from_record(array $record) {
+		$pair = self::assert_executable_policy($record);
+		if ('completed' !== sanitize_key(isset($record['status']) ? (string) $record['status'] : '')
+			|| WCOS_Merge_Recovery_State_Graph::COMPLETED !== WCOS_Merge_Recovery_State_Graph::assert_record($record)) {
+			throw new RuntimeException(__('The Merge terminal result requires durable completed authority.', 'wc-order-splitter'));
+		}
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$stored = isset($context['merge_terminal_result']) && is_array($context['merge_terminal_result']) ? $context['merge_terminal_result'] : array();
+		$expected_keys = array(
+			'operation_id', 'result_fingerprint', 'retirement_policy', 'schema_version', 'source_order_id',
+			'status', 'target_item_ids', 'target_order_id', 'target_tax_item_ids',
+		);
+		$actual_keys = array_keys($stored);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		if ($actual_keys !== $expected_keys || !is_array($stored['target_item_ids']) || !is_array($stored['target_tax_item_ids'])) {
+			throw new RuntimeException(__('Completed Merge authority is missing its bounded terminal result.', 'wc-order-splitter'));
+		}
+		$result = array(
+			'schema_version' => (int) $stored['schema_version'],
+			'status' => sanitize_key((string) $stored['status']),
+			'operation_id' => sanitize_key((string) $stored['operation_id']),
+			'source_order_id' => absint($stored['source_order_id']),
+			'target_order_id' => absint($stored['target_order_id']),
+			'retirement_policy' => sanitize_key((string) $stored['retirement_policy']),
+			'target_item_ids' => self::canonical_ids($stored['target_item_ids']),
+			'target_tax_item_ids' => self::canonical_ids($stored['target_tax_item_ids']),
+		);
+		$fingerprint = self::normalized_fingerprint($stored['result_fingerprint']);
+		$expected_item_ids = self::canonical_ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array());
+		$expected_tax_ids = self::canonical_ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
+		if (self::TERMINAL_RESULT_SCHEMA_VERSION !== $result['schema_version']
+			|| 'completed' !== $result['status']
+			|| sanitize_key((string) $record['operation_id']) !== $result['operation_id']
+			|| (int) $pair['source_order_id'] !== $result['source_order_id']
+			|| (int) $pair['target_order_id'] !== $result['target_order_id']
+			|| (string) $pair['retirement_policy_identifier'] !== $result['retirement_policy']
+			|| $expected_item_ids !== $result['target_item_ids']
+			|| $expected_tax_ids !== $result['target_tax_item_ids']
+			|| '' === $fingerprint
+			|| !hash_equals($fingerprint, self::terminal_result_fingerprint($result))) {
+			throw new RuntimeException(__('Completed Merge terminal result failed authority verification.', 'wc-order-splitter'));
+		}
+		return $result;
+	}
+
+	private static function terminal_result_fingerprint(array $result) {
+		unset($result['result_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create('merge_terminal_result_v1', absint(isset($result['source_order_id']) ? $result['source_order_id'] : 0), $result);
+	}
+
+	private static function canonical_ids(array $ids) {
+		$ids = array_values(array_unique(array_filter(array_map('absint', $ids))));
+		sort($ids, SORT_NUMERIC);
+		return $ids;
 	}
 
 	private static function authority_fingerprint(array $authority) {

--- a/inc/domain/class-wcos-merge-order-service.php
+++ b/inc/domain/class-wcos-merge-order-service.php
@@ -109,6 +109,7 @@ final class WCOS_Merge_Order_Service {
 					array(),
 					false
 				);
+				$this->event('after_target_line_checkpoint', $source, $target, $operation_id);
 			}
 
 			$source = $this->load_order($source_id, 'source');
@@ -245,47 +246,17 @@ final class WCOS_Merge_Order_Service {
 
 	private function completed_result($source_id, $target_id, $operation_id) {
 		$source = $this->load_order($source_id, 'source');
-		$target = $this->load_order($target_id, 'target');
 		$record = WCOS_Operation_Journal::get($source, $operation_id);
 		$pair = is_array($record) ? WCOS_Merge_Journal_Context::assert_executable_policy($record) : null;
 		if (!is_array($record) || !is_array($pair) || 'completed' !== sanitize_key((string) $record['status'])
 			|| WCOS_Merge_Recovery_State_Graph::COMPLETED !== WCOS_Merge_Recovery_State_Graph::assert_record($record)
-			|| 'trash' !== $source->get_status()) {
+			|| (int) $pair['source_order_id'] !== (int) $source_id
+			|| (int) $pair['target_order_id'] !== (int) $target_id) {
 			throw new RuntimeException(__('Completed Merge authority failed replay verification.', 'wc-order-splitter'));
 		}
-		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
-		$snapshot = isset($context['merge_recovery_snapshot']) && is_array($context['merge_recovery_snapshot']) ? $context['merge_recovery_snapshot'] : array();
-		$source_after = isset($context['merge_source_signature_after']) ? (string) $context['merge_source_signature_after'] : '';
-		$target_after = isset($context['merge_target_signature_after']) ? (string) $context['merge_target_signature_after'] : '';
-		if ('' === $source_after || '' === $target_after
-			|| !hash_equals($source_after, WCOS_Merge_Recovery_Snapshot::participant_signature($source))
-			|| !hash_equals($target_after, WCOS_Merge_Recovery_Snapshot::participant_signature($target))) {
-			throw new RuntimeException(__('Completed Merge participants changed after commit.', 'wc-order-splitter'));
-		}
-		WCOS_Merge_Recovery_Snapshot::assert_immutable_pair(
-			$snapshot,
-			$record,
-			$source,
-			$target,
-			isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array(),
-			isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array()
-		);
-		WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
-		WCOS_Merge_Recovery_Snapshot::assert_active_economic_conserved($snapshot, $target);
-		if (array('source' => true, 'target' => true) !== WCOS_Merge_Participation::state_for_pair($source, $target, $operation_id, $pair['pair_fingerprint'])) {
-			throw new RuntimeException(__('Completed Merge reciprocal relations are incomplete.', 'wc-order-splitter'));
-		}
-		$target_item_ids = $this->ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array());
-		$target_tax_item_ids = $this->ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
-		return array(
-			'status' => 'completed',
-			'operation_id' => sanitize_key((string) $operation_id),
-			'source_order_id' => (int) $source_id,
-			'target_order_id' => (int) $target_id,
-			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
-			'target_item_ids' => $target_item_ids,
-			'target_tax_item_ids' => $target_tax_item_ids,
-		);
+		$result = WCOS_Merge_Journal_Context::terminal_result_from_record($record);
+		unset($result['schema_version'], $result['result_fingerprint']);
+		return $result;
 	}
 
 	private function checkpoint_state($source_id, $target_id, $operation_id, $state, array $target_item_ids, array $target_tax_item_ids, $forward) {
@@ -322,14 +293,28 @@ final class WCOS_Merge_Order_Service {
 			throw new RuntimeException(__('The Merge journal disappeared before a commercial write.', 'wc-order-splitter'));
 		}
 		$this->event($stage, $source, $target, $operation_id);
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$expected_source_signature = isset($context['merge_source_signature_after']) ? (string) $context['merge_source_signature_after'] : '';
+		$expected_target_signature = isset($context['merge_target_signature_after']) ? (string) $context['merge_target_signature_after'] : '';
+		$recovery_state = WCOS_Merge_Recovery_State_Graph::assert_record($record);
+		$service_states = array(
+			WCOS_Merge_Recovery_State_Graph::NO_WRITE,
+			WCOS_Merge_Recovery_State_Graph::TARGET_STAGING,
+			WCOS_Merge_Recovery_State_Graph::TARGET_PERSISTED,
+			WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATING,
+			WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATED,
+		);
+		if (!in_array($recovery_state, $service_states, true)) {
+			throw new RuntimeException(__('The Merge service reached a write boundary outside its durable commercial stages.', 'wc-order-splitter'));
+		}
 		return WCOS_Merge_Commit_Guard::assert_boundary(
 			$lease,
 			$source,
 			$target,
 			$record,
-			WCOS_Merge_Recovery_Snapshot::participant_signature($source),
-			WCOS_Merge_Recovery_Snapshot::participant_signature($target),
-			'any'
+			$expected_source_signature,
+			$expected_target_signature,
+			'none'
 		);
 	}
 

--- a/inc/domain/class-wcos-merge-order-service.php
+++ b/inc/domain/class-wcos-merge-order-service.php
@@ -345,7 +345,10 @@ final class WCOS_Merge_Order_Service {
 			|| (string) $authority['subtotal_tax'] !== (string) $item->get_subtotal_tax()
 			|| (string) $authority['total'] !== (string) $item->get_total()
 			|| (string) $authority['total_tax'] !== (string) $item->get_total_tax()
-			|| $authority['taxes'] !== $item->get_taxes()) {
+			|| !hash_equals(
+				WCOS_Mutation_Fingerprint::create('merge_plan_line_taxes', $item->get_id(), $authority['taxes']),
+				WCOS_Mutation_Fingerprint::create('merge_plan_line_taxes', $item->get_id(), $item->get_taxes())
+			)) {
 			throw new RuntimeException(__('A Merge source line changed after its server-owned plan was bound.', 'wc-order-splitter'));
 		}
 		if ($check_reduced_stock) {

--- a/inc/domain/class-wcos-merge-order-service.php
+++ b/inc/domain/class-wcos-merge-order-service.php
@@ -1,0 +1,386 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Executes the approved two-order Merge saga without exposing a transport.
+ */
+final class WCOS_Merge_Order_Service {
+
+	const TYPE = 'merge';
+	const POLICY_VERSION = 1;
+
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $precision) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$precision = WCOS_Price_Precision_Scope::validate($precision);
+		if ('' === $operation_id || !$source_id || !$target_id || $source_id === $target_id) {
+			throw new InvalidArgumentException(__('Merge requires two distinct persisted orders and an operation ID.', 'wc-order-splitter'));
+		}
+
+		$existing = WCOS_Operation_Journal::get($source, $operation_id);
+		if (is_array($existing)) {
+			return $this->replay_existing($source_id, $target_id, $operation_id, $existing);
+		}
+
+		$lease = WCOS_Multi_Order_Lease::acquire(array($source_id, $target_id), $operation_id);
+		if (!$lease instanceof WCOS_Multi_Order_Lease) {
+			throw new RuntimeException(__('Another mutation already owns a Merge participant.', 'wc-order-splitter'));
+		}
+		$local_stock_guard = false;
+		if (!WCOS_Stock_Side_Effect_Guard::has_active_scope()) {
+			$local_stock_guard = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+		}
+
+		$record_started = false;
+		try {
+			$source = $this->load_order($source_id, 'source');
+			$target = $this->load_order($target_id, 'target');
+			$existing = WCOS_Operation_Journal::get($source, $operation_id);
+			if (is_array($existing)) {
+				return $this->replay_existing($source_id, $target_id, $operation_id, $existing);
+			}
+
+			$lease->assert_owned();
+			$report = WCOS_Merge_Preflight::assert_supported($source, $target, $precision);
+			$plan = WCOS_Merge_Plan::build($source, $target);
+			if (!hash_equals(WCOS_Merge_Plan::fingerprint($report['plan']), WCOS_Merge_Plan::fingerprint($plan))) {
+				throw new RuntimeException(__('The server-owned Merge plan changed during locked preflight.', 'wc-order-splitter'));
+			}
+			$journal_context = WCOS_Merge_Journal_Context::create_executable(
+				$source,
+				$target,
+				$plan,
+				$report['context_authority'],
+				$precision
+			);
+			$fingerprint = (string) $journal_context['merge_pair']['pair_fingerprint'];
+
+			$this->event('before_journal_start', $source, $target, $operation_id);
+			$this->lease_guard($lease);
+			if (!WCOS_Operation_Journal::start($source, $operation_id, self::TYPE, $journal_context, $fingerprint)) {
+				$existing = WCOS_Operation_Journal::get($source, $operation_id);
+				if (is_array($existing)) {
+					return $this->replay_existing($source_id, $target_id, $operation_id, $existing);
+				}
+				throw new RuntimeException(__('The authoritative Merge journal could not be started.', 'wc-order-splitter'));
+			}
+			$record_started = true;
+			$record = $this->checkpoint_state(
+				$source_id,
+				$target_id,
+				$operation_id,
+				WCOS_Merge_Recovery_State_Graph::NO_WRITE,
+				array(),
+				array(),
+				false
+			);
+			WCOS_Merge_Journal_Context::assert_executable_policy($record);
+			$snapshot = $record['context']['merge_recovery_snapshot'];
+			$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+
+			$this->event('before_target_write', $source, $target, $operation_id);
+			$target_item_ids = array();
+			foreach ($plan['lines'] as $source_item_id => $line_authority) {
+				list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_target_line_write');
+				$source_item = $source->get_item((int) $source_item_id);
+				$this->assert_plan_line($source_item, $line_authority);
+				$clone = WCOS_Order_Item_Cloner::product(
+					$source_item,
+					array(),
+					true,
+					WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE
+				);
+				$target->add_item($clone);
+				$target->save();
+				$target_item_id = absint($clone->get_id());
+				if (!$target_item_id) {
+					throw new RuntimeException(__('A fresh Merge target line did not persist.', 'wc-order-splitter'));
+				}
+				$target_item_ids[] = $target_item_id;
+				$this->event(1 === count($target_item_ids) ? 'after_first_target_line_persistence' : 'after_target_line_persistence', $source, $target, $operation_id);
+				$record = $this->checkpoint_state(
+					$source_id,
+					$target_id,
+					$operation_id,
+					WCOS_Merge_Recovery_State_Graph::TARGET_STAGING,
+					$target_item_ids,
+					array(),
+					false
+				);
+			}
+
+			$source = $this->load_order($source_id, 'source');
+			$target = $this->load_order($target_id, 'target');
+			$this->event('after_all_target_lines_before_target_money', $source, $target, $operation_id);
+			list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_target_money_tax_write');
+			$tax_ids_before = array_map('intval', array_keys($target->get_items('tax')));
+			WCOS_Tax_Item_Synchronizer::synchronize(
+				$target,
+				WCOS_Tax_Item_Synchronizer::templates($source),
+				$precision,
+				true,
+				WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE
+			);
+			WCOS_Order_Totals_Rebuilder::rebuild($target, $precision);
+			$target->save();
+			$target = $this->load_order($target_id, 'target');
+			$target_tax_item_ids = array_values(array_diff(array_map('intval', array_keys($target->get_items('tax'))), $tax_ids_before));
+			sort($target_tax_item_ids, SORT_NUMERIC);
+			$this->event('after_target_money_tax_persistence', $source, $target, $operation_id);
+			$record = $this->checkpoint_state(
+				$source_id,
+				$target_id,
+				$operation_id,
+				WCOS_Merge_Recovery_State_Graph::TARGET_PERSISTED,
+				$target_item_ids,
+				$target_tax_item_ids,
+				false
+			);
+
+			$source_before_flag = (bool) $snapshot['source']['order_stock_reduced'];
+			$target_before_flag = (bool) $snapshot['target']['order_stock_reduced'];
+			foreach ($plan['lines'] as $source_item_id => $line_authority) {
+				list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_source_line_ownership_write');
+				$source_item = $source->get_item((int) $source_item_id);
+				$this->assert_plan_line($source_item, $line_authority, false);
+				if ('' !== (string) $source_item->get_meta('_reduced_stock', true)) {
+					$source_item->delete_meta_data('_reduced_stock');
+					$source_item->save();
+				}
+				$this->event('after_source_line_ownership_write', $source, $target, $operation_id);
+				$record = $this->checkpoint_state(
+					$source_id,
+					$target_id,
+					$operation_id,
+					WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATING,
+					$target_item_ids,
+					$target_tax_item_ids,
+					false
+				);
+			}
+
+			list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_source_order_stock_flag_write');
+			$source->get_data_store()->set_stock_reduced($source_id, false);
+			$record = $this->checkpoint_state($source_id, $target_id, $operation_id, WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATING, $target_item_ids, $target_tax_item_ids, false);
+
+			list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_target_order_stock_flag_write');
+			$target->get_data_store()->set_stock_reduced($target_id, $source_before_flag || $target_before_flag);
+			$record = $this->checkpoint_state($source_id, $target_id, $operation_id, WCOS_Merge_Recovery_State_Graph::SOURCE_OWNERSHIP_MIGRATED, $target_item_ids, $target_tax_item_ids, false);
+			$source = $this->load_order($source_id, 'source');
+			$target = $this->load_order($target_id, 'target');
+			$this->event('after_ownership_migration_before_retirement', $source, $target, $operation_id);
+			WCOS_Order_Contract_Snapshot::assert_product_stock_equal($stock_before, WCOS_Order_Contract_Snapshot::product_stock($source));
+
+			list($source, $target, $record) = $this->boundary($lease, $source_id, $target_id, $operation_id, 'before_source_retirement');
+			WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+			$this->event('before_non_force_source_retirement', $source, $target, $operation_id);
+			$source->delete(false);
+			$source = $this->load_order($source_id, 'source');
+			if ('trash' !== $source->get_status()) {
+				throw new RuntimeException(__('The approved non-force Merge retirement did not archive the source.', 'wc-order-splitter'));
+			}
+			WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+			$this->event('after_non_force_source_retirement', $source, $target, $operation_id);
+			$record = $this->checkpoint_state(
+				$source_id,
+				$target_id,
+				$operation_id,
+				WCOS_Merge_Recovery_State_Graph::SOURCE_RETIRED,
+				$target_item_ids,
+				$target_tax_item_ids,
+				true
+			);
+
+			$source = $this->load_order($source_id, 'source');
+			$target = $this->load_order($target_id, 'target');
+			$outcome = WCOS_Merge_Compensator::recover($source, $target, $record, $lease);
+			if ('completed' !== $outcome) {
+				throw new RuntimeException(__('The Merge saga did not reach its verified completed state.', 'wc-order-splitter'));
+			}
+			$this->event('after_complete', $source, $target, $operation_id);
+			return $this->completed_result($source_id, $target_id, $operation_id);
+		} catch (Throwable $throwable) {
+			$fresh_source = wc_get_order($source_id);
+			$record = $fresh_source instanceof WC_Order ? WCOS_Operation_Journal::get($fresh_source, $operation_id) : null;
+			if ($record_started && $fresh_source instanceof WC_Order && is_array($record)) {
+				$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
+				if (!in_array($status, array('completed', 'compensated', 'manual_reconciliation', 'manual_reconciled'), true)) {
+					WCOS_Operation_Journal::require_recovery($fresh_source, $operation_id, array('error_code' => 'merge_service_interrupted'));
+				}
+			}
+			throw $throwable;
+		} finally {
+			if (false !== $local_stock_guard) {
+				WCOS_Stock_Side_Effect_Guard::end($local_stock_guard);
+			}
+			$lease->release();
+		}
+	}
+
+	private function replay_existing($source_id, $target_id, $operation_id, array $record) {
+		$pair = WCOS_Merge_Journal_Context::assert_executable_policy($record);
+		if ($pair['source_order_id'] !== $source_id || $pair['target_order_id'] !== $target_id) {
+			throw new RuntimeException(__('This Merge operation ID is already bound to a different participant pair.', 'wc-order-splitter'));
+		}
+		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
+		if ('completed' !== $status) {
+			$source = $this->load_order($source_id, 'source');
+			if (!WCOS_Operation_Journal::require_recovery($source, $operation_id, array('reason' => 'service_replay'))) {
+				throw new RuntimeException(__('The existing Merge saga could not dispatch recovery.', 'wc-order-splitter'));
+			}
+			$record = WCOS_Operation_Journal::get($this->load_order($source_id, 'source'), $operation_id);
+			$status = is_array($record) && isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+		}
+		if ('completed' !== $status) {
+			throw new RuntimeException(
+				'manual_reconciliation' === $status
+					? __('The Merge pair requires manual reconciliation.', 'wc-order-splitter')
+					: __('The previous Merge attempt did not complete and cannot be restarted as a new saga.', 'wc-order-splitter')
+			);
+		}
+		return $this->completed_result($source_id, $target_id, $operation_id);
+	}
+
+	private function completed_result($source_id, $target_id, $operation_id) {
+		$source = $this->load_order($source_id, 'source');
+		$target = $this->load_order($target_id, 'target');
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		$pair = is_array($record) ? WCOS_Merge_Journal_Context::assert_executable_policy($record) : null;
+		if (!is_array($record) || !is_array($pair) || 'completed' !== sanitize_key((string) $record['status'])
+			|| WCOS_Merge_Recovery_State_Graph::COMPLETED !== WCOS_Merge_Recovery_State_Graph::assert_record($record)
+			|| 'trash' !== $source->get_status()) {
+			throw new RuntimeException(__('Completed Merge authority failed replay verification.', 'wc-order-splitter'));
+		}
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$snapshot = isset($context['merge_recovery_snapshot']) && is_array($context['merge_recovery_snapshot']) ? $context['merge_recovery_snapshot'] : array();
+		$source_after = isset($context['merge_source_signature_after']) ? (string) $context['merge_source_signature_after'] : '';
+		$target_after = isset($context['merge_target_signature_after']) ? (string) $context['merge_target_signature_after'] : '';
+		if ('' === $source_after || '' === $target_after
+			|| !hash_equals($source_after, WCOS_Merge_Recovery_Snapshot::participant_signature($source))
+			|| !hash_equals($target_after, WCOS_Merge_Recovery_Snapshot::participant_signature($target))) {
+			throw new RuntimeException(__('Completed Merge participants changed after commit.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Recovery_Snapshot::assert_immutable_pair(
+			$snapshot,
+			$record,
+			$source,
+			$target,
+			isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array(),
+			isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array()
+		);
+		WCOS_Merge_Recovery_Snapshot::assert_archive_preserved($snapshot, $source);
+		WCOS_Merge_Recovery_Snapshot::assert_active_economic_conserved($snapshot, $target);
+		if (array('source' => true, 'target' => true) !== WCOS_Merge_Participation::state_for_pair($source, $target, $operation_id, $pair['pair_fingerprint'])) {
+			throw new RuntimeException(__('Completed Merge reciprocal relations are incomplete.', 'wc-order-splitter'));
+		}
+		$target_item_ids = $this->ids(isset($context['merge_target_item_ids']) ? (array) $context['merge_target_item_ids'] : array());
+		$target_tax_item_ids = $this->ids(isset($context['merge_target_tax_item_ids']) ? (array) $context['merge_target_tax_item_ids'] : array());
+		return array(
+			'status' => 'completed',
+			'operation_id' => sanitize_key((string) $operation_id),
+			'source_order_id' => (int) $source_id,
+			'target_order_id' => (int) $target_id,
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+			'target_item_ids' => $target_item_ids,
+			'target_tax_item_ids' => $target_tax_item_ids,
+		);
+	}
+
+	private function checkpoint_state($source_id, $target_id, $operation_id, $state, array $target_item_ids, array $target_tax_item_ids, $forward) {
+		$source = $this->load_order($source_id, 'source');
+		$target = $this->load_order($target_id, 'target');
+		$context = array(
+			'merge_recovery_state' => sanitize_key((string) $state),
+			'merge_source_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+			'merge_target_signature_after' => WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+			'merge_source_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($source),
+			'merge_target_state_after' => WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target),
+			'merge_target_item_ids' => $this->ids($target_item_ids),
+			'merge_target_tax_item_ids' => $this->ids($target_tax_item_ids),
+			'merge_forward_repair_allowed' => (bool) $forward,
+			'merge_retirement_candidate' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+			'merge_physical_stock_after_write' => false,
+		);
+		if (!WCOS_Operation_Journal::checkpoint($source, $operation_id, 'merge_service_checkpoint', $context)) {
+			throw new RuntimeException(__('A durable Merge service checkpoint could not be persisted.', 'wc-order-splitter'));
+		}
+		$record = WCOS_Operation_Journal::get($this->load_order($source_id, 'source'), $operation_id);
+		if (!is_array($record)) {
+			throw new RuntimeException(__('The Merge service checkpoint could not be reloaded.', 'wc-order-splitter'));
+		}
+		WCOS_Merge_Recovery_State_Graph::assert_record($record);
+		return $record;
+	}
+
+	private function boundary(WCOS_Multi_Order_Lease $lease, $source_id, $target_id, $operation_id, $stage) {
+		$source = $this->load_order($source_id, 'source');
+		$target = $this->load_order($target_id, 'target');
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		if (!is_array($record)) {
+			throw new RuntimeException(__('The Merge journal disappeared before a commercial write.', 'wc-order-splitter'));
+		}
+		$this->event($stage, $source, $target, $operation_id);
+		return WCOS_Merge_Commit_Guard::assert_boundary(
+			$lease,
+			$source,
+			$target,
+			$record,
+			WCOS_Merge_Recovery_Snapshot::participant_signature($source),
+			WCOS_Merge_Recovery_Snapshot::participant_signature($target),
+			'any'
+		);
+	}
+
+	private function assert_plan_line($item, array $authority, $check_reduced_stock = true) {
+		if (!$item instanceof WC_Order_Item_Product
+			|| (int) $item->get_id() !== (int) $authority['source_item_id']
+			|| !hash_equals((string) $authority['line_identity'], WCOS_Line_Identity::from_item($item))
+			|| (int) $authority['product_id'] !== (int) $item->get_product_id()
+			|| (int) $authority['variation_id'] !== (int) $item->get_variation_id()
+			|| (string) $authority['tax_class'] !== (string) $item->get_tax_class()
+			|| (string) $authority['quantity'] !== WCOS_Decimal::normalize($item->get_quantity(), 6)
+			|| (string) $authority['subtotal'] !== (string) $item->get_subtotal()
+			|| (string) $authority['subtotal_tax'] !== (string) $item->get_subtotal_tax()
+			|| (string) $authority['total'] !== (string) $item->get_total()
+			|| (string) $authority['total_tax'] !== (string) $item->get_total_tax()
+			|| $authority['taxes'] !== $item->get_taxes()) {
+			throw new RuntimeException(__('A Merge source line changed after its server-owned plan was bound.', 'wc-order-splitter'));
+		}
+		if ($check_reduced_stock) {
+			$current = $item->get_meta('_reduced_stock', true);
+			$current = '' === $current || null === $current ? null : WCOS_Decimal::normalize($current, 6);
+			if ($authority['reduced_stock'] !== $current) {
+				throw new RuntimeException(__('A Merge source reduced-stock marker changed after planning.', 'wc-order-splitter'));
+			}
+		}
+	}
+
+	private function lease_guard(WCOS_Multi_Order_Lease $lease) {
+		if (!$lease->refresh()) {
+			throw new RuntimeException(__('A Merge participant lease expired before journal start.', 'wc-order-splitter'));
+		}
+		WCOS_Stock_Side_Effect_Guard::assert_current_clean();
+	}
+
+	private function load_order($order_id, $role) {
+		$order = wc_get_order(absint($order_id));
+		if (!$order instanceof WC_Order || 'shop_order' !== $order->get_type()) {
+			throw new RuntimeException('target' === $role
+				? __('The Merge target is no longer available.', 'wc-order-splitter')
+				: __('The Merge source is no longer available.', 'wc-order-splitter'));
+		}
+		return $order;
+	}
+
+	private function ids(array $ids) {
+		$ids = array_values(array_unique(array_filter(array_map('absint', $ids))));
+		sort($ids, SORT_NUMERIC);
+		return $ids;
+	}
+
+	private function event($stage, WC_Order $source, WC_Order $target, $operation_id) {
+		do_action('wcos_merge_mutation_checkpoint', sanitize_key((string) $stage), $source, $target, sanitize_key((string) $operation_id));
+	}
+}

--- a/inc/domain/class-wcos-merge-plan.php
+++ b/inc/domain/class-wcos-merge-plan.php
@@ -7,7 +7,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Plan {
 
-	const SCHEMA_VERSION = 1;
+	const SCHEMA_VERSION = 2;
 
 	public static function build(WC_Order $source, WC_Order $target) {
 		$source_id = absint($source->get_id());
@@ -71,12 +71,16 @@ final class WCOS_Merge_Plan {
 			'target_order_id' => $target_order_id,
 			'line_policy' => 'fresh_target_line_per_source_line',
 			'coalesce_lines' => false,
-			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
 			'lines' => $canonical_lines,
 		);
 	}
 
 	public static function fingerprint(array $plan) {
+		if (!isset($plan['retirement_policy'])
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $plan['retirement_policy'])) {
+			throw new InvalidArgumentException(__('The Merge plan does not bind the approved retirement policy.', 'wc-order-splitter'));
+		}
 		$plan = self::canonicalize(
 			isset($plan['source_order_id']) ? $plan['source_order_id'] : 0,
 			isset($plan['target_order_id']) ? $plan['target_order_id'] : 0,

--- a/inc/domain/class-wcos-merge-preflight.php
+++ b/inc/domain/class-wcos-merge-preflight.php
@@ -41,7 +41,7 @@ final class WCOS_Merge_Preflight {
 			'line_coalescing' => 'never',
 			'historical_tax' => 'preserve_exact',
 			'catalog_recalculation' => 'never',
-			'retirement_policy' => 'unselected_candidates',
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
 		);
 	}
 
@@ -70,6 +70,7 @@ final class WCOS_Merge_Preflight {
 			'price_precision' => $precision,
 			'policy' => self::policy(),
 			'retirement_candidates' => WCOS_Merge_Retirement_Policy::identifiers(),
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
 			'context_authority' => array(),
 			'source_signature' => '',
 			'target_signature' => '',

--- a/inc/domain/class-wcos-merge-recovery-snapshot.php
+++ b/inc/domain/class-wcos-merge-recovery-snapshot.php
@@ -12,7 +12,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Recovery_Snapshot {
 
-	const SCHEMA_VERSION = 3;
+	const SCHEMA_VERSION = 4;
 
 	public static function capture(WC_Order $source, WC_Order $target, array $record) {
 		$pair = WCOS_Merge_Journal_Context::pair_from_record($record);
@@ -35,7 +35,8 @@ final class WCOS_Merge_Recovery_Snapshot {
 			'preflight_policy_version' => $pair['preflight_policy_version'],
 			'retirement_policy_schema_version' => $pair['retirement_policy_schema_version'],
 			'retirement_candidates' => $pair['retirement_candidates'],
-			'retirement_policy_selected' => false,
+			'retirement_policy_selected' => (bool) $pair['retirement_policy_selected'],
+			'retirement_policy_identifier' => (string) $pair['retirement_policy_identifier'],
 			'source' => self::participant_state($source),
 			'target' => self::participant_state($target),
 			'source_immutable_context' => self::immutable_guard($source),
@@ -53,7 +54,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 		$expected_keys = array(
 			'active_economic_contract_before', 'active_ownership_before_signature', 'archive_source_contract_before', 'archive_source_signature_before', 'pair_fingerprint',
 			'preflight_policy_version', 'price_precision', 'recovery_fingerprint', 'retirement_candidates',
-			'retirement_policy_schema_version', 'retirement_policy_selected', 'schema_version', 'source',
+			'retirement_policy_identifier', 'retirement_policy_schema_version', 'retirement_policy_selected', 'schema_version', 'source',
 			'source_immutable_context', 'source_order_id', 'target', 'target_immutable_context', 'target_order_id',
 		);
 		$actual_keys = array_keys($snapshot);
@@ -62,7 +63,9 @@ final class WCOS_Merge_Recovery_Snapshot {
 		if ($actual_keys !== $expected_keys
 			|| self::SCHEMA_VERSION !== (int) $snapshot['schema_version']
 			|| !is_array($snapshot['source']) || !is_array($snapshot['target'])
-			|| false !== (bool) $snapshot['retirement_policy_selected']) {
+			|| !in_array($snapshot['retirement_policy_selected'], array(true, false), true)
+			|| ((bool) $snapshot['retirement_policy_selected'] && WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $snapshot['retirement_policy_identifier']))
+			|| (!(bool) $snapshot['retirement_policy_selected'] && '' !== (string) $snapshot['retirement_policy_identifier'])) {
 			throw new RuntimeException(__('The Merge recovery snapshot has an invalid schema.', 'wc-order-splitter'));
 		}
 
@@ -90,6 +93,8 @@ final class WCOS_Merge_Recovery_Snapshot {
 				|| (int) $snapshot['preflight_policy_version'] !== $pair['preflight_policy_version']
 				|| (int) $snapshot['retirement_policy_schema_version'] !== $pair['retirement_policy_schema_version']
 				|| array_values($snapshot['retirement_candidates']) !== $pair['retirement_candidates']
+				|| (bool) $snapshot['retirement_policy_selected'] !== (bool) $pair['retirement_policy_selected']
+				|| (string) $snapshot['retirement_policy_identifier'] !== (string) $pair['retirement_policy_identifier']
 				|| !hash_equals((string) $snapshot['archive_source_signature_before'], $pair['archive_source_signature_before'])
 				|| !hash_equals((string) $snapshot['active_ownership_before_signature'], $pair['active_ownership_before_signature'])) {
 				throw new RuntimeException(__('The Merge recovery snapshot no longer matches pair authority.', 'wc-order-splitter'));
@@ -102,7 +107,7 @@ final class WCOS_Merge_Recovery_Snapshot {
 		$copy = $snapshot;
 		unset($copy['recovery_fingerprint']);
 		return WCOS_Mutation_Fingerprint::create(
-			'merge_pair_recovery_v3',
+			'merge_pair_recovery_v4',
 			isset($copy['source_order_id']) ? absint($copy['source_order_id']) : 0,
 			$copy
 		);

--- a/inc/domain/class-wcos-merge-recovery-state-graph.php
+++ b/inc/domain/class-wcos-merge-recovery-state-graph.php
@@ -7,6 +7,7 @@ defined('ABSPATH') || exit;
  */
 final class WCOS_Merge_Recovery_State_Graph {
 	const NO_WRITE = 'no_commercial_write';
+	const TARGET_STAGING = 'target_staging';
 	const TARGET_PERSISTED = 'target_persisted';
 	const SOURCE_OWNERSHIP_MIGRATING = 'source_ownership_migrating';
 	const SOURCE_OWNERSHIP_MIGRATED = 'source_ownership_migrated';
@@ -24,7 +25,7 @@ final class WCOS_Merge_Recovery_State_Graph {
 
 	public static function stages() {
 		return array(
-			self::NO_WRITE, self::TARGET_PERSISTED, self::SOURCE_OWNERSHIP_MIGRATING,
+				self::NO_WRITE, self::TARGET_STAGING, self::TARGET_PERSISTED, self::SOURCE_OWNERSHIP_MIGRATING,
 			self::SOURCE_OWNERSHIP_MIGRATED, self::SOURCE_RETIRED, self::SOURCE_RELATION,
 			self::RELATIONS_COMPLETE, self::VERIFIED, self::COMMITTED, self::COMPLETED,
 			self::COMPENSATING, self::SOURCE_RESTORED, self::TARGET_RESTORED,
@@ -79,7 +80,8 @@ final class WCOS_Merge_Recovery_State_Graph {
 			return true;
 		}
 		$forward = array(
-			self::NO_WRITE => array(self::TARGET_PERSISTED, self::COMPENSATING),
+			self::NO_WRITE => array(self::TARGET_STAGING, self::TARGET_PERSISTED, self::COMPENSATING),
+			self::TARGET_STAGING => array(self::TARGET_STAGING, self::TARGET_PERSISTED, self::COMPENSATING),
 			self::TARGET_PERSISTED => array(self::SOURCE_OWNERSHIP_MIGRATING, self::SOURCE_OWNERSHIP_MIGRATED, self::COMPENSATING),
 			self::SOURCE_OWNERSHIP_MIGRATING => array(self::SOURCE_OWNERSHIP_MIGRATED, self::COMPENSATING),
 			self::SOURCE_OWNERSHIP_MIGRATED => array(self::SOURCE_RETIRED, self::COMPENSATING),

--- a/inc/domain/class-wcos-merge-retirement-policy.php
+++ b/inc/domain/class-wcos-merge-retirement-policy.php
@@ -2,17 +2,13 @@
 
 defined('ABSPATH') || exit;
 
-/**
- * Unselected source-retirement candidates and their domain evidence model.
- *
- * This foundation registers no WooCommerce status and performs no lifecycle
- * transition. A later boundary decision must select an evidenced candidate.
- */
+/** Binding source-retirement policy and the retained comparison evidence. */
 final class WCOS_Merge_Retirement_Policy {
 
-	const SCHEMA_VERSION = 1;
+	const SCHEMA_VERSION = 2;
 	const NON_FORCE_TRASH_ARCHIVE = 'non_force_trash_archive';
 	const DEDICATED_MERGED_ARCHIVE = 'dedicated_merged_archive';
+	const APPROVED = self::NON_FORCE_TRASH_ARCHIVE;
 
 	public static function candidates() {
 		return array(
@@ -22,7 +18,7 @@ final class WCOS_Merge_Retirement_Policy {
 				'active_economic_owner_after' => false,
 				'normal_active_status_after' => false,
 				'hard_delete' => false,
-				'production_selected' => false,
+				'production_selected' => true,
 			),
 			self::DEDICATED_MERGED_ARCHIVE => array(
 				'identifier' => self::DEDICATED_MERGED_ARCHIVE,
@@ -39,6 +35,18 @@ final class WCOS_Merge_Retirement_Policy {
 		$identifiers = array_keys(self::candidates());
 		sort($identifiers, SORT_STRING);
 		return $identifiers;
+	}
+
+	public static function approved_identifier() {
+		return self::APPROVED;
+	}
+
+	public static function assert_approved($identifier) {
+		$identifier = sanitize_key((string) $identifier);
+		if (self::APPROVED !== $identifier) {
+			throw new RuntimeException(__('Executable Merge authority requires the approved non-force trash archive policy.', 'wc-order-splitter'));
+		}
+		return self::assert_candidate($identifier);
 	}
 
 	public static function assert_candidate($identifier) {

--- a/inc/domain/class-wcos-merge-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-merge-woocommerce-adapter.php
@@ -1,0 +1,147 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Merge_Adapter_Exception extends RuntimeException {
+	private $error_code;
+	private $report;
+
+	public function __construct($error_code, $message, array $report = array(), ?Throwable $previous = null) {
+		$this->error_code = sanitize_key((string) $error_code);
+		$this->report = $report;
+		parent::__construct((string) $message, 0, $previous);
+	}
+
+	public function get_error_code() {
+		return $this->error_code;
+	}
+
+	public function get_report() {
+		return $this->report;
+	}
+}
+
+/** WooCommerce-facing, transport-free adapter for the hardened Merge service. */
+final class WCOS_Merge_WooCommerce_Adapter {
+
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null) {
+		$operation_id = sanitize_key((string) $operation_id);
+		if ('' === $operation_id) {
+			throw new WCOS_Merge_Adapter_Exception('invalid_operation_id', __('A Merge operation ID is required.', 'wc-order-splitter'));
+		}
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		if (!$source_id || !$target_id || $source_id === $target_id) {
+			throw new WCOS_Merge_Adapter_Exception('invalid_participant_pair', __('Merge requires two distinct persisted shop orders.', 'wc-order-splitter'));
+		}
+
+		$precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
+		$precision_token = WCOS_Price_Precision_Scope::begin($precision);
+		$stock_token = false;
+		try {
+			$source = wc_get_order($source_id);
+			$target = wc_get_order($target_id);
+			if (!$source instanceof WC_Order || !$target instanceof WC_Order) {
+				throw new WCOS_Merge_Adapter_Exception('participant_unavailable', __('A Merge participant is no longer available.', 'wc-order-splitter'));
+			}
+			$existing = WCOS_Operation_Journal::get($source, $operation_id);
+			if (!is_array($existing)) {
+				WCOS_Merge_Preflight::assert_supported($source, $target, $precision);
+			}
+
+			$stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
+			$boundary_guard = function() use ($source_id, $target_id, $operation_id, $stock_token) {
+				$events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+				if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+					$this->mark_manual_stock_reconciliation($source_id, $target_id, $operation_id);
+				}
+				WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+			};
+			add_action('wcos_merge_mutation_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
+			add_action('wcos_merge_recovery_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
+
+			try {
+				$result = (new WCOS_Merge_Order_Service())->merge($source, $target, $operation_id, $precision);
+				WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
+				return $result;
+			} catch (WCOS_Merge_Adapter_Exception $exception) {
+				throw $exception;
+			} catch (WCOS_Merge_Preflight_Exception $exception) {
+				throw new WCOS_Merge_Adapter_Exception(
+					'merge_preflight_' . $exception->get_reason(),
+					$exception->getMessage(),
+					$exception->get_report(),
+					$exception
+				);
+			} catch (Throwable $throwable) {
+				$events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
+				if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+					$this->mark_manual_stock_reconciliation($source_id, $target_id, $operation_id);
+				}
+				if ($throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {
+					throw $throwable;
+				}
+				throw new WCOS_Merge_Adapter_Exception(
+					$this->current_error_code($source_id, $operation_id),
+					__('The hardened Merge request did not complete automatically.', 'wc-order-splitter'),
+					array('source_order_id' => $source_id, 'target_order_id' => $target_id, 'operation_id' => $operation_id),
+					$throwable
+				);
+			} finally {
+				remove_action('wcos_merge_mutation_checkpoint', $boundary_guard, PHP_INT_MAX);
+				remove_action('wcos_merge_recovery_checkpoint', $boundary_guard, PHP_INT_MAX);
+			}
+		} finally {
+			if (false !== $stock_token) {
+				WCOS_Stock_Side_Effect_Guard::end($stock_token);
+			}
+			WCOS_Price_Precision_Scope::end($precision_token);
+		}
+	}
+
+	public function preflight(WC_Order $source, WC_Order $target, $operation_id = '', $confirmed_precision = null) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
+		$token = WCOS_Price_Precision_Scope::begin($precision);
+		try {
+			$source = $source_id ? wc_get_order($source_id) : $source;
+			$target = $target_id ? wc_get_order($target_id) : $target;
+			if (!$source instanceof WC_Order || !$target instanceof WC_Order) {
+				return array(
+					'supported' => false,
+					'reason' => 'participant_unavailable',
+					'message' => __('A Merge participant is no longer available.', 'wc-order-splitter'),
+					'source_order_id' => $source_id,
+					'target_order_id' => $target_id,
+					'price_precision' => $precision,
+				);
+			}
+			return WCOS_Merge_Preflight::report($source, $target, $precision);
+		} finally {
+			WCOS_Price_Precision_Scope::end($token);
+		}
+	}
+
+	private function mark_manual_stock_reconciliation($source_id, $target_id, $operation_id) {
+		$source = wc_get_order(absint($source_id));
+		$target = wc_get_order(absint($target_id));
+		$record = $source instanceof WC_Order ? WCOS_Operation_Journal::get($source, $operation_id) : null;
+		if ($source instanceof WC_Order && $target instanceof WC_Order && is_array($record)) {
+			WCOS_Merge_Compensator::manual_reconciliation($source, $target, $record, 'physical_stock_after_write');
+		}
+	}
+
+	private function current_error_code($source_id, $operation_id) {
+		$source = wc_get_order(absint($source_id));
+		$record = $source instanceof WC_Order ? WCOS_Operation_Journal::get($source, $operation_id) : null;
+		$status = is_array($record) && isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+		if ('manual_reconciliation' === $status) {
+			return 'merge_manual_reconciliation';
+		}
+		if ('compensated' === $status) {
+			return 'merge_compensated';
+		}
+		return 'merge_execution_failed';
+	}
+}

--- a/inc/domain/class-wcos-merge-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-merge-woocommerce-adapter.php
@@ -50,10 +50,19 @@ final class WCOS_Merge_WooCommerce_Adapter {
 			}
 
 			$stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
-			$boundary_guard = function() use ($source_id, $target_id, $operation_id, $stock_token) {
+			$marking_manual = false;
+			$boundary_guard = function() use ($source_id, $target_id, $operation_id, $stock_token, &$marking_manual) {
+				if ($marking_manual) {
+					return;
+				}
 				$events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
 				if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
-					$this->mark_manual_stock_reconciliation($source_id, $target_id, $operation_id);
+					$marking_manual = true;
+					try {
+						$this->mark_manual_stock_reconciliation($source_id, $target_id, $operation_id);
+					} finally {
+						$marking_manual = false;
+					}
 				}
 				WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
 			};
@@ -75,7 +84,9 @@ final class WCOS_Merge_WooCommerce_Adapter {
 				);
 			} catch (Throwable $throwable) {
 				$events = WCOS_Stock_Side_Effect_Guard::events($stock_token);
-				if (!empty($events) && WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)) {
+				if (!empty($events)
+					&& WCOS_Stock_Side_Effect_Guard::events_require_manual_reconciliation($events)
+					&& 'merge_manual_reconciliation' !== $this->current_error_code($source_id, $operation_id)) {
 					$this->mark_manual_stock_reconciliation($source_id, $target_id, $operation_id);
 				}
 				if ($throwable instanceof WCOS_Unexpected_Stock_Mutation_Exception) {

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -48,10 +48,15 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
-	public function merge(WC_Order $source, WC_Order $target, $operation_id) {
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::MERGE);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $source, $target);
-		throw new RuntimeException(__('The hardened merge service has not been implemented.', 'wc-order-splitter'));
+		return (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, $confirmed_precision);
+	}
+
+	public function merge_preflight(WC_Order $source, WC_Order $target, $operation_id = '', $confirmed_precision = null) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $source, $target);
+		return (new WCOS_Merge_WooCommerce_Adapter())->preflight($source, $target, $operation_id, $confirmed_precision);
 	}
 
 	public function return_order(WC_Order $child, WC_Order $parent, $operation_id) {

--- a/inc/domain/class-wcos-tax-item-synchronizer.php
+++ b/inc/domain/class-wcos-tax-item-synchronizer.php
@@ -20,8 +20,12 @@ final class WCOS_Tax_Item_Synchronizer {
 		return $templates;
 	}
 
-	public static function synchronize(WC_Order $order, array $templates, $precision = null, $preserve_existing_ids = false) {
+	public static function synchronize(WC_Order $order, array $templates, $precision = null, $preserve_existing_ids = false, $context = WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT) {
 		$precision = null === $precision ? wc_get_price_decimals() : (int) $precision;
+		$context = sanitize_key((string) $context);
+		if (!in_array($context, array(WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT, WCOS_Order_Item_Meta_Policy::CONTEXT_MERGE), true)) {
+			throw new InvalidArgumentException(__('A supported historical tax synchronization context is required.', 'wc-order-splitter'));
+		}
 		$totals = self::collect($order, $precision);
 		$existing = array();
 		foreach ($order->get_items('tax') as $item) {
@@ -44,7 +48,7 @@ final class WCOS_Tax_Item_Synchronizer {
 				if (!isset($templates[$rate_id])) {
 					throw new RuntimeException(__('A historical tax-rate template is missing from the source order.', 'wc-order-splitter'));
 				}
-				$item = WCOS_Order_Item_Cloner::tax($templates[$rate_id], WCOS_Order_Item_Meta_Policy::CONTEXT_SPLIT);
+				$item = WCOS_Order_Item_Cloner::tax($templates[$rate_id], $context);
 				$order->add_item($item);
 			} else {
 				continue;

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -112,7 +112,11 @@ wcos_merge_foundation_assert(
 );
 wcos_merge_foundation_assert(
 	WCOS_Merge_Retirement_Policy::identifiers() === $report['retirement_candidates'],
-	'Retirement candidates changed or became selected.'
+	'Retirement comparison evidence changed.'
+);
+wcos_merge_foundation_assert(
+	WCOS_Merge_Retirement_Policy::approved_identifier() === $report['retirement_policy'],
+	'Preflight did not bind the approved non-force trash archive policy.'
 );
 
 /* Keyed compatibility proof contains no durable raw customer context. */
@@ -288,6 +292,13 @@ $verified_pair = WCOS_Merge_Journal_Context::pair_from_record($journal);
 wcos_merge_foundation_assert(is_array($verified_pair), 'Canonical Merge pair authority did not self-verify.');
 wcos_merge_foundation_assert($report['price_precision'] === $verified_pair['price_precision'], 'Pair authority lost price-precision authority.');
 wcos_merge_foundation_assert(WCOS_Merge_Preflight::POLICY_VERSION === $verified_pair['preflight_policy_version'], 'Pair authority lost preflight-policy authority.');
+$unselected_rejected = false;
+try {
+	WCOS_Merge_Journal_Context::assert_executable_policy($journal);
+} catch (RuntimeException $exception) {
+	$unselected_rejected = true;
+}
+wcos_merge_foundation_assert($unselected_rejected, 'An older unselected retirement-policy journal became executable.');
 
 /* Every durable pair-authority field is independently tamper-evident. */
 $authority_tamper_cases = array(

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -81,7 +81,7 @@ function wcos_merge_recovery_start(WC_Order $source, WC_Order $target, $operatio
 		$report['price_precision']
 	);
 	wcos_merge_recovery_assert(
-		WCOS_Operation_Journal::start($source, $operation_id, 'merge', $context, $report['pair_fingerprint']),
+		WCOS_Operation_Journal::start($source, $operation_id, 'merge', $context, $context['merge_pair']['pair_fingerprint']),
 		'Unable to start authoritative Merge recovery journal.'
 	);
 	wcos_merge_recovery_assert(

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -73,7 +73,7 @@ function wcos_merge_recovery_order(WC_Product $product, $email, $quantity, $redu
 
 function wcos_merge_recovery_start(WC_Order $source, WC_Order $target, $operation_id) {
 	$report = WCOS_Merge_Preflight::assert_supported($source, $target);
-	$context = WCOS_Merge_Journal_Context::create(
+	$context = WCOS_Merge_Journal_Context::create_executable(
 		$source,
 		$target,
 		$report['plan'],
@@ -672,7 +672,7 @@ try {
 wcos_merge_recovery_assert($before_rejected, 'Before-write physical stock hook was not rejected.');
 WCOS_Stock_Side_Effect_Guard::end($guard);
 
-/* Both unselected candidates run inside a real journaled pair and compensate. */
+/* Retained comparison evidence remains inspectable, but only the approved policy can compensate automatically. */
 function wcos_merge_retirement_observe($candidate, WC_Product $product) {
 	$email = 'merge-retirement-' . $candidate . '-' . wp_generate_uuid4() . '@example.test';
 	$source = wcos_merge_recovery_order($product, $email, 1, 1, true);
@@ -725,15 +725,30 @@ function wcos_merge_retirement_observe($candidate, WC_Product $product) {
 	wcos_merge_recovery_assert(WCOS_Operation_Journal::require_recovery($source, $operation_id), 'Retirement candidate compensation did not dispatch.');
 	$source = wc_get_order($source->get_id());
 	$target = wc_get_order($target->get_id());
-	wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($source, $operation_id)['status'], 'Retirement candidate did not compensate.');
-	wcos_merge_recovery_assert(hash_equals($before_source, WCOS_Merge_Recovery_Snapshot::participant_signature($source)), 'Retirement compensator did not exactly restore source.');
-	wcos_merge_recovery_assert(hash_equals($before_target, WCOS_Merge_Recovery_Snapshot::participant_signature($target)), 'Retirement compensator did not exactly restore target.');
+	if (WCOS_Merge_Retirement_Policy::approved_identifier() === $candidate) {
+		wcos_merge_recovery_assert('compensated' === WCOS_Operation_Journal::get($source, $operation_id)['status'], 'Approved retirement policy did not compensate.');
+		wcos_merge_recovery_assert(hash_equals($before_source, WCOS_Merge_Recovery_Snapshot::participant_signature($source)), 'Approved retirement compensator did not exactly restore source.');
+		wcos_merge_recovery_assert(hash_equals($before_target, WCOS_Merge_Recovery_Snapshot::participant_signature($target)), 'Approved retirement compensator did not exactly restore target.');
+	} else {
+		wcos_merge_recovery_assert('manual_reconciliation' === WCOS_Operation_Journal::get($source, $operation_id)['status'], 'Unapproved retirement policy did not fail closed.');
+		wcos_merge_recovery_assert(WCOS_Manual_Reconciliation_Blocker::has_active($source) && WCOS_Manual_Reconciliation_Blocker::has_active($target), 'Unapproved retirement policy did not block both participants.');
+	}
 	wcos_merge_recovery_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Retirement candidate changed physical stock.');
 	if (is_callable($status_filter)) { remove_filter('wc_order_statuses', $status_filter); }
+	delete_option('wcos_manual_reconcile_block_' . $source->get_id());
+	delete_option('wcos_manual_reconcile_block_' . $target->get_id());
 	WCOS_Operation_Journal::delete($source, $operation_id);
 	$source->delete(true);
 	$target->delete(true);
-	return array('candidate' => $candidate, 'source_status_observed' => $status_after, 'directly_inspectable_after_transition' => true, 'reversible' => true, 'stock_neutral' => true, 'journal_discoverable' => true, 'production_selected' => false);
+	return array(
+		'candidate' => $candidate,
+		'source_status_observed' => $status_after,
+		'directly_inspectable_after_transition' => true,
+		'reversible' => true,
+		'stock_neutral' => true,
+		'journal_discoverable' => true,
+		'production_selected' => WCOS_Merge_Retirement_Policy::approved_identifier() === $candidate,
+	);
 }
 
 $retirement = array(

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -173,7 +173,7 @@ $forward_suites = array(
 	'forward_after_verification_before_commit' => 'after_verification_before_commit',
 	'forward_after_commit_before_complete' => 'after_commit_before_complete',
 );
-wcos_merge_service_assert(in_array($suite, array_merge(array('all', 'core', 'crash_pre', 'crash_post_aux', 'drift_stock'), array_keys($forward_suites)), true), 'Unknown Merge service smoke suite.');
+wcos_merge_service_assert(in_array($suite, array_merge(array('all', 'core', 'crash_pre', 'response_loss', 'lease_loss', 'stock_guard_before', 'stock_guard_after', 'drift_stock'), array_keys($forward_suites)), true), 'Unknown Merge service smoke suite.');
 
 try {
 	$managed = wcos_merge_service_product('Merge managed fixture');
@@ -336,7 +336,7 @@ try {
 	}
 	}
 
-	if (in_array($suite, array('all', 'crash_post_aux'), true)) {
+	if (in_array($suite, array('all', 'response_loss'), true)) {
 	/* Response loss after complete replays the exact bounded result without writes. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'response-loss');
 	$operation_id = 'merge-service-response-loss-' . wp_generate_uuid4();
@@ -358,7 +358,9 @@ try {
 	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
 	wcos_merge_service_assert('completed' === $result['status'], 'Post-complete response loss did not replay safely.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
 
+	if (in_array($suite, array('all', 'lease_loss'), true)) {
 	/* Losing both participant leases between durable boundaries stops writes and recovers safely. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'lease-loss');
 	$operation_id = 'merge-service-lease-loss-' . wp_generate_uuid4();
@@ -386,9 +388,12 @@ try {
 	wcos_merge_service_assert(in_array(wcos_merge_service_status($source, $operation_id), array('compensated', 'manual_reconciliation'), true), 'Lease loss did not preserve safe durable authority.');
 	wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock(wc_get_order($source->get_id())), 'Lease-loss recovery changed physical stock.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
 
+	if (in_array($suite, array('all', 'stock_guard_before', 'stock_guard_after'), true)) {
 	/* Before-write attempts are blocked; after-write evidence becomes pair-wide manual-only. */
-	foreach (array('blocked_before_write', 'observed_after_write') as $stock_phase) {
+	$stock_phases = 'stock_guard_before' === $suite ? array('blocked_before_write') : ('stock_guard_after' === $suite ? array('observed_after_write') : array('blocked_before_write', 'observed_after_write'));
+	foreach ($stock_phases as $stock_phase) {
 		list($source, $target) = wcos_merge_service_pair($managed, 'stock-guard-' . $stock_phase);
 		$operation_id = 'merge-service-stock-guard-' . $stock_phase . '-' . wp_generate_uuid4();
 		$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -166,7 +166,14 @@ $manage_stock_before = get_option('woocommerce_manage_stock', 'yes');
 update_option('woocommerce_manage_stock', 'yes');
 $products = array();
 $suite = isset($args[0]) ? sanitize_key((string) $args[0]) : 'all';
-wcos_merge_service_assert(in_array($suite, array('all', 'core', 'crash_pre', 'crash_post', 'drift_stock'), true), 'Unknown Merge service smoke suite.');
+$forward_suites = array(
+	'forward_before_forward_relations' => 'before_forward_relations',
+	'forward_after_one_reciprocal_relation' => 'after_one_reciprocal_relation',
+	'forward_after_both_relations_before_verification' => 'after_both_relations_before_verification',
+	'forward_after_verification_before_commit' => 'after_verification_before_commit',
+	'forward_after_commit_before_complete' => 'after_commit_before_complete',
+);
+wcos_merge_service_assert(in_array($suite, array_merge(array('all', 'core', 'crash_pre', 'crash_post_aux', 'drift_stock'), array_keys($forward_suites)), true), 'Unknown Merge service smoke suite.');
 
 try {
 	$managed = wcos_merge_service_product('Merge managed fixture');
@@ -296,15 +303,15 @@ try {
 	wcos_merge_service_cleanup($source, $target, $operation_id);
 	}
 
-	if (in_array($suite, array('all', 'crash_post'), true)) {
+	if ('all' === $suite || isset($forward_suites[$suite])) {
 	/* Post-retirement forward-repair windows complete idempotently on retry. */
-	$forward_windows = array(
+	$forward_windows = 'all' === $suite ? array(
 		'before_forward_relations',
 		'after_one_reciprocal_relation',
 		'after_both_relations_before_verification',
 		'after_verification_before_commit',
 		'after_commit_before_complete',
-	);
+	) : array($forward_suites[$suite]);
 	foreach ($forward_windows as $stage_under_test) {
 		list($source, $target) = wcos_merge_service_pair($managed, 'forward-' . $stage_under_test);
 		$operation_id = 'merge-service-forward-' . $stage_under_test . '-' . wp_generate_uuid4();
@@ -327,7 +334,9 @@ try {
 		wcos_merge_service_assert('completed' === $result['status'], 'Real forward service crash did not complete on retry: ' . $stage_under_test);
 		wcos_merge_service_cleanup($source, $target, $operation_id);
 	}
+	}
 
+	if (in_array($suite, array('all', 'crash_post_aux'), true)) {
 	/* Response loss after complete replays the exact bounded result without writes. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'response-loss');
 	$operation_id = 'merge-service-response-loss-' . wp_generate_uuid4();

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -1,0 +1,376 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_merge_service_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_merge_service_product($name, $managed = true, $backorders = false, $stock = '40') {
+	$product = new WC_Product_Simple();
+	$product->set_name($name);
+	$product->set_regular_price('10.00');
+	$product->set_price('10.00');
+	$product->set_manage_stock($managed);
+	if ($managed) {
+		$product->set_stock_quantity($stock);
+		$product->set_backorders($backorders ? 'yes' : 'no');
+	}
+	wcos_merge_service_assert($product->save() > 0, 'Unable to save a Merge service product fixture.');
+	return $product;
+}
+
+function wcos_merge_service_parent_managed_variation() {
+	$parent = new WC_Product_Variable();
+	$parent->set_name('Merge parent-managed variable');
+	$parent->set_manage_stock(true);
+	$parent->set_stock_quantity('31.5');
+	wcos_merge_service_assert($parent->save() > 0, 'Unable to save the parent-managed Merge fixture.');
+
+	$variation = new WC_Product_Variation();
+	$variation->set_parent_id($parent->get_id());
+	$variation->set_regular_price('10.00');
+	$variation->set_price('10.00');
+	$variation->set_manage_stock(false);
+	wcos_merge_service_assert($variation->save() > 0, 'Unable to save the Merge variation fixture.');
+	return array($parent, $variation);
+}
+
+function wcos_merge_service_order(WC_Product $product, $email, array $reduced_markers, $shipping = false, $target_amount = false) {
+	$order = wc_create_order();
+	$order->set_status('pending');
+	$order->set_currency('USD');
+	$order->set_prices_include_tax(false);
+	$order->set_customer_id(0);
+	$order->set_billing_first_name('Merge');
+	$order->set_billing_last_name('Service');
+	$order->set_billing_email($email);
+	$order->set_billing_phone('+1 555 0142');
+	$order->set_billing_address_1('42 Merge Service Way');
+	$order->set_billing_city('Testville');
+	$order->set_billing_state('CA');
+	$order->set_billing_postcode('90001');
+	$order->set_billing_country('US');
+	$order->set_shipping_first_name('Merge');
+	$order->set_shipping_last_name('Service');
+	$order->set_shipping_address_1('42 Merge Service Way');
+	$order->set_shipping_city('Testville');
+	$order->set_shipping_state('CA');
+	$order->set_shipping_postcode('90001');
+	$order->set_shipping_country('US');
+	$order->set_payment_method('cod');
+	$order->set_payment_method_title('Cash on delivery');
+
+	foreach ($reduced_markers as $index => $marker) {
+		$item = new WC_Order_Item_Product();
+		$item->set_name($target_amount ? 'Existing target line' : 'Identical historical source line');
+		if ($product instanceof WC_Product_Variation) {
+			$item->set_product_id($product->get_parent_id());
+			$item->set_variation_id($product->get_id());
+		} else {
+			$item->set_product_id($product->get_id());
+		}
+		$item->set_quantity($target_amount ? '1' : ('fractional' === $marker ? '1.5' : '1'));
+		$item->set_subtotal($target_amount ? '5.00' : '10.00');
+		$item->set_total($target_amount ? '5.00' : '10.00');
+		$item->set_subtotal_tax($target_amount ? '0.50' : '1.00');
+		$item->set_total_tax($target_amount ? '0.50' : '1.00');
+		$item->set_taxes(array(
+			'subtotal' => array(701 => $target_amount ? '0.50' : '1.00'),
+			'total' => array(701 => $target_amount ? '0.50' : '1.00'),
+		));
+		$item->add_meta_data('Merge fixture', 'preserved-business-value', true);
+		if (null !== $marker) {
+			$item->add_meta_data('_reduced_stock', 'fractional' === $marker ? '1.5' : WCOS_Decimal::normalize($marker, 6), true);
+		}
+		$order->add_item($item);
+	}
+
+	if ($shipping) {
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_method_title('Supported target shipping');
+		$shipping_item->set_method_id('flat_rate');
+		$shipping_item->set_instance_id(9);
+		$shipping_item->set_total('3.00');
+		$shipping_item->set_total_tax('0.30');
+		$shipping_item->set_taxes(array('total' => array(701 => '0.30')));
+		$shipping_item->add_meta_data('Delivery window', 'morning', true);
+		$order->add_item($shipping_item);
+	}
+
+	$cart_tax = count($reduced_markers) * ($target_amount ? 0.5 : 1.0);
+	$tax = new WC_Order_Item_Tax();
+	$tax->set_rate_id(701);
+	$tax->set_label('Frozen historical rate');
+	$tax->set_compound(false);
+	$tax->set_rate_percent(10);
+	$tax->set_tax_total(wc_format_decimal($cart_tax, 2));
+	$tax->set_shipping_tax_total($shipping ? '0.30' : '0.00');
+	$order->add_item($tax);
+	WCOS_Order_Totals_Rebuilder::rebuild($order, 2);
+	$order->save();
+	$order->get_data_store()->set_stock_reduced($order->get_id(), !empty(array_filter($reduced_markers, static function($value) {
+		return null !== $value;
+	})));
+	return wc_get_order($order->get_id());
+}
+
+function wcos_merge_service_pair(WC_Product $product, $label, array $source_markers = array('1'), $shipping = false) {
+	$email = 'merge-service-' . $label . '-' . wp_generate_uuid4() . '@example.test';
+	return array(
+		wcos_merge_service_order($product, $email, $source_markers, false, false),
+		wcos_merge_service_order($product, $email, array(null), $shipping, true),
+	);
+}
+
+function wcos_merge_service_cleanup(WC_Order $source, WC_Order $target, $operation_id) {
+	$fresh_source = wc_get_order($source->get_id());
+	if ($fresh_source instanceof WC_Order) {
+		WCOS_Operation_Journal::delete($fresh_source, $operation_id);
+		$fresh_source->delete(true);
+	}
+	$fresh_target = wc_get_order($target->get_id());
+	if ($fresh_target instanceof WC_Order) {
+		$fresh_target->delete(true);
+	}
+}
+
+function wcos_merge_service_status(WC_Order $source, $operation_id) {
+	$record = WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $operation_id);
+	return is_array($record) && isset($record['status']) ? sanitize_key((string) $record['status']) : '';
+}
+
+function wcos_merge_service_assert_manual_pair(WC_Order $source, WC_Order $target, $operation_id) {
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_service_assert('manual_reconciliation' === wcos_merge_service_status($source, $operation_id), 'Immutable drift did not enter manual reconciliation.');
+	wcos_merge_service_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($source), true), 'Source lacks pair-wide manual authority.');
+	wcos_merge_service_assert(in_array($operation_id, WCOS_Manual_Reconciliation_Blocker::active_operation_ids($target), true), 'Target lacks pair-wide manual authority.');
+}
+
+$manage_stock_before = get_option('woocommerce_manage_stock', 'yes');
+update_option('woocommerce_manage_stock', 'yes');
+$products = array();
+
+try {
+	$managed = wcos_merge_service_product('Merge managed fixture');
+	$products[] = $managed;
+
+	/* Gateway stays hard-off while direct adapter/service acceptance is executable. */
+	list($gate_source, $gate_target) = wcos_merge_service_pair($managed, 'gate');
+	$gate_operation = 'merge-gate-' . wp_generate_uuid4();
+	$gate_rejected = false;
+	try {
+		(new WCOS_Mutation_Gateway())->merge($gate_source, $gate_target, $gate_operation, 2);
+	} catch (RuntimeException $exception) {
+		$gate_rejected = true;
+	}
+	wcos_merge_service_assert($gate_rejected, 'MERGE=false did not stop the gateway before delegation.');
+	wcos_merge_service_assert(null === WCOS_Operation_Journal::get($gate_source, $gate_operation), 'Hard-off gateway created journal state.');
+	$gate_source->delete(true);
+	$gate_target->delete(true);
+
+	/* Success: identical source lines stay distinct, historical tax/shipping survive, retry is stable. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'success', array('1.5', '2'), true);
+	$operation_id = 'merge-service-success-' . wp_generate_uuid4();
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$source_line_ids = array_map('intval', array_keys($source->get_items('line_item')));
+	$shipping_before = WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target)['order_props']['shipping_total'];
+	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	$retry = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+	wcos_merge_service_assert($result === $retry, 'Completed Merge retry did not return the stable result.');
+	wcos_merge_service_assert('completed' === $result['status'], 'Merge service did not complete.');
+	wcos_merge_service_assert('non_force_trash_archive' === $result['retirement_policy'], 'Result lost the binding retirement policy.');
+	wcos_merge_service_assert(2 === count($result['target_item_ids']), 'Merge did not create one fresh target line per source line.');
+	wcos_merge_service_assert(2 === count(array_unique($result['target_item_ids'])), 'Merge coalesced or reused a target line.');
+	wcos_merge_service_assert(empty(array_intersect($source_line_ids, $result['target_item_ids'])), 'Merge re-parented a persisted source item.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_service_assert('trash' === $source->get_status(), 'Approved non-force retirement did not trash the source.');
+	wcos_merge_service_assert($shipping_before === WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target)['order_props']['shipping_total'], 'Supported target shipping total changed.');
+	wcos_merge_service_assert(3 === count($target->get_items('line_item')), 'Target line count is not additive.');
+	wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($target), 'Successful Merge changed physical stock.');
+	foreach ($source->get_items('line_item') as $item) {
+		wcos_merge_service_assert('' === (string) $item->get_meta('_reduced_stock', true), 'Retired source retained stock ownership.');
+	}
+	$target_reduced = array();
+	foreach ($result['target_item_ids'] as $item_id) {
+		$target_reduced[] = WCOS_Decimal::normalize($target->get_item($item_id)->get_meta('_reduced_stock', true), 6);
+	}
+	sort($target_reduced, SORT_STRING);
+	wcos_merge_service_assert(array('1.500000', '2.000000') === $target_reduced, 'Target did not receive exact line stock ownership.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Real partial ownership crash: first source write and checkpoint are durable before the second boundary. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'partial-ownership', array('1', '2'));
+	$operation_id = 'merge-service-partial-' . wp_generate_uuid4();
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$ownership_boundaries = 0;
+	$partial_observed = false;
+	$partial_crash = static function($stage, $event_source) use (&$ownership_boundaries, &$partial_observed) {
+		if ('before_source_line_ownership_write' !== $stage) {
+			return;
+		}
+		$ownership_boundaries++;
+		if (2 !== $ownership_boundaries) {
+			return;
+		}
+		$markers = array_map(static function($item) {
+			return (string) $item->get_meta('_reduced_stock', true);
+		}, array_values(wc_get_order($event_source->get_id())->get_items('line_item')));
+		$partial_observed = 1 === count(array_filter($markers, static function($marker) { return '' === $marker; }))
+			&& 1 === count(array_filter($markers, static function($marker) { return '' !== $marker; }));
+		throw new WCOS_Merge_Recovery_Interruption_Exception('Injected crash after one durable ownership checkpoint.');
+	};
+	add_action('wcos_merge_mutation_checkpoint', $partial_crash, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* The durable journal outcome is asserted below. */
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $partial_crash, 10);
+	wcos_merge_service_assert($partial_observed, 'Crash fixture did not observe a genuinely partial durable source ownership migration.');
+	wcos_merge_service_assert('compensated' === wcos_merge_service_status($source, $operation_id), 'Partial ownership crash did not compensate safely.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_service_assert(2 === count($target->get_items('line_item')), 'Compensation did not remove operation-owned target lines.');
+	foreach ($source->get_items('line_item') as $item) {
+		wcos_merge_service_assert('' !== (string) $item->get_meta('_reduced_stock', true), 'Compensation did not restore source stock ownership.');
+	}
+	wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($source), 'Partial ownership recovery changed physical stock.');
+	$retry_failed_closed = false;
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (WCOS_Merge_Adapter_Exception $exception) {
+		$retry_failed_closed = 'merge_compensated' === $exception->get_error_code();
+	}
+	wcos_merge_service_assert($retry_failed_closed, 'Compensated operation retry did not fail closed with a stable code.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* A response-loss crash between reciprocal relation writes resumes forward on retry. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'relation-retry');
+	$operation_id = 'merge-service-relation-' . wp_generate_uuid4();
+	$relation_once = true;
+	$relation_crash = static function($stage) use (&$relation_once) {
+		if ($relation_once && 'after_one_reciprocal_relation' === $stage) {
+			$relation_once = false;
+			throw new WCOS_Merge_Recovery_Interruption_Exception('Injected reciprocal relation crash.');
+		}
+	};
+	add_action('wcos_merge_recovery_checkpoint', $relation_crash, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* Retry after removing the injected process-loss boundary. */
+	}
+	remove_action('wcos_merge_recovery_checkpoint', $relation_crash, 10);
+	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+	wcos_merge_service_assert('completed' === $result['status'], 'Forward relation recovery did not complete on retry.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Independent immutable-context drifts fail closed before automatic recovery writes and remain untouched. */
+	$drift_cases = array(
+		'source_billing' => static function(WC_Order $source, WC_Order $target) {
+			$source->set_billing_address_1('Externally changed billing address');
+			$source->save();
+		},
+		'target_payment' => static function(WC_Order $source, WC_Order $target) {
+			$target->set_payment_method_title('Externally changed payment title');
+			$target->save();
+		},
+		'target_shipping_item' => static function(WC_Order $source, WC_Order $target) {
+			$shipping_items = array_values($target->get_items('shipping'));
+			$shipping = $shipping_items[0];
+			$shipping->set_method_title('Externally changed shipping method');
+			$shipping->save();
+			$line_items = array_values($target->get_items('line_item'));
+			$line = $line_items[0];
+			$line->set_name('Externally changed target item');
+			$line->update_meta_data('Merge fixture', 'external-item-state');
+			$line->save();
+		},
+	);
+	foreach ($drift_cases as $label => $mutate) {
+		list($source, $target) = wcos_merge_service_pair($managed, 'drift-' . $label, array('1'), 'target_shipping_item' === $label);
+		$operation_id = 'merge-service-drift-' . $label . '-' . wp_generate_uuid4();
+		$source_lines_before = array_values($source->get_items('line_item'));
+		$source_quantity = (string) $source_lines_before[0]->get_quantity();
+		$target_total_at_drift = '';
+		$drift_once = true;
+		$drift = static function($stage, $event_source, $event_target) use (&$drift_once, &$target_total_at_drift, $mutate) {
+			if ($drift_once && 'after_target_money_tax_persistence' === $stage) {
+				$drift_once = false;
+				$fresh_target = wc_get_order($event_target->get_id());
+				$target_total_at_drift = (string) $fresh_target->get_total();
+				$mutate(wc_get_order($event_source->get_id()), $fresh_target);
+				throw new WCOS_Merge_Recovery_Interruption_Exception('Injected immutable participant drift.');
+			}
+		};
+		add_action('wcos_merge_mutation_checkpoint', $drift, 10, 4);
+		try {
+			(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+		} catch (Throwable $throwable) {
+			/* Manual state is asserted after the recovery coordinator returns. */
+		}
+		remove_action('wcos_merge_mutation_checkpoint', $drift, 10);
+		wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
+		$fresh_source = wc_get_order($source->get_id());
+		$fresh_target = wc_get_order($target->get_id());
+		$fresh_source_lines = array_values($fresh_source->get_items('line_item'));
+		wcos_merge_service_assert($source_quantity === (string) $fresh_source_lines[0]->get_quantity(), 'Immutable drift fixture changed source quantity.');
+		if ('source_billing' === $label) {
+			wcos_merge_service_assert('Externally changed billing address' === $fresh_source->get_billing_address_1(), 'Recovery overwrote external billing state.');
+		} elseif ('target_payment' === $label) {
+			wcos_merge_service_assert('Externally changed payment title' === $fresh_target->get_payment_method_title(), 'Recovery overwrote external payment state.');
+		} else {
+			$fresh_shipping_items = array_values($fresh_target->get_items('shipping'));
+			$fresh_target_lines = array_values($fresh_target->get_items('line_item'));
+			wcos_merge_service_assert('Externally changed shipping method' === $fresh_shipping_items[0]->get_method_title(), 'Recovery overwrote external target shipping state.');
+			wcos_merge_service_assert('Externally changed target item' === $fresh_target_lines[0]->get_name(), 'Recovery overwrote external target item state.');
+		}
+		wcos_merge_service_assert($target_total_at_drift === (string) $fresh_target->get_total(), 'Immutable-context recovery overwrote target totals.');
+		wcos_merge_service_cleanup($fresh_source, $fresh_target, $operation_id);
+	}
+
+	/* Service-level stock matrix: unmanaged, backorder, fractional, parent-managed variation, and deleted product. */
+	$unmanaged = wcos_merge_service_product('Merge unmanaged fixture', false);
+	$backorder = wcos_merge_service_product('Merge backorder fixture', true, true, '-2.5');
+	list($parent, $variation) = wcos_merge_service_parent_managed_variation();
+	$deleted = wcos_merge_service_product('Merge deleted-product fixture');
+	$products = array_merge($products, array($unmanaged, $backorder, $variation, $parent));
+	$stock_cases = array(
+		'unmanaged' => array($unmanaged, array(null), false),
+		'backorder_fractional' => array($backorder, array('fractional'), false),
+		'parent_managed_variation' => array($variation, array('1'), false),
+		'deleted_product' => array($deleted, array('1'), true),
+	);
+	foreach ($stock_cases as $label => $case) {
+		list($case_product, $markers, $delete_product) = $case;
+		list($source, $target) = wcos_merge_service_pair($case_product, 'stock-' . $label, $markers);
+		$operation_id = 'merge-service-stock-' . $label . '-' . wp_generate_uuid4();
+		if ($delete_product) {
+			$case_product->delete(true);
+			$source = wc_get_order($source->get_id());
+			$target = wc_get_order($target->get_id());
+		}
+		$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+		$result = (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+		wcos_merge_service_assert('completed' === $result['status'], 'Stock matrix Merge did not complete: ' . $label);
+		$fresh_target = wc_get_order($target->get_id());
+		wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($fresh_target), 'Stock matrix changed physical stock: ' . $label);
+		wcos_merge_service_cleanup(wc_get_order($source->get_id()), $fresh_target, $operation_id);
+	}
+} finally {
+	update_option('woocommerce_manage_stock', $manage_stock_before);
+	foreach ($products as $product) {
+		if ($product instanceof WC_Product && $product->get_id() && wc_get_product($product->get_id())) {
+			$product->delete(true);
+		}
+	}
+}
+
+echo "merge-service-adapter-ok\n";

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -92,12 +92,15 @@ function wcos_merge_service_order(WC_Product $product, $email, array $reduced_ma
 
 	if ($shipping) {
 		$shipping_item = new WC_Order_Item_Shipping();
-		$shipping_item->set_method_title('Supported target shipping');
-		$shipping_item->set_method_id('flat_rate');
-		$shipping_item->set_instance_id(9);
-		$shipping_item->set_total('3.00');
-		$shipping_item->set_total_tax('0.30');
-		$shipping_item->set_taxes(array('total' => array(701 => '0.30')));
+		$shipping_props = $shipping_item->set_props(array(
+			'method_title' => 'Supported target shipping',
+			'method_id' => 'flat_rate',
+			'instance_id' => 9,
+			'total' => '3.00',
+			'total_tax' => '0.30',
+			'taxes' => array('total' => array(701 => '0.30')),
+		));
+		wcos_merge_service_assert(!is_wp_error($shipping_props), 'Unable to set supported target shipping fixture props.');
 		$shipping_item->add_meta_data('Delivery window', 'morning', true);
 		$order->add_item($shipping_item);
 	}

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -40,7 +40,7 @@ function wcos_merge_service_parent_managed_variation() {
 	return array($parent, $variation);
 }
 
-function wcos_merge_service_order(WC_Product $product, $email, array $reduced_markers, $shipping = false, $target_amount = false) {
+function wcos_merge_service_order(WC_Product $product, $email, array $reduced_markers, $shipping = false, $target_amount = false, $multiple_rates = false) {
 	$order = wc_create_order();
 	$order->set_status('pending');
 	$order->set_currency('USD');
@@ -65,7 +65,10 @@ function wcos_merge_service_order(WC_Product $product, $email, array $reduced_ma
 	$order->set_payment_method('cod');
 	$order->set_payment_method_title('Cash on delivery');
 
+	$tax_totals = array();
 	foreach ($reduced_markers as $index => $marker) {
+		$rate_id = $multiple_rates && 0 < $index ? 702 : 701;
+		$line_tax = $target_amount ? '0.50' : '1.00';
 		$item = new WC_Order_Item_Product();
 		$item->set_name($target_amount ? 'Existing target line' : 'Identical historical source line');
 		if ($product instanceof WC_Product_Variation) {
@@ -80,9 +83,10 @@ function wcos_merge_service_order(WC_Product $product, $email, array $reduced_ma
 		$item->set_subtotal_tax($target_amount ? '0.50' : '1.00');
 		$item->set_total_tax($target_amount ? '0.50' : '1.00');
 		$item->set_taxes(array(
-			'subtotal' => array(701 => $target_amount ? '0.50' : '1.00'),
-			'total' => array(701 => $target_amount ? '0.50' : '1.00'),
+			'subtotal' => array($rate_id => $line_tax),
+			'total' => array($rate_id => $line_tax),
 		));
+		$tax_totals[$rate_id] = isset($tax_totals[$rate_id]) ? $tax_totals[$rate_id] + (float) $line_tax : (float) $line_tax;
 		$item->add_meta_data('Merge fixture', 'preserved-business-value', true);
 		if (null !== $marker) {
 			$item->add_meta_data('_reduced_stock', 'fractional' === $marker ? '1.5' : WCOS_Decimal::normalize($marker, 6), true);
@@ -105,15 +109,16 @@ function wcos_merge_service_order(WC_Product $product, $email, array $reduced_ma
 		$order->add_item($shipping_item);
 	}
 
-	$cart_tax = count($reduced_markers) * ($target_amount ? 0.5 : 1.0);
-	$tax = new WC_Order_Item_Tax();
-	$tax->set_rate_id(701);
-	$tax->set_label('Frozen historical rate');
-	$tax->set_compound(false);
-	$tax->set_rate_percent(10);
-	$tax->set_tax_total(wc_format_decimal($cart_tax, 2));
-	$tax->set_shipping_tax_total($shipping ? '0.30' : '0.00');
-	$order->add_item($tax);
+	foreach ($tax_totals as $rate_id => $cart_tax) {
+		$tax = new WC_Order_Item_Tax();
+		$tax->set_rate_id($rate_id);
+		$tax->set_label('Frozen historical rate ' . $rate_id);
+		$tax->set_compound(false);
+		$tax->set_rate_percent(10);
+		$tax->set_tax_total(wc_format_decimal($cart_tax, 2));
+		$tax->set_shipping_tax_total($shipping && 701 === (int) $rate_id ? '0.30' : '0.00');
+		$order->add_item($tax);
+	}
 	WCOS_Order_Totals_Rebuilder::rebuild($order, 2);
 	$order->save();
 	$order->get_data_store()->set_stock_reduced($order->get_id(), !empty(array_filter($reduced_markers, static function($value) {
@@ -122,10 +127,10 @@ function wcos_merge_service_order(WC_Product $product, $email, array $reduced_ma
 	return wc_get_order($order->get_id());
 }
 
-function wcos_merge_service_pair(WC_Product $product, $label, array $source_markers = array('1'), $shipping = false) {
+function wcos_merge_service_pair(WC_Product $product, $label, array $source_markers = array('1'), $shipping = false, $multiple_rates = false) {
 	$email = 'merge-service-' . $label . '-' . wp_generate_uuid4() . '@example.test';
 	return array(
-		wcos_merge_service_order($product, $email, $source_markers, false, false),
+		wcos_merge_service_order($product, $email, $source_markers, false, false, $multiple_rates),
 		wcos_merge_service_order($product, $email, array(null), $shipping, true),
 	);
 }
@@ -180,10 +185,11 @@ try {
 	$gate_target->delete(true);
 
 	/* Success: identical source lines stay distinct, historical tax/shipping survive, retry is stable. */
-	list($source, $target) = wcos_merge_service_pair($managed, 'success', array('1.5', '2'), true);
+	list($source, $target) = wcos_merge_service_pair($managed, 'success', array('1.5', '2'), true, true);
 	$operation_id = 'merge-service-success-' . wp_generate_uuid4();
 	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
 	$source_line_ids = array_map('intval', array_keys($source->get_items('line_item')));
+	$source_line_identities = array_map(static function($item) { return WCOS_Line_Identity::from_item($item); }, array_values($source->get_items('line_item')));
 	$shipping_before = WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target)['order_props']['shipping_total'];
 	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
 	$retry = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
@@ -198,6 +204,16 @@ try {
 	wcos_merge_service_assert('trash' === $source->get_status(), 'Approved non-force retirement did not trash the source.');
 	wcos_merge_service_assert($shipping_before === WCOS_Merge_Recovery_Snapshot::participant_checkpoint($target)['order_props']['shipping_total'], 'Supported target shipping total changed.');
 	wcos_merge_service_assert(3 === count($target->get_items('line_item')), 'Target line count is not additive.');
+	$target_line_identities = array();
+	foreach ($result['target_item_ids'] as $item_id) {
+		$target_line_identities[] = WCOS_Line_Identity::from_item($target->get_item($item_id));
+	}
+	sort($source_line_identities, SORT_STRING);
+	sort($target_line_identities, SORT_STRING);
+	wcos_merge_service_assert($source_line_identities === $target_line_identities, 'Fresh target lines lost exact variation/business-metadata identity.');
+	$target_rate_ids = array_map(static function($item) { return (int) $item->get_rate_id(); }, array_values($target->get_items('tax')));
+	sort($target_rate_ids, SORT_NUMERIC);
+	wcos_merge_service_assert(array(701, 702) === $target_rate_ids, 'Merge did not preserve multiple historical tax rates.');
 	wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($target), 'Successful Merge changed physical stock.');
 	foreach ($source->get_items('line_item') as $item) {
 		wcos_merge_service_assert('' === (string) $item->get_meta('_reduced_stock', true), 'Retired source retained stock ownership.');
@@ -381,7 +397,11 @@ try {
 			} catch (Throwable $throwable) {
 				/* A compensated saga intentionally remains non-restartable. */
 			}
-			wcos_merge_service_assert('compensated' === wcos_merge_service_status($source, $operation_id), 'Blocked stock attempt did not compensate after clean retry.');
+			$blocked_status = wcos_merge_service_status($source, $operation_id);
+			wcos_merge_service_assert(in_array($blocked_status, array('compensated', 'manual_reconciliation'), true), 'Blocked stock attempt did not reach a safe recovery outcome.');
+			if ('manual_reconciliation' === $blocked_status) {
+				wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
+			}
 		} else {
 			wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
 		}

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -131,6 +131,8 @@ function wcos_merge_service_pair(WC_Product $product, $label, array $source_mark
 }
 
 function wcos_merge_service_cleanup(WC_Order $source, WC_Order $target, $operation_id) {
+	delete_option('wcos_manual_reconcile_block_' . $source->get_id());
+	delete_option('wcos_manual_reconcile_block_' . $target->get_id());
 	$fresh_source = wc_get_order($source->get_id());
 	if ($fresh_source instanceof WC_Order) {
 		WCOS_Operation_Journal::delete($fresh_source, $operation_id);
@@ -207,6 +209,185 @@ try {
 	sort($target_reduced, SORT_STRING);
 	wcos_merge_service_assert(array('1.500000', '2.000000') === $target_reduced, 'Target did not receive exact line stock ownership.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Exercise every remaining material crash boundary through the real adapter/service. */
+	$compensation_windows = array(
+		'before_target_write',
+		'after_first_target_line_persistence',
+		'after_all_target_lines_before_target_money',
+		'after_target_money_tax_persistence',
+		'after_ownership_migration_before_retirement',
+		'before_source_retirement',
+		'after_non_force_source_retirement',
+	);
+	foreach ($compensation_windows as $stage_under_test) {
+		list($source, $target) = wcos_merge_service_pair($managed, 'crash-' . $stage_under_test, array('1', '2'));
+		$operation_id = 'merge-service-crash-' . $stage_under_test . '-' . wp_generate_uuid4();
+		$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+		$hit = false;
+		$crash = static function($stage) use ($stage_under_test, &$hit) {
+			if (!$hit && $stage_under_test === $stage) {
+				$hit = true;
+				throw new WCOS_Merge_Recovery_Interruption_Exception('Injected service crash at ' . $stage_under_test);
+			}
+		};
+		add_action('wcos_merge_mutation_checkpoint', $crash, 10, 4);
+		try {
+			(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+		} catch (Throwable $throwable) {
+			/* The synchronous recovery result is asserted below. */
+		}
+		remove_action('wcos_merge_mutation_checkpoint', $crash, 10);
+		wcos_merge_service_assert($hit, 'Real service crash boundary did not execute: ' . $stage_under_test);
+		$status = wcos_merge_service_status($source, $operation_id);
+		wcos_merge_service_assert(in_array($status, array('compensated', 'manual_reconciliation'), true), 'Real service crash did not reach a safe outcome: ' . $stage_under_test);
+		$fresh_source = wc_get_order($source->get_id());
+		wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($fresh_source), 'Real service crash changed physical stock: ' . $stage_under_test);
+		if ('manual_reconciliation' === $status) {
+			wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
+		}
+		wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
+
+	/* A failure before journal authority performs no commercial or journal write. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'before-journal', array('1'));
+	$operation_id = 'merge-service-before-journal-' . wp_generate_uuid4();
+	$source_before = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
+	$target_before = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+	$before_journal_hit = false;
+	$before_journal = static function($stage) use (&$before_journal_hit) {
+		if ('before_journal_start' === $stage) {
+			$before_journal_hit = true;
+			throw new WCOS_Merge_Recovery_Interruption_Exception('Injected crash before journal start.');
+		}
+	};
+	add_action('wcos_merge_mutation_checkpoint', $before_journal, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* No journal exists yet. */
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $before_journal, 10);
+	wcos_merge_service_assert($before_journal_hit, 'Before-journal service crash did not execute.');
+	wcos_merge_service_assert(null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $operation_id), 'Before-journal crash created authority.');
+	wcos_merge_service_assert(hash_equals($source_before, WCOS_Merge_Recovery_Snapshot::participant_signature(wc_get_order($source->get_id()))), 'Before-journal crash changed source.');
+	wcos_merge_service_assert(hash_equals($target_before, WCOS_Merge_Recovery_Snapshot::participant_signature(wc_get_order($target->get_id()))), 'Before-journal crash changed target.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Post-retirement forward-repair windows complete idempotently on retry. */
+	$forward_windows = array(
+		'before_forward_relations',
+		'after_one_reciprocal_relation',
+		'after_both_relations_before_verification',
+		'after_verification_before_commit',
+		'after_commit_before_complete',
+	);
+	foreach ($forward_windows as $stage_under_test) {
+		list($source, $target) = wcos_merge_service_pair($managed, 'forward-' . $stage_under_test);
+		$operation_id = 'merge-service-forward-' . $stage_under_test . '-' . wp_generate_uuid4();
+		$hit = false;
+		$crash = static function($stage) use ($stage_under_test, &$hit) {
+			if (!$hit && $stage_under_test === $stage) {
+				$hit = true;
+				throw new WCOS_Merge_Recovery_Interruption_Exception('Injected forward crash at ' . $stage_under_test);
+			}
+		};
+		add_action('wcos_merge_recovery_checkpoint', $crash, 10, 4);
+		try {
+			(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+		} catch (Throwable $throwable) {
+			/* Retry below after removing the one-shot fault. */
+		}
+		remove_action('wcos_merge_recovery_checkpoint', $crash, 10);
+		wcos_merge_service_assert($hit, 'Real forward service crash boundary did not execute: ' . $stage_under_test);
+		$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+		wcos_merge_service_assert('completed' === $result['status'], 'Real forward service crash did not complete on retry: ' . $stage_under_test);
+		wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
+
+	/* Response loss after complete replays the exact bounded result without writes. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'response-loss');
+	$operation_id = 'merge-service-response-loss-' . wp_generate_uuid4();
+	$response_loss_hit = false;
+	$response_loss = static function($stage) use (&$response_loss_hit) {
+		if ('after_complete' === $stage) {
+			$response_loss_hit = true;
+			throw new WCOS_Merge_Recovery_Interruption_Exception('Injected response loss after complete.');
+		}
+	};
+	add_action('wcos_merge_mutation_checkpoint', $response_loss, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* The completed replay is asserted below. */
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $response_loss, 10);
+	wcos_merge_service_assert($response_loss_hit, 'Post-complete response-loss boundary did not execute.');
+	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+	wcos_merge_service_assert('completed' === $result['status'], 'Post-complete response loss did not replay safely.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Losing both participant leases between durable boundaries stops writes and recovers safely. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'lease-loss');
+	$operation_id = 'merge-service-lease-loss-' . wp_generate_uuid4();
+	$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+	$lease_loss_hit = false;
+	$lease_loss = static function($stage, $event_source, $event_target, $event_operation) use (&$lease_loss_hit) {
+		if (!$lease_loss_hit && 'before_target_money_tax_write' === $stage) {
+			$lease_loss_hit = true;
+			foreach (array($event_source->get_id(), $event_target->get_id()) as $order_id) {
+				$token = WCOS_Operation_Lock::current_token_for($order_id, $event_operation);
+				if (false !== $token) {
+					WCOS_Operation_Lock::release($order_id, $token);
+				}
+			}
+		}
+	};
+	add_action('wcos_merge_mutation_checkpoint', $lease_loss, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* Recovery reacquires the canonical pair after the lost lease. */
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $lease_loss, 10);
+	wcos_merge_service_assert($lease_loss_hit, 'Real service lease-loss boundary did not execute.');
+	wcos_merge_service_assert(in_array(wcos_merge_service_status($source, $operation_id), array('compensated', 'manual_reconciliation'), true), 'Lease loss did not preserve safe durable authority.');
+	wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock(wc_get_order($source->get_id())), 'Lease-loss recovery changed physical stock.');
+	wcos_merge_service_cleanup($source, $target, $operation_id);
+
+	/* Before-write attempts are blocked; after-write evidence becomes pair-wide manual-only. */
+	foreach (array('blocked_before_write', 'observed_after_write') as $stock_phase) {
+		list($source, $target) = wcos_merge_service_pair($managed, 'stock-guard-' . $stock_phase);
+		$operation_id = 'merge-service-stock-guard-' . $stock_phase . '-' . wp_generate_uuid4();
+		$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+		$stock_hook_hit = false;
+		$stock_fault = static function($stage) use (&$stock_hook_hit, $stock_phase, $managed) {
+			if (!$stock_hook_hit && 'after_first_target_line_persistence' === $stage) {
+				$stock_hook_hit = true;
+				do_action('blocked_before_write' === $stock_phase ? 'woocommerce_product_before_set_stock' : 'woocommerce_product_set_stock', $managed);
+			}
+		};
+		add_action('wcos_merge_mutation_checkpoint', $stock_fault, 10, 4);
+		try {
+			(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+		} catch (Throwable $throwable) {
+			/* Stable recovery/manual outcome is asserted below. */
+		}
+		remove_action('wcos_merge_mutation_checkpoint', $stock_fault, 10);
+		wcos_merge_service_assert($stock_hook_hit, 'Real service stock-guard boundary did not execute: ' . $stock_phase);
+		if ('blocked_before_write' === $stock_phase) {
+			try {
+				(new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+			} catch (Throwable $throwable) {
+				/* A compensated saga intentionally remains non-restartable. */
+			}
+			wcos_merge_service_assert('compensated' === wcos_merge_service_status($source, $operation_id), 'Blocked stock attempt did not compensate after clean retry.');
+		} else {
+			wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
+		}
+		wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock(wc_get_order($source->get_id())), 'Stock guard fixture changed physical stock: ' . $stock_phase);
+		wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
 
 	/* Real partial ownership crash: first source write and checkpoint are durable before the second boundary. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'partial-ownership', array('1', '2'));

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -165,11 +165,14 @@ function wcos_merge_service_assert_manual_pair(WC_Order $source, WC_Order $targe
 $manage_stock_before = get_option('woocommerce_manage_stock', 'yes');
 update_option('woocommerce_manage_stock', 'yes');
 $products = array();
+$suite = isset($args[0]) ? sanitize_key((string) $args[0]) : 'all';
+wcos_merge_service_assert(in_array($suite, array('all', 'core', 'crash_pre', 'crash_post', 'drift_stock'), true), 'Unknown Merge service smoke suite.');
 
 try {
 	$managed = wcos_merge_service_product('Merge managed fixture');
 	$products[] = $managed;
 
+	if (in_array($suite, array('all', 'core'), true)) {
 	/* Gateway stays hard-off while direct adapter/service acceptance is executable. */
 	list($gate_source, $gate_target) = wcos_merge_service_pair($managed, 'gate');
 	$gate_operation = 'merge-gate-' . wp_generate_uuid4();
@@ -225,7 +228,9 @@ try {
 	sort($target_reduced, SORT_STRING);
 	wcos_merge_service_assert(array('1.500000', '2.000000') === $target_reduced, 'Target did not receive exact line stock ownership.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
 
+	if (in_array($suite, array('all', 'crash_pre'), true)) {
 	/* Exercise every remaining material crash boundary through the real adapter/service. */
 	$compensation_windows = array(
 		'before_target_write',
@@ -289,7 +294,9 @@ try {
 	wcos_merge_service_assert(hash_equals($source_before, WCOS_Merge_Recovery_Snapshot::participant_signature(wc_get_order($source->get_id()))), 'Before-journal crash changed source.');
 	wcos_merge_service_assert(hash_equals($target_before, WCOS_Merge_Recovery_Snapshot::participant_signature(wc_get_order($target->get_id()))), 'Before-journal crash changed target.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
 
+	if (in_array($suite, array('all', 'crash_post'), true)) {
 	/* Post-retirement forward-repair windows complete idempotently on retry. */
 	$forward_windows = array(
 		'before_forward_relations',
@@ -408,7 +415,9 @@ try {
 		wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock(wc_get_order($source->get_id())), 'Stock guard fixture changed physical stock: ' . $stock_phase);
 		wcos_merge_service_cleanup($source, $target, $operation_id);
 	}
+	}
 
+	if (in_array($suite, array('all', 'crash_pre'), true)) {
 	/* Real partial ownership crash: first source write and checkpoint are durable before the second boundary. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'partial-ownership', array('1', '2'));
 	$operation_id = 'merge-service-partial-' . wp_generate_uuid4();
@@ -454,28 +463,9 @@ try {
 	}
 	wcos_merge_service_assert($retry_failed_closed, 'Compensated operation retry did not fail closed with a stable code.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
-
-	/* A response-loss crash between reciprocal relation writes resumes forward on retry. */
-	list($source, $target) = wcos_merge_service_pair($managed, 'relation-retry');
-	$operation_id = 'merge-service-relation-' . wp_generate_uuid4();
-	$relation_once = true;
-	$relation_crash = static function($stage) use (&$relation_once) {
-		if ($relation_once && 'after_one_reciprocal_relation' === $stage) {
-			$relation_once = false;
-			throw new WCOS_Merge_Recovery_Interruption_Exception('Injected reciprocal relation crash.');
-		}
-	};
-	add_action('wcos_merge_recovery_checkpoint', $relation_crash, 10, 4);
-	try {
-		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
-	} catch (Throwable $throwable) {
-		/* Retry after removing the injected process-loss boundary. */
 	}
-	remove_action('wcos_merge_recovery_checkpoint', $relation_crash, 10);
-	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
-	wcos_merge_service_assert('completed' === $result['status'], 'Forward relation recovery did not complete on retry.');
-	wcos_merge_service_cleanup($source, $target, $operation_id);
 
+	if (in_array($suite, array('all', 'drift_stock'), true)) {
 	/* Independent immutable-context drifts fail closed before automatic recovery writes and remain untouched. */
 	$drift_cases = array(
 		'source_billing' => static function(WC_Order $source, WC_Order $target) {
@@ -567,6 +557,7 @@ try {
 		$fresh_target = wc_get_order($target->get_id());
 		wcos_merge_service_assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($fresh_target), 'Stock matrix changed physical stock: ' . $label);
 		wcos_merge_service_cleanup(wc_get_order($source->get_id()), $fresh_target, $operation_id);
+	}
 	}
 } finally {
 	update_option('woocommerce_manage_stock', $manage_stock_before);

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -240,7 +240,7 @@ try {
 	wcos_merge_service_assert('compensated' === wcos_merge_service_status($source, $operation_id), 'Partial ownership crash did not compensate safely.');
 	$source = wc_get_order($source->get_id());
 	$target = wc_get_order($target->get_id());
-	wcos_merge_service_assert(2 === count($target->get_items('line_item')), 'Compensation did not remove operation-owned target lines.');
+	wcos_merge_service_assert(1 === count($target->get_items('line_item')), 'Compensation did not remove operation-owned target lines.');
 	foreach ($source->get_items('line_item') as $item) {
 		wcos_merge_service_assert('' !== (string) $item->get_meta('_reduced_stock', true), 'Compensation did not restore source stock ownership.');
 	}

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -173,7 +173,7 @@ $forward_suites = array(
 	'forward_after_verification_before_commit' => 'after_verification_before_commit',
 	'forward_after_commit_before_complete' => 'after_commit_before_complete',
 );
-wcos_merge_service_assert(in_array($suite, array_merge(array('all', 'core', 'crash_pre', 'response_loss', 'lease_loss', 'stock_guard_before', 'stock_guard_after', 'drift_stock'), array_keys($forward_suites)), true), 'Unknown Merge service smoke suite.');
+wcos_merge_service_assert(in_array($suite, array_merge(array('all', 'core', 'crash_pre', 'response_loss', 'lease_loss', 'stock_guard_before', 'stock_guard_after', 'drift_stock', 'checkpoint_drift'), array_keys($forward_suites)), true), 'Unknown Merge service smoke suite.');
 
 try {
 	$managed = wcos_merge_service_product('Merge managed fixture');
@@ -204,6 +204,41 @@ try {
 	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
 	$retry = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
 	wcos_merge_service_assert($result === $retry, 'Completed Merge retry did not return the stable result.');
+	$target_before_lifecycle = wc_get_order($target->get_id());
+	$item_ids_before_lifecycle = array_map('intval', array_keys($target_before_lifecycle->get_items('line_item')));
+	$tax_ids_before_lifecycle = array_map('intval', array_keys($target_before_lifecycle->get_items('tax')));
+	$completed_record = WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $operation_id);
+	$completed_pair = WCOS_Merge_Journal_Context::assert_executable_policy($completed_record);
+	$terminal_authority = WCOS_Merge_Journal_Context::terminal_result_from_record($completed_record);
+	wcos_merge_service_assert($result['target_item_ids'] === $terminal_authority['target_item_ids'], 'Terminal result did not bind the operation-owned target lines.');
+	wcos_merge_service_assert(false === strpos(wp_json_encode($completed_record['context']['merge_terminal_result']), '@example.test'), 'Terminal result persisted fixture PII.');
+	$tampered_terminal_record = $completed_record;
+	$tampered_terminal_record['context']['merge_terminal_result']['target_order_id']++;
+	$terminal_tamper_rejected = false;
+	try {
+		WCOS_Merge_Journal_Context::terminal_result_from_record($tampered_terminal_record);
+	} catch (RuntimeException $exception) {
+		$terminal_tamper_rejected = true;
+	}
+	wcos_merge_service_assert($terminal_tamper_rejected, 'Tampered Merge terminal result did not fail self-verification.');
+	$relation_before_lifecycle = WCOS_Merge_Participation::state_for_pair(wc_get_order($source->get_id()), $target_before_lifecycle, $operation_id, $completed_pair['pair_fingerprint']);
+	$ownership_before_lifecycle = array();
+	foreach ($target_before_lifecycle->get_items('line_item') as $item) {
+		$ownership_before_lifecycle[(int) $item->get_id()] = (string) $item->get_meta('_reduced_stock', true);
+	}
+	$target_before_lifecycle->set_status('processing');
+	$target_before_lifecycle->save();
+	$lifecycle_retry = (new WCOS_Merge_WooCommerce_Adapter())->merge(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $operation_id, 2);
+	$target_after_lifecycle = wc_get_order($target->get_id());
+	$ownership_after_lifecycle = array();
+	foreach ($target_after_lifecycle->get_items('line_item') as $item) {
+		$ownership_after_lifecycle[(int) $item->get_id()] = (string) $item->get_meta('_reduced_stock', true);
+	}
+	wcos_merge_service_assert($result === $lifecycle_retry, 'Post-completion target lifecycle progression lost the stable terminal result.');
+	wcos_merge_service_assert($item_ids_before_lifecycle === array_map('intval', array_keys($target_after_lifecycle->get_items('line_item'))), 'Terminal replay added target lines after lifecycle progression.');
+	wcos_merge_service_assert($tax_ids_before_lifecycle === array_map('intval', array_keys($target_after_lifecycle->get_items('tax'))), 'Terminal replay added target tax rows after lifecycle progression.');
+	wcos_merge_service_assert($relation_before_lifecycle === WCOS_Merge_Participation::state_for_pair(wc_get_order($source->get_id()), $target_after_lifecycle, $operation_id, $completed_pair['pair_fingerprint']), 'Terminal replay changed reciprocal relations after lifecycle progression.');
+	wcos_merge_service_assert($ownership_before_lifecycle === $ownership_after_lifecycle, 'Terminal replay changed stock ownership after lifecycle progression.');
 	wcos_merge_service_assert('completed' === $result['status'], 'Merge service did not complete.');
 	wcos_merge_service_assert('non_force_trash_archive' === $result['retirement_policy'], 'Result lost the binding retirement policy.');
 	wcos_merge_service_assert(2 === count($result['target_item_ids']), 'Merge did not create one fresh target line per source line.');
@@ -477,6 +512,53 @@ try {
 	}
 	wcos_merge_service_assert($retry_failed_closed, 'Compensated operation retry did not fail closed with a stable code.');
 	wcos_merge_service_cleanup($source, $target, $operation_id);
+	}
+
+	if (in_array($suite, array('all', 'drift_stock', 'checkpoint_drift'), true)) {
+	/* Persisted checkpoint-owned drift is rejected at the next service boundary before another commercial write. */
+	list($source, $target) = wcos_merge_service_pair($managed, 'checkpoint-economic-drift', array('1'));
+	$operation_id = 'merge-service-checkpoint-drift-' . wp_generate_uuid4();
+	$preexisting_target_ids = array_map('intval', array_keys($target->get_items('line_item')));
+	$drifted_total = '';
+	$drifted_checkpoint = array();
+	$tax_count_at_drift = 0;
+	$checkpoint_drift_hit = false;
+	$checkpoint_drift = static function($stage, $event_source, $event_target) use (&$checkpoint_drift_hit, &$drifted_total, &$drifted_checkpoint, &$tax_count_at_drift, $preexisting_target_ids) {
+		if ($checkpoint_drift_hit || 'after_target_line_checkpoint' !== $stage) {
+			return;
+		}
+		$checkpoint_drift_hit = true;
+		$fresh_target = wc_get_order($event_target->get_id());
+		$line = $fresh_target->get_item($preexisting_target_ids[0]);
+		$line->set_quantity(7);
+		$line->set_subtotal('70.00');
+		$line->set_total('70.00');
+		$line->save();
+		WCOS_Order_Totals_Rebuilder::rebuild($fresh_target, 2);
+		$fresh_target->save();
+		$fresh_target = wc_get_order($event_target->get_id());
+		$drifted_total = (string) $fresh_target->get_total();
+		$drifted_checkpoint = WCOS_Merge_Recovery_Snapshot::participant_checkpoint($fresh_target);
+		$tax_count_at_drift = count($fresh_target->get_items('tax'));
+	};
+	add_action('wcos_merge_mutation_checkpoint', $checkpoint_drift, 10, 4);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, 2);
+	} catch (Throwable $throwable) {
+		/* Pair-wide manual authority and untouched drift are asserted below. */
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $checkpoint_drift, 10);
+	wcos_merge_service_assert($checkpoint_drift_hit, 'Persisted checkpoint-owned drift boundary did not execute.');
+	wcos_merge_service_assert_manual_pair($source, $target, $operation_id);
+	$fresh_target = wc_get_order($target->get_id());
+	$fresh_line = $fresh_target->get_item($preexisting_target_ids[0]);
+	$checkpoint_after_rejection = WCOS_Merge_Recovery_Snapshot::participant_checkpoint($fresh_target);
+	unset($drifted_checkpoint['relation_meta'], $checkpoint_after_rejection['relation_meta']);
+	wcos_merge_service_assert('7' === (string) $fresh_line->get_quantity(), 'Recovery overwrote persisted target quantity drift.');
+	wcos_merge_service_assert($drifted_total === (string) $fresh_target->get_total(), 'Recovery overwrote persisted target amount drift.');
+	wcos_merge_service_assert($drifted_checkpoint === $checkpoint_after_rejection, 'Recovery changed checkpoint-owned target commercial state after rejecting drift.');
+	wcos_merge_service_assert($tax_count_at_drift === count($fresh_target->get_items('tax')), 'The rejected boundary persisted new tax rows.');
+	wcos_merge_service_cleanup(wc_get_order($source->get_id()), $fresh_target, $operation_id);
 	}
 
 	if (in_array($suite, array('all', 'drift_stock'), true)) {

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -252,21 +252,30 @@ $tests['merge plan rejects self merge and normalized item collisions'] = static 
 	}, InvalidArgumentException::class);
 };
 
-$tests['merge retirement candidates preserve archive and remain unselected'] = static function() {
+$tests['merge retirement policy binds non-force trash archive'] = static function() {
 	$candidates = WCOS_Merge_Retirement_Policy::candidates();
 	assert_same(array('dedicated_merged_archive', 'non_force_trash_archive'), WCOS_Merge_Retirement_Policy::identifiers());
+	assert_same('non_force_trash_archive', WCOS_Merge_Retirement_Policy::approved_identifier());
 	foreach ($candidates as $candidate) {
 		assert_same(true, $candidate['preserve_commercial_record']);
 		assert_same(false, $candidate['active_economic_owner_after']);
 		assert_same(false, $candidate['normal_active_status_after']);
 		assert_same(false, $candidate['hard_delete']);
-		assert_same(false, $candidate['production_selected']);
 	}
+	assert_same(true, $candidates['non_force_trash_archive']['production_selected']);
+	assert_same(false, $candidates['dedicated_merged_archive']['production_selected']);
+	WCOS_Merge_Retirement_Policy::assert_approved('non_force_trash_archive');
+	assert_throws(static function() {
+		WCOS_Merge_Retirement_Policy::assert_approved('dedicated_merged_archive');
+	}, RuntimeException::class);
 	WCOS_Merge_Retirement_Policy::assert_archive_preserved(str_repeat('a', 64), str_repeat('a', 64));
 	WCOS_Merge_Retirement_Policy::assert_active_ownership_conserved(str_repeat('b', 64), str_repeat('b', 64));
 };
 
 $tests['merge recovery graph accepts forward and source-first compensation paths'] = static function() {
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('no_commercial_write', 'target_staging'), 'Initial target staging transition was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('target_staging', 'target_staging'), 'Resumable target staging checkpoint was rejected.');
+	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('target_staging', 'target_persisted'), 'Target staging completion was rejected.');
 	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('no_commercial_write', 'target_persisted'), 'Initial target transition was rejected.');
 	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('source_retired', 'source_relation_persisted'), 'Reciprocal relation transition was rejected.');
 	assert_true(WCOS_Merge_Recovery_State_Graph::transition_allowed('commercial_verified', 'committed'), 'Verified commit transition was rejected.');


### PR DESCRIPTION
## Scope

Implements only the hardened Merge Service / WooCommerce Adapter requested by #42.

- binds `RETIREMENT_POLICY_APPROVED: non_force_trash_archive` in executable plan, journal, recovery, and result authority before commercial writes
- keeps `WCOS_Feature_Gates::MERGE = false`; the gateway rejects Merge before adapter delegation
- uses the existing source-keyed journal, canonical pair lease, recovery coordinator, and pair-wide manual-reconciliation authority
- creates one fresh target line per source line without re-parenting or coalescing, preserving historical line identity, taxes, totals, and supported target shipping state
- transfers `_reduced_stock` ownership line-by-line without physical stock mutation
- retires the source with non-force trash/archive semantics and verifies archived source plus active target economic conservation
- enforces immutable participant/context and commit guards before forward completion and every resumable compensation write boundary
- adds real service crash, response-loss, lease-loss, stock-guard, immutable-drift, replay, and storage-mode evidence
- adds no Review Store, Confirmation Store, AJAX/REST/admin transport, Backbone UI, sandbox enablement, or production enablement

## Exact authority

- base: `fdd820599b36c2123c74dacdef2e6b1be5e91cf7`
- head: `3f7d24d514b97e8c0a12e9ee786a187e05332c7c`
- merge base: `fdd820599b36c2123c74dacdef2e6b1be5e91cf7`
- retirement policy: `non_force_trash_archive`
- Merge gate: `false`

## Validation

- local PHP syntax and mutation-domain unit contracts: pass
- full `origin/main...HEAD` diff self-review and `git diff --check`: pass
- canonical exact-head CI: https://github.com/yoohwz/wc-order-splitter/actions/runs/32565995604
- PHP 7.4, 8.1, and 8.3 syntax/unit contracts: pass
- architecture and package safety contracts: pass
- WooCommerce 11.0.1 legacy storage: pass
- WooCommerce 11.0.1 HPOS-only storage: pass
- WooCommerce 11.0.1 HPOS-sync storage: pass
- Required CI: pass

Draft remains open pending independent technical review.
