### PR TITLE
WOS-MERGE-006 — WooCommerce Backbone Merge UI / Launcher Foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,9 @@ jobs:
           grep -Fq 'class-wcos-merge-confirmation-store.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-admin-controller.php' inc/cores/script.php
           grep -Fq 'WCOS_Merge_Admin_Controller::bootstrap();' inc/cores/script.php
+          grep -Fq "const SEARCH_ACTION = 'wcos_merge_target_search';" inc/backend/class-wcos-merge-admin-controller.php
+          grep -Fq "'wcos-merge-admin'" inc/backend/class-wcos-admin-backbone-modal-assets.php
+          grep -Fq 'window.WCOSBackboneModal.open' js/p2-merge-admin.js
           grep -Fq 'inc/domain/' AGENTS.md
           grep -Fq 'inc/domain/' docs/order-mutation-v2-contract.md
 
@@ -250,6 +253,8 @@ jobs:
             'inc/backend/class-wcos-merge-review-store.php' \
             'inc/backend/class-wcos-merge-confirmation-store.php' \
             'inc/backend/class-wcos-merge-admin-controller.php' \
+            'css/p2-merge-admin.css' \
+            'js/p2-merge-admin.js' \
             'inc/domain/class-wcos-split-strategy-gates.php' \
             'inc/domain/class-wcos-category-split-planner.php' \
             'inc/domain/class-wcos-stock-status-split-planner.php' \
@@ -319,6 +324,8 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-review-store.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-confirmation-store.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-merge-admin-controller.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-merge-admin.js'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-merge-admin.css'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-split-strategy-woocommerce-adapter.php'
@@ -439,6 +446,7 @@ jobs:
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::SEARCH_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
@@ -490,6 +498,9 @@ jobs:
 
       - name: Verify hard-off Merge Review Confirm Execute authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-review-confirm-execute-smoke.php
+
+      - name: Verify hard-off Merge UI launcher foundation
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-ui-foundation-smoke.php
 
       - name: Verify hardened Merge pre-retirement crash contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_pre

