### PR TITLE
WOS-MERGE-008 — Production Merge Enablement / Exact-State CI

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -42,7 +42,7 @@ jobs:
           grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
           grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
-          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
@@ -61,6 +61,10 @@ jobs:
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
             wc-order-splitter.php inc/cores inc/domain; then
             echo 'Externally overrideable mutation gates must not return.' >&2
+            exit 1
+          fi
+          if grep -R --line-number --fixed-strings 'wc-merged' wc-order-splitter.php inc; then
+            echo 'A custom production merged order status was introduced.' >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
           grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
-          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
@@ -91,6 +91,10 @@ jobs:
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
             wc-order-splitter.php inc/cores inc/domain; then
             echo 'An externally overrideable mutation gate returned to runtime source.' >&2
+            exit 1
+          fi
+          if grep -R --line-number --fixed-strings 'wc-merged' wc-order-splitter.php inc; then
+            echo 'A custom production merged order status was introduced.' >&2
             exit 1
           fi
 
@@ -174,7 +178,7 @@ jobs:
           grep -Fq 'return WCOS_Feature_Gates::any_enabled();' inc/cores/safety.php
           grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
-          grep -Fq 'self::MERGE => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::MERGE => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
@@ -193,6 +197,10 @@ jobs:
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
             wc-order-splitter.php inc/cores inc/domain; then
             echo 'Externally overrideable mutation gates must not return.' >&2
+            exit 1
+          fi
+          if grep -R --line-number --fixed-strings 'wc-merged' wc-order-splitter.php inc; then
+            echo 'A custom production merged order status was introduced.' >&2
             exit 1
           fi
 
@@ -308,7 +316,7 @@ jobs:
           test "$archive_version" = "$archive_stable_tag"
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::SPLIT => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::DUPLICATE => true'
-          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
@@ -419,7 +427,7 @@ jobs:
           npx wp-env run cli wp option update woocommerce_custom_orders_table_enabled yes
           npx wp-env run cli wp option update woocommerce_custom_orders_table_data_sync_enabled yes
 
-      - name: Verify plugin, storage mode, and Split + Duplicate production state
+      - name: Verify plugin, storage mode, and enabled production gate state
         shell: bash
         run: |
           set -euo pipefail
@@ -431,10 +439,10 @@ jobs:
             if (("legacy" === $expected && $hpos) || ("legacy" !== $expected && !$hpos)) { exit(1); }
             if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT)) { exit(1); }
             if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE)) { exit(1); }
