### PR TITLE
WOS-MERGE-005 — Merge Review / Confirm / Execute Authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
             fi
           done
 
-          if grep -R --line-number -E 'new[[:space:]]+WCOS_(Split|Duplicate)_Order_Service' inc/backend inc/cores; then
+          if grep -R --line-number -E 'new[[:space:]]+WCOS_(Split|Duplicate|Merge)_(Order_Service|WooCommerce_Adapter)' inc/backend inc/cores; then
             echo 'A production controller bypasses WCOS_Mutation_Gateway.' >&2
             exit 1
           fi
@@ -144,9 +144,10 @@ jobs:
           grep -Fq 'class-wcos-merge-woocommerce-adapter.php' inc/cores/script.php
           grep -Fq 'new WCOS_Merge_WooCommerce_Adapter' inc/domain/class-wcos-mutation-gateway.php
           grep -Fq 'const APPROVED = self::NON_FORCE_TRASH_ARCHIVE;' inc/domain/class-wcos-merge-retirement-policy.php
-          test ! -e inc/backend/class-wcos-merge-admin-controller.php
-          test ! -e inc/backend/class-wcos-merge-confirmation-store.php
-          test ! -e inc/backend/class-wcos-merge-review-store.php
+          grep -Fq 'class-wcos-merge-review-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-confirmation-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-merge-admin-controller.php' inc/cores/script.php
+          grep -Fq 'WCOS_Merge_Admin_Controller::bootstrap();' inc/cores/script.php
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -246,6 +247,9 @@ jobs:
             'inc/backend/class-wcos-split-strategy-review-store.php' \
             'inc/backend/class-wcos-split-strategy-confirmation-store.php' \
             'inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'inc/backend/class-wcos-merge-review-store.php' \
+            'inc/backend/class-wcos-merge-confirmation-store.php' \
+            'inc/backend/class-wcos-merge-admin-controller.php' \
             'inc/domain/class-wcos-split-strategy-gates.php' \
             'inc/domain/class-wcos-category-split-planner.php' \
             'inc/domain/class-wcos-stock-status-split-planner.php' \
@@ -312,6 +316,9 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-review-store.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-confirmation-store.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-split-strategy-admin-controller.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-review-store.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-confirmation-store.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-admin-controller.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php'
@@ -432,6 +439,9 @@ jobs:
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
             foreach (array(
               "WC_ORDER_SPLITTER_MUTATIONS_ENABLED",
               "WC_ORDER_SPLITTER_SPLIT_ENABLED",
@@ -477,6 +487,9 @@ jobs:
 
       - name: Verify hardened Merge service and adapter core contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php core
+
+      - name: Verify hard-off Merge Review Confirm Execute authority
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-review-confirm-execute-smoke.php
 
       - name: Verify hardened Merge pre-retirement crash contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
             fi
           done
 
-          if grep -R --line-number -E 'new[[:space:]]+WCOS_(Split|Duplicate|Merge)_(Order_Service|WooCommerce_Adapter)' inc/backend inc/cores; then
+          if grep -R --line-number -E 'new[[:space:]]+WCOS_((Split|Duplicate)_Order_Service|Merge_(Order_Service|WooCommerce_Adapter))' inc/backend inc/cores; then
             echo 'A production controller bypasses WCOS_Mutation_Gateway.' >&2
             exit 1
           fi

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -1,0 +1,229 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Merge_Transport_Exception extends RuntimeException {
+	private $error_code;
+	private $http_status;
+	private $retryable;
+
+	public function __construct($error_code, $message, $http_status = 400, $retryable = false) {
+		$this->error_code = sanitize_key((string) $error_code);
+		$this->http_status = max(400, min(599, (int) $http_status));
+		$this->retryable = (bool) $retryable;
+		parent::__construct((string) $message);
+	}
+
+	public function get_error_code() { return $this->error_code; }
+	public function get_http_status() { return $this->http_status; }
+	public function is_retryable() { return $this->retryable; }
+}
+
+/** Gate-aware request boundary for a future Merge admin UI. */
+final class WCOS_Merge_Admin_Controller {
+	const REVIEW_ACTION = 'wcos_merge_review';
+	const CONFIRM_ACTION = 'wcos_merge_confirm';
+	const EXECUTE_ACTION = 'wcos_merge_execute';
+
+	private static $instance = null;
+	private $registered = false;
+
+	public static function bootstrap() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) {
+			return null;
+		}
+		if (!self::$instance instanceof self) {
+			self::$instance = new self();
+		}
+		self::$instance->register_hooks();
+		return self::$instance;
+	}
+
+	public function register_hooks() {
+		if ($this->registered || !WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) {
+			return false;
+		}
+		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		$this->registered = true;
+		return true;
+	}
+
+	public function unregister_hooks() {
+		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		$this->registered = false;
+		return true;
+	}
+
+	public function review_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'source_order_id', 'target_order_id'));
+		list($source, $target) = $this->authorized_pair($request);
+		try {
+			$report = (new WCOS_Mutation_Gateway())->merge_preflight($source, $target);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Transport_Exception('review_failed', __('Unable to review this Merge pair.', 'wc-order-splitter'), 409, false);
+		}
+		if (empty($report['supported'])) {
+			throw new WCOS_Merge_Transport_Exception(
+				'preflight_' . sanitize_key(isset($report['reason']) ? (string) $report['reason'] : 'unsupported'),
+				isset($report['message']) ? (string) $report['message'] : __('This Merge pair is not supported.', 'wc-order-splitter'),
+				409,
+				false
+			);
+		}
+		try {
+			$stored = WCOS_Merge_Review_Store::create($source, $target, $report, get_current_user_id());
+		} catch (WCOS_Merge_Review_Exception $exception) {
+			throw $this->review_exception($exception);
+		}
+
+		return array(
+			'review_id' => $stored['review_id'],
+			'review_token' => $stored['review_token'],
+			'expires_at' => $stored['expires_at'],
+			'summary' => $this->review_summary($source, $target, $report),
+		);
+	}
+
+	public function confirm_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'source_order_id', 'target_order_id', 'review_id', 'review_token'));
+		list($source, $target) = $this->authorized_pair($request);
+		$review_id = isset($request['review_id']) ? sanitize_key((string) $request['review_id']) : '';
+		$review_token = isset($request['review_token']) ? (string) $request['review_token'] : '';
+		$claimed = false;
+		try {
+			$authority = WCOS_Merge_Review_Store::claim($source, $target, $review_id, $review_token, get_current_user_id());
+			$claimed = true;
+			$confirmation = WCOS_Merge_Confirmation_Store::create($source, $target, $authority, get_current_user_id());
+			WCOS_Merge_Review_Store::consume($review_id);
+			$claimed = false;
+		} catch (WCOS_Merge_Review_Exception $exception) {
+			throw $this->review_exception($exception);
+		} catch (WCOS_Merge_Confirmation_Exception $exception) {
+			throw $this->confirmation_exception($exception);
+		} finally {
+			if ($claimed) {
+				WCOS_Merge_Review_Store::release_claim($review_id);
+			}
+		}
+
+		return array(
+			'operation_id' => $confirmation['operation_id'],
+			'confirmation_token' => $confirmation['confirmation_token'],
+			'expires_at' => $confirmation['expires_at'],
+			'source_order_id' => $source->get_id(),
+			'target_order_id' => $target->get_id(),
+		);
+	}
+
+	public function execute_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'source_order_id', 'target_order_id', 'operation_id', 'confirmation_token'));
+		list($source, $target) = $this->authorized_pair($request);
+		$operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
+		$token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
+		try {
+			$confirmation = WCOS_Merge_Confirmation_Store::verify($source, $target, $operation_id, $token, get_current_user_id());
+		} catch (WCOS_Merge_Confirmation_Exception $exception) {
+			throw $this->confirmation_exception($exception);
+		}
+
+		try {
+			$result = (new WCOS_Mutation_Gateway())->merge(
+				$source,
+				$target,
+				$operation_id,
+				$confirmation['price_precision'],
+				WCOS_Merge_Confirmation_Store::operation_authority($confirmation)
+			);
+		} catch (RuntimeException $exception) {
+			if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) {
+				throw new WCOS_Merge_Transport_Exception('workflow_disabled', __('Hardened Merge is not enabled for production use yet.', 'wc-order-splitter'), 503, false);
+			}
+			throw new WCOS_Merge_Transport_Exception('merge_failed', __('The hardened Merge request did not complete automatically.', 'wc-order-splitter'), 409, true);
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'status' => sanitize_key(isset($result['status']) ? (string) $result['status'] : 'completed'),
+			'source_order_id' => absint(isset($result['source_order_id']) ? $result['source_order_id'] : $source->get_id()),
+			'target_order_id' => absint(isset($result['target_order_id']) ? $result['target_order_id'] : $target->get_id()),
+			'retirement_policy' => sanitize_key(isset($result['retirement_policy']) ? (string) $result['retirement_policy'] : WCOS_Merge_Retirement_Policy::approved_identifier()),
+		);
+	}
+
+	public function ajax_review() { $this->send_ajax('review_request'); }
+	public function ajax_confirm() { $this->send_ajax('confirm_request'); }
+	public function ajax_execute() { $this->send_ajax('execute_request'); }
+
+	private function authorized_pair(array $request) {
+		$source_id = isset($request['source_order_id']) ? absint($request['source_order_id']) : 0;
+		$target_id = isset($request['target_order_id']) ? absint($request['target_order_id']) : 0;
+		if (!$source_id || !$target_id || $source_id === $target_id) {
+			throw new WCOS_Merge_Transport_Exception('invalid_pair', __('Merge requires two distinct order IDs.', 'wc-order-splitter'), 400, false);
+		}
+		$nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
+		if (!wp_verify_nonce($nonce, 'wcos_merge_orders_' . $source_id . '_' . $target_id)) {
+			throw new WCOS_Merge_Transport_Exception('invalid_nonce', __('The Merge request failed nonce verification.', 'wc-order-splitter'), 403, false);
+		}
+		$source = wc_get_order($source_id);
+		$target = wc_get_order($target_id);
+		if (!$source instanceof WC_Order || !$target instanceof WC_Order) {
+			throw new WCOS_Merge_Transport_Exception('participant_not_found', __('A Merge participant could not be found.', 'wc-order-splitter'), 404, false);
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $source, $target);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Transport_Exception('authorization_failed', __('You are not allowed to merge this order pair.', 'wc-order-splitter'), 403, false);
+		}
+		return array($source, $target);
+	}
+
+	private function reject_client_authority(array $request, array $allowed) {
+		foreach (array_keys($request) as $field) {
+			if (!in_array((string) $field, $allowed, true)) {
+				throw new WCOS_Merge_Transport_Exception('unexpected_field', __('The Merge request contains an unsupported field.', 'wc-order-splitter'), 400, false);
+			}
+		}
+	}
+
+	private function review_summary(WC_Order $source, WC_Order $target, array $report) {
+		$precision = (int) $report['price_precision'];
+		$projected_units = WCOS_Decimal::to_units($source->get_total(), $precision)
+			+ WCOS_Decimal::to_units($target->get_total(), $precision);
+		return array(
+			'source' => array('id' => $source->get_id(), 'number' => (string) $source->get_order_number(), 'line_count' => count($source->get_items('line_item')), 'total' => (string) $source->get_total()),
+			'target' => array('id' => $target->get_id(), 'number' => (string) $target->get_order_number(), 'line_count' => count($target->get_items('line_item')), 'total' => (string) $target->get_total()),
+			'transferable_line_count' => count($report['plan']['lines']),
+			'projected_active_target_total' => WCOS_Decimal::from_units($projected_units, $precision),
+			'currency' => (string) $source->get_currency(),
+			'price_precision' => $precision,
+			'compatibility' => array('supported' => true, 'reason' => 'supported'),
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+		);
+	}
+
+	private function review_exception(WCOS_Merge_Review_Exception $exception) {
+		$reason = $exception->get_reason();
+		$status = in_array($reason, array('invalid_identity'), true) ? 400 : (in_array($reason, array('invalid_token', 'owner_mismatch'), true) ? 403 : (in_array($reason, array('expired', 'already_consumed'), true) ? 410 : 409));
+		return new WCOS_Merge_Transport_Exception('review_' . $reason, $exception->getMessage(), $status, false);
+	}
+
+	private function confirmation_exception(WCOS_Merge_Confirmation_Exception $exception) {
+		$reason = $exception->get_reason();
+		$status = 'invalid_identity' === $reason ? 400 : (in_array($reason, array('invalid_token', 'owner_mismatch'), true) ? 403 : ('expired' === $reason ? 410 : 409));
+		return new WCOS_Merge_Transport_Exception('confirmation_' . $reason, $exception->getMessage(), $status, false);
+	}
+
+	private function send_ajax($method) {
+		try {
+			wp_send_json_success($this->{$method}(wp_unslash($_POST)));
+		} catch (WCOS_Merge_Transport_Exception $exception) {
+			wp_send_json_error(array('code' => $exception->get_error_code(), 'message' => $exception->getMessage(), 'retryable' => $exception->is_retryable()), $exception->get_http_status());
+		} catch (Throwable $throwable) {
+			wp_send_json_error(array('code' => 'merge_request_failed', 'message' => __('The Merge request could not be completed.', 'wc-order-splitter'), 'retryable' => true), 500);
+		}
+	}
+}

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -98,7 +98,10 @@ final class WCOS_Merge_Admin_Controller {
 			$authority = WCOS_Merge_Review_Store::claim($source, $target, $review_id, $review_token, get_current_user_id());
 			$claimed = true;
 			$confirmation = WCOS_Merge_Confirmation_Store::create($source, $target, $authority, get_current_user_id());
-			WCOS_Merge_Review_Store::consume($review_id);
+			if (!WCOS_Merge_Review_Store::consume($review_id)) {
+				WCOS_Merge_Confirmation_Store::delete($confirmation['operation_id']);
+				throw new WCOS_Merge_Review_Exception('consume_failed', __('The Merge Review could not be consumed safely. Review the pair again.', 'wc-order-splitter'));
+			}
 			$claimed = false;
 		} catch (WCOS_Merge_Review_Exception $exception) {
 			throw $this->review_exception($exception);

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -93,24 +93,17 @@ final class WCOS_Merge_Admin_Controller {
 		list($source, $target) = $this->authorized_pair($request);
 		$review_id = isset($request['review_id']) ? sanitize_key((string) $request['review_id']) : '';
 		$review_token = isset($request['review_token']) ? (string) $request['review_token'] : '';
-		$claimed = false;
 		try {
-			$authority = WCOS_Merge_Review_Store::claim($source, $target, $review_id, $review_token, get_current_user_id());
-			$claimed = true;
+			$authority = WCOS_Merge_Review_Store::verify($source, $target, $review_id, $review_token, get_current_user_id());
 			$confirmation = WCOS_Merge_Confirmation_Store::create($source, $target, $authority, get_current_user_id());
 			if (!WCOS_Merge_Review_Store::consume($review_id)) {
 				WCOS_Merge_Confirmation_Store::delete($confirmation['operation_id']);
-				throw new WCOS_Merge_Review_Exception('consume_failed', __('The Merge Review could not be consumed safely. Review the pair again.', 'wc-order-splitter'));
+				throw new WCOS_Merge_Review_Exception('already_consumed', __('This Merge Review was already consumed. Review the pair again.', 'wc-order-splitter'));
 			}
-			$claimed = false;
 		} catch (WCOS_Merge_Review_Exception $exception) {
 			throw $this->review_exception($exception);
 		} catch (WCOS_Merge_Confirmation_Exception $exception) {
 			throw $this->confirmation_exception($exception);
-		} finally {
-			if ($claimed) {
-				WCOS_Merge_Review_Store::release_claim($review_id);
-			}
 		}
 
 		return array(

--- a/inc/backend/class-wcos-merge-confirmation-store.php
+++ b/inc/backend/class-wcos-merge-confirmation-store.php
@@ -1,0 +1,245 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Merge_Confirmation_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/** Temporary Merge authority until the source-keyed operation journal exists. */
+final class WCOS_Merge_Confirmation_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 1800;
+
+	public static function create(WC_Order $source, WC_Order $target, array $review_authority, $user_id) {
+		$user_id = absint($user_id);
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		if (!$user_id || !$source_id || !$target_id || $source_id === $target_id) {
+			throw new WCOS_Merge_Confirmation_Exception('invalid_identity', __('Merge Confirmation requires a signed-in operator and two distinct persisted orders.', 'wc-order-splitter'));
+		}
+		if (absint(isset($review_authority['source_order_id']) ? $review_authority['source_order_id'] : 0) !== $source_id
+			|| absint(isset($review_authority['target_order_id']) ? $review_authority['target_order_id'] : 0) !== $target_id) {
+			throw new WCOS_Merge_Confirmation_Exception('review_mismatch', __('The Merge Review does not match this participant pair.', 'wc-order-splitter'));
+		}
+
+		$operation_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$now = time();
+		$record = array_merge(
+			$review_authority,
+			array(
+				'schema_version' => self::SCHEMA_VERSION,
+				'operation_id' => $operation_id,
+				'token_hash' => self::token_hash($token),
+				'user_id' => $user_id,
+				'created_at' => $now,
+				'expires_at' => $now + self::TTL,
+			)
+		);
+		self::assert_complete($record);
+		if (!set_transient(self::key($operation_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to store the temporary Merge Confirmation.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'confirmation_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'record' => $record,
+		);
+	}
+
+	public static function verify(WC_Order $source, WC_Order $target, $operation_id, $token, $user_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($operation_id) || !$user_id) {
+			throw new WCOS_Merge_Confirmation_Exception('invalid_identity', __('The Merge Confirmation identity is invalid.', 'wc-order-splitter'));
+		}
+
+		$journal = WCOS_Operation_Journal::get($source, $operation_id);
+		$record = get_transient(self::key($operation_id));
+		if (is_array($journal)) {
+			$durable = self::durable_replay($source, $target, $operation_id, $user_id, $journal);
+			if (is_array($record)) {
+				self::assert_confirmation_matches_durable($record, $durable);
+			}
+			return $durable;
+		}
+		if (!is_array($record)) {
+			throw new WCOS_Merge_Confirmation_Exception('expired', __('The Merge Confirmation expired before a journal existed. Review the pair again.', 'wc-order-splitter'));
+		}
+		if ('' === (string) $token || empty($record['token_hash']) || !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Merge_Confirmation_Exception('invalid_token', __('The Merge Confirmation token is invalid.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id
+			|| absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0) !== $source->get_id()
+			|| absint(isset($record['target_order_id']) ? $record['target_order_id'] : 0) !== $target->get_id()) {
+			throw new WCOS_Merge_Confirmation_Exception('owner_mismatch', __('The Merge Confirmation does not belong to this operator and order pair.', 'wc-order-splitter'));
+		}
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($operation_id);
+			throw new WCOS_Merge_Confirmation_Exception('expired', __('The Merge Confirmation expired before a journal existed. Review the pair again.', 'wc-order-splitter'));
+		}
+
+		self::assert_complete($record);
+		$precision = WCOS_Price_Precision_Scope::validate($record['price_precision']);
+		$report = WCOS_Merge_Preflight::report(wc_get_order($source->get_id()), wc_get_order($target->get_id()), $precision);
+		if (empty($report['supported'])) {
+			throw new WCOS_Merge_Confirmation_Exception('pair_changed', __('The Merge pair changed after Confirmation. Review it again.', 'wc-order-splitter'));
+		}
+		$current_context = WCOS_Merge_Journal_Context::create_executable(
+			wc_get_order($source->get_id()),
+			wc_get_order($target->get_id()),
+			$report['plan'],
+			$report['context_authority'],
+			$precision
+		);
+		$current = $current_context['merge_pair']['authority'];
+		if (!hash_equals((string) $record['pair_fingerprint'], (string) $current_context['merge_pair']['pair_fingerprint'])
+			|| !hash_equals((string) $record['source_signature'], (string) $current['source_signature'])
+			|| !hash_equals((string) $record['target_signature'], (string) $current['target_signature'])
+			|| $record['plan'] !== $report['plan']) {
+			throw new WCOS_Merge_Confirmation_Exception('authority_changed', __('The frozen Merge authority changed after Confirmation. Review the pair again.', 'wc-order-splitter'));
+		}
+
+		$record['replay_authority'] = 'confirmation';
+		return $record;
+	}
+
+	public static function operation_authority(array $record) {
+		self::assert_complete($record);
+		return array(
+			'confirmation_schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => sanitize_key((string) $record['operation_id']),
+			'operator_user_id' => absint($record['user_id']),
+			'source_order_id' => absint($record['source_order_id']),
+			'target_order_id' => absint($record['target_order_id']),
+			'source_signature' => sanitize_key((string) $record['source_signature']),
+			'target_signature' => sanitize_key((string) $record['target_signature']),
+			'plan' => $record['plan'],
+			'plan_fingerprint' => sanitize_key((string) $record['plan_fingerprint']),
+			'pair_fingerprint' => sanitize_key((string) $record['pair_fingerprint']),
+			'context_authority_fingerprint' => sanitize_key((string) $record['context_authority_fingerprint']),
+			'price_precision' => WCOS_Price_Precision_Scope::validate($record['price_precision']),
+			'preflight_policy_version' => absint($record['preflight_policy_version']),
+			'plan_schema_version' => absint($record['plan_schema_version']),
+			'context_signature_version' => absint($record['context_signature_version']),
+			'retirement_policy_schema_version' => absint($record['retirement_policy_schema_version']),
+			'retirement_policy' => sanitize_key((string) $record['retirement_policy']),
+		);
+	}
+
+	public static function delete($operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		return self::is_uuid($operation_id) ? delete_transient(self::key($operation_id)) : false;
+	}
+
+	private static function durable_replay(WC_Order $source, WC_Order $target, $operation_id, $user_id, array $journal) {
+		try {
+			$pair = WCOS_Merge_Journal_Context::assert_executable_policy($journal);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal authority is invalid.', 'wc-order-splitter'));
+		}
+		$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+		$confirmed = isset($context['merge_confirmation_authority']) && is_array($context['merge_confirmation_authority'])
+			? $context['merge_confirmation_authority'] : array();
+		if (absint($pair['source_order_id']) !== $source->get_id()
+			|| absint($pair['target_order_id']) !== $target->get_id()
+			|| sanitize_key(isset($journal['operation_id']) ? (string) $journal['operation_id'] : '') !== $operation_id
+			|| absint(isset($confirmed['operator_user_id']) ? $confirmed['operator_user_id'] : 0) !== $user_id
+			|| sanitize_key(isset($confirmed['confirmed_pair_fingerprint']) ? (string) $confirmed['confirmed_pair_fingerprint'] : '') !== $pair['pair_fingerprint']) {
+			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal does not match this operation, operator, and participant pair.', 'wc-order-splitter'));
+		}
+		$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		if ('manual_reconciliation' === $status) {
+			throw new WCOS_Merge_Confirmation_Exception('manual_reconciliation', __('This Merge operation requires manual reconciliation.', 'wc-order-splitter'));
+		}
+		if (in_array($status, array('compensated', 'manual_reconciled'), true)) {
+			throw new WCOS_Merge_Confirmation_Exception('operation_closed', __('This Merge operation is closed and cannot be replayed.', 'wc-order-splitter'));
+		}
+		if ('completed' === $status) {
+			$result = WCOS_Merge_Journal_Context::terminal_result_from_record($journal);
+		} elseif (in_array($status, array('recovery_required', 'recovering', 'started', 'committed', 'failed', 'compensating'), true)) {
+			if (!WCOS_Operation_Journal::require_recovery($source, $operation_id, array('reason' => 'confirmation_replay'))) {
+				throw new WCOS_Merge_Confirmation_Exception('recovery_required', __('The durable Merge operation requires recovery.', 'wc-order-splitter'));
+			}
+			$result = array();
+		} else {
+			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal has an unsupported state.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => $operation_id,
+			'user_id' => $user_id,
+			'source_order_id' => (int) $pair['source_order_id'],
+			'target_order_id' => (int) $pair['target_order_id'],
+			'source_signature' => (string) $pair['source_signature'],
+			'target_signature' => (string) $pair['target_signature'],
+			'plan' => isset($context['merge_plan']) && is_array($context['merge_plan']) ? $context['merge_plan'] : array(),
+			'plan_fingerprint' => (string) $pair['plan_fingerprint'],
+			'pair_fingerprint' => (string) $pair['pair_fingerprint'],
+			'context_authority_fingerprint' => (string) $pair['context_authority_fingerprint'],
+			'price_precision' => (int) $pair['price_precision'],
+			'preflight_policy_version' => (int) $pair['preflight_policy_version'],
+			'plan_schema_version' => (int) $pair['plan_schema_version'],
+			'context_signature_version' => (int) $pair['context_signature_version'],
+			'retirement_policy_schema_version' => (int) $pair['retirement_policy_schema_version'],
+			'retirement_policy' => (string) $pair['retirement_policy_identifier'],
+			'replay_authority' => 'journal',
+			'journal_status' => $status,
+			'terminal_result' => $result,
+		);
+	}
+
+	private static function assert_confirmation_matches_durable(array $record, array $durable) {
+		foreach (array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
+			if (!isset($record[$field], $durable[$field]) || (string) $record[$field] !== (string) $durable[$field]) {
+				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('Temporary Merge Confirmation no longer matches durable journal authority.', 'wc-order-splitter'));
+			}
+		}
+		if (!empty($durable['plan']) && $record['plan'] !== $durable['plan']) {
+			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The temporary Merge plan no longer matches durable journal authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function assert_complete(array $record) {
+		$required = array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy');
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $record) || (is_string($record[$field]) && '' === $record[$field])) {
+				throw new WCOS_Merge_Confirmation_Exception('authority_incomplete', __('The Merge Confirmation is missing frozen server authority.', 'wc-order-splitter'));
+			}
+		}
+		if (!is_array($record['plan'])
+			|| WCOS_Merge_Plan::fingerprint($record['plan']) !== (string) $record['plan_fingerprint']
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $record['retirement_policy'])
+			|| (int) $record['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
+			|| (int) $record['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
+			|| (int) $record['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (int) $record['retirement_policy_schema_version'] !== (int) WCOS_Merge_Retirement_Policy::SCHEMA_VERSION) {
+			throw new WCOS_Merge_Confirmation_Exception('authority_changed', __('The Merge Confirmation policy, plan, or schema authority changed.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($operation_id) {
+		return 'wcos_merge_confirm_' . hash('sha256', sanitize_key((string) $operation_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/backend/class-wcos-merge-confirmation-store.php
+++ b/inc/backend/class-wcos-merge-confirmation-store.php
@@ -131,6 +131,7 @@ final class WCOS_Merge_Confirmation_Store {
 			'pair_fingerprint' => sanitize_key((string) $record['pair_fingerprint']),
 			'context_authority_fingerprint' => sanitize_key((string) $record['context_authority_fingerprint']),
 			'price_precision' => WCOS_Price_Precision_Scope::validate($record['price_precision']),
+			'merge_service_policy_version' => absint($record['merge_service_policy_version']),
 			'preflight_policy_version' => absint($record['preflight_policy_version']),
 			'plan_schema_version' => absint($record['plan_schema_version']),
 			'context_signature_version' => absint($record['context_signature_version']),
@@ -147,20 +148,39 @@ final class WCOS_Merge_Confirmation_Store {
 	private static function durable_replay(WC_Order $source, WC_Order $target, $operation_id, $user_id, array $journal) {
 		try {
 			$pair = WCOS_Merge_Journal_Context::assert_executable_policy($journal);
+			$confirmed = WCOS_Merge_Journal_Context::confirmation_handoff_from_record($journal);
 		} catch (Throwable $throwable) {
 			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal authority is invalid.', 'wc-order-splitter'));
 		}
 		$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
-		$confirmed = isset($context['merge_confirmation_authority']) && is_array($context['merge_confirmation_authority'])
-			? $context['merge_confirmation_authority'] : array();
 		if (absint($pair['source_order_id']) !== $source->get_id()
 			|| absint($pair['target_order_id']) !== $target->get_id()
 			|| sanitize_key(isset($journal['operation_id']) ? (string) $journal['operation_id'] : '') !== $operation_id
 			|| absint(isset($confirmed['operator_user_id']) ? $confirmed['operator_user_id'] : 0) !== $user_id
-			|| sanitize_key(isset($confirmed['confirmed_pair_fingerprint']) ? (string) $confirmed['confirmed_pair_fingerprint'] : '') !== $pair['pair_fingerprint']) {
+			|| (int) $confirmed['confirmation_schema_version'] !== self::SCHEMA_VERSION
+			|| (int) $confirmed['merge_service_policy_version'] !== WCOS_Merge_Order_Service::POLICY_VERSION) {
 			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal does not match this operation, operator, and participant pair.', 'wc-order-splitter'));
 		}
 		$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		if (in_array($status, array('recovery_required', 'recovering', 'started', 'committed', 'failed', 'compensating'), true)) {
+			WCOS_Operation_Journal::require_recovery($source, $operation_id, array('reason' => 'confirmation_replay'));
+			$source = wc_get_order($source->get_id());
+			$journal = $source instanceof WC_Order ? WCOS_Operation_Journal::get($source, $operation_id) : null;
+			if (!is_array($journal)) {
+				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The authoritative Merge journal disappeared during recovery dispatch.', 'wc-order-splitter'));
+			}
+			try {
+				$pair = WCOS_Merge_Journal_Context::assert_executable_policy($journal);
+				$reloaded_confirmed = WCOS_Merge_Journal_Context::confirmation_handoff_from_record($journal);
+			} catch (Throwable $throwable) {
+				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The reloaded durable Merge journal authority is invalid.', 'wc-order-splitter'));
+			}
+			if ($confirmed !== $reloaded_confirmed) {
+				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge Confirmation authority changed during recovery dispatch.', 'wc-order-splitter'));
+			}
+			$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+			$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		}
 		if ('manual_reconciliation' === $status) {
 			throw new WCOS_Merge_Confirmation_Exception('manual_reconciliation', __('This Merge operation requires manual reconciliation.', 'wc-order-splitter'));
 		}
@@ -168,11 +188,12 @@ final class WCOS_Merge_Confirmation_Store {
 			throw new WCOS_Merge_Confirmation_Exception('operation_closed', __('This Merge operation is closed and cannot be replayed.', 'wc-order-splitter'));
 		}
 		if ('completed' === $status) {
-			$result = WCOS_Merge_Journal_Context::terminal_result_from_record($journal);
-		} elseif (in_array($status, array('recovery_required', 'recovering', 'started', 'committed', 'failed', 'compensating'), true)) {
-			if (!WCOS_Operation_Journal::require_recovery($source, $operation_id, array('reason' => 'confirmation_replay'))) {
-				throw new WCOS_Merge_Confirmation_Exception('recovery_required', __('The durable Merge operation requires recovery.', 'wc-order-splitter'));
+			try {
+				$result = WCOS_Merge_Journal_Context::terminal_result_from_record($journal);
+			} catch (Throwable $throwable) {
+				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge terminal result failed authority verification.', 'wc-order-splitter'));
 			}
+		} elseif (in_array($status, array('recovery_required', 'recovering', 'started', 'committed', 'failed', 'compensating'), true)) {
 			$result = array();
 		} else {
 			throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('The durable Merge journal has an unsupported state.', 'wc-order-splitter'));
@@ -191,6 +212,7 @@ final class WCOS_Merge_Confirmation_Store {
 			'pair_fingerprint' => (string) $pair['pair_fingerprint'],
 			'context_authority_fingerprint' => (string) $pair['context_authority_fingerprint'],
 			'price_precision' => (int) $pair['price_precision'],
+			'merge_service_policy_version' => (int) $confirmed['merge_service_policy_version'],
 			'preflight_policy_version' => (int) $pair['preflight_policy_version'],
 			'plan_schema_version' => (int) $pair['plan_schema_version'],
 			'context_signature_version' => (int) $pair['context_signature_version'],
@@ -199,11 +221,13 @@ final class WCOS_Merge_Confirmation_Store {
 			'replay_authority' => 'journal',
 			'journal_status' => $status,
 			'terminal_result' => $result,
+			'recovery_state' => 'completed' === $status ? 'terminal' : 'recovery_pending',
+			'retryable' => 'completed' !== $status,
 		);
 	}
 
 	private static function assert_confirmation_matches_durable(array $record, array $durable) {
-		foreach (array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
+		foreach (array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'merge_service_policy_version', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
 			if (!isset($record[$field], $durable[$field]) || (string) $record[$field] !== (string) $durable[$field]) {
 				throw new WCOS_Merge_Confirmation_Exception('journal_mismatch', __('Temporary Merge Confirmation no longer matches durable journal authority.', 'wc-order-splitter'));
 			}
@@ -214,7 +238,7 @@ final class WCOS_Merge_Confirmation_Store {
 	}
 
 	private static function assert_complete(array $record) {
-		$required = array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy');
+		$required = array('operation_id', 'user_id', 'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'merge_service_policy_version', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy');
 		foreach ($required as $field) {
 			if (!array_key_exists($field, $record) || (is_string($record[$field]) && '' === $record[$field])) {
 				throw new WCOS_Merge_Confirmation_Exception('authority_incomplete', __('The Merge Confirmation is missing frozen server authority.', 'wc-order-splitter'));
@@ -239,6 +263,7 @@ final class WCOS_Merge_Confirmation_Store {
 		if ($precision !== (int) $record['price_precision']
 			|| !hash_equals((string) $record['plan_fingerprint'], $plan_fingerprint)
 			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $record['retirement_policy'])
+			|| (int) $record['merge_service_policy_version'] !== (int) WCOS_Merge_Order_Service::POLICY_VERSION
 			|| (int) $record['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
 			|| (int) $record['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
 			|| (int) $record['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION

--- a/inc/backend/class-wcos-merge-confirmation-store.php
+++ b/inc/backend/class-wcos-merge-confirmation-store.php
@@ -220,8 +220,24 @@ final class WCOS_Merge_Confirmation_Store {
 				throw new WCOS_Merge_Confirmation_Exception('authority_incomplete', __('The Merge Confirmation is missing frozen server authority.', 'wc-order-splitter'));
 			}
 		}
-		if (!is_array($record['plan'])
-			|| WCOS_Merge_Plan::fingerprint($record['plan']) !== (string) $record['plan_fingerprint']
+		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| !self::is_uuid(sanitize_key((string) $record['operation_id']))
+			|| !absint($record['user_id']) || !absint($record['source_order_id']) || !absint($record['target_order_id'])
+			|| absint($record['source_order_id']) === absint($record['target_order_id'])
+			|| !is_array($record['plan'])
+			|| !self::is_fingerprint($record['source_signature']) || !self::is_fingerprint($record['target_signature'])
+			|| !self::is_fingerprint($record['plan_fingerprint']) || !self::is_fingerprint($record['pair_fingerprint'])
+			|| !self::is_fingerprint($record['context_authority_fingerprint'])) {
+			throw new WCOS_Merge_Confirmation_Exception('authority_incomplete', __('The Merge Confirmation identity or fingerprint authority is malformed.', 'wc-order-splitter'));
+		}
+		try {
+			$precision = WCOS_Price_Precision_Scope::validate($record['price_precision']);
+			$plan_fingerprint = WCOS_Merge_Plan::fingerprint($record['plan']);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Confirmation_Exception('authority_incomplete', __('The Merge Confirmation plan or precision authority is malformed.', 'wc-order-splitter'));
+		}
+		if ($precision !== (int) $record['price_precision']
+			|| !hash_equals((string) $record['plan_fingerprint'], $plan_fingerprint)
 			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $record['retirement_policy'])
 			|| (int) $record['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
 			|| (int) $record['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
@@ -241,5 +257,9 @@ final class WCOS_Merge_Confirmation_Store {
 
 	private static function is_uuid($value) {
 		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+
+	private static function is_fingerprint($value) {
+		return 1 === preg_match('/^[0-9a-f]{64}$/D', (string) $value);
 	}
 }

--- a/inc/backend/class-wcos-merge-review-store.php
+++ b/inc/backend/class-wcos-merge-review-store.php
@@ -1,0 +1,201 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Merge_Review_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/** Short-lived, server-owned authority for one Merge Review. */
+final class WCOS_Merge_Review_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 900;
+
+	public static function create(WC_Order $source, WC_Order $target, array $report, $user_id) {
+		$source_id = absint($source->get_id());
+		$target_id = absint($target->get_id());
+		$user_id = absint($user_id);
+		if (!$source_id || !$target_id || $source_id === $target_id || !$user_id) {
+			throw new WCOS_Merge_Review_Exception('invalid_identity', __('Merge Review requires two distinct persisted orders and a signed-in operator.', 'wc-order-splitter'));
+		}
+
+		$authority = self::authority_from_report($report, $source_id, $target_id);
+		self::assert_current($source, $target, $authority);
+		$review_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$now = time();
+		$record = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'review_id' => $review_id,
+			'token_hash' => self::token_hash($token),
+			'user_id' => $user_id,
+			'authority' => $authority,
+			'created_at' => $now,
+			'expires_at' => $now + self::TTL,
+		);
+		if (!set_transient(self::key($review_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to store the temporary Merge Review.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'review_id' => $review_id,
+			'review_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'authority' => $authority,
+		);
+	}
+
+	public static function claim(WC_Order $source, WC_Order $target, $review_id, $token, $user_id) {
+		$review_id = sanitize_key((string) $review_id);
+		if (!self::is_uuid($review_id) || !absint($user_id)) {
+			throw new WCOS_Merge_Review_Exception('invalid_identity', __('The Merge Review identity is invalid.', 'wc-order-splitter'));
+		}
+		$claim_key = self::claim_key($review_id);
+		if (!add_option($claim_key, time() + self::TTL, '', false)) {
+			$claim_expiry = (int) get_option($claim_key, 0);
+			if (!$claim_expiry || $claim_expiry >= time()) {
+				throw new WCOS_Merge_Review_Exception('already_consumed', __('This Merge Review is already being confirmed or was consumed.', 'wc-order-splitter'));
+			}
+			delete_option($claim_key);
+			if (!add_option($claim_key, time() + self::TTL, '', false)) {
+				throw new WCOS_Merge_Review_Exception('already_consumed', __('This Merge Review is already being confirmed or was consumed.', 'wc-order-splitter'));
+			}
+		}
+		try {
+			return self::verify($source, $target, $review_id, $token, $user_id);
+		} catch (Throwable $throwable) {
+			self::release_claim($review_id);
+			throw $throwable;
+		}
+	}
+
+	public static function verify(WC_Order $source, WC_Order $target, $review_id, $token, $user_id) {
+		$review_id = sanitize_key((string) $review_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($review_id) || !$user_id) {
+			throw new WCOS_Merge_Review_Exception('invalid_identity', __('The Merge Review identity is invalid.', 'wc-order-splitter'));
+		}
+		$record = get_transient(self::key($review_id));
+		if (!is_array($record)) {
+			throw new WCOS_Merge_Review_Exception('expired', __('The Merge Review expired. Review the pair again.', 'wc-order-splitter'));
+		}
+		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| empty($record['token_hash']) || '' === (string) $token
+			|| !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Merge_Review_Exception('invalid_token', __('The Merge Review token is invalid.', 'wc-order-splitter'));
+		}
+		$authority = isset($record['authority']) && is_array($record['authority']) ? $record['authority'] : array();
+		if (absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id
+			|| absint(isset($authority['source_order_id']) ? $authority['source_order_id'] : 0) !== $source->get_id()
+			|| absint(isset($authority['target_order_id']) ? $authority['target_order_id'] : 0) !== $target->get_id()) {
+			throw new WCOS_Merge_Review_Exception('owner_mismatch', __('The Merge Review does not belong to this operator and order pair.', 'wc-order-splitter'));
+		}
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($review_id);
+			throw new WCOS_Merge_Review_Exception('expired', __('The Merge Review expired. Review the pair again.', 'wc-order-splitter'));
+		}
+		self::assert_current($source, $target, $authority);
+		return $authority;
+	}
+
+	public static function consume($review_id) {
+		$deleted = self::delete($review_id);
+		self::release_claim($review_id);
+		return $deleted;
+	}
+
+	public static function release_claim($review_id) {
+		$review_id = sanitize_key((string) $review_id);
+		return self::is_uuid($review_id) ? delete_option(self::claim_key($review_id)) : false;
+	}
+
+	public static function delete($review_id) {
+		$review_id = sanitize_key((string) $review_id);
+		return self::is_uuid($review_id) ? delete_transient(self::key($review_id)) : false;
+	}
+
+	private static function authority_from_report(array $report, $source_id, $target_id) {
+		if (empty($report['supported'])
+			|| absint(isset($report['source_order_id']) ? $report['source_order_id'] : 0) !== $source_id
+			|| absint(isset($report['target_order_id']) ? $report['target_order_id'] : 0) !== $target_id
+			|| empty($report['plan']) || !is_array($report['plan'])
+			|| empty($report['context_authority']) || !is_array($report['context_authority'])) {
+			throw new WCOS_Merge_Review_Exception('review_invalid', __('The server Merge Review is incomplete or mismatched.', 'wc-order-splitter'));
+		}
+		$precision = WCOS_Price_Precision_Scope::validate(isset($report['price_precision']) ? $report['price_precision'] : null);
+		$plan = WCOS_Merge_Plan::canonicalize($source_id, $target_id, $report['plan']['lines']);
+		$context = WCOS_Merge_Journal_Context::create_executable(
+			wc_get_order($source_id),
+			wc_get_order($target_id),
+			$plan,
+			$report['context_authority'],
+			$precision
+		);
+		$pair = $context['merge_pair']['authority'];
+		return array(
+			'source_order_id' => $source_id,
+			'target_order_id' => $target_id,
+			'source_signature' => $pair['source_signature'],
+			'target_signature' => $pair['target_signature'],
+			'plan' => $plan,
+			'plan_fingerprint' => $pair['plan_fingerprint'],
+			'pair_fingerprint' => $context['merge_pair']['pair_fingerprint'],
+			'context_authority' => $pair['context_authority'],
+			'context_authority_fingerprint' => $pair['context_authority_fingerprint'],
+			'price_precision' => $precision,
+			'preflight_policy_version' => (int) $pair['preflight_policy_version'],
+			'plan_schema_version' => (int) $pair['plan_schema_version'],
+			'context_signature_version' => (int) $pair['context_signature_version'],
+			'retirement_policy_schema_version' => (int) $pair['retirement_policy_schema_version'],
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+		);
+	}
+
+	private static function assert_current(WC_Order $source, WC_Order $target, array $authority) {
+		$precision = WCOS_Price_Precision_Scope::validate(isset($authority['price_precision']) ? $authority['price_precision'] : null);
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+		if (!$source instanceof WC_Order || !$target instanceof WC_Order) {
+			throw new WCOS_Merge_Review_Exception('participant_missing', __('A Merge participant is no longer available.', 'wc-order-splitter'));
+		}
+		$report = WCOS_Merge_Preflight::report($source, $target, $precision);
+		if (empty($report['supported'])) {
+			throw new WCOS_Merge_Review_Exception('pair_changed', __('The Merge pair is no longer supported. Review it again.', 'wc-order-splitter'));
+		}
+		$current = self::authority_from_report($report, $source->get_id(), $target->get_id());
+		foreach (array('source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
+			if (!array_key_exists($field, $authority) || (string) $authority[$field] !== (string) $current[$field]) {
+				$reason = 'source_signature' === $field ? 'source_changed' : ('target_signature' === $field ? 'target_changed' : 'authority_changed');
+				throw new WCOS_Merge_Review_Exception($reason, __('The Merge pair authority changed after Review. Review the pair again.', 'wc-order-splitter'));
+			}
+		}
+		if ($authority['plan'] !== $current['plan'] || $authority['context_authority'] !== $current['context_authority']) {
+			throw new WCOS_Merge_Review_Exception('authority_changed', __('The frozen Merge plan or context changed after Review.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($review_id) {
+		return 'wcos_merge_review_' . hash('sha256', sanitize_key((string) $review_id));
+	}
+
+	private static function claim_key($review_id) {
+		return 'wcos_merge_review_claim_' . hash('sha256', sanitize_key((string) $review_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/backend/class-wcos-merge-review-store.php
+++ b/inc/backend/class-wcos-merge-review-store.php
@@ -94,6 +94,7 @@ final class WCOS_Merge_Review_Store {
 			throw new WCOS_Merge_Review_Exception('invalid_token', __('The Merge Review token is invalid.', 'wc-order-splitter'));
 		}
 		$authority = isset($record['authority']) && is_array($record['authority']) ? $record['authority'] : array();
+		self::assert_authority_complete($authority);
 		if (absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id
 			|| absint(isset($authority['source_order_id']) ? $authority['source_order_id'] : 0) !== $source->get_id()
 			|| absint(isset($authority['target_order_id']) ? $authority['target_order_id'] : 0) !== $target->get_id()) {
@@ -161,6 +162,7 @@ final class WCOS_Merge_Review_Store {
 	}
 
 	private static function assert_current(WC_Order $source, WC_Order $target, array $authority) {
+		self::assert_authority_complete($authority);
 		$precision = WCOS_Price_Precision_Scope::validate(isset($authority['price_precision']) ? $authority['price_precision'] : null);
 		$source = wc_get_order($source->get_id());
 		$target = wc_get_order($target->get_id());
@@ -183,6 +185,43 @@ final class WCOS_Merge_Review_Store {
 		}
 	}
 
+	private static function assert_authority_complete(array $authority) {
+		$required = array(
+			'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan', 'plan_fingerprint',
+			'pair_fingerprint', 'context_authority', 'context_authority_fingerprint', 'price_precision',
+			'preflight_policy_version', 'plan_schema_version', 'context_signature_version',
+			'retirement_policy_schema_version', 'retirement_policy',
+		);
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $authority)) {
+				throw new WCOS_Merge_Review_Exception('review_invalid', __('The stored Merge Review authority is incomplete.', 'wc-order-splitter'));
+			}
+		}
+		if (!absint($authority['source_order_id']) || !absint($authority['target_order_id'])
+			|| absint($authority['source_order_id']) === absint($authority['target_order_id'])
+			|| !is_array($authority['plan']) || !is_array($authority['context_authority'])
+			|| !self::is_fingerprint($authority['source_signature']) || !self::is_fingerprint($authority['target_signature'])
+			|| !self::is_fingerprint($authority['plan_fingerprint']) || !self::is_fingerprint($authority['pair_fingerprint'])
+			|| !self::is_fingerprint($authority['context_authority_fingerprint'])) {
+			throw new WCOS_Merge_Review_Exception('review_invalid', __('The stored Merge Review authority is malformed.', 'wc-order-splitter'));
+		}
+		try {
+			$precision = WCOS_Price_Precision_Scope::validate($authority['price_precision']);
+			$plan_fingerprint = WCOS_Merge_Plan::fingerprint($authority['plan']);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Review_Exception('review_invalid', __('The stored Merge Review plan or precision is malformed.', 'wc-order-splitter'));
+		}
+		if ($precision !== (int) $authority['price_precision']
+			|| !hash_equals((string) $authority['plan_fingerprint'], $plan_fingerprint)
+			|| (int) $authority['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
+			|| (int) $authority['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
+			|| (int) $authority['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (int) $authority['retirement_policy_schema_version'] !== (int) WCOS_Merge_Retirement_Policy::SCHEMA_VERSION
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $authority['retirement_policy'])) {
+			throw new WCOS_Merge_Review_Exception('authority_changed', __('The stored Merge Review policy or plan authority is no longer current.', 'wc-order-splitter'));
+		}
+	}
+
 	private static function token_hash($token) {
 		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
 	}
@@ -197,5 +236,9 @@ final class WCOS_Merge_Review_Store {
 
 	private static function is_uuid($value) {
 		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+
+	private static function is_fingerprint($value) {
+		return 1 === preg_match('/^[0-9a-f]{64}$/D', (string) $value);
 	}
 }

--- a/inc/backend/class-wcos-merge-review-store.php
+++ b/inc/backend/class-wcos-merge-review-store.php
@@ -54,30 +54,6 @@ final class WCOS_Merge_Review_Store {
 		);
 	}
 
-	public static function claim(WC_Order $source, WC_Order $target, $review_id, $token, $user_id) {
-		$review_id = sanitize_key((string) $review_id);
-		if (!self::is_uuid($review_id) || !absint($user_id)) {
-			throw new WCOS_Merge_Review_Exception('invalid_identity', __('The Merge Review identity is invalid.', 'wc-order-splitter'));
-		}
-		$claim_key = self::claim_key($review_id);
-		if (!add_option($claim_key, time() + self::TTL, '', false)) {
-			$claim_expiry = (int) get_option($claim_key, 0);
-			if (!$claim_expiry || $claim_expiry >= time()) {
-				throw new WCOS_Merge_Review_Exception('already_consumed', __('This Merge Review is already being confirmed or was consumed.', 'wc-order-splitter'));
-			}
-			delete_option($claim_key);
-			if (!add_option($claim_key, time() + self::TTL, '', false)) {
-				throw new WCOS_Merge_Review_Exception('already_consumed', __('This Merge Review is already being confirmed or was consumed.', 'wc-order-splitter'));
-			}
-		}
-		try {
-			return self::verify($source, $target, $review_id, $token, $user_id);
-		} catch (Throwable $throwable) {
-			self::release_claim($review_id);
-			throw $throwable;
-		}
-	}
-
 	public static function verify(WC_Order $source, WC_Order $target, $review_id, $token, $user_id) {
 		$review_id = sanitize_key((string) $review_id);
 		$user_id = absint($user_id);
@@ -109,14 +85,7 @@ final class WCOS_Merge_Review_Store {
 	}
 
 	public static function consume($review_id) {
-		$deleted = self::delete($review_id);
-		self::release_claim($review_id);
-		return $deleted;
-	}
-
-	public static function release_claim($review_id) {
-		$review_id = sanitize_key((string) $review_id);
-		return self::is_uuid($review_id) ? delete_option(self::claim_key($review_id)) : false;
+		return self::delete($review_id);
 	}
 
 	public static function delete($review_id) {
@@ -153,6 +122,7 @@ final class WCOS_Merge_Review_Store {
 			'context_authority' => $pair['context_authority'],
 			'context_authority_fingerprint' => $pair['context_authority_fingerprint'],
 			'price_precision' => $precision,
+			'merge_service_policy_version' => (int) WCOS_Merge_Order_Service::POLICY_VERSION,
 			'preflight_policy_version' => (int) $pair['preflight_policy_version'],
 			'plan_schema_version' => (int) $pair['plan_schema_version'],
 			'context_signature_version' => (int) $pair['context_signature_version'],
@@ -174,7 +144,7 @@ final class WCOS_Merge_Review_Store {
 			throw new WCOS_Merge_Review_Exception('pair_changed', __('The Merge pair is no longer supported. Review it again.', 'wc-order-splitter'));
 		}
 		$current = self::authority_from_report($report, $source->get_id(), $target->get_id());
-		foreach (array('source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
+		foreach (array('source_signature', 'target_signature', 'plan_fingerprint', 'pair_fingerprint', 'context_authority_fingerprint', 'price_precision', 'merge_service_policy_version', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy') as $field) {
 			if (!array_key_exists($field, $authority) || (string) $authority[$field] !== (string) $current[$field]) {
 				$reason = 'source_signature' === $field ? 'source_changed' : ('target_signature' === $field ? 'target_changed' : 'authority_changed');
 				throw new WCOS_Merge_Review_Exception($reason, __('The Merge pair authority changed after Review. Review the pair again.', 'wc-order-splitter'));
@@ -189,7 +159,7 @@ final class WCOS_Merge_Review_Store {
 		$required = array(
 			'source_order_id', 'target_order_id', 'source_signature', 'target_signature', 'plan', 'plan_fingerprint',
 			'pair_fingerprint', 'context_authority', 'context_authority_fingerprint', 'price_precision',
-			'preflight_policy_version', 'plan_schema_version', 'context_signature_version',
+			'merge_service_policy_version', 'preflight_policy_version', 'plan_schema_version', 'context_signature_version',
 			'retirement_policy_schema_version', 'retirement_policy',
 		);
 		foreach ($required as $field) {
@@ -213,6 +183,7 @@ final class WCOS_Merge_Review_Store {
 		}
 		if ($precision !== (int) $authority['price_precision']
 			|| !hash_equals((string) $authority['plan_fingerprint'], $plan_fingerprint)
+			|| (int) $authority['merge_service_policy_version'] !== (int) WCOS_Merge_Order_Service::POLICY_VERSION
 			|| (int) $authority['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
 			|| (int) $authority['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
 			|| (int) $authority['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION
@@ -228,10 +199,6 @@ final class WCOS_Merge_Review_Store {
 
 	private static function key($review_id) {
 		return 'wcos_merge_review_' . hash('sha256', sanitize_key((string) $review_id));
-	}
-
-	private static function claim_key($review_id) {
-		return 'wcos_merge_review_claim_' . hash('sha256', sanitize_key((string) $review_id));
 	}
 
 	private static function is_uuid($value) {

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -94,6 +94,11 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'backend/class-wcos-duplicate-admin-controller.php';
 		new WCOS_Duplicate_Admin_Controller();
 
+		include_once $root . 'backend/class-wcos-merge-review-store.php';
+		include_once $root . 'backend/class-wcos-merge-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-merge-admin-controller.php';
+		WCOS_Merge_Admin_Controller::bootstrap();
+
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';
 		include_once $root . 'backend/yoohw-woo-settings-tabs-reorder.php';

--- a/inc/domain/class-wcos-merge-journal-context.php
+++ b/inc/domain/class-wcos-merge-journal-context.php
@@ -9,6 +9,7 @@ final class WCOS_Merge_Journal_Context {
 
 	const SCHEMA_VERSION = 3;
 	const TERMINAL_RESULT_SCHEMA_VERSION = 1;
+	const CONFIRMATION_HANDOFF_SCHEMA_VERSION = 1;
 
 	public static function create(WC_Order $source, WC_Order $target, array $plan, array $context_authority, $price_precision, array $evidence = array(), $selected_retirement_policy = '') {
 		$source_id = absint($source->get_id());
@@ -151,6 +152,58 @@ final class WCOS_Merge_Journal_Context {
 		return $pair;
 	}
 
+	public static function create_confirmation_handoff(array $authority, array $pair) {
+		$pair_authority = isset($pair['authority']) && is_array($pair['authority']) ? $pair['authority'] : array();
+		$canonical = self::canonical_confirmation_authority($authority);
+		if (!is_array($canonical)
+			|| !isset($pair['pair_fingerprint'])
+			|| $canonical['source_order_id'] !== absint(isset($pair_authority['source_order_id']) ? $pair_authority['source_order_id'] : 0)
+			|| $canonical['target_order_id'] !== absint(isset($pair_authority['target_order_id']) ? $pair_authority['target_order_id'] : 0)
+			|| !hash_equals($canonical['pair_fingerprint'], self::normalized_fingerprint($pair['pair_fingerprint']))
+			|| !hash_equals($canonical['plan_fingerprint'], self::normalized_fingerprint(isset($pair_authority['plan_fingerprint']) ? $pair_authority['plan_fingerprint'] : ''))
+			|| !hash_equals($canonical['context_authority_fingerprint'], self::normalized_fingerprint(isset($pair_authority['context_authority_fingerprint']) ? $pair_authority['context_authority_fingerprint'] : ''))) {
+			throw new RuntimeException(__('The Merge Confirmation handoff does not match locked pair authority.', 'wc-order-splitter'));
+		}
+		return array(
+			'schema_version' => self::CONFIRMATION_HANDOFF_SCHEMA_VERSION,
+			'authority' => $canonical,
+			'authority_fingerprint' => self::confirmation_authority_fingerprint($canonical),
+		);
+	}
+
+	public static function confirmation_handoff_from_record(array $record) {
+		$pair = self::assert_executable_policy($record);
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$handoff = isset($context['merge_confirmation_authority']) && is_array($context['merge_confirmation_authority'])
+			? $context['merge_confirmation_authority'] : array();
+		$expected_keys = array('authority', 'authority_fingerprint', 'schema_version');
+		$actual_keys = array_keys($handoff);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		$authority = isset($handoff['authority']) && is_array($handoff['authority'])
+			? self::canonical_confirmation_authority($handoff['authority']) : null;
+		$fingerprint = self::normalized_fingerprint(isset($handoff['authority_fingerprint']) ? $handoff['authority_fingerprint'] : '');
+		if ($actual_keys !== $expected_keys
+			|| (int) (isset($handoff['schema_version']) ? $handoff['schema_version'] : 0) !== self::CONFIRMATION_HANDOFF_SCHEMA_VERSION
+			|| !is_array($authority) || $authority !== $handoff['authority'] || '' === $fingerprint
+			|| !hash_equals($fingerprint, self::confirmation_authority_fingerprint($authority))
+			|| sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '') !== $authority['operation_id']
+			|| (int) $pair['source_order_id'] !== $authority['source_order_id']
+			|| (int) $pair['target_order_id'] !== $authority['target_order_id']
+			|| !hash_equals((string) $pair['pair_fingerprint'], $authority['pair_fingerprint'])
+			|| !hash_equals((string) $pair['plan_fingerprint'], $authority['plan_fingerprint'])
+			|| !hash_equals((string) $pair['context_authority_fingerprint'], $authority['context_authority_fingerprint'])
+			|| (int) $pair['price_precision'] !== $authority['price_precision']
+			|| (int) $pair['preflight_policy_version'] !== $authority['preflight_policy_version']
+			|| (int) $pair['plan_schema_version'] !== $authority['plan_schema_version']
+			|| (int) $pair['context_signature_version'] !== $authority['context_signature_version']
+			|| (int) $pair['retirement_policy_schema_version'] !== $authority['retirement_policy_schema_version']
+			|| (string) $pair['retirement_policy_identifier'] !== $authority['retirement_policy']) {
+			throw new RuntimeException(__('The durable Merge Confirmation handoff failed authority verification.', 'wc-order-splitter'));
+		}
+		return $authority;
+	}
+
 	public static function is_unsafe_record(array $record) {
 		if (!is_array(self::pair_from_record($record))) {
 			return true;
@@ -232,6 +285,59 @@ final class WCOS_Merge_Journal_Context {
 	private static function terminal_result_fingerprint(array $result) {
 		unset($result['result_fingerprint']);
 		return WCOS_Mutation_Fingerprint::create('merge_terminal_result_v1', absint(isset($result['source_order_id']) ? $result['source_order_id'] : 0), $result);
+	}
+
+	private static function confirmation_authority_fingerprint(array $authority) {
+		return WCOS_Mutation_Fingerprint::create('merge_confirmation_handoff_v1', $authority['source_order_id'], $authority);
+	}
+
+	private static function canonical_confirmation_authority(array $authority) {
+		$expected_keys = array(
+			'confirmation_schema_version', 'context_authority_fingerprint', 'context_signature_version',
+			'merge_service_policy_version', 'operation_id', 'operator_user_id', 'pair_fingerprint',
+			'plan_fingerprint', 'plan_schema_version', 'preflight_policy_version', 'price_precision',
+			'retirement_policy', 'retirement_policy_schema_version', 'source_order_id', 'target_order_id',
+		);
+		$actual_keys = array_keys($authority);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		$operation_id = sanitize_key(isset($authority['operation_id']) ? (string) $authority['operation_id'] : '');
+		$source_id = absint(isset($authority['source_order_id']) ? $authority['source_order_id'] : 0);
+		$target_id = absint(isset($authority['target_order_id']) ? $authority['target_order_id'] : 0);
+		$pair_fingerprint = self::normalized_fingerprint(isset($authority['pair_fingerprint']) ? $authority['pair_fingerprint'] : '');
+		$plan_fingerprint = self::normalized_fingerprint(isset($authority['plan_fingerprint']) ? $authority['plan_fingerprint'] : '');
+		$context_fingerprint = self::normalized_fingerprint(isset($authority['context_authority_fingerprint']) ? $authority['context_authority_fingerprint'] : '');
+		$precision = isset($authority['price_precision']) ? (int) $authority['price_precision'] : -1;
+		if ($actual_keys !== $expected_keys || '' === $operation_id || !$source_id || !$target_id || $source_id === $target_id
+			|| !absint(isset($authority['operator_user_id']) ? $authority['operator_user_id'] : 0)
+			|| '' === $pair_fingerprint || '' === $plan_fingerprint || '' === $context_fingerprint
+			|| $precision !== WCOS_Price_Precision_Scope::validate($precision)
+			|| !absint(isset($authority['confirmation_schema_version']) ? $authority['confirmation_schema_version'] : 0)
+			|| (int) $authority['merge_service_policy_version'] !== WCOS_Merge_Order_Service::POLICY_VERSION
+			|| (int) $authority['preflight_policy_version'] !== WCOS_Merge_Preflight::POLICY_VERSION
+			|| (int) $authority['plan_schema_version'] !== WCOS_Merge_Plan::SCHEMA_VERSION
+			|| (int) $authority['context_signature_version'] !== WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (int) $authority['retirement_policy_schema_version'] !== WCOS_Merge_Retirement_Policy::SCHEMA_VERSION
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $authority['retirement_policy'])) {
+			return null;
+		}
+		return array(
+			'operation_id' => $operation_id,
+			'operator_user_id' => absint($authority['operator_user_id']),
+			'source_order_id' => $source_id,
+			'target_order_id' => $target_id,
+			'confirmation_schema_version' => absint($authority['confirmation_schema_version']),
+			'merge_service_policy_version' => WCOS_Merge_Order_Service::POLICY_VERSION,
+			'preflight_policy_version' => WCOS_Merge_Preflight::POLICY_VERSION,
+			'plan_schema_version' => WCOS_Merge_Plan::SCHEMA_VERSION,
+			'plan_fingerprint' => $plan_fingerprint,
+			'context_signature_version' => WCOS_Merge_Context_Signature::SCHEMA_VERSION,
+			'context_authority_fingerprint' => $context_fingerprint,
+			'pair_fingerprint' => $pair_fingerprint,
+			'price_precision' => $precision,
+			'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
+			'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+		);
 	}
 
 	private static function canonical_ids(array $ids) {

--- a/inc/domain/class-wcos-merge-order-service.php
+++ b/inc/domain/class-wcos-merge-order-service.php
@@ -362,7 +362,7 @@ final class WCOS_Merge_Order_Service {
 			'confirmation_schema_version', 'operation_id', 'operator_user_id', 'source_order_id', 'target_order_id',
 			'source_signature', 'target_signature', 'plan', 'plan_fingerprint', 'pair_fingerprint',
 			'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version',
-			'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy',
+			'merge_service_policy_version', 'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy',
 		);
 		foreach ($required as $field) {
 			if (!array_key_exists($field, $authority)) {
@@ -375,6 +375,7 @@ final class WCOS_Merge_Order_Service {
 			|| absint($authority['source_order_id']) !== $source_id
 			|| absint($authority['target_order_id']) !== $target_id
 			|| (int) $authority['price_precision'] !== (int) $precision
+			|| (int) $authority['merge_service_policy_version'] !== self::POLICY_VERSION
 			|| (int) $authority['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
 			|| (int) $authority['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
 			|| (int) $authority['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION
@@ -388,10 +389,25 @@ final class WCOS_Merge_Order_Service {
 			|| !hash_equals((string) $authority['context_authority_fingerprint'], (string) $pair_authority['context_authority_fingerprint'])) {
 			throw new RuntimeException(__('The Merge Confirmation no longer matches locked server authority.', 'wc-order-splitter'));
 		}
-		return array(
-			'schema_version' => absint($authority['confirmation_schema_version']),
-			'operator_user_id' => absint($authority['operator_user_id']),
-			'confirmed_pair_fingerprint' => sanitize_key((string) $authority['pair_fingerprint']),
+		return WCOS_Merge_Journal_Context::create_confirmation_handoff(
+			array(
+				'operation_id' => $operation_id,
+				'operator_user_id' => absint($authority['operator_user_id']),
+				'source_order_id' => $source_id,
+				'target_order_id' => $target_id,
+				'confirmation_schema_version' => absint($authority['confirmation_schema_version']),
+				'merge_service_policy_version' => self::POLICY_VERSION,
+				'preflight_policy_version' => WCOS_Merge_Preflight::POLICY_VERSION,
+				'plan_schema_version' => WCOS_Merge_Plan::SCHEMA_VERSION,
+				'plan_fingerprint' => sanitize_key((string) $authority['plan_fingerprint']),
+				'context_signature_version' => WCOS_Merge_Context_Signature::SCHEMA_VERSION,
+				'context_authority_fingerprint' => sanitize_key((string) $authority['context_authority_fingerprint']),
+				'pair_fingerprint' => sanitize_key((string) $authority['pair_fingerprint']),
+				'price_precision' => $precision,
+				'retirement_policy_schema_version' => WCOS_Merge_Retirement_Policy::SCHEMA_VERSION,
+				'retirement_policy' => WCOS_Merge_Retirement_Policy::approved_identifier(),
+			),
+			$pair
 		);
 	}
 

--- a/inc/domain/class-wcos-merge-order-service.php
+++ b/inc/domain/class-wcos-merge-order-service.php
@@ -10,7 +10,7 @@ final class WCOS_Merge_Order_Service {
 	const TYPE = 'merge';
 	const POLICY_VERSION = 1;
 
-	public function merge(WC_Order $source, WC_Order $target, $operation_id, $precision) {
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $precision, array $confirmation_authority = array()) {
 		$operation_id = sanitize_key((string) $operation_id);
 		$source_id = absint($source->get_id());
 		$target_id = absint($target->get_id());
@@ -56,6 +56,18 @@ final class WCOS_Merge_Order_Service {
 				$precision
 			);
 			$fingerprint = (string) $journal_context['merge_pair']['pair_fingerprint'];
+			if (!empty($confirmation_authority)) {
+				$journal_context['merge_confirmation_authority'] = $this->assert_confirmation_authority(
+					$confirmation_authority,
+					$operation_id,
+					$source_id,
+					$target_id,
+					$precision,
+					$plan,
+					$journal_context['merge_pair']
+				);
+				$journal_context['merge_plan'] = $plan;
+			}
 
 			$this->event('before_journal_start', $source, $target, $operation_id);
 			$this->lease_guard($lease);
@@ -343,6 +355,44 @@ final class WCOS_Merge_Order_Service {
 				throw new RuntimeException(__('A Merge source reduced-stock marker changed after planning.', 'wc-order-splitter'));
 			}
 		}
+	}
+
+	private function assert_confirmation_authority(array $authority, $operation_id, $source_id, $target_id, $precision, array $plan, array $pair) {
+		$required = array(
+			'confirmation_schema_version', 'operation_id', 'operator_user_id', 'source_order_id', 'target_order_id',
+			'source_signature', 'target_signature', 'plan', 'plan_fingerprint', 'pair_fingerprint',
+			'context_authority_fingerprint', 'price_precision', 'preflight_policy_version', 'plan_schema_version',
+			'context_signature_version', 'retirement_policy_schema_version', 'retirement_policy',
+		);
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $authority)) {
+				throw new RuntimeException(__('The Merge Confirmation authority is incomplete.', 'wc-order-splitter'));
+			}
+		}
+		$pair_authority = isset($pair['authority']) && is_array($pair['authority']) ? $pair['authority'] : array();
+		if (sanitize_key((string) $authority['operation_id']) !== $operation_id
+			|| !absint($authority['operator_user_id'])
+			|| absint($authority['source_order_id']) !== $source_id
+			|| absint($authority['target_order_id']) !== $target_id
+			|| (int) $authority['price_precision'] !== (int) $precision
+			|| (int) $authority['preflight_policy_version'] !== (int) WCOS_Merge_Preflight::POLICY_VERSION
+			|| (int) $authority['plan_schema_version'] !== (int) WCOS_Merge_Plan::SCHEMA_VERSION
+			|| (int) $authority['context_signature_version'] !== (int) WCOS_Merge_Context_Signature::SCHEMA_VERSION
+			|| (int) $authority['retirement_policy_schema_version'] !== (int) WCOS_Merge_Retirement_Policy::SCHEMA_VERSION
+			|| WCOS_Merge_Retirement_Policy::approved_identifier() !== sanitize_key((string) $authority['retirement_policy'])
+			|| $authority['plan'] !== $plan
+			|| !hash_equals((string) $authority['plan_fingerprint'], WCOS_Merge_Plan::fingerprint($plan))
+			|| !hash_equals((string) $authority['pair_fingerprint'], (string) $pair['pair_fingerprint'])
+			|| !hash_equals((string) $authority['source_signature'], (string) $pair_authority['source_signature'])
+			|| !hash_equals((string) $authority['target_signature'], (string) $pair_authority['target_signature'])
+			|| !hash_equals((string) $authority['context_authority_fingerprint'], (string) $pair_authority['context_authority_fingerprint'])) {
+			throw new RuntimeException(__('The Merge Confirmation no longer matches locked server authority.', 'wc-order-splitter'));
+		}
+		return array(
+			'schema_version' => absint($authority['confirmation_schema_version']),
+			'operator_user_id' => absint($authority['operator_user_id']),
+			'confirmed_pair_fingerprint' => sanitize_key((string) $authority['pair_fingerprint']),
+		);
 	}
 
 	private function lease_guard(WCOS_Multi_Order_Lease $lease) {

--- a/inc/domain/class-wcos-merge-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-merge-woocommerce-adapter.php
@@ -24,7 +24,7 @@ final class WCOS_Merge_Adapter_Exception extends RuntimeException {
 /** WooCommerce-facing, transport-free adapter for the hardened Merge service. */
 final class WCOS_Merge_WooCommerce_Adapter {
 
-	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null) {
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null, array $confirmation_authority = array()) {
 		$operation_id = sanitize_key((string) $operation_id);
 		if ('' === $operation_id) {
 			throw new WCOS_Merge_Adapter_Exception('invalid_operation_id', __('A Merge operation ID is required.', 'wc-order-splitter'));
@@ -70,7 +70,7 @@ final class WCOS_Merge_WooCommerce_Adapter {
 			add_action('wcos_merge_recovery_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
 
 			try {
-				$result = (new WCOS_Merge_Order_Service())->merge($source, $target, $operation_id, $precision);
+				$result = (new WCOS_Merge_Order_Service())->merge($source, $target, $operation_id, $precision, $confirmation_authority);
 				WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
 				return $result;
 			} catch (WCOS_Merge_Adapter_Exception $exception) {

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -48,10 +48,10 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Duplicate_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
 	}
 
-	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null) {
+	public function merge(WC_Order $source, WC_Order $target, $operation_id, $confirmed_precision = null, array $confirmation_authority = array()) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::MERGE);
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $source, $target);
-		return (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, $confirmed_precision);
+		return (new WCOS_Merge_WooCommerce_Adapter())->merge($source, $target, $operation_id, $confirmed_precision, $confirmation_authority);
 	}
 
 	public function merge_preflight(WC_Order $source, WC_Order $target, $operation_id = '', $confirmed_precision = null) {

--- a/tests/integration/merge-review-confirm-execute-smoke.php
+++ b/tests/integration/merge-review-confirm-execute-smoke.php
@@ -65,6 +65,11 @@ function wcos_merge_authority_cleanup(WC_Order $source, WC_Order $target, $opera
 	}
 }
 
+function wcos_merge_authority_write_journal(WC_Order $source, $operation_id, array $record) {
+	$key = 'wcos_mutation_op_' . hash('sha256', absint($source->get_id()) . '|' . sanitize_key($operation_id));
+	return update_option($key, $record, false);
+}
+
 $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
 wcos_merge_authority_assert(!empty($admins), 'Merge authority smoke requires an administrator fixture.');
 $operator_id = absint($admins[0]);
@@ -96,6 +101,7 @@ try {
 	wcos_merge_authority_assert(false === strpos($review_json, '@example.test') && false === strpos($review_json, 'Review Way'), 'Merge Review response exposed customer PII.');
 	$review_record = get_transient('wcos_merge_review_' . hash('sha256', $review['review_id']));
 	wcos_merge_authority_assert(is_array($review_record) && !empty($review_record['token_hash']), 'Merge Review hash authority was not stored.');
+	wcos_merge_authority_assert(WCOS_Merge_Order_Service::POLICY_VERSION === (int) $review_record['authority']['merge_service_policy_version'], 'Merge Review did not bind current Merge service policy authority.');
 	wcos_merge_authority_assert(false === strpos(wp_json_encode($review_record), $review['review_token']), 'Raw Merge Review token was persisted.');
 	$wrong_token_rejected = false;
 	try {
@@ -175,16 +181,25 @@ try {
 	$pairs[] = array($race_source, $race_target, '');
 	$race_request = wcos_merge_authority_request($race_source, $race_target);
 	$race_review = $controller->review_request($race_request);
-	WCOS_Merge_Review_Store::claim($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
-	$second_claim_rejected = false;
-	try {
-		WCOS_Merge_Review_Store::claim($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
-	} catch (WCOS_Merge_Review_Exception $exception) {
-		$second_claim_rejected = 'already_consumed' === $exception->get_reason();
+	$race_authority_one = WCOS_Merge_Review_Store::verify($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
+	$race_authority_two = WCOS_Merge_Review_Store::verify($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
+	$race_candidate_one = WCOS_Merge_Confirmation_Store::create($race_source, $race_target, $race_authority_one, $operator_id);
+	$race_candidate_two = WCOS_Merge_Confirmation_Store::create($race_source, $race_target, $race_authority_two, $operator_id);
+	wcos_merge_authority_assert(WCOS_Merge_Review_Store::consume($race_review['review_id']), 'The first racing Confirm did not consume the Review.');
+	$second_consumed = WCOS_Merge_Review_Store::consume($race_review['review_id']);
+	if (!$second_consumed) {
+		WCOS_Merge_Confirmation_Store::delete($race_candidate_two['operation_id']);
 	}
-	wcos_merge_authority_assert($second_claim_rejected, 'Two racing Confirm claims acquired one Merge Review.');
-	WCOS_Merge_Review_Store::release_claim($race_review['review_id']);
-	WCOS_Merge_Review_Store::delete($race_review['review_id']);
+	wcos_merge_authority_assert(false === $second_consumed, 'Two racing Confirm candidates consumed one Merge Review.');
+	wcos_merge_authority_assert(is_array(get_transient('wcos_merge_confirm_' . hash('sha256', $race_candidate_one['operation_id']))), 'The winning racing Confirmation did not survive.');
+	wcos_merge_authority_assert(false === get_transient('wcos_merge_confirm_' . hash('sha256', $race_candidate_two['operation_id'])), 'The losing racing Confirmation was not deleted.');
+	global $wpdb;
+	$claim_option_count = (int) $wpdb->get_var($wpdb->prepare(
+		"SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE %s",
+		$wpdb->esc_like('wcos_merge_review_' . 'claim_') . '%'
+	));
+	wcos_merge_authority_assert(0 === $claim_option_count, 'A persistent Merge Review coordination option remained.');
+	WCOS_Merge_Confirmation_Store::delete($race_candidate_one['operation_id']);
 
 	list($drift_source, $drift_target) = wcos_merge_authority_pair($product, 'drift');
 	$pairs[] = array($drift_source, $drift_target, '');
@@ -267,10 +282,117 @@ try {
 	$journal = WCOS_Operation_Journal::get(wc_get_order($durable_source->get_id()), $durable_confirm['operation_id']);
 	wcos_merge_authority_assert(is_array($journal) && 'completed' === $journal['status'], 'Confirmed Merge source journal is missing.');
 	wcos_merge_authority_assert(false === strpos(wp_json_encode($journal), $durable_confirm['confirmation_token']), 'Raw Confirmation token entered the durable journal.');
+	$handoff = isset($journal['context']['merge_confirmation_authority']) ? $journal['context']['merge_confirmation_authority'] : array();
+	wcos_merge_authority_assert(
+		isset($handoff['schema_version'], $handoff['authority'], $handoff['authority_fingerprint'])
+		&& WCOS_Merge_Journal_Context::CONFIRMATION_HANDOFF_SCHEMA_VERSION === (int) $handoff['schema_version']
+		&& WCOS_Merge_Order_Service::POLICY_VERSION === (int) $handoff['authority']['merge_service_policy_version'],
+		'Confirmed Merge journal is missing bounded service-policy handoff authority.'
+	);
+	wcos_merge_authority_assert(false === strpos(wp_json_encode($handoff), '@example.test'), 'Durable Merge Confirmation handoff stored plaintext customer PII.');
 	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($durable_target->get_id()), $durable_confirm['operation_id']), 'A forbidden target shadow journal was created.');
+	$matched_journal_replay = WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], $durable_confirm['confirmation_token'], $operator_id);
+	wcos_merge_authority_assert('completed' === $matched_journal_replay['journal_status'], 'Matching surviving Confirmation did not defer to the completed journal.');
+	$durable_confirm_key = 'wcos_merge_confirm_' . hash('sha256', $durable_confirm['operation_id']);
+	$surviving_confirmation = get_transient($durable_confirm_key);
+	$surviving_confirmation['user_id'] = $operator_id + 100000;
+	set_transient($durable_confirm_key, $surviving_confirmation, WCOS_Merge_Confirmation_Store::TTL);
+	$mismatched_transient_rejected = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], $durable_confirm['confirmation_token'], $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$mismatched_transient_rejected = 'journal_mismatch' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($mismatched_transient_rejected, 'A surviving mismatched Confirmation overrode durable journal authority.');
+	set_transient($durable_confirm_key, $durable_record, WCOS_Merge_Confirmation_Store::TTL);
+	$original_journal = $journal;
+	foreach (array('operator_user_id' => $operator_id + 100000, 'merge_service_policy_version' => WCOS_Merge_Order_Service::POLICY_VERSION + 1) as $field => $tampered_value) {
+		$tampered_journal = $original_journal;
+		$tampered_journal['context']['merge_confirmation_authority']['authority'][$field] = $tampered_value;
+		wcos_merge_authority_write_journal(wc_get_order($durable_source->get_id()), $durable_confirm['operation_id'], $tampered_journal);
+		$handoff_tamper_rejected = false;
+		try {
+			WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], '', $operator_id);
+		} catch (WCOS_Merge_Confirmation_Exception $exception) {
+			$handoff_tamper_rejected = 'journal_mismatch' === $exception->get_reason();
+		}
+		wcos_merge_authority_assert($handoff_tamper_rejected, 'Durable Merge handoff tamper was trusted for ' . $field . '.');
+		wcos_merge_authority_write_journal(wc_get_order($durable_source->get_id()), $durable_confirm['operation_id'], $original_journal);
+	}
 	WCOS_Merge_Confirmation_Store::delete($durable_confirm['operation_id']);
 	$journal_replay = WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], '', $operator_id);
 	wcos_merge_authority_assert('journal' === $journal_replay['replay_authority'] && 'completed' === $journal_replay['journal_status'], 'Transient loss did not defer to completed source journal authority.');
+
+	list($recovery_source, $recovery_target) = wcos_merge_authority_pair($product, 'recovery-dispatch');
+	$pairs[] = array($recovery_source, $recovery_target, '');
+	$recovery_request = wcos_merge_authority_request($recovery_source, $recovery_target);
+	$recovery_review = $controller->review_request($recovery_request);
+	$recovery_confirm = $controller->confirm_request(array_merge($recovery_request, array('review_id' => $recovery_review['review_id'], 'review_token' => $recovery_review['review_token'])));
+	$pairs[count($pairs) - 1][2] = $recovery_confirm['operation_id'];
+	$recovery_confirmation = WCOS_Merge_Confirmation_Store::verify($recovery_source, $recovery_target, $recovery_confirm['operation_id'], $recovery_confirm['confirmation_token'], $operator_id);
+	$interrupt_before_write = static function($stage) {
+		if ('before_target_write' === $stage) {
+			throw new RuntimeException('deterministic-confirmed-recovery-dispatch');
+		}
+	};
+	remove_action('wcos_mutation_recovery_required', array('WCOS_Mutation_Recovery_Coordinator', 'handle'), 10);
+	add_action('wcos_merge_mutation_checkpoint', $interrupt_before_write, PHP_INT_MAX, 1);
+	try {
+		(new WCOS_Merge_WooCommerce_Adapter())->merge(
+			$recovery_source,
+			$recovery_target,
+			$recovery_confirm['operation_id'],
+			$recovery_confirmation['price_precision'],
+			WCOS_Merge_Confirmation_Store::operation_authority($recovery_confirmation)
+		);
+	} catch (Throwable $throwable) {
+		// Expected deterministic interruption after the confirmed journal and recovery snapshot exist.
+	}
+	remove_action('wcos_merge_mutation_checkpoint', $interrupt_before_write, PHP_INT_MAX);
+	add_action('wcos_mutation_recovery_required', array('WCOS_Mutation_Recovery_Coordinator', 'handle'), 10, 3);
+	$recovery_before = WCOS_Operation_Journal::get(wc_get_order($recovery_source->get_id()), $recovery_confirm['operation_id']);
+	wcos_merge_authority_assert(is_array($recovery_before) && 'recovery_required' === $recovery_before['status'], 'Confirmed recovery fixture did not stop at recovery_required.');
+	$dispatched_closed = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify(wc_get_order($recovery_source->get_id()), wc_get_order($recovery_target->get_id()), $recovery_confirm['operation_id'], $recovery_confirm['confirmation_token'], $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$dispatched_closed = 'operation_closed' === $exception->get_reason();
+	}
+	$recovery_after = WCOS_Operation_Journal::get(wc_get_order($recovery_source->get_id()), $recovery_confirm['operation_id']);
+	wcos_merge_authority_assert($dispatched_closed && is_array($recovery_after) && 'compensated' === $recovery_after['status'], 'Recovery replay returned stale recovery_required instead of reloaded compensated authority.');
+	$compensated_closed = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify(wc_get_order($recovery_source->get_id()), wc_get_order($recovery_target->get_id()), $recovery_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$compensated_closed = 'operation_closed' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($compensated_closed, 'Compensated confirmed Merge journal was replayable.');
+
+	list($manual_source, $manual_target) = wcos_merge_authority_pair($product, 'manual-replay');
+	$pairs[] = array($manual_source, $manual_target, '');
+	$manual_request = wcos_merge_authority_request($manual_source, $manual_target);
+	$manual_review = $controller->review_request($manual_request);
+	$manual_confirm = $controller->confirm_request(array_merge($manual_request, array('review_id' => $manual_review['review_id'], 'review_token' => $manual_review['review_token'])));
+	$pairs[count($pairs) - 1][2] = $manual_confirm['operation_id'];
+	$manual_confirmation = WCOS_Merge_Confirmation_Store::verify($manual_source, $manual_target, $manual_confirm['operation_id'], $manual_confirm['confirmation_token'], $operator_id);
+	(new WCOS_Merge_WooCommerce_Adapter())->merge($manual_source, $manual_target, $manual_confirm['operation_id'], $manual_confirmation['price_precision'], WCOS_Merge_Confirmation_Store::operation_authority($manual_confirmation));
+	$manual_source = wc_get_order($manual_source->get_id());
+	wcos_merge_authority_assert(WCOS_Operation_Journal::mark_manual_reconciliation($manual_source, $manual_confirm['operation_id'], array('reason' => 'confirmed_replay_fixture')), 'Unable to establish confirmed manual-reconciliation authority.');
+	$manual_closed = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify($manual_source, wc_get_order($manual_target->get_id()), $manual_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$manual_closed = 'manual_reconciliation' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($manual_closed, 'Manual-reconciliation confirmed Merge journal did not fail closed.');
+	wcos_merge_authority_assert(WCOS_Operation_Journal::mark_manual_reconciled($manual_source, $manual_confirm['operation_id'], array('reason' => 'confirmed_replay_fixture_closed')), 'Unable to close confirmed manual-reconciliation authority.');
+	$manual_reconciled_closed = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify($manual_source, wc_get_order($manual_target->get_id()), $manual_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$manual_reconciled_closed = 'operation_closed' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($manual_reconciled_closed, 'Manual-reconciled confirmed Merge journal was replayable.');
 } finally {
 	foreach ($pairs as $pair) {
 		wcos_merge_authority_cleanup($pair[0], $pair[1], $pair[2]);

--- a/tests/integration/merge-review-confirm-execute-smoke.php
+++ b/tests/integration/merge-review-confirm-execute-smoke.php
@@ -1,0 +1,281 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_merge_authority_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_merge_authority_order(WC_Product $product, $email, $quantity) {
+	$order = wc_create_order();
+	$order->set_status('pending');
+	$order->set_currency('USD');
+	$order->set_prices_include_tax(false);
+	$order->set_billing_first_name('Authority');
+	$order->set_billing_last_name('Fixture');
+	$order->set_billing_email($email);
+	$order->set_billing_address_1('1 Review Way');
+	$order->set_billing_city('Testville');
+	$order->set_billing_country('US');
+	$order->set_shipping_first_name('Authority');
+	$order->set_shipping_last_name('Fixture');
+	$order->set_shipping_address_1('1 Review Way');
+	$order->set_shipping_city('Testville');
+	$order->set_shipping_country('US');
+	$order->set_payment_method('cod');
+	$order->set_payment_method_title('Cash on delivery');
+	$order->add_product($product, $quantity);
+	$order->calculate_totals(false);
+	$order->save();
+	return wc_get_order($order->get_id());
+}
+
+function wcos_merge_authority_pair(WC_Product $product, $label) {
+	$email = 'merge-authority-' . $label . '-' . wp_generate_uuid4() . '@example.test';
+	return array(
+		wcos_merge_authority_order($product, $email, 1),
+		wcos_merge_authority_order($product, $email, 2),
+	);
+}
+
+function wcos_merge_authority_request(WC_Order $source, WC_Order $target) {
+	return array(
+		'source_order_id' => $source->get_id(),
+		'target_order_id' => $target->get_id(),
+		'nonce' => wp_create_nonce('wcos_merge_orders_' . $source->get_id() . '_' . $target->get_id()),
+	);
+}
+
+function wcos_merge_authority_cleanup(WC_Order $source, WC_Order $target, $operation_id = '') {
+	$source = wc_get_order($source->get_id());
+	if ($source instanceof WC_Order) {
+		if ('' !== $operation_id) {
+			WCOS_Operation_Journal::delete($source, $operation_id);
+			WCOS_Merge_Confirmation_Store::delete($operation_id);
+		}
+		$source->delete(true);
+	}
+	$target = wc_get_order($target->get_id());
+	if ($target instanceof WC_Order) {
+		$target->delete(true);
+	}
+}
+
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_merge_authority_assert(!empty($admins), 'Merge authority smoke requires an administrator fixture.');
+$operator_id = absint($admins[0]);
+wp_set_current_user($operator_id);
+
+wcos_merge_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate unexpectedly enabled.');
+wcos_merge_authority_assert(null === WCOS_Merge_Admin_Controller::bootstrap(), 'Hard-off Merge controller bootstrapped.');
+$controller = new WCOS_Merge_Admin_Controller();
+wcos_merge_authority_assert(false === $controller->register_hooks(), 'Hard-off Merge controller registered hooks.');
+foreach (array(WCOS_Merge_Admin_Controller::REVIEW_ACTION, WCOS_Merge_Admin_Controller::CONFIRM_ACTION, WCOS_Merge_Admin_Controller::EXECUTE_ACTION) as $action) {
+	wcos_merge_authority_assert(false === has_action('wp_ajax_' . $action), 'A hard-off Merge AJAX hook is production-visible.');
+}
+
+$product = new WC_Product_Simple();
+$product->set_name('Merge Review authority fixture');
+$product->set_regular_price('10.00');
+$product->set_price('10.00');
+$product->set_manage_stock(false);
+wcos_merge_authority_assert($product->save() > 0, 'Unable to create Merge authority product.');
+
+$pairs = array();
+try {
+	list($source, $target) = wcos_merge_authority_pair($product, 'primary');
+	$pairs[] = array($source, $target, '');
+	$request = wcos_merge_authority_request($source, $target);
+	$review = $controller->review_request($request);
+	wcos_merge_authority_assert(!empty($review['review_id']) && !empty($review['review_token']), 'Valid Merge Review was not created.');
+	$review_json = wp_json_encode($review);
+	wcos_merge_authority_assert(false === strpos($review_json, '@example.test') && false === strpos($review_json, 'Review Way'), 'Merge Review response exposed customer PII.');
+	$review_record = get_transient('wcos_merge_review_' . hash('sha256', $review['review_id']));
+	wcos_merge_authority_assert(is_array($review_record) && !empty($review_record['token_hash']), 'Merge Review hash authority was not stored.');
+	wcos_merge_authority_assert(false === strpos(wp_json_encode($review_record), $review['review_token']), 'Raw Merge Review token was persisted.');
+	$wrong_token_rejected = false;
+	try {
+		WCOS_Merge_Review_Store::verify($source, $target, $review['review_id'], 'wrong-token', $operator_id);
+	} catch (WCOS_Merge_Review_Exception $exception) {
+		$wrong_token_rejected = 'invalid_token' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($wrong_token_rejected, 'Invalid Merge Review token was accepted.');
+	$wrong_user_rejected = false;
+	try {
+		WCOS_Merge_Review_Store::verify($source, $target, $review['review_id'], $review['review_token'], $operator_id + 100000);
+	} catch (WCOS_Merge_Review_Exception $exception) {
+		$wrong_user_rejected = 'owner_mismatch' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($wrong_user_rejected, 'Merge Review accepted the wrong operator.');
+
+	$bad_request = $request;
+	$bad_request['plan'] = array('client' => 'authority');
+	$unexpected_rejected = false;
+	try {
+		$controller->review_request($bad_request);
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$unexpected_rejected = 'unexpected_field' === $exception->get_error_code();
+	}
+	wcos_merge_authority_assert($unexpected_rejected, 'Client-authored Merge plan input was not rejected.');
+
+	$confirm = $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+	$pairs[0][2] = $confirm['operation_id'];
+	wcos_merge_authority_assert(!empty($confirm['operation_id']) && !empty($confirm['confirmation_token']), 'Valid Merge Confirmation was not created.');
+	$confirm_record = get_transient('wcos_merge_confirm_' . hash('sha256', $confirm['operation_id']));
+	wcos_merge_authority_assert(is_array($confirm_record) && !empty($confirm_record['token_hash']), 'Merge Confirmation hash authority was not stored.');
+	wcos_merge_authority_assert(false === strpos(wp_json_encode($confirm_record), $confirm['confirmation_token']), 'Raw Merge Confirmation token was persisted.');
+	wcos_merge_authority_assert(false === strpos(wp_json_encode($confirm_record), '@example.test'), 'Merge Confirmation stored plaintext customer PII.');
+	wcos_merge_authority_assert(false === get_transient('wcos_merge_review_' . hash('sha256', $review['review_id'])), 'Consumed Merge Review remained usable.');
+
+	$replay_rejected = false;
+	try {
+		$controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$replay_rejected = in_array($exception->get_error_code(), array('review_expired', 'review_already_consumed'), true);
+	}
+	wcos_merge_authority_assert($replay_rejected, 'A consumed Merge Review produced another Confirmation.');
+
+	$source_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id()));
+	$target_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id()));
+	$gate_rejected = false;
+	try {
+		$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$gate_rejected = 'workflow_disabled' === $exception->get_error_code();
+	}
+	wcos_merge_authority_assert($gate_rejected, 'Controller Execute did not stop at the Merge gateway hard-off boundary.');
+	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $confirm['operation_id']), 'Gate-off Execute created a Merge journal.');
+	wcos_merge_authority_assert($source_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id())), 'Gate-off Execute changed the source.');
+	wcos_merge_authority_assert($target_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id())), 'Gate-off Execute changed the target.');
+	$second_gate_rejected = false;
+	try {
+		$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$second_gate_rejected = 'workflow_disabled' === $exception->get_error_code();
+	}
+	wcos_merge_authority_assert($second_gate_rejected && null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $confirm['operation_id']), 'Repeated gate-off Execute changed operation authority.');
+
+	$original_confirm_record = $confirm_record;
+	$confirm_record['price_precision'] = 3;
+	set_transient('wcos_merge_confirm_' . hash('sha256', $confirm['operation_id']), $confirm_record, WCOS_Merge_Confirmation_Store::TTL);
+	$precision_drift_rejected = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify($source, $target, $confirm['operation_id'], $confirm['confirmation_token'], $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$precision_drift_rejected = in_array($exception->get_reason(), array('authority_changed', 'pair_changed'), true);
+	}
+	wcos_merge_authority_assert($precision_drift_rejected, 'Merge Confirmation precision drift was accepted.');
+	set_transient('wcos_merge_confirm_' . hash('sha256', $confirm['operation_id']), $original_confirm_record, WCOS_Merge_Confirmation_Store::TTL);
+
+	list($race_source, $race_target) = wcos_merge_authority_pair($product, 'race');
+	$pairs[] = array($race_source, $race_target, '');
+	$race_request = wcos_merge_authority_request($race_source, $race_target);
+	$race_review = $controller->review_request($race_request);
+	WCOS_Merge_Review_Store::claim($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
+	$second_claim_rejected = false;
+	try {
+		WCOS_Merge_Review_Store::claim($race_source, $race_target, $race_review['review_id'], $race_review['review_token'], $operator_id);
+	} catch (WCOS_Merge_Review_Exception $exception) {
+		$second_claim_rejected = 'already_consumed' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($second_claim_rejected, 'Two racing Confirm claims acquired one Merge Review.');
+	WCOS_Merge_Review_Store::release_claim($race_review['review_id']);
+	WCOS_Merge_Review_Store::delete($race_review['review_id']);
+
+	list($drift_source, $drift_target) = wcos_merge_authority_pair($product, 'drift');
+	$pairs[] = array($drift_source, $drift_target, '');
+	$drift_request = wcos_merge_authority_request($drift_source, $drift_target);
+	$drift_review = $controller->review_request($drift_request);
+	$drift_item = current($drift_target->get_items('line_item'));
+	$drift_item->set_quantity(3);
+	$drift_item->save();
+	$target_drift_rejected = false;
+	try {
+		$controller->confirm_request(array_merge($drift_request, array('review_id' => $drift_review['review_id'], 'review_token' => $drift_review['review_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$target_drift_rejected = in_array($exception->get_error_code(), array('review_target_changed', 'review_pair_changed', 'review_authority_changed'), true);
+	}
+	wcos_merge_authority_assert($target_drift_rejected, 'Target drift after Review was not rejected.');
+	WCOS_Merge_Review_Store::delete($drift_review['review_id']);
+
+	list($source_drift_source, $source_drift_target) = wcos_merge_authority_pair($product, 'source-drift');
+	$pairs[] = array($source_drift_source, $source_drift_target, '');
+	$source_drift_request = wcos_merge_authority_request($source_drift_source, $source_drift_target);
+	$source_drift_review = $controller->review_request($source_drift_request);
+	$source_drift_item = current($source_drift_source->get_items('line_item'));
+	$source_drift_item->set_quantity(4);
+	$source_drift_item->save();
+	$source_drift_rejected = false;
+	try {
+		$controller->confirm_request(array_merge($source_drift_request, array('review_id' => $source_drift_review['review_id'], 'review_token' => $source_drift_review['review_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$source_drift_rejected = in_array($exception->get_error_code(), array('review_source_changed', 'review_pair_changed', 'review_authority_changed'), true);
+	}
+	wcos_merge_authority_assert($source_drift_rejected, 'Source drift after Review was not rejected.');
+	WCOS_Merge_Review_Store::delete($source_drift_review['review_id']);
+
+	list($expiry_source, $expiry_target) = wcos_merge_authority_pair($product, 'expiry');
+	$pairs[] = array($expiry_source, $expiry_target, '');
+	$expiry_request = wcos_merge_authority_request($expiry_source, $expiry_target);
+	$expiry_review = $controller->review_request($expiry_request);
+	$expiry_review_key = 'wcos_merge_review_' . hash('sha256', $expiry_review['review_id']);
+	$expiry_review_record = get_transient($expiry_review_key);
+	$expiry_review_record['expires_at'] = time() - 1;
+	set_transient($expiry_review_key, $expiry_review_record, WCOS_Merge_Review_Store::TTL);
+	$review_expired = false;
+	try {
+		WCOS_Merge_Review_Store::verify($expiry_source, $expiry_target, $expiry_review['review_id'], $expiry_review['review_token'], $operator_id);
+	} catch (WCOS_Merge_Review_Exception $exception) {
+		$review_expired = 'expired' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($review_expired, 'Expired Merge Review was accepted.');
+
+	$expiry_review = $controller->review_request($expiry_request);
+	$expiry_confirm = $controller->confirm_request(array_merge($expiry_request, array('review_id' => $expiry_review['review_id'], 'review_token' => $expiry_review['review_token'])));
+	$pairs[count($pairs) - 1][2] = $expiry_confirm['operation_id'];
+	$expiry_confirm_key = 'wcos_merge_confirm_' . hash('sha256', $expiry_confirm['operation_id']);
+	$expiry_confirm_record = get_transient($expiry_confirm_key);
+	$expiry_confirm_record['expires_at'] = time() - 1;
+	set_transient($expiry_confirm_key, $expiry_confirm_record, WCOS_Merge_Confirmation_Store::TTL);
+	$confirmation_expired = false;
+	try {
+		WCOS_Merge_Confirmation_Store::verify($expiry_source, $expiry_target, $expiry_confirm['operation_id'], $expiry_confirm['confirmation_token'], $operator_id);
+	} catch (WCOS_Merge_Confirmation_Exception $exception) {
+		$confirmation_expired = 'expired' === $exception->get_reason();
+	}
+	wcos_merge_authority_assert($confirmation_expired, 'Expired pre-journal Merge Confirmation was accepted.');
+
+	list($durable_source, $durable_target) = wcos_merge_authority_pair($product, 'durable');
+	$pairs[] = array($durable_source, $durable_target, '');
+	$durable_request = wcos_merge_authority_request($durable_source, $durable_target);
+	$durable_review = $controller->review_request($durable_request);
+	$durable_confirm = $controller->confirm_request(array_merge($durable_request, array('review_id' => $durable_review['review_id'], 'review_token' => $durable_review['review_token'])));
+	$pairs[count($pairs) - 1][2] = $durable_confirm['operation_id'];
+	$durable_record = WCOS_Merge_Confirmation_Store::verify($durable_source, $durable_target, $durable_confirm['operation_id'], $durable_confirm['confirmation_token'], $operator_id);
+	$result = (new WCOS_Merge_WooCommerce_Adapter())->merge(
+		$durable_source,
+		$durable_target,
+		$durable_confirm['operation_id'],
+		$durable_record['price_precision'],
+		WCOS_Merge_Confirmation_Store::operation_authority($durable_record)
+	);
+	wcos_merge_authority_assert('completed' === $result['status'], 'Confirmed Merge did not establish completed durable replay authority.');
+	$journal = WCOS_Operation_Journal::get(wc_get_order($durable_source->get_id()), $durable_confirm['operation_id']);
+	wcos_merge_authority_assert(is_array($journal) && 'completed' === $journal['status'], 'Confirmed Merge source journal is missing.');
+	wcos_merge_authority_assert(false === strpos(wp_json_encode($journal), $durable_confirm['confirmation_token']), 'Raw Confirmation token entered the durable journal.');
+	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($durable_target->get_id()), $durable_confirm['operation_id']), 'A forbidden target shadow journal was created.');
+	WCOS_Merge_Confirmation_Store::delete($durable_confirm['operation_id']);
+	$journal_replay = WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], '', $operator_id);
+	wcos_merge_authority_assert('journal' === $journal_replay['replay_authority'] && 'completed' === $journal_replay['journal_status'], 'Transient loss did not defer to completed source journal authority.');
+} finally {
+	foreach ($pairs as $pair) {
+		wcos_merge_authority_cleanup($pair[0], $pair[1], $pair[2]);
+	}
+	$product->delete(true);
+}
+
+echo "merge-review-confirm-execute-authority-ok\n";


### PR DESCRIPTION
## Classification

P2_WOOCOMMERCE_ADAPTER

Closes #44.

## Summary

- adds short-lived, server-owned Merge Review authority with opaque HMAC-only tokens;
- consumes Review authority with the accepted candidate-Confirmation pattern: verify, create candidate, atomically consume, delete the losing candidate, expose only the winner;
- adds temporary Merge Confirmation authority only until the source-keyed journal exists, with no target shadow journal;
- creates one bounded PII-free durable Confirmation handoff before journal start, integrity-fingerprinted and bound to operation, operator, participant pair, Confirmation schema, Merge service policy, preflight/plan/context authority, precision, and retirement policy;
- makes journal replay verify that handoff before trusting operator identity or replay authority;
- reloads the authoritative source journal after recovery dispatch and normalizes completed, compensated, manual-reconciliation, closed, and unresolved retry states;
- keeps controller Execute exclusively behind WCOS_Mutation_Gateway.

## A1-A3 correction evidence

- removed all Merge-specific add_option() Review claim coordination;
- deterministic interleaving proves two candidate Confirmations can reach pre-consume, exactly one Review delete succeeds, exactly one usable Confirmation survives, the loser is deleted, and no orphan coordination option exists;
- tamper/drift evidence covers durable operator and Merge service-policy authority plus surviving transient-vs-journal mismatch;
- real confirmed-operation replay evidence covers completed, compensated, manual_reconciliation, manual_reconciled, and recovery_required dispatch reloaded to its actual compensated outcome.

## Local runtime evidence

- active Local worktree branch and pushed HEAD: codex/wos-merge-005-review-confirm-execute @ 15e45b04483bf42f9a0ab2fa61d83fa7a95cdb16;
- full PHP syntax pass and unit contracts pass;
- merge-domain-foundation-ok;
- merge-recovery-foundation-ok;
- merge-service-adapter-ok;
- merge-review-confirm-execute-authority-ok.

## Canonical exact-head CI

- exact head: 15e45b04483bf42f9a0ab2fa61d83fa7a95cdb16;
- run: https://github.com/yoohwz/wc-order-splitter/actions/runs/32571499165;
- PHP 7.4, 8.1, and 8.3 syntax/unit jobs: success;
- architecture and package safety: success;
- WooCommerce 11.0.1 legacy, HPOS, and HPOS-sync storage jobs: success;
- Required CI: success.

## Self-review

Reviewed the complete origin/main...HEAD diff. No unresolved findings. The diff remains limited to Review/Confirm/Execute authority, its gateway/service handoff, packaging/CI coverage, and tests.

## Safety

MERGE remains false. No Merge launcher, modal, assets, production-reachable AJAX hook, sandbox/production gate enablement, or paid/refund/source-shipping/coupon/fee/coalescing scope is introduced. Review/Confirmation/durable evidence contains no raw tokens or plaintext customer/payment PII.