--- a/css/p2-merge-admin.css
+++ b/css/p2-merge-admin.css
@@ -1,0 +1,90 @@
+.wcos-merge-launcher-description {
+	margin-left: 8px;
+}
+
+.wcos-merge-dialog[hidden],
+.wcos-merge-review[hidden],
+.wcos-merge-error[hidden],
+.wcos-merge-result[hidden] {
+	display: none !important;
+}
+
+.wcos-merge-backbone-modal .wc-backbone-modal-content {
+	max-width: 720px;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-target-field,
+.wcos-merge-backbone-modal .wcos-merge-policy,
+.wcos-merge-backbone-modal .wcos-merge-review {
+	margin-bottom: 18px;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-target-field label,
+.wcos-merge-backbone-modal .wcos-merge-policy h3,
+.wcos-merge-backbone-modal .wcos-merge-review h3 {
+	display: block;
+	margin: 0 0 8px;
+	font-weight: 600;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-policy {
+	padding: 12px 14px;
+	border-left: 4px solid #dba617;
+	background: #fcf9e8;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-policy p,
+.wcos-merge-backbone-modal .wcos-merge-target-field .description {
+	margin: 6px 0 0;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-review-summary {
+	display: grid;
+	grid-template-columns: minmax(150px, 0.7fr) minmax(220px, 1.3fr);
+	gap: 6px 16px;
+	margin: 0 0 14px;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-review-summary dt {
+	font-weight: 600;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-review-summary dd {
+	margin: 0;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-confirm-label {
+	display: flex;
+	gap: 8px;
+	align-items: flex-start;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-status {
+	min-height: 24px;
+	margin: 8px 0;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-error,
+.wcos-merge-backbone-modal .wcos-merge-result {
+	margin: 12px 0 0;
+	padding: 10px 12px;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-result p {
+	margin: 0 0 6px;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-result p:last-child {
+	margin-bottom: 0;
+}
+
+@media (max-width: 782px) {
+	.wcos-merge-backbone-modal .wcos-merge-review-summary {
+		grid-template-columns: 1fr;
+		gap: 3px;
+	}
+
+	.wcos-merge-backbone-modal .wcos-merge-review-summary dd {
+		margin-bottom: 8px;
+	}
+}

--- a/inc/backend/class-wcos-admin-backbone-modal-assets.php
+++ b/inc/backend/class-wcos-admin-backbone-modal-assets.php
@@ -47,7 +47,7 @@ final class WCOS_Admin_Backbone_Modal_Assets {
 			return;
 		}
 
-		foreach (array('wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin') as $handle) {
+		foreach (array('wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin', 'wcos-merge-admin') as $handle) {
 			if (!isset($scripts->registered[$handle])) {
 				continue;
 			}

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -19,14 +19,20 @@ final class WCOS_Merge_Transport_Exception extends RuntimeException {
 	public function is_retryable() { return $this->retryable; }
 }
 
-/** Gate-aware request boundary for a future Merge admin UI. */
+/** Gate-aware request and presentation boundary for the future Merge workflow. */
 final class WCOS_Merge_Admin_Controller {
+	const SEARCH_ACTION = 'wcos_merge_target_search';
 	const REVIEW_ACTION = 'wcos_merge_review';
 	const CONFIRM_ACTION = 'wcos_merge_confirm';
 	const EXECUTE_ACTION = 'wcos_merge_execute';
+	const SEARCH_LIMIT = 20;
+	const SEARCH_SCAN_LIMIT = 100;
+	const SEARCH_MAX_PAGE = 5;
+	const SEARCH_MAX_TERM_LENGTH = 40;
 
 	private static $instance = null;
 	private $registered = false;
+	private $current_order = null;
 
 	public static function bootstrap() {
 		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) {
@@ -43,19 +49,84 @@ final class WCOS_Merge_Admin_Controller {
 		if ($this->registered || !WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) {
 			return false;
 		}
+		add_action('wp_ajax_' . self::SEARCH_ACTION, array($this, 'ajax_search'));
 		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 22, 1);
+		add_action('admin_footer', array($this, 'render_dialog'));
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = true;
 		return true;
 	}
 
 	public function unregister_hooks() {
+		remove_action('wp_ajax_' . self::SEARCH_ACTION, array($this, 'ajax_search'));
 		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		remove_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 22);
+		remove_action('admin_footer', array($this, 'render_dialog'));
+		remove_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = false;
 		return true;
+	}
+
+	public function search_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'source_order_id', 'term', 'page'));
+		$source = $this->authorized_source($request);
+		$term = isset($request['term']) ? sanitize_text_field((string) $request['term']) : '';
+		if (strlen($term) > self::SEARCH_MAX_TERM_LENGTH || preg_match('/[\x00-\x1F\x7F]/', $term)) {
+			throw new WCOS_Merge_Transport_Exception('invalid_search', __('The Merge target search is not valid.', 'wc-order-splitter'), 400, false);
+		}
+		$page = isset($request['page']) ? absint($request['page']) : 1;
+		if ($page < 1 || $page > self::SEARCH_MAX_PAGE) {
+			throw new WCOS_Merge_Transport_Exception('invalid_search_page', __('The Merge target search page is out of range.', 'wc-order-splitter'), 400, false);
+		}
+		return $this->search_targets($source, $term, $page);
+	}
+
+	/** Bounded PII-free selector data; production access is only through the gated AJAX hook. */
+	private function search_targets(WC_Order $source, $term = '', $page = 1) {
+		$term = strtolower(trim((string) $term));
+		$page = max(1, min(self::SEARCH_MAX_PAGE, (int) $page));
+		$statuses = array_map(
+			function ($status) { return 0 === strpos((string) $status, 'wc-') ? substr((string) $status, 3) : (string) $status; },
+			(array) get_option('order_splitter_status_allowed', array('wc-processing'))
+		);
+		$orders = wc_get_orders(
+			array(
+				'type' => 'shop_order',
+				'status' => array_values(array_filter(array_map('sanitize_key', $statuses))),
+				'exclude' => array($source->get_id()),
+				'limit' => self::SEARCH_SCAN_LIMIT,
+				'orderby' => 'date',
+				'order' => 'DESC',
+				'return' => 'objects',
+			)
+		);
+		$matches = array();
+		foreach ((array) $orders as $order) {
+			if (!$order instanceof WC_Order || $order->get_id() === $source->get_id() || !current_user_can('edit_shop_order', $order->get_id())) {
+				continue;
+			}
+			$id = (string) $order->get_id();
+			$number = (string) $order->get_order_number();
+			if ('' !== $term && false === strpos(strtolower($id), $term) && false === strpos(strtolower($number), ltrim($term, '#'))) {
+				continue;
+			}
+			$matches[] = array(
+				'id' => $order->get_id(),
+				'number' => $number,
+				'status' => (string) $order->get_status(),
+				'currency' => (string) $order->get_currency(),
+			);
+		}
+		$offset = ($page - 1) * self::SEARCH_LIMIT;
+		return array(
+			'results' => array_slice($matches, $offset, self::SEARCH_LIMIT),
+			'more' => count($matches) > $offset + self::SEARCH_LIMIT,
+		);
 	}
 
 	public function review_request(array $request) {
@@ -141,32 +212,171 @@ final class WCOS_Merge_Admin_Controller {
 			throw new WCOS_Merge_Transport_Exception('merge_failed', __('The hardened Merge request did not complete automatically.', 'wc-order-splitter'), 409, true);
 		}
 
+		$target_id = absint(isset($result['target_order_id']) ? $result['target_order_id'] : $target->get_id());
+		$persisted_target = wc_get_order($target_id);
+		if (!$persisted_target instanceof WC_Order) {
+			$persisted_target = $target;
+		}
 		return array(
 			'operation_id' => $operation_id,
 			'status' => sanitize_key(isset($result['status']) ? (string) $result['status'] : 'completed'),
 			'source_order_id' => absint(isset($result['source_order_id']) ? $result['source_order_id'] : $source->get_id()),
-			'target_order_id' => absint(isset($result['target_order_id']) ? $result['target_order_id'] : $target->get_id()),
+			'target_order_id' => $persisted_target->get_id(),
+			'target' => array(
+				'id' => $persisted_target->get_id(),
+				'number' => (string) $persisted_target->get_order_number(),
+				'status' => (string) $persisted_target->get_status(),
+				'edit_url' => method_exists($persisted_target, 'get_edit_order_url') ? esc_url_raw((string) $persisted_target->get_edit_order_url()) : '',
+			),
 			'retirement_policy' => sanitize_key(isset($result['retirement_policy']) ? (string) $result['retirement_policy'] : WCOS_Merge_Retirement_Policy::approved_identifier()),
 		);
 	}
 
+	public function ajax_search() { $this->send_ajax('search_request'); }
 	public function ajax_review() { $this->send_ajax('review_request'); }
 	public function ajax_confirm() { $this->send_ajax('confirm_request'); }
 	public function ajax_execute() { $this->send_ajax('execute_request'); }
 
-	private function authorized_pair(array $request) {
+	public function render_launcher($order) {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE) || !$order instanceof WC_Order) {
+			return;
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_merge_source($order);
+			$this->assert_status_enabled($order);
+		} catch (Throwable $throwable) {
+			return;
+		}
+		$this->current_order = $order;
+		$dialog_id = 'wcos-merge-dialog-' . $order->get_id();
+		$description_id = 'wcos-merge-launcher-description-' . $order->get_id();
+		echo '<button type="button" class="button wcos-merge-launcher" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '">';
+		echo esc_html__('Merge into another order', 'wc-order-splitter');
+		echo '</button>';
+		echo '<span id="' . esc_attr($description_id) . '" class="description wcos-merge-launcher-description">';
+		echo esc_html__('Select a target order, then review the server-owned Merge plan.', 'wc-order-splitter');
+		echo '</span>';
+	}
+
+	public function enqueue_assets() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE) || !$this->is_order_edit_screen()) {
+			return;
+		}
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_style('wcos-merge-admin', plugins_url('css/p2-merge-admin.css', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION);
+		wp_enqueue_script('wcos-merge-admin', plugins_url('js/p2-merge-admin.js', $plugin_file), array('jquery', 'selectWoo'), WC_ORDER_SPLITTER_VERSION, true);
+		wp_localize_script('wcos-merge-admin', 'wcosMergeAdminStrings', array(
+			'searching' => __('Searching orders…', 'wc-order-splitter'),
+			'reviewing' => __('Reviewing Merge pair…', 'wc-order-splitter'),
+			'reviewReady' => __('The pair passed server review. Confirm the acknowledgement to merge.', 'wc-order-splitter'),
+			'confirming' => __('Confirming reviewed Merge authority…', 'wc-order-splitter'),
+			'executing' => __('Merging orders…', 'wc-order-splitter'),
+			'retrying' => __('Retrying the same Merge operation…', 'wc-order-splitter'),
+			'completed' => __('Orders merged successfully. The source order was retired under the approved policy.', 'wc-order-splitter'),
+			'requestFailed' => __('The Merge request could not be completed.', 'wc-order-splitter'),
+			'selectTarget' => __('Select a target order first.', 'wc-order-splitter'),
+			'retryMerge' => __('Retry merge', 'wc-order-splitter'),
+			'confirmMerge' => __('Confirm and merge', 'wc-order-splitter'),
+			'closedOperation' => __('The Merge operation closed without a completed Merge. Review the orders before trying again.', 'wc-order-splitter'),
+			'targetOrder' => __('Active target order', 'wc-order-splitter'),
+		));
+	}
+
+	public function render_dialog() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE) || !$this->current_order instanceof WC_Order) {
+			return;
+		}
+		echo $this->dialog_html($this->current_order); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/** Direct template harness; production rendering remains guarded by render_dialog(). */
+	public function dialog_html(WC_Order $source) {
+		if (!$source->get_id() || 'shop_order' !== $source->get_type()) {
+			return '';
+		}
+		$dialog_id = 'wcos-merge-dialog-' . $source->get_id();
+		$title_id = $dialog_id . '-title';
+		$description_id = $dialog_id . '-description';
+		$nonce = wp_create_nonce('wcos_merge_order_' . $source->get_id());
+
+		ob_start();
+		?>
+		<div id="<?php echo esc_attr($dialog_id); ?>" class="wcos-merge-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($title_id); ?>" aria-describedby="<?php echo esc_attr($description_id); ?>" data-source-order-id="<?php echo esc_attr($source->get_id()); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" data-search-action="<?php echo esc_attr(self::SEARCH_ACTION); ?>" data-review-action="<?php echo esc_attr(self::REVIEW_ACTION); ?>" data-confirm-action="<?php echo esc_attr(self::CONFIRM_ACTION); ?>" data-execute-action="<?php echo esc_attr(self::EXECUTE_ACTION); ?>" hidden>
+			<div class="wcos-merge-dialog__backdrop" aria-hidden="true"></div>
+			<div class="wcos-merge-dialog__panel" tabindex="-1">
+				<div class="wcos-merge-dialog__header">
+					<div>
+						<h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Merge into another order', 'wc-order-splitter'); ?></h2>
+						<p id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html(sprintf(__('Current source: order #%1$s (ID %2$d). Select the active target that will receive its supported historical lines.', 'wc-order-splitter'), $source->get_order_number(), $source->get_id())); ?></p>
+					</div>
+					<button type="button" class="button-link wcos-merge-close" aria-label="<?php esc_attr_e('Close Merge dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
+				</div>
+
+				<div class="wcos-merge-target-field">
+					<label for="<?php echo esc_attr($dialog_id . '-target'); ?>"><?php esc_html_e('Target order', 'wc-order-splitter'); ?></label>
+					<select id="<?php echo esc_attr($dialog_id . '-target'); ?>" class="wcos-merge-target-select" data-placeholder="<?php esc_attr_e('Search by order ID or number', 'wc-order-splitter'); ?>"></select>
+					<p class="description"><?php esc_html_e('Search results contain only order identity, status, and currency. Selecting a target does not authorize Merge.', 'wc-order-splitter'); ?></p>
+				</div>
+
+				<div class="wcos-merge-policy" aria-labelledby="<?php echo esc_attr($dialog_id . '-policy-title'); ?>">
+					<h3 id="<?php echo esc_attr($dialog_id . '-policy-title'); ?>"><?php esc_html_e('Retirement policy', 'wc-order-splitter'); ?></h3>
+					<p><?php esc_html_e('After a successful Merge, the current source order is archived/trash using non_force_trash_archive. The selected target remains the active order.', 'wc-order-splitter'); ?></p>
+				</div>
+
+				<div class="wcos-merge-review" hidden>
+					<h3><?php esc_html_e('Server-owned Review', 'wc-order-splitter'); ?></h3>
+					<dl class="wcos-merge-review-summary"></dl>
+					<label class="wcos-merge-confirm-label">
+						<input type="checkbox" class="wcos-merge-confirm-checkbox" />
+						<span><?php esc_html_e('I reviewed this source/target pair and understand that the source will be retired while the target remains active.', 'wc-order-splitter'); ?></span>
+					</label>
+				</div>
+
+				<div class="wcos-merge-status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
+				<div class="wcos-merge-error notice notice-error inline" role="alert" tabindex="-1" hidden></div>
+				<div class="wcos-merge-result notice notice-success inline" tabindex="-1" hidden></div>
+
+				<div class="wcos-merge-dialog__actions">
+					<button type="button" class="button wcos-merge-cancel"><?php esc_html_e('Cancel', 'wc-order-splitter'); ?></button>
+					<button type="button" class="button button-secondary wcos-merge-review-button" disabled><?php esc_html_e('Review merge', 'wc-order-splitter'); ?></button>
+					<button type="button" class="button button-primary wcos-merge-execute-button" disabled><?php esc_html_e('Confirm and merge', 'wc-order-splitter'); ?></button>
+				</div>
+			</div>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	private function authorized_source(array $request) {
 		$source_id = isset($request['source_order_id']) ? absint($request['source_order_id']) : 0;
-		$target_id = isset($request['target_order_id']) ? absint($request['target_order_id']) : 0;
-		if (!$source_id || !$target_id || $source_id === $target_id) {
-			throw new WCOS_Merge_Transport_Exception('invalid_pair', __('Merge requires two distinct order IDs.', 'wc-order-splitter'), 400, false);
+		if (!$source_id) {
+			throw new WCOS_Merge_Transport_Exception('invalid_source', __('A valid Merge source order is required.', 'wc-order-splitter'), 400, false);
 		}
 		$nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
-		if (!wp_verify_nonce($nonce, 'wcos_merge_orders_' . $source_id . '_' . $target_id)) {
+		if (!wp_verify_nonce($nonce, 'wcos_merge_order_' . $source_id)) {
 			throw new WCOS_Merge_Transport_Exception('invalid_nonce', __('The Merge request failed nonce verification.', 'wc-order-splitter'), 403, false);
 		}
 		$source = wc_get_order($source_id);
+		if (!$source instanceof WC_Order) {
+			throw new WCOS_Merge_Transport_Exception('participant_not_found', __('The Merge source order could not be found.', 'wc-order-splitter'), 404, false);
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_merge_source($source);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Merge_Transport_Exception('authorization_failed', __('You are not allowed to merge this source order.', 'wc-order-splitter'), 403, false);
+		}
+		$this->assert_status_enabled($source);
+		return $source;
+	}
+
+	private function authorized_pair(array $request) {
+		$source = $this->authorized_source($request);
+		$target_id = isset($request['target_order_id']) ? absint($request['target_order_id']) : 0;
+		if (!$target_id || $source->get_id() === $target_id) {
+			throw new WCOS_Merge_Transport_Exception('invalid_pair', __('Merge requires two distinct order IDs.', 'wc-order-splitter'), 400, false);
+		}
 		$target = wc_get_order($target_id);
-		if (!$source instanceof WC_Order || !$target instanceof WC_Order) {
+		if (!$target instanceof WC_Order) {
 			throw new WCOS_Merge_Transport_Exception('participant_not_found', __('A Merge participant could not be found.', 'wc-order-splitter'), 404, false);
 		}
 		try {
@@ -174,7 +384,15 @@ final class WCOS_Merge_Admin_Controller {
 		} catch (Throwable $throwable) {
 			throw new WCOS_Merge_Transport_Exception('authorization_failed', __('You are not allowed to merge this order pair.', 'wc-order-splitter'), 403, false);
 		}
+		$this->assert_status_enabled($target);
 		return array($source, $target);
+	}
+
+	private function assert_status_enabled(WC_Order $order) {
+		$allowed = (array) get_option('order_splitter_status_allowed', array('wc-processing'));
+		if (!in_array('wc-' . $order->get_status(), $allowed, true)) {
+			throw new WCOS_Merge_Transport_Exception('status_disabled', __('This order status is disabled in the Order Splitter settings.', 'wc-order-splitter'), 409, false);
+		}
 	}
 
 	private function reject_client_authority(array $request, array $allowed) {
@@ -187,8 +405,7 @@ final class WCOS_Merge_Admin_Controller {
 
 	private function review_summary(WC_Order $source, WC_Order $target, array $report) {
 		$precision = (int) $report['price_precision'];
-		$projected_units = WCOS_Decimal::to_units($source->get_total(), $precision)
-			+ WCOS_Decimal::to_units($target->get_total(), $precision);
+		$projected_units = WCOS_Decimal::to_units($source->get_total(), $precision) + WCOS_Decimal::to_units($target->get_total(), $precision);
 		return array(
 			'source' => array('id' => $source->get_id(), 'number' => (string) $source->get_order_number(), 'line_count' => count($source->get_items('line_item')), 'total' => (string) $source->get_total()),
 			'target' => array('id' => $target->get_id(), 'number' => (string) $target->get_order_number(), 'line_count' => count($target->get_items('line_item')), 'total' => (string) $target->get_total()),
@@ -221,5 +438,15 @@ final class WCOS_Merge_Admin_Controller {
 		} catch (Throwable $throwable) {
 			wp_send_json_error(array('code' => 'merge_request_failed', 'message' => __('The Merge request could not be completed.', 'wc-order-splitter'), 'retryable' => true), 500);
 		}
+	}
+
+	private function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
 	}
 }

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -90,6 +90,13 @@ final class WCOS_Merge_Admin_Controller {
 	private function search_targets(WC_Order $source, $term = '', $page = 1) {
 		$term = strtolower(trim((string) $term));
 		$page = max(1, min(self::SEARCH_MAX_PAGE, (int) $page));
+		if (preg_match('/^#?([1-9][0-9]*)$/D', $term, $matches)) {
+			$target = wc_get_order(absint($matches[1]));
+			return array(
+				'results' => $this->is_searchable_target($source, $target) ? array($this->search_result($target)) : array(),
+				'more' => false,
+			);
+		}
 		$statuses = array_map(
 			function ($status) { return 0 === strpos((string) $status, 'wc-') ? substr((string) $status, 3) : (string) $status; },
 			(array) get_option('order_splitter_status_allowed', array('wc-processing'))
@@ -107,7 +114,7 @@ final class WCOS_Merge_Admin_Controller {
 		);
 		$matches = array();
 		foreach ((array) $orders as $order) {
-			if (!$order instanceof WC_Order || $order->get_id() === $source->get_id() || !current_user_can('edit_shop_order', $order->get_id())) {
+			if (!$this->is_searchable_target($source, $order)) {
 				continue;
 			}
 			$id = (string) $order->get_id();
@@ -115,12 +122,7 @@ final class WCOS_Merge_Admin_Controller {
 			if ('' !== $term && false === strpos(strtolower($id), $term) && false === strpos(strtolower($number), ltrim($term, '#'))) {
 				continue;
 			}
-			$matches[] = array(
-				'id' => $order->get_id(),
-				'number' => $number,
-				'status' => (string) $order->get_status(),
-				'currency' => (string) $order->get_currency(),
-			);
+			$matches[] = $this->search_result($order);
 		}
 		$offset = ($page - 1) * self::SEARCH_LIMIT;
 		return array(
@@ -188,13 +190,18 @@ final class WCOS_Merge_Admin_Controller {
 
 	public function execute_request(array $request) {
 		$this->reject_client_authority($request, array('action', 'nonce', 'source_order_id', 'target_order_id', 'operation_id', 'confirmation_token'));
-		list($source, $target) = $this->authorized_pair($request);
 		$operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
 		$token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
-		try {
-			$confirmation = WCOS_Merge_Confirmation_Store::verify($source, $target, $operation_id, $token, get_current_user_id());
-		} catch (WCOS_Merge_Confirmation_Exception $exception) {
-			throw $this->confirmation_exception($exception);
+		list($source, $target) = $this->authorized_pair($request, false);
+		$journal = WCOS_Operation_Journal::get($source, $operation_id);
+		if (is_array($journal)) {
+			// Durable replay authority is fully self-verified before stale UI status is relaxed.
+			$confirmation = $this->verified_confirmation($source, $target, $operation_id, $token);
+		} else {
+			// A first Execute remains bound to the current source/target surface eligibility.
+			$this->assert_status_enabled($source);
+			$this->assert_status_enabled($target);
+			$confirmation = $this->verified_confirmation($source, $target, $operation_id, $token);
 		}
 
 		try {
@@ -347,7 +354,7 @@ final class WCOS_Merge_Admin_Controller {
 		return (string) ob_get_clean();
 	}
 
-	private function authorized_source(array $request) {
+	private function authorized_source(array $request, $require_status = true) {
 		$source_id = isset($request['source_order_id']) ? absint($request['source_order_id']) : 0;
 		if (!$source_id) {
 			throw new WCOS_Merge_Transport_Exception('invalid_source', __('A valid Merge source order is required.', 'wc-order-splitter'), 400, false);
@@ -365,12 +372,14 @@ final class WCOS_Merge_Admin_Controller {
 		} catch (Throwable $throwable) {
 			throw new WCOS_Merge_Transport_Exception('authorization_failed', __('You are not allowed to merge this source order.', 'wc-order-splitter'), 403, false);
 		}
-		$this->assert_status_enabled($source);
+		if ($require_status) {
+			$this->assert_status_enabled($source);
+		}
 		return $source;
 	}
 
-	private function authorized_pair(array $request) {
-		$source = $this->authorized_source($request);
+	private function authorized_pair(array $request, $require_status = true) {
+		$source = $this->authorized_source($request, $require_status);
 		$target_id = isset($request['target_order_id']) ? absint($request['target_order_id']) : 0;
 		if (!$target_id || $source->get_id() === $target_id) {
 			throw new WCOS_Merge_Transport_Exception('invalid_pair', __('Merge requires two distinct order IDs.', 'wc-order-splitter'), 400, false);
@@ -384,13 +393,44 @@ final class WCOS_Merge_Admin_Controller {
 		} catch (Throwable $throwable) {
 			throw new WCOS_Merge_Transport_Exception('authorization_failed', __('You are not allowed to merge this order pair.', 'wc-order-splitter'), 403, false);
 		}
-		$this->assert_status_enabled($target);
+		if ($require_status) {
+			$this->assert_status_enabled($target);
+		}
 		return array($source, $target);
 	}
 
-	private function assert_status_enabled(WC_Order $order) {
+	private function verified_confirmation(WC_Order $source, WC_Order $target, $operation_id, $token) {
+		try {
+			return WCOS_Merge_Confirmation_Store::verify($source, $target, $operation_id, $token, get_current_user_id());
+		} catch (WCOS_Merge_Confirmation_Exception $exception) {
+			throw $this->confirmation_exception($exception);
+		}
+	}
+
+	private function is_searchable_target(WC_Order $source, $target) {
+		return $target instanceof WC_Order
+			&& 'shop_order' === $target->get_type()
+			&& $target->get_id() !== $source->get_id()
+			&& current_user_can('edit_shop_order', $target->get_id())
+			&& $this->status_enabled($target);
+	}
+
+	private function search_result(WC_Order $order) {
+		return array(
+			'id' => $order->get_id(),
+			'number' => (string) $order->get_order_number(),
+			'status' => (string) $order->get_status(),
+			'currency' => (string) $order->get_currency(),
+		);
+	}
+
+	private function status_enabled(WC_Order $order) {
 		$allowed = (array) get_option('order_splitter_status_allowed', array('wc-processing'));
-		if (!in_array('wc-' . $order->get_status(), $allowed, true)) {
+		return in_array('wc-' . $order->get_status(), $allowed, true);
+	}
+
+	private function assert_status_enabled(WC_Order $order) {
+		if (!$this->status_enabled($order)) {
 			throw new WCOS_Merge_Transport_Exception('status_disabled', __('This order status is disabled in the Order Splitter settings.', 'wc-order-splitter'), 409, false);
 		}
 	}

--- a/inc/domain/class-wcos-order-mutation-authorizer.php
+++ b/inc/domain/class-wcos-order-mutation-authorizer.php
@@ -71,12 +71,17 @@ final class WCOS_Order_Mutation_Authorizer {
 	}
 
 	public static function assert_merge(WC_Order $source, WC_Order $target) {
-		self::assert_shop_manager_policy();
+		self::assert_merge_source($source);
 		if ($source->get_id() === $target->get_id()) {
 			throw new RuntimeException(__('An order cannot be merged into itself.', 'wc-order-splitter'));
 		}
-		self::assert_can_edit($source);
 		self::assert_can_edit($target);
+	}
+
+	/** Authorize the current edited order before a Merge target is selected. */
+	public static function assert_merge_source(WC_Order $source) {
+		self::assert_shop_manager_policy();
+		self::assert_can_edit($source);
 		self::assert_can_delete($source);
 	}
 

--- a/js/p2-merge-admin.js
+++ b/js/p2-merge-admin.js
@@ -1,0 +1,358 @@
+(function ($) {
+	'use strict';
+
+	var strings = window.wcosMergeAdminStrings || {};
+	var launcher = document.querySelector('.wcos-merge-launcher');
+	if (!launcher || !window.WCOSBackboneModal || !$.fn.selectWoo) {
+		return;
+	}
+
+	var sourceDialogId = launcher.getAttribute('aria-controls');
+	var sourceDialog = sourceDialogId ? document.getElementById(sourceDialogId) : null;
+	if (!sourceDialog) {
+		return;
+	}
+
+	function text(key, fallback) {
+		return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
+	}
+
+	function removeExternalDescription(button) {
+		var descriptionId = button.getAttribute('aria-describedby');
+		var description = descriptionId ? document.getElementById(descriptionId) : null;
+		var value = description ? description.textContent.trim() : '';
+		if (description && description.parentNode) {
+			description.parentNode.removeChild(description);
+		}
+		button.removeAttribute('aria-describedby');
+		return value;
+	}
+
+	var launcherDescription = removeExternalDescription(launcher);
+	launcher.removeAttribute('aria-controls');
+
+	function cloneBody(sourcePanel, body) {
+		Array.prototype.forEach.call(sourcePanel.children, function (child) {
+			if (child.classList.contains('wcos-merge-dialog__header') || child.classList.contains('wcos-merge-dialog__actions')) {
+				return;
+			}
+			body.appendChild(child.cloneNode(true));
+		});
+	}
+
+	function cloneFooter(sourceActions, footer) {
+		Array.prototype.forEach.call(sourceActions ? sourceActions.children : [], function (sourceButton) {
+			var button = sourceButton.cloneNode(true);
+			if (button.classList.contains('wcos-merge-cancel')) {
+				button.classList.add('modal-close');
+				button.classList.add('button-large');
+			}
+			footer.appendChild(button);
+		});
+	}
+
+	function openMergeModal() {
+		var busy = false;
+		var completed = false;
+		var selectedTarget = '';
+		var reviewAuthority = null;
+		var confirmationAuthority = null;
+		var retryReady = false;
+		var dialog;
+		var closeButton;
+		var cancelButton;
+		var reviewButton;
+		var executeButton;
+		var confirmCheckbox;
+		var targetSelect;
+		var reviewBox;
+		var reviewSummary;
+		var statusBox;
+		var errorBox;
+		var resultBox;
+
+		function request(action, data) {
+			var body = new URLSearchParams();
+			body.set('action', action);
+			Object.keys(data).forEach(function (key) {
+				body.set(key, String(data[key]));
+			});
+			return window.fetch(sourceDialog.getAttribute('data-ajax-url'), {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+				body: body.toString()
+			}).then(function (response) {
+				return response.json().catch(function () {
+					throw new Error(text('requestFailed', 'The Merge request could not be completed.'));
+				});
+			}).then(function (payload) {
+				if (!payload || payload.success !== true) {
+					var failure = payload && payload.data ? payload.data : {};
+					var error = new Error(failure.message || text('requestFailed', 'The Merge request could not be completed.'));
+					error.code = failure.code || 'request_failed';
+					error.retryable = !!failure.retryable;
+					throw error;
+				}
+				return payload.data || {};
+			});
+		}
+
+		function clearError() {
+			errorBox.hidden = true;
+			errorBox.textContent = '';
+		}
+
+		function showError(message) {
+			errorBox.textContent = message || text('requestFailed', 'The Merge request could not be completed.');
+			errorBox.hidden = false;
+			errorBox.focus();
+		}
+
+		function setStatus(message) {
+			statusBox.textContent = message || '';
+		}
+
+		function clearResult() {
+			resultBox.hidden = true;
+			resultBox.textContent = '';
+		}
+
+		function addSummary(label, value) {
+			var term = document.createElement('dt');
+			var detail = document.createElement('dd');
+			term.textContent = label;
+			detail.textContent = value;
+			reviewSummary.appendChild(term);
+			reviewSummary.appendChild(detail);
+		}
+
+		function renderReview(summary) {
+			var source = summary.source || {};
+			var target = summary.target || {};
+			reviewSummary.textContent = '';
+			addSummary('Source', '#' + String(source.number || source.id || '') + ' · ' + String(source.line_count || 0) + ' lines · ' + String(source.total || '0') + ' ' + String(summary.currency || ''));
+			addSummary('Target', '#' + String(target.number || target.id || '') + ' · ' + String(target.line_count || 0) + ' lines · ' + String(target.total || '0') + ' ' + String(summary.currency || ''));
+			addSummary('Transferable lines', String(summary.transferable_line_count || 0));
+			addSummary('Projected active-target historical aggregate', String(summary.projected_active_target_total || '0') + ' ' + String(summary.currency || ''));
+			addSummary('Price precision', String(summary.price_precision || 0));
+			addSummary('Retirement policy', String(summary.retirement_policy || 'non_force_trash_archive'));
+			reviewBox.hidden = false;
+		}
+
+		function invalidateReview() {
+			if (completed) {
+				return;
+			}
+			reviewAuthority = null;
+			confirmationAuthority = null;
+			retryReady = false;
+			reviewBox.hidden = true;
+			reviewSummary.textContent = '';
+			confirmCheckbox.checked = false;
+			confirmCheckbox.disabled = false;
+			$(targetSelect).prop('disabled', false);
+			executeButton.textContent = text('confirmMerge', 'Confirm and merge');
+			clearResult();
+		}
+
+		function setBusy(nextBusy) {
+			busy = !!nextBusy;
+			dialog.setAttribute('aria-busy', busy ? 'true' : 'false');
+			$(targetSelect).prop('disabled', busy || completed || !!confirmationAuthority);
+			reviewButton.disabled = busy || completed || !selectedTarget || !!confirmationAuthority;
+			confirmCheckbox.disabled = busy || completed || !!confirmationAuthority;
+			executeButton.disabled = busy || completed || (!retryReady && (!reviewAuthority || !confirmCheckbox.checked));
+			cancelButton.disabled = busy;
+			closeButton.disabled = busy;
+		}
+
+		function reviewMerge() {
+			if (busy || completed || !selectedTarget || confirmationAuthority) {
+				return;
+			}
+			clearError();
+			invalidateReview();
+			setBusy(true);
+			setStatus(text('reviewing', 'Reviewing Merge pair…'));
+			request(sourceDialog.getAttribute('data-review-action'), {
+				source_order_id: sourceDialog.getAttribute('data-source-order-id'),
+				target_order_id: selectedTarget,
+				nonce: sourceDialog.getAttribute('data-nonce')
+			}).then(function (data) {
+				reviewAuthority = { reviewId: data.review_id, token: data.review_token };
+				renderReview(data.summary || {});
+				setStatus(text('reviewReady', 'The pair passed server review. Confirm the acknowledgement to merge.'));
+				confirmCheckbox.focus();
+			}).catch(function (error) {
+				invalidateReview();
+				setStatus('');
+				showError(error.message);
+			}).finally(function () {
+				setBusy(false);
+			});
+		}
+
+		function executeSameOperation() {
+			return request(sourceDialog.getAttribute('data-execute-action'), {
+				source_order_id: sourceDialog.getAttribute('data-source-order-id'),
+				target_order_id: selectedTarget,
+				nonce: sourceDialog.getAttribute('data-nonce'),
+				operation_id: confirmationAuthority.operationId,
+				confirmation_token: confirmationAuthority.token
+			});
+		}
+
+		function renderSuccess(data) {
+			resultBox.textContent = '';
+			var message = document.createElement('p');
+			message.textContent = text('completed', 'Orders merged successfully. The source order was retired under the approved policy.');
+			resultBox.appendChild(message);
+			var target = data && data.target ? data.target : null;
+			if (target) {
+				var detail = document.createElement('p');
+				if (target.edit_url) {
+					var link = document.createElement('a');
+					link.href = target.edit_url;
+					link.textContent = text('targetOrder', 'Active target order') + ' #' + String(target.number || target.id || '');
+					detail.appendChild(link);
+				} else {
+					detail.textContent = text('targetOrder', 'Active target order') + ' #' + String(target.number || target.id || '');
+				}
+				resultBox.appendChild(detail);
+			}
+			resultBox.hidden = false;
+			resultBox.focus();
+		}
+
+		function handleExecuteFailure(error) {
+			if (!error.retryable || !confirmationAuthority) {
+				invalidateReview();
+			} else {
+				retryReady = true;
+				executeButton.textContent = text('retryMerge', 'Retry merge');
+			}
+			setStatus('');
+			showError(error.message);
+		}
+
+		function finishExecute(data) {
+			if (!data || data.status !== 'completed') {
+				var closed = new Error(text('closedOperation', 'The Merge operation closed without a completed Merge. Review the orders before trying again.'));
+				closed.retryable = !!data && ['recovery_required', 'recovery_pending', 'retry_required'].indexOf(data.status) !== -1;
+				throw closed;
+			}
+			completed = true;
+			retryReady = false;
+			setStatus(text('completed', 'Orders merged successfully.'));
+			renderSuccess(data);
+		}
+
+		function confirmAndMerge() {
+			if (busy || completed || (!confirmationAuthority && (!reviewAuthority || !confirmCheckbox.checked))) {
+				return;
+			}
+			clearError();
+			clearResult();
+			setBusy(true);
+
+			if (confirmationAuthority) {
+				setStatus(text('retrying', 'Retrying the same Merge operation…'));
+				executeSameOperation().then(finishExecute).catch(handleExecuteFailure).finally(function () { setBusy(false); });
+				return;
+			}
+
+			setStatus(text('confirming', 'Confirming reviewed Merge authority…'));
+			request(sourceDialog.getAttribute('data-confirm-action'), {
+				source_order_id: sourceDialog.getAttribute('data-source-order-id'),
+				target_order_id: selectedTarget,
+				nonce: sourceDialog.getAttribute('data-nonce'),
+				review_id: reviewAuthority.reviewId,
+				review_token: reviewAuthority.token
+			}).then(function (data) {
+				confirmationAuthority = { operationId: data.operation_id, token: data.confirmation_token };
+				reviewAuthority = null;
+				$(targetSelect).prop('disabled', true);
+				confirmCheckbox.disabled = true;
+				setStatus(text('executing', 'Merging orders…'));
+				return executeSameOperation();
+			}).then(finishExecute).catch(handleExecuteFailure).finally(function () {
+				setBusy(false);
+			});
+		}
+
+		window.WCOSBackboneModal.open({
+			trigger: launcher,
+			title: (sourceDialog.querySelector('.wcos-merge-dialog__header h2') || {}).textContent || 'Merge into another order',
+			description: (sourceDialog.querySelector('.wcos-merge-dialog__header p') || {}).textContent || launcherDescription,
+			modalClass: 'wcos-merge-backbone-modal',
+			isBusy: function () { return busy; },
+			build: function (body, footer, root) {
+				var sourcePanel = sourceDialog.querySelector('.wcos-merge-dialog__panel');
+				var sourceActions = sourceDialog.querySelector('.wcos-merge-dialog__actions');
+				cloneBody(sourcePanel, body);
+				cloneFooter(sourceActions, footer);
+				dialog = root;
+				closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
+				cancelButton = root.querySelector('.wcos-merge-cancel');
+				reviewButton = root.querySelector('.wcos-merge-review-button');
+				executeButton = root.querySelector('.wcos-merge-execute-button');
+				confirmCheckbox = root.querySelector('.wcos-merge-confirm-checkbox');
+				targetSelect = root.querySelector('.wcos-merge-target-select');
+				reviewBox = root.querySelector('.wcos-merge-review');
+				reviewSummary = root.querySelector('.wcos-merge-review-summary');
+				statusBox = root.querySelector('.wcos-merge-status');
+				errorBox = root.querySelector('.wcos-merge-error');
+				resultBox = root.querySelector('.wcos-merge-result');
+			},
+			onReady: function () {
+				$(targetSelect).selectWoo({
+					width: '100%',
+					placeholder: targetSelect.getAttribute('data-placeholder') || '',
+					allowClear: true,
+					minimumInputLength: 0,
+					ajax: {
+						url: sourceDialog.getAttribute('data-ajax-url'),
+						type: 'POST',
+						dataType: 'json',
+						delay: 250,
+						data: function (params) {
+							return {
+								action: sourceDialog.getAttribute('data-search-action'),
+								source_order_id: sourceDialog.getAttribute('data-source-order-id'),
+								nonce: sourceDialog.getAttribute('data-nonce'),
+								term: params.term || '',
+								page: params.page || 1
+							};
+						},
+						processResults: function (payload) {
+							var data = payload && payload.success === true ? payload.data : {};
+							return {
+								results: (data.results || []).map(function (order) {
+									return { id: String(order.id), text: '#' + String(order.number || order.id) + ' · ' + String(order.status || '') + ' · ' + String(order.currency || '') };
+								}),
+								pagination: { more: !!data.more }
+							};
+						}
+					}
+				});
+				$(targetSelect).on('change', function () {
+					if (completed || confirmationAuthority) {
+						return;
+					}
+					selectedTarget = String($(targetSelect).val() || '');
+					invalidateReview();
+					clearError();
+					setStatus(selectedTarget ? '' : text('selectTarget', 'Select a target order first.'));
+					setBusy(false);
+				});
+				reviewButton.addEventListener('click', reviewMerge);
+				executeButton.addEventListener('click', confirmAndMerge);
+				confirmCheckbox.addEventListener('change', function () { setBusy(false); });
+				$(targetSelect).selectWoo('open');
+			}
+		});
+	}
+
+	launcher.addEventListener('click', openMergeModal);
+})(jQuery);

--- a/tests/integration/merge-review-confirm-execute-smoke.php
+++ b/tests/integration/merge-review-confirm-execute-smoke.php
@@ -46,7 +46,7 @@ function wcos_merge_authority_request(WC_Order $source, WC_Order $target) {
 	return array(
 		'source_order_id' => $source->get_id(),
 		'target_order_id' => $target->get_id(),
-		'nonce' => wp_create_nonce('wcos_merge_orders_' . $source->get_id() . '_' . $target->get_id()),
+		'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()),
 	);
 }
 
@@ -74,12 +74,14 @@ $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 
 wcos_merge_authority_assert(!empty($admins), 'Merge authority smoke requires an administrator fixture.');
 $operator_id = absint($admins[0]);
 wp_set_current_user($operator_id);
+$original_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+update_option('order_splitter_status_allowed', array('wc-pending'));
 
 wcos_merge_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate unexpectedly enabled.');
 wcos_merge_authority_assert(null === WCOS_Merge_Admin_Controller::bootstrap(), 'Hard-off Merge controller bootstrapped.');
 $controller = new WCOS_Merge_Admin_Controller();
 wcos_merge_authority_assert(false === $controller->register_hooks(), 'Hard-off Merge controller registered hooks.');
-foreach (array(WCOS_Merge_Admin_Controller::REVIEW_ACTION, WCOS_Merge_Admin_Controller::CONFIRM_ACTION, WCOS_Merge_Admin_Controller::EXECUTE_ACTION) as $action) {
+foreach (array(WCOS_Merge_Admin_Controller::SEARCH_ACTION, WCOS_Merge_Admin_Controller::REVIEW_ACTION, WCOS_Merge_Admin_Controller::CONFIRM_ACTION, WCOS_Merge_Admin_Controller::EXECUTE_ACTION) as $action) {
 	wcos_merge_authority_assert(false === has_action('wp_ajax_' . $action), 'A hard-off Merge AJAX hook is production-visible.');
 }
 
@@ -398,6 +400,7 @@ try {
 		wcos_merge_authority_cleanup($pair[0], $pair[1], $pair[2]);
 	}
 	$product->delete(true);
+	update_option('order_splitter_status_allowed', $original_allowed_statuses);
 }
 
 echo "merge-review-confirm-execute-authority-ok\n";

--- a/tests/integration/merge-review-confirm-execute-smoke.php
+++ b/tests/integration/merge-review-confirm-execute-smoke.php
@@ -167,6 +167,23 @@ try {
 	}
 	wcos_merge_authority_assert($second_gate_rejected && null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $confirm['operation_id']), 'Repeated gate-off Execute changed operation authority.');
 
+	list($surface_source, $surface_target) = wcos_merge_authority_pair($product, 'first-execute-surface');
+	$pairs[] = array($surface_source, $surface_target, '');
+	$surface_request = wcos_merge_authority_request($surface_source, $surface_target);
+	$surface_review = $controller->review_request($surface_request);
+	$surface_confirm = $controller->confirm_request(array_merge($surface_request, array('review_id' => $surface_review['review_id'], 'review_token' => $surface_review['review_token'])));
+	$pairs[count($pairs) - 1][2] = $surface_confirm['operation_id'];
+	$surface_source->set_status('on-hold');
+	$surface_source->save();
+	$first_execute_status_rejected = false;
+	try {
+		$controller->execute_request(array_merge($surface_request, array('operation_id' => $surface_confirm['operation_id'], 'confirmation_token' => $surface_confirm['confirmation_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$first_execute_status_rejected = 'status_disabled' === $exception->get_error_code();
+	}
+	wcos_merge_authority_assert($first_execute_status_rejected, 'First Execute without a durable journal bypassed current surface-status eligibility.');
+	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($surface_source->get_id()), $surface_confirm['operation_id']), 'Rejected first Execute created a durable journal.');
+
 	$original_confirm_record = $confirm_record;
 	$confirm_record['price_precision'] = 3;
 	set_transient('wcos_merge_confirm_' . hash('sha256', $confirm['operation_id']), $confirm_record, WCOS_Merge_Confirmation_Store::TTL);
@@ -293,6 +310,34 @@ try {
 	);
 	wcos_merge_authority_assert(false === strpos(wp_json_encode($handoff), '@example.test'), 'Durable Merge Confirmation handoff stored plaintext customer PII.');
 	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($durable_target->get_id()), $durable_confirm['operation_id']), 'A forbidden target shadow journal was created.');
+	$durable_source = wc_get_order($durable_source->get_id());
+	$durable_target = wc_get_order($durable_target->get_id());
+	wcos_merge_authority_assert('trash' === $durable_source->get_status(), 'Completed confirmed Merge did not retire the source to trash.');
+	$durable_target->set_status('on-hold');
+	$durable_target->save();
+	$durable_target = wc_get_order($durable_target->get_id());
+	$replay_journal_before = wp_json_encode(WCOS_Operation_Journal::get($durable_source, $durable_confirm['operation_id']));
+	$replay_source_before = WCOS_Merge_Recovery_Snapshot::participant_signature($durable_source);
+	$replay_target_before = WCOS_Merge_Recovery_Snapshot::participant_signature($durable_target);
+	$replay_target_line_ids_before = array_map('absint', array_keys($durable_target->get_items('line_item')));
+	$replay_target_tax_ids_before = array_map('absint', array_keys($durable_target->get_items('tax')));
+	$replay_stock_before = $product->get_stock_quantity();
+	$controller_replay_reached_gateway = false;
+	try {
+		$controller->execute_request(array_merge($durable_request, array('operation_id' => $durable_confirm['operation_id'], 'confirmation_token' => $durable_confirm['confirmation_token'])));
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$controller_replay_reached_gateway = 'workflow_disabled' === $exception->get_error_code();
+	}
+	wcos_merge_authority_assert($controller_replay_reached_gateway, 'Completed Merge controller replay was blocked by stale source/target surface status before the gateway.');
+	$durable_source = wc_get_order($durable_source->get_id());
+	$durable_target = wc_get_order($durable_target->get_id());
+	wcos_merge_authority_assert($replay_journal_before === wp_json_encode(WCOS_Operation_Journal::get($durable_source, $durable_confirm['operation_id'])), 'Controller replay changed or created durable journal authority.');
+	wcos_merge_authority_assert($replay_source_before === WCOS_Merge_Recovery_Snapshot::participant_signature($durable_source), 'Controller replay changed retired-source item, tax, relation, lifecycle, or stock ownership.');
+	wcos_merge_authority_assert($replay_target_before === WCOS_Merge_Recovery_Snapshot::participant_signature($durable_target), 'Controller replay changed target item, tax, relation, lifecycle, or stock ownership.');
+	wcos_merge_authority_assert($replay_target_line_ids_before === array_map('absint', array_keys($durable_target->get_items('line_item'))), 'Controller replay created a second target line item operation.');
+	wcos_merge_authority_assert($replay_target_tax_ids_before === array_map('absint', array_keys($durable_target->get_items('tax'))), 'Controller replay created a second target tax operation.');
+	wcos_merge_authority_assert($replay_stock_before === wc_get_product($product->get_id())->get_stock_quantity(), 'Controller replay changed physical stock ownership.');
+	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get($durable_target, $durable_confirm['operation_id']), 'Controller replay created a target shadow journal.');
 	$matched_journal_replay = WCOS_Merge_Confirmation_Store::verify(wc_get_order($durable_source->get_id()), wc_get_order($durable_target->get_id()), $durable_confirm['operation_id'], $durable_confirm['confirmation_token'], $operator_id);
 	wcos_merge_authority_assert('completed' === $matched_journal_replay['journal_status'], 'Matching surviving Confirmation did not defer to the completed journal.');
 	$durable_confirm_key = 'wcos_merge_confirm_' . hash('sha256', $durable_confirm['operation_id']);

--- a/tests/integration/merge-ui-foundation-smoke.php
+++ b/tests/integration/merge-ui-foundation-smoke.php
@@ -64,6 +64,11 @@ try {
 	$address = '46 Private Search Lane';
 	$source = wcos_merge_ui_order($email, $address);
 	$targets[] = wcos_merge_ui_order('merge-ui-target-' . wp_generate_uuid4() . '@example.test', 'Target Secret Street');
+	$targets[0]->set_date_created(time() - DAY_IN_SECONDS);
+	$targets[0]->save();
+	for ($index = 0; $index <= WCOS_Merge_Admin_Controller::SEARCH_SCAN_LIMIT; $index++) {
+		$targets[] = wcos_merge_ui_order('merge-ui-newer-' . $index . '-' . wp_generate_uuid4() . '@example.test', 'Newer Private Street');
+	}
 
 	ob_start();
 	$controller->render_launcher($source);
@@ -87,6 +92,16 @@ try {
 		'term' => (string) $targets[0]->get_id(),
 		'page' => 1,
 	);
+	$browse = $controller->search_request(array_merge($request, array('term' => '')));
+	$old_target_in_browse = false;
+	foreach ($browse['results'] as $result) {
+		if ($targets[0]->get_id() === (int) $result['id']) {
+			$old_target_in_browse = true;
+		}
+	}
+	wcos_merge_ui_assert(!$old_target_in_browse, 'Old-target fixture was not outside the bounded recent browse window.');
+	wcos_merge_ui_assert(count($browse['results']) <= WCOS_Merge_Admin_Controller::SEARCH_LIMIT, 'Target browse exceeded its result limit.');
+
 	$search = $controller->search_request($request);
 	$found_target = null;
 	foreach ($search['results'] as $result) {
@@ -96,6 +111,7 @@ try {
 		}
 	}
 	wcos_merge_ui_assert(is_array($found_target), 'Bounded target search did not find the exact target identity.');
+	wcos_merge_ui_assert(1 === count($search['results']) && false === $search['more'], 'Exact old-target search was not bounded to one result.');
 	wcos_merge_ui_assert(array('id', 'number', 'status', 'currency') === array_keys($found_target), 'Target search returned fields outside the PII-free selector contract.');
 	$search_json = wp_json_encode($search);
 	wcos_merge_ui_assert(false === strpos($search_json, '@example.test'), 'Target search exposed customer email.');
@@ -103,8 +119,10 @@ try {
 	wcos_merge_ui_assert(false === strpos($search_json, 'Private payment'), 'Target search exposed payment identity.');
 	wcos_merge_ui_assert(false === strpos($search_json, '"id":' . $source->get_id()), 'Target search included the current source order.');
 
-	$bounded = $controller->search_request(array_merge($request, array('term' => '')));
-	wcos_merge_ui_assert(count($bounded['results']) <= WCOS_Merge_Admin_Controller::SEARCH_LIMIT, 'Target search exceeded its result limit.');
+	$hash_search = $controller->search_request(array_merge($request, array('term' => '#' . $targets[0]->get_id())));
+	wcos_merge_ui_assert(1 === count($hash_search['results']) && $targets[0]->get_id() === (int) $hash_search['results'][0]['id'], 'Hash-prefixed exact old-target ID did not resolve.');
+	$source_search = $controller->search_request(array_merge($request, array('term' => (string) $source->get_id())));
+	wcos_merge_ui_assert(empty($source_search['results']), 'Exact target search did not exclude the source order.');
 
 	$bad_nonce = $request;
 	$bad_nonce['nonce'] = 'invalid';

--- a/tests/integration/merge-ui-foundation-smoke.php
+++ b/tests/integration/merge-ui-foundation-smoke.php
@@ -1,0 +1,198 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_merge_ui_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_merge_ui_order($email, $address) {
+	$order = wc_create_order();
+	$order->set_status('processing');
+	$order->set_currency('USD');
+	$order->set_billing_first_name('Private');
+	$order->set_billing_last_name('Fixture');
+	$order->set_billing_email($email);
+	$order->set_billing_phone('555-0104');
+	$order->set_billing_address_1($address);
+	$order->set_payment_method('cod');
+	$order->set_payment_method_title('Private payment title');
+	$order->save();
+	return wc_get_order($order->get_id());
+}
+
+$root = dirname(__DIR__, 2);
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_merge_ui_assert(!empty($admins), 'Merge UI smoke requires an administrator fixture.');
+wp_set_current_user(absint($admins[0]));
+
+wcos_merge_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate unexpectedly enabled.');
+wcos_merge_ui_assert(null === WCOS_Merge_Admin_Controller::bootstrap(), 'Hard-off Merge UI controller bootstrapped.');
+$controller = new WCOS_Merge_Admin_Controller();
+wcos_merge_ui_assert(false === $controller->register_hooks(), 'Hard-off Merge UI controller registered hooks.');
+
+$hook_contracts = array(
+	'wp_ajax_' . WCOS_Merge_Admin_Controller::SEARCH_ACTION => 'ajax_search',
+	'wp_ajax_' . WCOS_Merge_Admin_Controller::REVIEW_ACTION => 'ajax_review',
+	'wp_ajax_' . WCOS_Merge_Admin_Controller::CONFIRM_ACTION => 'ajax_confirm',
+	'wp_ajax_' . WCOS_Merge_Admin_Controller::EXECUTE_ACTION => 'ajax_execute',
+	'woocommerce_order_item_add_action_buttons' => 'render_launcher',
+	'admin_footer' => 'render_dialog',
+	'admin_enqueue_scripts' => 'enqueue_assets',
+);
+foreach ($hook_contracts as $hook => $method) {
+	wcos_merge_ui_assert(false === has_action($hook, array($controller, $method)), 'A hard-off Merge hook is production-visible: ' . $hook);
+}
+
+wp_dequeue_script('wcos-merge-admin');
+wp_dequeue_style('wcos-merge-admin');
+$controller->enqueue_assets();
+wcos_merge_ui_assert(!wp_script_is('wcos-merge-admin', 'enqueued'), 'Hard-off Merge script was enqueued.');
+wcos_merge_ui_assert(!wp_style_is('wcos-merge-admin', 'enqueued'), 'Hard-off Merge stylesheet was enqueued.');
+
+$old_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+update_option('order_splitter_status_allowed', array('wc-processing'));
+$source = null;
+$targets = array();
+
+try {
+	$email = 'merge-ui-private-' . wp_generate_uuid4() . '@example.test';
+	$address = '46 Private Search Lane';
+	$source = wcos_merge_ui_order($email, $address);
+	$targets[] = wcos_merge_ui_order('merge-ui-target-' . wp_generate_uuid4() . '@example.test', 'Target Secret Street');
+
+	ob_start();
+	$controller->render_launcher($source);
+	$hard_off_launcher = (string) ob_get_clean();
+	wcos_merge_ui_assert('' === $hard_off_launcher, 'Hard-off Merge launcher rendered.');
+
+	$template = $controller->dialog_html($source);
+	wcos_merge_ui_assert(false !== strpos($template, 'wcos-merge-target-select'), 'Merge target selector template is missing.');
+	wcos_merge_ui_assert(false !== strpos($template, 'wcos-merge-confirm-checkbox'), 'Merge acknowledgement template is missing.');
+	wcos_merge_ui_assert(false !== strpos($template, 'aria-live="polite"'), 'Merge modal status is not announced.');
+	wcos_merge_ui_assert(false !== strpos($template, 'non_force_trash_archive'), 'Approved retirement warning is missing.');
+	wcos_merge_ui_assert(false !== strpos($template, 'data-source-order-id="' . $source->get_id() . '"'), 'Current order is not frozen as the Merge source.');
+	wcos_merge_ui_assert(false === strpos($template, $email), 'Merge template exposed customer email.');
+	wcos_merge_ui_assert(false === strpos($template, $address), 'Merge template exposed customer address.');
+	wcos_merge_ui_assert(false === strpos($template, '555-0104'), 'Merge template exposed customer phone.');
+	wcos_merge_ui_assert(false === strpos($template, 'Private payment title'), 'Merge template exposed payment identity.');
+
+	$request = array(
+		'source_order_id' => $source->get_id(),
+		'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()),
+		'term' => (string) $targets[0]->get_id(),
+		'page' => 1,
+	);
+	$search = $controller->search_request($request);
+	$found_target = null;
+	foreach ($search['results'] as $result) {
+		if ($targets[0]->get_id() === (int) $result['id']) {
+			$found_target = $result;
+			break;
+		}
+	}
+	wcos_merge_ui_assert(is_array($found_target), 'Bounded target search did not find the exact target identity.');
+	wcos_merge_ui_assert(array('id', 'number', 'status', 'currency') === array_keys($found_target), 'Target search returned fields outside the PII-free selector contract.');
+	$search_json = wp_json_encode($search);
+	wcos_merge_ui_assert(false === strpos($search_json, '@example.test'), 'Target search exposed customer email.');
+	wcos_merge_ui_assert(false === strpos($search_json, 'Secret Street'), 'Target search exposed customer address.');
+	wcos_merge_ui_assert(false === strpos($search_json, 'Private payment'), 'Target search exposed payment identity.');
+	wcos_merge_ui_assert(false === strpos($search_json, '"id":' . $source->get_id()), 'Target search included the current source order.');
+
+	$bounded = $controller->search_request(array_merge($request, array('term' => '')));
+	wcos_merge_ui_assert(count($bounded['results']) <= WCOS_Merge_Admin_Controller::SEARCH_LIMIT, 'Target search exceeded its result limit.');
+
+	$bad_nonce = $request;
+	$bad_nonce['nonce'] = 'invalid';
+	$nonce_rejected = false;
+	try {
+		$controller->search_request($bad_nonce);
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$nonce_rejected = 'invalid_nonce' === $exception->get_error_code();
+	}
+	wcos_merge_ui_assert($nonce_rejected, 'Target search accepted an invalid nonce.');
+
+	$subscriber_id = wp_create_user('wcos-merge-ui-' . wp_generate_uuid4(), wp_generate_password(24), 'merge-ui-subscriber-' . wp_generate_uuid4() . '@example.test');
+	wcos_merge_ui_assert(!is_wp_error($subscriber_id), 'Unable to create target-search capability fixture.');
+	wp_set_current_user($subscriber_id);
+	$capability_request = $request;
+	$capability_request['nonce'] = wp_create_nonce('wcos_merge_order_' . $source->get_id());
+	$capability_rejected = false;
+	try {
+		$controller->search_request($capability_request);
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$capability_rejected = 'authorization_failed' === $exception->get_error_code();
+	}
+	wp_set_current_user(absint($admins[0]));
+	if (!function_exists('wp_delete_user')) {
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+	}
+	wp_delete_user($subscriber_id);
+	wcos_merge_ui_assert($capability_rejected, 'Target search accepted an operator without order mutation capability.');
+
+	$excessive = $request;
+	$excessive['term'] = str_repeat('x', WCOS_Merge_Admin_Controller::SEARCH_MAX_TERM_LENGTH + 1);
+	$excessive_rejected = false;
+	try {
+		$controller->search_request($excessive);
+	} catch (WCOS_Merge_Transport_Exception $exception) {
+		$excessive_rejected = 'invalid_search' === $exception->get_error_code();
+	}
+	wcos_merge_ui_assert($excessive_rejected, 'Target search accepted an excessive query.');
+
+	$client = file_get_contents($root . '/js/p2-merge-admin.js');
+	wcos_merge_ui_assert(is_string($client) && '' !== $client, 'Merge UI client asset is missing.');
+	foreach (array(
+		'window.WCOSBackboneModal.open',
+		'.selectWoo({',
+		'var reviewAuthority = null;',
+		'var confirmationAuthority = null;',
+		'function invalidateReview()',
+		"$(targetSelect).on('change'",
+		'if (confirmationAuthority) {',
+		'function executeSameOperation()',
+		'operation_id: confirmationAuthority.operationId',
+		'confirmation_token: confirmationAuthority.token',
+		'review_id: reviewAuthority.reviewId',
+		'review_token: reviewAuthority.token',
+		'if (!error.retryable || !confirmationAuthority)',
+		'confirmCheckbox.checked',
+		'data.status !== \'completed\'',
+	) as $needle) {
+		wcos_merge_ui_assert(false !== strpos($client, $needle), 'Merge client state contract is missing: ' . $needle);
+	}
+	wcos_merge_ui_assert(1 === substr_count($client, "getAttribute('data-confirm-action')"), 'Merge retry path can issue more than one Confirm request site.');
+	foreach (array('localStorage', 'sessionStorage', 'document.cookie', '.innerHTML') as $forbidden) {
+		wcos_merge_ui_assert(false === strpos($client, $forbidden), 'Merge client uses forbidden state/rendering authority: ' . $forbidden);
+	}
+	foreach (array('plan:', 'tax:', 'line:', 'policy:', 'precision:', 'fingerprint:', 'total:') as $forbidden_payload) {
+		wcos_merge_ui_assert(false === strpos($client, $forbidden_payload), 'Merge client authors forbidden request authority: ' . $forbidden_payload);
+	}
+
+	$controller_source = file_get_contents($root . '/inc/backend/class-wcos-merge-admin-controller.php');
+	wcos_merge_ui_assert(false !== strpos($controller_source, 'WCOS_Order_Mutation_Authorizer::assert_merge_source($order);'), 'Launcher does not use bounded source-only authorization.');
+	wcos_merge_ui_assert(false === strpos(substr($controller_source, strpos($controller_source, 'public function render_launcher'), 1500), 'merge_preflight'), 'Launcher performs pair preflight before target selection.');
+	wcos_merge_ui_assert(false === strpos($controller_source, 'new WCOS_Merge_Order_Service'), 'Merge controller directly instantiates the Merge service.');
+	wcos_merge_ui_assert(false === strpos($controller_source, 'new WCOS_Merge_WooCommerce_Adapter'), 'Merge controller directly instantiates the Merge adapter.');
+
+	$asset_contract = file_get_contents($root . '/inc/backend/class-wcos-admin-backbone-modal-assets.php');
+	wcos_merge_ui_assert(false !== strpos($asset_contract, "'wcos-merge-admin'"), 'Merge client is not bound to the shared Backbone modal dependency.');
+	$css = file_get_contents($root . '/css/p2-merge-admin.css');
+	wcos_merge_ui_assert(is_string($css) && false !== strpos($css, '.wcos-merge-backbone-modal .wc-backbone-modal-content'), 'Merge CSS does not target the shared WooCommerce Backbone shell.');
+} finally {
+	if ($source instanceof WC_Order) {
+		$source->delete(true);
+	}
+	foreach ($targets as $target) {
+		if ($target instanceof WC_Order) {
+			$target->delete(true);
+		}
+	}
+	update_option('order_splitter_status_allowed', $old_statuses);
+}
+
+echo "merge-ui-foundation-ok\n";


### PR DESCRIPTION
## Classification

P2_ADMIN_UI_INTEGRATION

Closes #46.

## Summary

- extends the existing gate-aware Merge controller with a future source launcher, bounded PII-free target search, template, assets, and bounded target result
- reuses WCOSBackboneModal and SelectWoo without adding another controller, modal framework, or client state store
- implements in-memory Review -> Confirm -> Execute authority; retryable Execute reuses the same operation ID and Confirmation token
- preserves durable Execute replay after source retirement only after a matching source-keyed journal and full Confirmation/handoff authority verify
- resolves exact persisted numeric order IDs and #IDs regardless of the bounded recent browse window
- keeps MERGE=false and registers/enqueues/renders no Merge production surface while hard-off

## Authority and privacy boundaries

- current edited order is always the source
- browser sends only source/target IDs, source-scoped nonce, and opaque Review/Confirmation authority
- target changes invalidate Review; non-retryable authority failures reset to Review
- first Execute without a journal still requires current source and target status eligibility
- durable replay keeps capability, operator, pair, plan, policy, precision, handoff, and journal verification while relaxing only stale post-Merge UI status
- broad target browse is capped at 20 results/page, 100 scanned orders, five pages, and 40 query characters
- exact target lookup validates shop_order type, source exclusion, edit capability, and allowed status
- search and future markup expose no customer/payment PII
- controller Execute still enters only through WCOS_Mutation_Gateway

## U1-U2 correction evidence

- a first Execute after surface-status drift fails status_disabled and creates no journal
- a real confirmed Merge retires the source to trash and completes its source-keyed journal
- controller retry of that exact operation passes stale source/target status validation and reaches the mandatory MERGE=false gateway boundary as workflow_disabled
- replay creates no second journal, item, tax, relation, or stock ownership operation and no target shadow journal
- an eligible old target outside the 100-order recent browse window resolves by exact ID and #ID
- exact target results stay bounded to one PII-free record and the source remains excluded

## Exact-head Local-runtime evidence

Local worktree: /Users/nguyenquocbao/Local Sites/yoplay8/app/public/wp-content/plugins/wc-order-splitter

HEAD: 33d4c85cbbb8901c1b5fc27dccbbf6f2843705b8

- local HEAD equals origin/codex/wos-merge-006-backbone-ui
- plugin active in WordPress Local yoplay8
- merge-ui-foundation-ok
- merge-review-confirm-execute-authority-ok
- runtime gate check: SPLIT=1, DUPLICATE=1, MERGE=0
- Merge Search/Review/Confirm/Execute AJAX hooks absent; wcos-merge-admin asset absent
- all PHP files linted
- php tests/unit/run.php passed
- node --check js/p2-merge-admin.js passed
- git diff --check passed

PHP 8.4 emitted only pre-existing nullable-parameter deprecation notices outside this correction tranche.

## Exact-head canonical CI

Run: https://github.com/yoohwz/wc-order-splitter/actions/runs/32687633667

Result: success

- exact headSha: 33d4c85cbbb8901c1b5fc27dccbbf6f2843705b8
- PHP 7.4 / 8.1 / 8.3 syntax and unit contracts: success
- package safety: success
- architecture and approved production gate contract: success
- WooCommerce 11.0.1 legacy: success
- WooCommerce 11.0.1 HPOS-only: success
- WooCommerce 11.0.1 HPOS-sync: success
- Required CI: success

## Gate state

- SPLIT=true
- DUPLICATE=true
- MERGE=false
- RETURN_ORDER=false
- BULK_RETURN=false
- manual_quantity=true
- category=false
- stock_status=false

## Self-review

Reviewed the complete origin/main...HEAD diff (8 files, 1,015 insertions, 20 deletions). No production gate change, Merge launcher/AJAX/search/asset visibility, generic status bypass, direct Merge service/adapter controller construction, client-authored mutation authority, durable client state, PII exposure, commercial envelope expansion, or unrelated scope was found.

The PR remains Draft for independent ChatGPT technical review and Human Gate.