+            if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) { exit(1); }
             if (!WCOS_Feature_Gates::any_enabled()) { exit(1); }
             if (!WC_Order_Splitter_Safety_Guard::mutations_enabled()) { exit(1); }
             foreach (array(
-              WCOS_Feature_Gates::MERGE,
               WCOS_Feature_Gates::RETURN_ORDER,
               WCOS_Feature_Gates::BULK_RETURN
             ) as $disabled_workflow) {
@@ -446,10 +454,39 @@ jobs:
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
             if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::SEARCH_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::REVIEW_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Merge_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            foreach (array(
+              WCOS_Merge_Admin_Controller::SEARCH_ACTION,
+              WCOS_Merge_Admin_Controller::REVIEW_ACTION,
+              WCOS_Merge_Admin_Controller::CONFIRM_ACTION,
+              WCOS_Merge_Admin_Controller::EXECUTE_ACTION
+            ) as $merge_action) {
+              if (false === has_action("wp_ajax_" . $merge_action)) { exit(1); }
+            }
+            $has_controller_method = static function($hook, $method) {
+              global $wp_filter;
+              if (empty($wp_filter[$hook]) || empty($wp_filter[$hook]->callbacks)) { return false; }
+              foreach ($wp_filter[$hook]->callbacks as $callbacks) {
+                foreach ($callbacks as $callback) {
+                  $function = isset($callback["function"]) ? $callback["function"] : null;
+                  if (is_array($function)
+                    && isset($function[0], $function[1])
+                    && $function[0] instanceof WCOS_Merge_Admin_Controller
+                    && $method === $function[1]) { return true; }
+                }
+              }
+              return false;
+            };
+            foreach (array(
+              "wp_ajax_" . WCOS_Merge_Admin_Controller::SEARCH_ACTION => "ajax_search",
+              "wp_ajax_" . WCOS_Merge_Admin_Controller::REVIEW_ACTION => "ajax_review",
+              "wp_ajax_" . WCOS_Merge_Admin_Controller::CONFIRM_ACTION => "ajax_confirm",
+              "wp_ajax_" . WCOS_Merge_Admin_Controller::EXECUTE_ACTION => "ajax_execute",
+              "woocommerce_order_item_add_action_buttons" => "render_launcher",
+              "admin_footer" => "render_dialog",
+              "admin_enqueue_scripts" => "enqueue_assets"
+            ) as $hook => $method) {
+              if (!$has_controller_method($hook, $method)) { exit(1); }
+            }
             foreach (array(
               "WC_ORDER_SPLITTER_MUTATIONS_ENABLED",
               "WC_ORDER_SPLITTER_SPLIT_ENABLED",
@@ -469,13 +506,14 @@ jobs:
               "wp_ajax_split_order_by_category",
               "wp_ajax_split_order_by_stock_status",
               "wp_ajax_merge_order",
+              "wp_ajax_yoos_merge_order_action",
               "woocommerce_order_action_yoos_duplicate_order",
               "woocommerce_order_action_yoos_return_order"
             );
             foreach ($legacy_hooks as $hook) {
               if (false !== has_action($hook)) { exit(1); }
             }
-            echo "storage-and-split-duplicate-production-state-ok\n";
+            echo "storage-and-enabled-production-state-ok\n";
           '
 
       - name: Verify mutation lease and durable journal controls
@@ -487,19 +525,22 @@ jobs:
       - name: Verify governance, authorization, and metadata policy
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
 
-      - name: Verify hard-off Merge domain foundation contracts
+      - name: Verify Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php
 
-      - name: Verify hard-off Merge recovery and retirement evidence
+      - name: Verify Merge recovery and retirement evidence
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-recovery-foundation-smoke.php
 
       - name: Verify hardened Merge service and adapter core contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php core
 
-      - name: Verify hard-off Merge Review Confirm Execute authority
+      - name: Verify enabled Merge Review Confirm Execute authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-review-confirm-execute-smoke.php
 
-      - name: Verify hard-off Merge UI launcher foundation
+      - name: Verify enabled Merge permissions and unsupported envelope
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-production-enabled-smoke.php
+
+      - name: Verify enabled Merge UI launcher foundation
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-ui-foundation-smoke.php
 
       - name: Verify hardened Merge pre-retirement crash contracts

--- a/inc/domain/class-wcos-feature-gates.php
+++ b/inc/domain/class-wcos-feature-gates.php
@@ -22,7 +22,7 @@ final class WCOS_Feature_Gates {
 	private static $states = array(
 		self::SPLIT => true,
 		self::DUPLICATE => true,
-		self::MERGE => false,
+		self::MERGE => true,
 		self::RETURN_ORDER => false,
 		self::BULK_RETURN => false,
 	);

--- a/tests/integration/governance-smoke.php
+++ b/tests/integration/governance-smoke.php
@@ -34,10 +34,10 @@ foreach (array(
 }
 wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Approved manual quantity Split gate is not enabled.');
 wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Approved hardened Duplicate gate is not enabled.');
+wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Approved hardened Merge gate is not enabled.');
 wcos_governance_assert(WCOS_Feature_Gates::any_enabled(), 'Approved production workflow set was reported as entirely disabled.');
 wcos_governance_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved production gate set.');
 foreach (array(
-	WCOS_Feature_Gates::MERGE,
 	WCOS_Feature_Gates::RETURN_ORDER,
 	WCOS_Feature_Gates::BULK_RETURN,
 ) as $disabled_workflow) {
@@ -104,7 +104,7 @@ wcos_governance_expect_runtime(
 	static function() use ($gateway, $order) {
 		$gateway->merge($order, $order, 'governance-disabled-' . wp_generate_uuid4());
 	},
-	'The mandatory gateway did not keep Merge hard-off.'
+		'The mandatory gateway accepted a forbidden self-Merge.'
 );
 
 /* Public business metadata is copied; private metadata needs an explicit adapter. */

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -85,20 +85,12 @@ $target = wcos_merge_foundation_order($email, 1);
 $source_id = $source->get_id();
 $target_id = $target->get_id();
 
-/* Production enablement and routing remain intentionally absent. */
-wcos_merge_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'MERGE gate became enabled.');
+/* Production enablement preserves the accepted domain and strategy contracts. */
+wcos_merge_foundation_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production MERGE gate is not enabled.');
 wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual strategy gate changed.');
 wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate changed.');
 wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock strategy gate changed.');
-$gateway = new WCOS_Mutation_Gateway();
-$merge_rejected_at_gate = false;
-try {
-	$gateway->merge($source, $target, 'merge-foundation-disabled');
-} catch (RuntimeException $exception) {
-	$merge_rejected_at_gate = true;
-	wcos_merge_foundation_assert(false === strpos($exception->getMessage(), 'has not been implemented'), 'Gateway reached the Merge implementation placeholder instead of the hard-off gate.');
-}
-wcos_merge_foundation_assert($merge_rejected_at_gate, 'Gateway unexpectedly exposed Merge execution.');
+wcos_merge_foundation_assert(class_exists('WCOS_Mutation_Gateway'), 'Mandatory production gateway is unavailable.');
 
 /* Canonical historical-state planning is read-only and never coalesces lines. */
 $report = WCOS_Merge_Preflight::assert_supported($source, $target);

--- a/tests/integration/merge-production-enabled-smoke.php
+++ b/tests/integration/merge-production-enabled-smoke.php
@@ -150,6 +150,9 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 		list($source, $target) = self::pair('search');
 		$target->set_date_created('2020-01-01 00:00:00');
 		$target->save();
+		for ($index = 0; $index < WCOS_Merge_Admin_Controller::SEARCH_LIMIT; $index++) {
+			self::order('search-newer-' . $index);
+		}
 		$controller = WCOS_Merge_Admin_Controller::bootstrap();
 		$base = array('source_order_id' => $source->get_id(), 'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()), 'page' => 1);
 		$browse = $controller->search_request(array_merge($base, array('term' => '')));

--- a/tests/integration/merge-production-enabled-smoke.php
+++ b/tests/integration/merge-production-enabled-smoke.php
@@ -12,6 +12,7 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 	private static $results = array();
 	private static $admin_id = 0;
 	private static $old_shop_permission = 'no';
+	private static $old_allowed_statuses = array();
 
 	public static function run() {
 		$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
@@ -19,6 +20,8 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 		self::$admin_id = (int) $admins[0];
 		wp_set_current_user(self::$admin_id);
 		self::$old_shop_permission = get_option('order_splitter_shop_manager_permission', 'no');
+		self::$old_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+		update_option('order_splitter_status_allowed', array('wc-on-hold', 'wc-processing'));
 		self::create_product();
 		try {
 			self::search_and_permissions();
@@ -30,6 +33,7 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 		} finally {
 			wp_set_current_user(self::$admin_id);
 			update_option('order_splitter_shop_manager_permission', self::$old_shop_permission);
+			update_option('order_splitter_status_allowed', self::$old_allowed_statuses);
 			if (!function_exists('wp_delete_user')) {
 				require_once ABSPATH . 'wp-admin/includes/user.php';
 			}

--- a/tests/integration/merge-production-enabled-smoke.php
+++ b/tests/integration/merge-production-enabled-smoke.php
@@ -1,0 +1,431 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+final class WCOS_Merge_Production_Enabled_Matrix {
+	private static $order_ids = array();
+	private static $user_ids = array();
+	private static $product_id = 0;
+	private static $operations = array();
+	private static $results = array();
+	private static $admin_id = 0;
+	private static $old_shop_permission = 'no';
+
+	public static function run() {
+		$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+		self::assert(!empty($admins), 'Administrator fixture unavailable.');
+		self::$admin_id = (int) $admins[0];
+		wp_set_current_user(self::$admin_id);
+		self::$old_shop_permission = get_option('order_splitter_shop_manager_permission', 'no');
+		self::create_product();
+		try {
+			self::search_and_permissions();
+			self::successful_operation();
+			self::drift_and_authority();
+			self::unsupported_matrix();
+			self::valid_recovery_after_errors();
+			echo wp_json_encode(array('status' => 'pass', 'results' => self::$results), JSON_PRETTY_PRINT) . "\n";
+		} finally {
+			wp_set_current_user(self::$admin_id);
+			update_option('order_splitter_shop_manager_permission', self::$old_shop_permission);
+			if (!function_exists('wp_delete_user')) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+			foreach (array_reverse(self::$user_ids) as $user_id) {
+				wp_delete_user($user_id);
+			}
+			foreach (array_reverse(self::$order_ids) as $order_id) {
+				$order = wc_get_order($order_id);
+				if ($order instanceof WC_Order) {
+					if (!empty(self::$operations[$order_id])) {
+						WCOS_Operation_Journal::delete($order, self::$operations[$order_id]);
+						WCOS_Merge_Confirmation_Store::delete(self::$operations[$order_id]);
+					}
+					$order->delete(true);
+				}
+			}
+			if (self::$product_id) {
+				wp_delete_post(self::$product_id, true);
+			}
+		}
+	}
+
+	private static function create_product() {
+		$product = new WC_Product_Simple();
+		$product->set_name('WOS-MERGE-008 Negative Matrix Product');
+		$product->set_status('publish');
+		$product->set_regular_price('10.00');
+		$product->set_price('10.00');
+		$product->set_tax_status('none');
+		$product->set_manage_stock(true);
+		$product->set_stock_quantity(100);
+		self::$product_id = (int) $product->save();
+		self::assert(self::$product_id > 0, 'Negative matrix product creation failed.');
+	}
+
+	private static function order($label, array $overrides = array()) {
+		$order = wc_create_order(array('status' => 'pending'));
+		self::assert($order instanceof WC_Order, 'Order creation failed: ' . $label);
+		self::$order_ids[] = $order->get_id();
+		$order->set_currency(isset($overrides['currency']) ? $overrides['currency'] : 'USD');
+		$order->set_prices_include_tax(true);
+		$order->set_billing_first_name('Sandbox');
+		$order->set_billing_last_name('Matrix');
+		$order->set_billing_email(isset($overrides['email']) ? $overrides['email'] : 'wos-merge-production-enabled-matrix@example.test');
+		$order->set_billing_address_1(isset($overrides['address']) ? $overrides['address'] : '7 Matrix Way');
+		$order->set_billing_city('Testville');
+		$order->set_billing_country('US');
+		$order->set_shipping_first_name('Sandbox');
+		$order->set_shipping_last_name('Matrix');
+		$order->set_shipping_address_1(isset($overrides['address']) ? $overrides['address'] : '7 Matrix Way');
+		$order->set_shipping_city('Testville');
+		$order->set_shipping_country('US');
+		$order->set_payment_method('cod');
+		$order->set_payment_method_title('Cash on delivery');
+		if (empty($overrides['no_lines'])) {
+			$product = wc_get_product(self::$product_id);
+			$item_id = $order->add_product($product, 1);
+			$item = $order->get_item($item_id);
+			$item->add_meta_data('Sandbox matrix', $label, true);
+			$item->save();
+		}
+		if (!empty($overrides['coupon'])) {
+			$coupon = new WC_Order_Item_Coupon();
+			$coupon->set_code('sandbox-' . sanitize_key($label));
+			$coupon->set_discount('1.00');
+			$order->add_item($coupon);
+		}
+		if (!empty($overrides['fee'])) {
+			$fee = new WC_Order_Item_Fee();
+			$fee->set_name('Sandbox fee');
+			$fee->set_amount('1.00');
+			$fee->set_total('1.00');
+			$order->add_item($fee);
+		}
+		if (!empty($overrides['shipping'])) {
+			$shipping = new WC_Order_Item_Shipping();
+			$shipping->set_method_title('Sandbox matrix shipping');
+			$shipping->set_method_id('flat_rate');
+			$shipping->set_total('2.00');
+			$order->add_item($shipping);
+		}
+		$order->calculate_totals(false);
+		if (!empty($overrides['transaction_id'])) {
+			$order->set_transaction_id($overrides['transaction_id']);
+		}
+		$order->set_status(isset($overrides['status']) ? $overrides['status'] : 'on-hold');
+		$order->save();
+		if (!empty($overrides['refund'])) {
+			$refund = wc_create_refund(array(
+				'order_id' => $order->get_id(),
+				'amount' => '1.00',
+				'reason' => 'WOS-MERGE-008 sandbox refund fixture',
+				'refund_payment' => false,
+				'restock_items' => false,
+			));
+			self::assert($refund instanceof WC_Order_Refund, 'Refund fixture creation failed.');
+		}
+		return wc_get_order($order->get_id());
+	}
+
+	private static function pair($label, array $source_overrides = array(), array $target_overrides = array()) {
+		return array(self::order($label . '-source', $source_overrides), self::order($label . '-target', $target_overrides));
+	}
+
+	private static function request(WC_Order $source, WC_Order $target) {
+		return array(
+			'source_order_id' => $source->get_id(),
+			'target_order_id' => $target->get_id(),
+			'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()),
+		);
+	}
+
+	private static function search_and_permissions() {
+		list($source, $target) = self::pair('search');
+		$target->set_date_created('2020-01-01 00:00:00');
+		$target->save();
+		$controller = WCOS_Merge_Admin_Controller::bootstrap();
+		$base = array('source_order_id' => $source->get_id(), 'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()), 'page' => 1);
+		$browse = $controller->search_request(array_merge($base, array('term' => '')));
+		self::assert(count($browse['results']) <= WCOS_Merge_Admin_Controller::SEARCH_LIMIT, 'Browse exceeded result limit.');
+		self::assert(!in_array($target->get_id(), array_map(function($r){ return (int) $r['id']; }, $browse['results']), true), 'Old target remained in bounded recent browse.');
+		foreach (array((string) $target->get_id(), '#' . $target->get_id()) as $term) {
+			$exact = $controller->search_request(array_merge($base, array('term' => $term)));
+			self::assert(1 === count($exact['results']) && $target->get_id() === (int) $exact['results'][0]['id'], 'Exact old target search failed: ' . $term);
+			self::assert(array('id', 'number', 'status', 'currency') === array_keys($exact['results'][0]), 'Search result exceeded PII-free fields.');
+			self::assert(false === strpos(wp_json_encode($exact), '@example.test') && false === strpos(wp_json_encode($exact), 'Matrix Way'), 'Search response exposed PII.');
+		}
+		$source_result = $controller->search_request(array_merge($base, array('term' => (string) $source->get_id())));
+		self::assert(empty($source_result['results']), 'Search included current source.');
+		self::expect_transport(function() use ($controller, $base) { $controller->search_request(array_merge($base, array('term' => str_repeat('x', 41)))); }, 'invalid_search');
+		self::expect_transport(function() use ($controller, $base) { $controller->search_request(array_merge($base, array('term' => '', 'page' => 6))); }, 'invalid_search_page');
+
+		$subscriber = wp_create_user('wcos-merge-007-sub-' . wp_generate_uuid4(), wp_generate_password(24), 'wos-merge-production-enabled-sub-' . wp_generate_uuid4() . '@example.test');
+		self::assert(!is_wp_error($subscriber), 'Subscriber fixture creation failed.');
+		self::$user_ids[] = (int) $subscriber;
+		wp_set_current_user((int) $subscriber);
+		$unauthorized = array('source_order_id' => $source->get_id(), 'nonce' => wp_create_nonce('wcos_merge_order_' . $source->get_id()), 'term' => (string) $target->get_id(), 'page' => 1);
+		self::expect_transport(function() use ($controller, $unauthorized) { $controller->search_request($unauthorized); }, 'authorization_failed');
+
+		$manager = wp_create_user('wcos-merge-007-manager-' . wp_generate_uuid4(), wp_generate_password(24), 'wos-merge-production-enabled-manager-' . wp_generate_uuid4() . '@example.test');
+		self::assert(!is_wp_error($manager), 'Shop manager fixture creation failed.');
+		self::$user_ids[] = (int) $manager;
+		$user = get_user_by('id', (int) $manager);
+		$user->set_role('shop_manager');
+		wp_set_current_user((int) $manager);
+		update_option('order_splitter_shop_manager_permission', 'no');
+		$manager_request = self::request($source, $target);
+		self::expect_transport(function() use ($controller, $manager_request) { $controller->review_request($manager_request); }, 'authorization_failed');
+		update_option('order_splitter_shop_manager_permission', 'yes');
+		$manager_request['nonce'] = wp_create_nonce('wcos_merge_order_' . $source->get_id());
+		$manager_review = $controller->review_request($manager_request);
+		self::assert(!empty($manager_review['review_id']), 'Enabled shop-manager semantics did not allow Review.');
+		WCOS_Merge_Review_Store::delete($manager_review['review_id']);
+		wp_set_current_user(self::$admin_id);
+		update_option('order_splitter_shop_manager_permission', self::$old_shop_permission);
+
+		self::$results['search_permissions'] = array(
+			'browse_count' => count($browse['results']),
+			'exact_numeric' => true,
+			'exact_hash' => true,
+			'old_target_outside_browse' => true,
+			'pii_free' => true,
+			'source_excluded' => true,
+			'invalid_input_rejected' => true,
+			'unauthorized_rejected' => true,
+			'shop_manager_option_enforced' => true,
+		);
+	}
+
+	private static function drift_and_authority() {
+		$controller = WCOS_Merge_Admin_Controller::bootstrap();
+
+		list($source, $target) = self::pair('target-drift');
+		$request = self::request($source, $target);
+		$review = $controller->review_request($request);
+		self::change_first_line($target, 2);
+		$target_after_drift = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id()));
+		self::expect_transport(function() use ($controller, $request, $review) {
+			$controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		}, array('review_authority_changed', 'review_pair_changed', 'review_target_changed'));
+		self::assert($target_after_drift === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id())), 'Rejected target drift changed target again.');
+		self::assert(empty($source->get_meta(WCOS_Merge_Participation::SOURCE_OPERATION_META, false)), 'Target drift started a journal.');
+
+		list($source, $target) = self::pair('source-drift');
+		$request = self::request($source, $target);
+		$review = $controller->review_request($request);
+		self::change_first_line($source, 3);
+		$source_after_drift = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id()));
+		self::expect_transport(function() use ($controller, $request, $review) {
+			$controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		}, array('review_authority_changed', 'review_pair_changed', 'review_source_changed'));
+		self::assert($source_after_drift === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id())), 'Rejected source drift changed source again.');
+		self::assert(empty($source->get_meta(WCOS_Merge_Participation::SOURCE_OPERATION_META, false)), 'Source drift started a journal.');
+
+		$source = self::order('target-change-source');
+		$target_a = self::order('target-change-a');
+		$target_b = self::order('target-change-b');
+		$request_a = self::request($source, $target_a);
+		$review = $controller->review_request($request_a);
+		$request_b = self::request($source, $target_b);
+		self::expect_transport(function() use ($controller, $request_b, $review) {
+			$controller->confirm_request(array_merge($request_b, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		}, array('review_owner_mismatch', 'review_authority_changed'));
+		self::assert(empty($source->get_meta(WCOS_Merge_Participation::SOURCE_OPERATION_META, false)), 'Target switch reused stale Review.');
+
+		list($source, $target) = self::pair('review-reuse');
+		$request = self::request($source, $target);
+		$review = $controller->review_request($request);
+		$confirmation = $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		self::expect_transport(function() use ($controller, $request, $review) {
+			$controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		}, array('review_expired', 'review_already_consumed'));
+		WCOS_Merge_Confirmation_Store::delete($confirmation['operation_id']);
+
+		$injected = self::request($source, $target);
+		$injected['plan'] = array('client' => 'authority');
+		self::expect_transport(function() use ($controller, $injected) { $controller->review_request($injected); }, 'unexpected_field');
+
+		self::$results['authority_drift'] = array(
+			'target_drift_fail_closed' => true,
+			'source_drift_fail_closed' => true,
+			'target_switch_discarded' => true,
+			'review_single_use' => true,
+			'client_authority_rejected' => true,
+			'no_journal_on_rejection' => true,
+		);
+	}
+
+	private static function successful_operation() {
+		$controller = WCOS_Merge_Admin_Controller::bootstrap();
+		list($source, $target) = self::pair('enabled-success');
+		$source_items = array_values($source->get_items('line_item'));
+		self::assert(1 === count($source_items), 'Enabled success source fixture is invalid.');
+		$source_items[0]->update_meta_data('_reduced_stock', '1.000000');
+		$source_items[0]->save();
+		$second_id = $source->add_product(wc_get_product(self::$product_id), 2);
+		$second = $source->get_item($second_id);
+		self::assert($second instanceof WC_Order_Item_Product, 'Second enabled source line was not created.');
+		$second->add_meta_data('Sandbox matrix', 'enabled-success-source-second', true);
+		$second->add_meta_data('_reduced_stock', '2.000000', true);
+		$second->save();
+		$source->calculate_totals(false);
+		$source->save();
+		$source->get_data_store()->set_stock_reduced($source->get_id(), true);
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+
+		$before = WCOS_Order_Contract_Snapshot::aggregate(array($source, $target), 2);
+		$stock_before = WCOS_Order_Contract_Snapshot::product_stock($source);
+		$source_line_ids = array_map('absint', array_keys($source->get_items('line_item')));
+		$target_line_ids_before = array_map('absint', array_keys($target->get_items('line_item')));
+		$request = self::request($source, $target);
+		$review = $controller->review_request($request);
+		$confirmation = $controller->confirm_request(array_merge($request, array(
+			'review_id' => $review['review_id'],
+			'review_token' => $review['review_token'],
+		)));
+		self::$operations[$source->get_id()] = $confirmation['operation_id'];
+		$result = $controller->execute_request(array_merge($request, array(
+			'operation_id' => $confirmation['operation_id'],
+			'confirmation_token' => $confirmation['confirmation_token'],
+		)));
+		self::assert('completed' === $result['status'], 'Production-enabled controller chain did not complete.');
+		self::assert(false === strpos(wp_json_encode($result), '@example.test') && false === strpos(wp_json_encode($result), 'Matrix Way'), 'Production-enabled result exposed PII.');
+
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+		self::assert('trash' === $source->get_status(), 'Production-enabled source was not retired through trash archive.');
+		self::assert('on-hold' === $target->get_status(), 'Production-enabled target status changed.');
+		self::assert(2 === count($source->get_items('line_item')), 'Retired source commercial lines are not inspectable.');
+		$target_line_ids_after = array_map('absint', array_keys($target->get_items('line_item')));
+		$fresh_ids = array_values(array_diff($target_line_ids_after, $target_line_ids_before));
+		self::assert(2 === count($fresh_ids) && 2 === count(array_unique($fresh_ids)), 'Production-enabled Merge coalesced or omitted fresh target lines.');
+		self::assert(empty(array_intersect($source_line_ids, $fresh_ids)), 'Production-enabled Merge re-parented source item IDs.');
+		foreach ($source->get_items('line_item') as $item) {
+			self::assert($source->get_id() === $item->get_order_id(), 'A persisted source item changed ownership.');
+			self::assert('' === (string) $item->get_meta('_reduced_stock', true), 'Retired source retained reduced-stock ownership.');
+		}
+		$target_reduced = array();
+		foreach ($fresh_ids as $item_id) {
+			$target_reduced[] = WCOS_Decimal::normalize($target->get_item($item_id)->get_meta('_reduced_stock', true), 6);
+		}
+		sort($target_reduced, SORT_STRING);
+		self::assert(array('1.000000', '2.000000') === $target_reduced, 'Active target did not receive exact reduced-stock ownership once.');
+		WCOS_Mutation_Contract::assert_conserved($before, WCOS_Order_Contract_Snapshot::aggregate(array($target), 2), 2);
+		self::assert($stock_before === WCOS_Order_Contract_Snapshot::product_stock($target), 'Production-enabled Merge changed physical stock.');
+
+		$journal = WCOS_Operation_Journal::get($source, $confirmation['operation_id']);
+		self::assert(is_array($journal) && 'completed' === $journal['status'], 'Production-enabled source journal is not completed.');
+		self::assert(null === WCOS_Operation_Journal::get($target, $confirmation['operation_id']), 'Production-enabled Merge created a target shadow journal.');
+		$pair = WCOS_Merge_Journal_Context::assert_executable_policy($journal);
+		self::assert(true === $pair['retirement_policy_selected'] && 'non_force_trash_archive' === $pair['retirement_policy_identifier'], 'Production-enabled journal lost retirement authority.');
+		self::assert(array('source' => true, 'target' => true) === WCOS_Merge_Participation::state_for_pair($source, $target, $confirmation['operation_id'], $pair['pair_fingerprint']), 'Production-enabled reciprocal participation is incomplete.');
+
+		$journal_before_replay = wp_json_encode($journal);
+		$source_before_replay = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
+		$target_before_replay = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+		$replay = $controller->execute_request(array_merge($request, array(
+			'operation_id' => $confirmation['operation_id'],
+			'confirmation_token' => $confirmation['confirmation_token'],
+		)));
+		self::assert($result === $replay, 'Production-enabled durable replay did not return the original result.');
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+		self::assert($journal_before_replay === wp_json_encode(WCOS_Operation_Journal::get($source, $confirmation['operation_id'])), 'Durable replay changed the journal.');
+		self::assert($source_before_replay === WCOS_Merge_Recovery_Snapshot::participant_signature($source), 'Durable replay changed source state.');
+		self::assert($target_before_replay === WCOS_Merge_Recovery_Snapshot::participant_signature($target), 'Durable replay changed target state.');
+
+		WCOS_Operation_Journal::delete($source, $confirmation['operation_id']);
+		WCOS_Merge_Confirmation_Store::delete($confirmation['operation_id']);
+		unset(self::$operations[$source->get_id()]);
+		self::$results['successful_operation'] = array(
+			'controller_chain' => true,
+			'conservation' => true,
+			'stock_neutral' => true,
+			'reciprocal_relations' => true,
+			'durable_replay' => true,
+		);
+	}
+
+	private static function unsupported_matrix() {
+		list($same_source, $same_target) = self::pair('same');
+		self::expect_review_failure('same_order', $same_source, $same_source, 'invalid_pair');
+		list($source, $target) = self::pair('status', array('status' => 'on-hold'), array('status' => 'processing'));
+		self::expect_review_failure('incompatible_status', $source, $target, 'preflight_incompatible_status');
+		list($source, $target) = self::pair('currency', array(), array('currency' => 'EUR'));
+		self::expect_review_failure('different_currency', $source, $target, 'preflight_incompatible_currency');
+		list($source, $target) = self::pair('context', array(), array('email' => 'different@example.test', 'address' => '99 Other Way'));
+		self::expect_review_failure('incompatible_context', $source, $target, 'preflight_incompatible_pair_context');
+		list($source, $target) = self::pair('paid', array(), array('transaction_id' => 'sandbox-transaction'));
+		self::expect_review_failure('paid_transaction', $source, $target, 'preflight_paid_order_unsupported');
+		list($source, $target) = self::pair('refund', array(), array('refund' => true));
+		self::expect_review_failure('refunded', $source, $target, 'preflight_refund_policy_missing');
+		list($source, $target) = self::pair('coupon', array(), array('coupon' => true));
+		self::expect_review_failure('coupon', $source, $target, 'preflight_coupon_policy_missing');
+		list($source, $target) = self::pair('fee', array(), array('fee' => true));
+		self::expect_review_failure('fee', $source, $target, 'preflight_fee_policy_missing');
+		list($source, $target) = self::pair('source-shipping', array('shipping' => true), array());
+		self::expect_review_failure('source_shipping', $source, $target, 'preflight_source_shipping_policy_missing');
+		list($source, $target) = self::pair('no-source-lines', array('no_lines' => true), array());
+		self::expect_review_failure('no_source_lines', $source, $target, 'preflight_no_source_lines');
+	}
+
+	private static function valid_recovery_after_errors() {
+		list($source, $target) = self::pair('recoverable-valid');
+		$review = WCOS_Merge_Admin_Controller::bootstrap()->review_request(self::request($source, $target));
+		self::assert(!empty($review['review_id']), 'UI/transport did not recover for a later valid selection.');
+		WCOS_Merge_Review_Store::delete($review['review_id']);
+		self::$results['recoverability'] = array('valid_review_after_rejections' => true);
+	}
+
+	private static function expect_review_failure($label, WC_Order $source, WC_Order $target, $expected_code) {
+		$source_before = WCOS_Order_Contract_Snapshot::source_signature($source);
+		$target_before = WCOS_Order_Contract_Snapshot::source_signature($target);
+		$error = self::expect_transport(function() use ($source, $target) {
+			WCOS_Merge_Admin_Controller::bootstrap()->review_request(self::request($source, $target));
+		}, $expected_code);
+		$source = wc_get_order($source->get_id());
+		$target = wc_get_order($target->get_id());
+		self::assert($source_before === WCOS_Order_Contract_Snapshot::source_signature($source), $label . ' rejection changed source.');
+		self::assert($target_before === WCOS_Order_Contract_Snapshot::source_signature($target), $label . ' rejection changed target.');
+		self::assert(empty($source->get_meta(WCOS_Merge_Participation::SOURCE_OPERATION_META, false)), $label . ' rejection started source authority.');
+		self::assert(empty($target->get_meta(WCOS_Merge_Participation::TARGET_OPERATION_META, false)), $label . ' rejection started target authority.');
+		self::assert(strlen($error['message']) <= 240 && false === strpos($error['message'], '@example.test') && false === strpos($error['message'], 'Matrix Way'), $label . ' error is unbounded or exposes PII.');
+		self::$results['unsupported'][$label] = array('code' => $error['code'], 'no_mutation' => true, 'pii_free' => true);
+	}
+
+	private static function expect_transport(callable $callback, $expected_codes) {
+		$expected_codes = (array) $expected_codes;
+		try {
+			$callback();
+		} catch (WCOS_Merge_Transport_Exception $exception) {
+			self::assert(in_array($exception->get_error_code(), $expected_codes, true), 'Unexpected transport code: ' . $exception->get_error_code());
+			return array('code' => $exception->get_error_code(), 'message' => $exception->getMessage());
+		}
+		throw new RuntimeException('Expected transport rejection did not occur: ' . implode(',', $expected_codes));
+	}
+
+	private static function change_first_line(WC_Order $order, $quantity) {
+		$items = $order->get_items('line_item');
+		$item = reset($items);
+		self::assert($item instanceof WC_Order_Item_Product, 'Drift line unavailable.');
+		$item->set_quantity($quantity);
+		$item->set_subtotal((string) (10 * $quantity));
+		$item->set_total((string) (10 * $quantity));
+		$item->save();
+		$order = wc_get_order($order->get_id());
+		$order->calculate_totals(false);
+		$order->save();
+	}
+
+	private static function assert($condition, $message) {
+		if (!$condition) {
+			throw new RuntimeException($message);
+		}
+	}
+}
+
+WCOS_Merge_Production_Enabled_Matrix::run();

--- a/tests/integration/merge-recovery-foundation-smoke.php
+++ b/tests/integration/merge-recovery-foundation-smoke.php
@@ -320,7 +320,7 @@ function wcos_merge_recovery_run_immutable_drift_case($label, WC_Product $produc
 	return array('label' => $label, 'manual_before_recovery_write' => true, 'stock_neutral' => true);
 }
 
-wcos_merge_recovery_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'MERGE gate changed during recovery work.');
+wcos_merge_recovery_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production MERGE gate is not enabled during recovery evidence.');
 $managed = wcos_merge_recovery_product(true, false);
 $backorder = wcos_merge_recovery_product(true, true);
 $unmanaged = wcos_merge_recovery_product(false, false);
@@ -847,6 +847,6 @@ echo 'merge-recovery-evidence=' . wp_json_encode(array(
 	'immutable_drift_matrix' => $immutable_drift_matrix,
 	'retirement_candidates' => $retirement,
 	'failure_windows' => $failure_windows,
-	'merge_gate' => false,
+	'merge_gate' => WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE),
 )) . "\n";
 echo "merge-recovery-foundation-ok\n";

--- a/tests/integration/merge-review-confirm-execute-smoke.php
+++ b/tests/integration/merge-review-confirm-execute-smoke.php
@@ -77,12 +77,11 @@ wp_set_current_user($operator_id);
 $original_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
 update_option('order_splitter_status_allowed', array('wc-pending'));
 
-wcos_merge_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate unexpectedly enabled.');
-wcos_merge_authority_assert(null === WCOS_Merge_Admin_Controller::bootstrap(), 'Hard-off Merge controller bootstrapped.');
+wcos_merge_authority_assert(true === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate is not enabled.');
 $controller = new WCOS_Merge_Admin_Controller();
-wcos_merge_authority_assert(false === $controller->register_hooks(), 'Hard-off Merge controller registered hooks.');
+wcos_merge_authority_assert(true === $controller->register_hooks(), 'Enabled Merge controller did not register hooks.');
 foreach (array(WCOS_Merge_Admin_Controller::SEARCH_ACTION, WCOS_Merge_Admin_Controller::REVIEW_ACTION, WCOS_Merge_Admin_Controller::CONFIRM_ACTION, WCOS_Merge_Admin_Controller::EXECUTE_ACTION) as $action) {
-	wcos_merge_authority_assert(false === has_action('wp_ajax_' . $action), 'A hard-off Merge AJAX hook is production-visible.');
+	wcos_merge_authority_assert(false !== has_action('wp_ajax_' . $action), 'An enabled Merge AJAX hook is missing.');
 }
 
 $product = new WC_Product_Simple();
@@ -147,25 +146,29 @@ try {
 	}
 	wcos_merge_authority_assert($replay_rejected, 'A consumed Merge Review produced another Confirmation.');
 
-	$source_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id()));
-	$target_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id()));
-	$gate_rejected = false;
-	try {
-		$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
-	} catch (WCOS_Merge_Transport_Exception $exception) {
-		$gate_rejected = 'workflow_disabled' === $exception->get_error_code();
-	}
-	wcos_merge_authority_assert($gate_rejected, 'Controller Execute did not stop at the Merge gateway hard-off boundary.');
-	wcos_merge_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $confirm['operation_id']), 'Gate-off Execute created a Merge journal.');
-	wcos_merge_authority_assert($source_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($source->get_id())), 'Gate-off Execute changed the source.');
-	wcos_merge_authority_assert($target_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($target->get_id())), 'Gate-off Execute changed the target.');
-	$second_gate_rejected = false;
-	try {
-		$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
-	} catch (WCOS_Merge_Transport_Exception $exception) {
-		$second_gate_rejected = 'workflow_disabled' === $exception->get_error_code();
-	}
-	wcos_merge_authority_assert($second_gate_rejected && null === WCOS_Operation_Journal::get(wc_get_order($source->get_id()), $confirm['operation_id']), 'Repeated gate-off Execute changed operation authority.');
+	$source_line_ids = array_map('absint', array_keys($source->get_items('line_item')));
+	$target_line_ids_before = array_map('absint', array_keys($target->get_items('line_item')));
+	$execute = $controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
+	wcos_merge_authority_assert('completed' === $execute['status'], 'Enabled controller Execute did not complete.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	$journal = WCOS_Operation_Journal::get($source, $confirm['operation_id']);
+	wcos_merge_authority_assert(is_array($journal) && 'completed' === $journal['status'], 'Enabled controller Execute did not create one completed source journal.');
+	wcos_merge_authority_assert('trash' === $source->get_status(), 'Enabled controller Execute did not retire the source.');
+	$target_line_ids_after = array_map('absint', array_keys($target->get_items('line_item')));
+	$fresh_line_ids = array_values(array_diff($target_line_ids_after, $target_line_ids_before));
+	wcos_merge_authority_assert(count($source_line_ids) === count($fresh_line_ids), 'Enabled controller Execute did not create one fresh target line per source line.');
+	wcos_merge_authority_assert(empty(array_intersect($source_line_ids, $fresh_line_ids)), 'Enabled controller Execute re-parented a persisted source line.');
+	$source_after = WCOS_Merge_Recovery_Snapshot::participant_signature($source);
+	$target_after = WCOS_Merge_Recovery_Snapshot::participant_signature($target);
+	$journal_after = wp_json_encode($journal);
+	$execute_replay = $controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
+	wcos_merge_authority_assert($execute === $execute_replay, 'Enabled controller same-operation replay did not return the stable result.');
+	$source = wc_get_order($source->get_id());
+	$target = wc_get_order($target->get_id());
+	wcos_merge_authority_assert($journal_after === wp_json_encode(WCOS_Operation_Journal::get($source, $confirm['operation_id'])), 'Enabled controller replay changed durable journal authority.');
+	wcos_merge_authority_assert($source_after === WCOS_Merge_Recovery_Snapshot::participant_signature($source), 'Enabled controller replay changed retired source state.');
+	wcos_merge_authority_assert($target_after === WCOS_Merge_Recovery_Snapshot::participant_signature($target), 'Enabled controller replay changed target state.');
 
 	list($surface_source, $surface_target) = wcos_merge_authority_pair($product, 'first-execute-surface');
 	$pairs[] = array($surface_source, $surface_target, '');
@@ -191,7 +194,7 @@ try {
 	try {
 		WCOS_Merge_Confirmation_Store::verify($source, $target, $confirm['operation_id'], $confirm['confirmation_token'], $operator_id);
 	} catch (WCOS_Merge_Confirmation_Exception $exception) {
-		$precision_drift_rejected = in_array($exception->get_reason(), array('authority_changed', 'pair_changed'), true);
+		$precision_drift_rejected = in_array($exception->get_reason(), array('authority_changed', 'pair_changed', 'journal_mismatch'), true);
 	}
 	wcos_merge_authority_assert($precision_drift_rejected, 'Merge Confirmation precision drift was accepted.');
 	set_transient('wcos_merge_confirm_' . hash('sha256', $confirm['operation_id']), $original_confirm_record, WCOS_Merge_Confirmation_Store::TTL);
@@ -322,13 +325,8 @@ try {
 	$replay_target_line_ids_before = array_map('absint', array_keys($durable_target->get_items('line_item')));
 	$replay_target_tax_ids_before = array_map('absint', array_keys($durable_target->get_items('tax')));
 	$replay_stock_before = $product->get_stock_quantity();
-	$controller_replay_reached_gateway = false;
-	try {
-		$controller->execute_request(array_merge($durable_request, array('operation_id' => $durable_confirm['operation_id'], 'confirmation_token' => $durable_confirm['confirmation_token'])));
-	} catch (WCOS_Merge_Transport_Exception $exception) {
-		$controller_replay_reached_gateway = 'workflow_disabled' === $exception->get_error_code();
-	}
-	wcos_merge_authority_assert($controller_replay_reached_gateway, 'Completed Merge controller replay was blocked by stale source/target surface status before the gateway.');
+	$controller_replay = $controller->execute_request(array_merge($durable_request, array('operation_id' => $durable_confirm['operation_id'], 'confirmation_token' => $durable_confirm['confirmation_token'])));
+	wcos_merge_authority_assert('completed' === $controller_replay['status'], 'Completed Merge controller replay did not reach the enabled gateway.');
 	$durable_source = wc_get_order($durable_source->get_id());
 	$durable_target = wc_get_order($durable_target->get_id());
 	wcos_merge_authority_assert($replay_journal_before === wp_json_encode(WCOS_Operation_Journal::get($durable_source, $durable_confirm['operation_id'])), 'Controller replay changed or created durable journal authority.');

--- a/tests/integration/merge-service-adapter-smoke.php
+++ b/tests/integration/merge-service-adapter-smoke.php
@@ -180,19 +180,7 @@ try {
 	$products[] = $managed;
 
 	if (in_array($suite, array('all', 'core'), true)) {
-	/* Gateway stays hard-off while direct adapter/service acceptance is executable. */
-	list($gate_source, $gate_target) = wcos_merge_service_pair($managed, 'gate');
-	$gate_operation = 'merge-gate-' . wp_generate_uuid4();
-	$gate_rejected = false;
-	try {
-		(new WCOS_Mutation_Gateway())->merge($gate_source, $gate_target, $gate_operation, 2);
-	} catch (RuntimeException $exception) {
-		$gate_rejected = true;
-	}
-	wcos_merge_service_assert($gate_rejected, 'MERGE=false did not stop the gateway before delegation.');
-	wcos_merge_service_assert(null === WCOS_Operation_Journal::get($gate_source, $gate_operation), 'Hard-off gateway created journal state.');
-	$gate_source->delete(true);
-	$gate_target->delete(true);
+	wcos_merge_service_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate is not enabled for adapter evidence.');
 
 	/* Success: identical source lines stay distinct, historical tax/shipping survive, retry is stable. */
 	list($source, $target) = wcos_merge_service_pair($managed, 'success', array('1.5', '2'), true, true);

--- a/tests/integration/merge-ui-foundation-smoke.php
+++ b/tests/integration/merge-ui-foundation-smoke.php
@@ -30,10 +30,9 @@ $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 
 wcos_merge_ui_assert(!empty($admins), 'Merge UI smoke requires an administrator fixture.');
 wp_set_current_user(absint($admins[0]));
 
-wcos_merge_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate unexpectedly enabled.');
-wcos_merge_ui_assert(null === WCOS_Merge_Admin_Controller::bootstrap(), 'Hard-off Merge UI controller bootstrapped.');
+wcos_merge_ui_assert(true === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate is not enabled.');
 $controller = new WCOS_Merge_Admin_Controller();
-wcos_merge_ui_assert(false === $controller->register_hooks(), 'Hard-off Merge UI controller registered hooks.');
+wcos_merge_ui_assert(true === $controller->register_hooks(), 'Enabled Merge UI controller did not register hooks.');
 
 $hook_contracts = array(
 	'wp_ajax_' . WCOS_Merge_Admin_Controller::SEARCH_ACTION => 'ajax_search',
@@ -45,14 +44,14 @@ $hook_contracts = array(
 	'admin_enqueue_scripts' => 'enqueue_assets',
 );
 foreach ($hook_contracts as $hook => $method) {
-	wcos_merge_ui_assert(false === has_action($hook, array($controller, $method)), 'A hard-off Merge hook is production-visible: ' . $hook);
+	wcos_merge_ui_assert(false !== has_action($hook, array($controller, $method)), 'Enabled Merge hook is missing: ' . $hook);
 }
 
 wp_dequeue_script('wcos-merge-admin');
 wp_dequeue_style('wcos-merge-admin');
 $controller->enqueue_assets();
-wcos_merge_ui_assert(!wp_script_is('wcos-merge-admin', 'enqueued'), 'Hard-off Merge script was enqueued.');
-wcos_merge_ui_assert(!wp_style_is('wcos-merge-admin', 'enqueued'), 'Hard-off Merge stylesheet was enqueued.');
+wcos_merge_ui_assert(!wp_script_is('wcos-merge-admin', 'enqueued'), 'Merge script was enqueued outside an order edit screen.');
+wcos_merge_ui_assert(!wp_style_is('wcos-merge-admin', 'enqueued'), 'Merge stylesheet was enqueued outside an order edit screen.');
 
 $old_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
 update_option('order_splitter_status_allowed', array('wc-processing'));
@@ -72,8 +71,16 @@ try {
 
 	ob_start();
 	$controller->render_launcher($source);
-	$hard_off_launcher = (string) ob_get_clean();
-	wcos_merge_ui_assert('' === $hard_off_launcher, 'Hard-off Merge launcher rendered.');
+	$enabled_launcher = (string) ob_get_clean();
+	wcos_merge_ui_assert(false !== strpos($enabled_launcher, 'Merge into another order'), 'Enabled Merge launcher did not render.');
+	wcos_merge_ui_assert(false === strpos($enabled_launcher, $email) && false === strpos($enabled_launcher, $address), 'Enabled Merge launcher exposed customer PII.');
+
+	$order_screen_id = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+	set_current_screen($order_screen_id);
+	$_GET['id'] = (string) $source->get_id();
+	$controller->enqueue_assets();
+	wcos_merge_ui_assert(wp_script_is('wcos-merge-admin', 'enqueued'), 'Enabled Merge script was not enqueued on the order edit screen.');
+	wcos_merge_ui_assert(wp_style_is('wcos-merge-admin', 'enqueued'), 'Enabled Merge stylesheet was not enqueued on the order edit screen.');
 
 	$template = $controller->dialog_html($source);
 	wcos_merge_ui_assert(false !== strpos($template, 'wcos-merge-target-select'), 'Merge target selector template is missing.');

--- a/tests/integration/p2-production-duplicate-enabled-smoke.php
+++ b/tests/integration/p2-production-duplicate-enabled-smoke.php
@@ -17,10 +17,10 @@ function wcos_p2_duplicate_enabled_expect_transport($code, $http_status, callabl
 
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Production Split gate was lost while enabling Duplicate.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Hardened Duplicate is not production-enabled in the enablement contract.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate was lost while validating Duplicate.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::any_enabled(), 'Approved production gate set was reported as fully disabled.');
 wcos_p2_adapter_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved Duplicate gate.');
 foreach (array(
-	WCOS_Feature_Gates::MERGE,
 	WCOS_Feature_Gates::RETURN_ORDER,
 	WCOS_Feature_Gates::BULK_RETURN,
 ) as $disabled_workflow) {

--- a/tests/integration/p2-production-split-enabled-smoke.php
+++ b/tests/integration/p2-production-split-enabled-smoke.php
@@ -16,10 +16,10 @@ function wcos_p2_enabled_expect_transport($code, $http_status, callable $callbac
 }
 
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Manual quantity Split is not production-enabled in the enablement contract.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate was lost while validating Split.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::any_enabled(), 'Production gate set was reported as fully disabled.');
 wcos_p2_adapter_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved Split gate.');
 foreach (array(
-	WCOS_Feature_Gates::MERGE,
 	WCOS_Feature_Gates::RETURN_ORDER,
 	WCOS_Feature_Gates::BULK_RETURN,
 ) as $disabled_workflow) {


### PR DESCRIPTION
## Classification

`P3_PRODUCTION_ENABLEMENT`

## Scope

Enables the already-accepted hardened Merge workflow in production source code. **No release is being performed.**

- Exact production base: `8cc3108951c37eceec4b9c67d31d06b94dd9a043`
- Exact candidate head: `3333863e00c9f7305083dc88c86eb4e8ccce160c`
- Branch was created directly from `origin/main`; the WOS-MERGE-007 sandbox branch/history was not used
- Closes no issue at merge time: #49 must remain open through mandatory post-merge `push/main` verification

## Production PHP diff

The only production PHP behavior change is the central code-owned gate:

```diff
- self::MERGE => false,
+ self::MERGE => true,
```

No Merge service, adapter, controller, authority, recovery, commercial-policy, retirement-policy, settings, version, changelog, readme, translation, or release behavior changed.

Final production gate target:

- `SPLIT=true`
- `DUPLICATE=true`
- `MERGE=true`
- `RETURN_ORDER=false`
- `BULK_RETURN=false`
- `manual_quantity=true`
- `category=false`
- `stock_status=false`

## CI / test-only diff

- Exact-state CI, ZIP, and release-package assertions now require `MERGE=true`
- Runtime storage contract now requires the existing Merge Search/Review/Confirm/Execute/controller/UI hooks and rejects legacy Merge transport
- Obsolete hard-off-only assertions were replaced by production-enabled assertions without removing authority/recovery/security coverage
- Added `merge-production-enabled-smoke.php` for real controller-chain success, persisted conservation, stock neutrality, source-keyed journal, reciprocal relations, durable replay, permissions, drift, PII-free search, and unsupported-envelope rejection
- Existing hardened crash/recovery/lease/stock/tax plus Split/Duplicate chains remain in the canonical matrix

## Evidence status

Local active checkout evidence completed on HPOS-only with WordPress 7.1 / WooCommerce 11.0.1:

- full PHP lint and unit contracts: pass
- Merge domain/recovery/service core: pass
- enabled Review → Confirm → Execute and durable replay authority: pass
- enabled Merge UI foundation: pass
- production-enabled success + permissions/drift/unsupported matrix: pass
- exact filesystem HEAD equaled the pushed PR head immediately before browser Execute
- real browser `Search → Review → Confirm → Execute` succeeded for disposable orders `#22592 → #22593`
- browser success was followed by persisted database re-read: source `trash` and inspectable; target `on-hold`; historical aggregate `36.00 USD`; fresh line IDs/no re-parent/no coalesce; source-keyed completed journal; no target shadow journal; reciprocal relations; `non_force_trash_archive`; PII-free terminal result
- durable retry/replay passed in the focused Local smoke and in every canonical storage job
- disposable orders `22592/22593`, product `22591`, operation `74f64773-a51d-4290-b0f3-8ffcebb11121`, confirmation/journal, and manifest were permanently deleted and verified absent
- only pre-existing PHP 8.4 implicit-nullable deprecations were observed; no new warning/fatal came from this tranche

Canonical run [`32693128824`](https://github.com/yoohwz/wc-order-splitter/actions/runs/32693128824) completed `success` for exact head `3333863e00c9f7305083dc88c86eb4e8ccce160c`:

- PHP 7.4 / 8.1 / 8.3: pass
- package safety: pass
- architecture/exact production gates: pass
- WooCommerce 11.0.1 legacy with Merge enabled: pass
- WooCommerce 11.0.1 HPOS-only with Merge enabled: pass
- WooCommerce 11.0.1 HPOS-sync with Merge enabled: pass
- Required CI aggregate: pass

## Full `origin/main...HEAD` self-review

- `origin/main` and merge-base remain exact authority `8cc3108951c37eceec4b9c67d31d06b94dd9a043`
- `git diff --check origin/main...HEAD`: pass
- worktree: clean
- production PHP diff: only `inc/domain/class-wcos-feature-gates.php`, changing `MERGE=false → true`
- all other changes are limited to `.github/workflows/{ci,build-plugin}.yml` and focused integration tests
- exact workflow/strategy gate maps preserved; no configurable gate, second controller/gateway/journal/recovery path, custom `wc-merged` status, legacy transport registration, version/readme/changelog/translation/release change, or commercial-envelope expansion found

## Boundaries

- No commercial-scope expansion
- No release, tag, package publication, deployment, or production merge in this task
- Do not merge before independent ChatGPT Technical Review and a separate explicit Human Gate for the exact accepted head
- Any real service/controller/authority/recovery defect discovered by gate-enabled validation must leave this PR and follow Issue #49's hard-off correction boundary
