### PR TITLE
Release 1.4.15: document hardened Merge enablement

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -122,6 +122,11 @@ jobs:
             'inc/backend/class-wcos-split-strategy-review-store.php' \
             'inc/backend/class-wcos-split-strategy-confirmation-store.php' \
             'inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'inc/backend/class-wcos-merge-review-store.php' \
+            'inc/backend/class-wcos-merge-confirmation-store.php' \
+            'inc/backend/class-wcos-merge-admin-controller.php' \
+            'css/p2-merge-admin.css' \
+            'js/p2-merge-admin.js' \
             'inc/domain/class-wcos-split-strategy-gates.php' \
             'inc/domain/class-wcos-category-split-planner.php' \
             'inc/domain/class-wcos-stock-status-split-planner.php' \
@@ -137,6 +142,8 @@ jobs:
             'inc/domain/class-wcos-merge-compensator.php' \
             'inc/domain/class-wcos-merge-preflight.php' \
             'inc/domain/class-wcos-merge-retirement-policy.php' \
+            'inc/domain/class-wcos-merge-order-service.php' \
+            'inc/domain/class-wcos-merge-woocommerce-adapter.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -172,6 +179,28 @@ jobs:
           archive_stable_tag=$(unzip -p wc-order-splitter.zip wc-order-splitter/readme.txt | sed -n 's/^Stable tag: //p' | head -n 1)
           test -n "$archive_version"
           test "$archive_version" = "$archive_stable_tag"
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::SPLIT => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::DUPLICATE => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::MERGE => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
+
+          for forbidden_archive_path in \
+            'wc-order-splitter/inc/backend/order-merge-option.php' \
+            'wc-order-splitter/js/merge-action.js'; do
+            if unzip -Z1 wc-order-splitter.zip | grep -Fxq "$forbidden_archive_path"; then
+              echo "Legacy Merge path entered the ZIP: $forbidden_archive_path" >&2
+              exit 1
+            fi
+          done
+
+          if unzip -p wc-order-splitter.zip wc-order-splitter/wc-order-splitter.php 'wc-order-splitter/inc/*/*.php' | grep --fixed-strings 'wc-merged'; then
+            echo 'A custom production merged order status entered the ZIP.' >&2
+            exit 1
+          fi
 
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
             echo 'Development-only content entered the ZIP.' >&2
@@ -182,6 +211,11 @@ jobs:
             'wc-order-splitter/inc/backend/class-wcos-split-strategy-review-store.php' \
             'wc-order-splitter/inc/backend/class-wcos-split-strategy-confirmation-store.php' \
             'wc-order-splitter/inc/backend/class-wcos-split-strategy-admin-controller.php' \
+            'wc-order-splitter/inc/backend/class-wcos-merge-review-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-merge-confirmation-store.php' \
+            'wc-order-splitter/inc/backend/class-wcos-merge-admin-controller.php' \
+            'wc-order-splitter/css/p2-merge-admin.css' \
+            'wc-order-splitter/js/p2-merge-admin.js' \
             'wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php' \
             'wc-order-splitter/inc/domain/class-wcos-category-split-planner.php' \
             'wc-order-splitter/inc/domain/class-wcos-stock-status-split-planner.php' \
@@ -197,6 +231,8 @@ jobs:
             'wc-order-splitter/inc/domain/class-wcos-merge-compensator.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-preflight.php' \
             'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-order-service.php' \
+            'wc-order-splitter/inc/domain/class-wcos-merge-woocommerce-adapter.php' \
             'wc-order-splitter/css/p2-split-strategy-admin.css' \
             'wc-order-splitter/js/p2-split-strategy-admin.js'; do
             if ! unzip -Z1 wc-order-splitter.zip | grep -Fxq "$required_archive_path"; then

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,16 @@
 
 == Changelog ==
 
+= 1.4.15 (Aug 24, 2026) =
+* New: Enabled hardened single-source Merge for supported WooCommerce source/target order pairs.
+* Safety: Added server-owned Search -> Review -> Confirm -> Execute authority, pair authorization, dual-order leases, a durable source-keyed journal, and fail-closed rejection of unsupported participant state.
+* Integrity: Merge creates fresh target items without re-parenting or line coalescing, preserves historical quantities, money, and per-rate tax state, and preserves existing target-owned shipping under the accepted policy without current-catalog repricing or tax recalculation.
+* Stock: Merge keeps physical inventory neutral while transferring WooCommerce `_reduced_stock` operational ownership to the active target exactly once.
+* Recovery: Added deterministic replay, recovery, and compensation without a target shadow journal; the source uses non-force trash/archive retirement and the target remains active.
+* Compatibility: Validated Merge with WooCommerce 11.0.1 across legacy, HPOS-only, and HPOS compatibility/synchronization storage, with WordPress 7.1 compatibility evidence.
+* Architecture/UI: Added a shared WooCommerce Backbone modal flow for hardened Merge review and confirmation.
+* Safety boundary: Return, Bulk Return, Category Split, and Stock-status Split remain disabled; unsupported Merge pairs fail closed.
+
 = 1.4.14 (Aug 19, 2026) =
 * New: Enabled the hardened single-order Duplicate workflow for supported WooCommerce orders.
 * Safety: Added server-reviewed Duplicate confirmation, nonce/capability enforcement, source-state verification, operation leases, durable journals, and idempotent retry under the approved production gate.

--- a/inc/domain/class-wcos-feature-gates.php
+++ b/inc/domain/class-wcos-feature-gates.php
@@ -5,11 +5,10 @@ defined('ABSPATH') || exit;
 /**
  * Central fail-closed workflow gates.
  *
- * Manual quantity Split and hardened single-order Duplicate are the approved
- * production mutation workflows. Every other mutation path remains internally
- * hard-off. Gate state is code, not constants/options/filters, so another
- * plugin, mu-plugin, or wp-config.php cannot opt an unfinished workflow into
- * production.
+ * Split, Duplicate, and Merge are the approved production mutation workflows.
+ * Return and Bulk Return remain internally hard-off. Gate state is code, not
+ * constants/options/filters, so another plugin, mu-plugin, or wp-config.php
+ * cannot opt an unfinished workflow into production.
  */
 final class WCOS_Feature_Gates {
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,18 +2,30 @@
 Contributors: yoohw
 Tags: woocommerce, split order, order management, duplicate order, merge orders
 Requires at least: 6.5
-Tested up to: 7.0
+Tested up to: 7.1
 WC tested up to: 11.0
 Requires PHP: 7.4
-Stable tag: 1.4.14
+Stable tag: 1.4.15
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Safely split and duplicate WooCommerce orders with server-side review, HPOS support, idempotent retries, and preserved historical order values.
+Safely split, duplicate, and merge supported WooCommerce orders with server-side review, HPOS support, idempotent retries, and preserved historical order values.
 
 == Description ==
 
 Order Splitter for WooCommerce provides administrative tooling for WooCommerce order operations and split-order relationships.
+
+= Hardened Merge in 1.4.15 =
+
+Version 1.4.15 enables hardened single-source Merge from supported WooCommerce order edit screens. The current edited order is the source and the order selected in Search is the target. Server-owned Search -> Review -> Confirm -> Execute authority revalidates the pair before mutation.
+
+Merge creates fresh target order items without re-parenting source items or coalescing lines. It preserves historical line quantities, monetary values, and tax context without treating current-catalog prices or tax calculations as mutation authority. Existing target-owned shipping remains on the active target; source-owned shipping is not transferable.
+
+The source is retired through WooCommerce-supported `non_force_trash_archive` semantics and remains inspectable until the normal trash lifecycle removes it. The target remains active, and no custom production `merged` order status is introduced.
+
+Physical inventory remains unchanged while WooCommerce `_reduced_stock` operational ownership moves to the active target exactly once. A durable source-keyed journal, replay, recovery, and compensation contract prevents duplicate execution and target shadow journals.
+
+The initial hardened Merge envelope fails closed for unsupported pairs, including paid or transaction-bearing orders, refunds, coupons, fees, source-owned shipping, incompatible status, currency, or customer context, and a source without product lines.
 
 = Hardened Duplicate in 1.4.14 =
 
@@ -23,7 +35,7 @@ Duplicate uses the same fail-closed production architecture as the hardened Spli
 
 The duplicated order is always created as Pending payment. Historical line, shipping, fee, tax, and coupon rows are copied through fresh order-item objects, while the source transaction ID, paid state, order-level stock-reduction state, and line `_reduced_stock` markers are deliberately not copied. The Duplicate request is designed not to write physical product stock.
 
-Merge, Return, and Bulk Return remain unavailable while their hardened replacements complete the same production-readiness process.
+Return and Bulk Return remain unavailable while their hardened replacements complete the same production-readiness process.
 
 = Manual quantity Split in 1.4.13 =
 
@@ -37,19 +49,21 @@ The Split request is designed as an order-only mutation and must not change phys
 
 == Current functionality ==
 
-In 1.4.14:
+In 1.4.15:
 
 * Manual quantity Split is available on supported WooCommerce orders.
 * Hardened single-order Duplicate is available on supported WooCommerce orders.
-* Server-side review validates the source order before either production mutation executes.
+* Hardened single-source Merge is available for supported source/target pairs.
+* Server-side review validates participating orders before a production mutation executes.
 * Split child orders and Duplicate targets are created as Pending payment and do not inherit the source payment transaction ID.
 * Duplicate preserves supported historical line, shipping, fee, tax, coupon, and business-metadata state through fresh order-item objects.
 * Historical line totals and taxes are preserved at the operation's captured price precision.
-* Split and Duplicate do not intentionally write physical product stock.
-* Operation IDs, durable journals, leases, confirmation tokens, source-state verification, and idempotent retry handling protect against duplicate execution.
+* Split and Duplicate do not intentionally write physical product stock; Merge is physically stock-neutral and transfers `_reduced_stock` ownership exactly once.
+* Operation IDs, durable journals, leases, confirmation tokens, source-state verification, recovery, and idempotent retry handling protect against duplicate execution.
 * Legacy split-order relationship labels remain available.
 * WooCommerce legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode are supported by the production acceptance matrix.
-* Merge, Return, and Bulk Return remain disabled in the free plugin.
+* Return and Bulk Return remain disabled.
+* Manual quantity Split is enabled; Category and Stock-status Split remain disabled.
 
 == Split safety policy ==
 
@@ -74,9 +88,17 @@ Duplicate fails closed for unsupported conditions such as refunds, unresolved ma
 
 The source transaction ID, paid state, order-level stock-reduced state, and line `_reduced_stock` markers are not copied. Arbitrary custom order-level metadata is not copied by the first hardened Duplicate workflow. Deleted catalog products remain supported when their persisted historical order-line state can be proven.
 
+== Merge safety policy ==
+
+The hardened Merge workflow moves one supported source order into a selected target direction. It creates fresh target product-line items, does not re-parent or coalesce source lines, preserves historical money and per-rate tax state, and does not reprice or recalculate tax from the current catalog.
+
+The source is retired with non-force trash/archive semantics while the target remains active. Merge keeps physical stock neutral and transfers `_reduced_stock` operational ownership exactly once under its durable source-keyed journal and recovery contract.
+
+Unsupported pairs fail closed before mutation. Paid or transaction-bearing orders, refunds, coupons, fees, source-owned shipping, incompatible status/currency/customer context, and sources without product lines are not supported by this release.
+
 == High-Performance Order Storage (HPOS) ==
 
-The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual quantity Split and hardened Duplicate are validated in CI against legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode.
+The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual quantity Split, hardened Duplicate, and hardened Merge are validated in CI against legacy order storage, HPOS-only storage, and HPOS compatibility/synchronization mode.
 
 == Installation ==
 
@@ -84,13 +106,13 @@ The plugin uses WooCommerce CRUD APIs and declares HPOS compatibility. Manual qu
 2. Activate the plugin from Plugins in the WordPress admin.
 3. Make sure WooCommerce is installed and active.
 4. Go to WooCommerce > Settings > Orders to review Order Splitter settings.
-5. Open a supported WooCommerce order and use Split or Duplicate to review and confirm the requested operation.
+5. Open a supported WooCommerce order and use Split, Duplicate, or Merge to review and confirm the requested operation.
 
 == Frequently Asked Questions ==
 
-= Which mutation workflows are enabled in 1.4.14? =
+= Which mutation workflows are enabled in 1.4.15? =
 
-Manual quantity Split and hardened single-order Duplicate are enabled. Merge, Return, and Bulk Return remain disabled until their hardened replacements complete production acceptance.
+Manual quantity Split, hardened single-order Duplicate, and hardened single-source Merge are enabled. Return and Bulk Return remain disabled. Category and Stock-status Split remain disabled.
 
 = Does Split change physical product stock? =
 
@@ -100,13 +122,17 @@ The Split request is an order-only mutation and is designed not to write physica
 
 Duplicate copies supported historical line, shipping, fee, tax, coupon, payment-method context, addresses, and business item metadata into fresh WooCommerce order-item objects. It does not copy the source transaction ID, paid state, order-level stock-reduction state, line `_reduced_stock`, or arbitrary custom order-level metadata.
 
-= Why can a Split or Duplicate request be rejected before execution? =
+= Why can a Split, Duplicate, or Merge request be rejected before execution? =
 
-The hardened workflows intentionally fail closed when they cannot prove conservation, source-state integrity, or compatibility. Split and Duplicate have different operation policies, but both reject ambiguous or unsupported state before mutation.
+The hardened workflows intentionally fail closed when they cannot prove conservation, participant-state integrity, or compatibility. Split, Duplicate, and Merge have different operation policies, but each rejects ambiguous or unsupported state before mutation.
+
+= How does Merge handle the source and target orders? =
+
+The edited order is the source and the selected order is the target. The target remains active with its existing target-owned shipping preserved. Fresh target product-line items preserve the supported historical source values, while the source is retired through WooCommerce non-force trash/archive semantics. Source-owned shipping and other unsupported participant state are rejected rather than transferred.
 
 = What happens if I retry an interrupted operation? =
 
-The workflows use server-generated operation IDs, durable journals, source-order leases, confirmation authority, and idempotent target discovery. A valid retry resumes or returns the original child/target set instead of creating duplicate orders.
+The workflows use server-generated operation IDs, durable journals, operation leases, confirmation authority, and idempotent target discovery. A valid retry resumes or returns the original result instead of creating duplicate orders or repeating a Merge.
 
 = Are existing split-order relationships preserved? =
 
@@ -121,6 +147,16 @@ No. The automatic external subscription request was removed in 1.4.12 and remain
 Older release notes are available in `changelog.txt`.
 
 == Changelog ==
+
+= 1.4.15 (Aug 24, 2026) =
+* New: Enabled hardened single-source Merge for supported WooCommerce source/target order pairs.
+* Safety: Added server-owned Search -> Review -> Confirm -> Execute authority, pair authorization, dual-order leases, a durable source-keyed journal, and fail-closed rejection of unsupported participant state.
+* Integrity: Merge creates fresh target items without re-parenting or line coalescing, preserves historical quantities, money, and per-rate tax state, and preserves existing target-owned shipping under the accepted policy without current-catalog repricing or tax recalculation.
+* Stock: Merge keeps physical inventory neutral while transferring WooCommerce `_reduced_stock` operational ownership to the active target exactly once.
+* Recovery: Added deterministic replay, recovery, and compensation without a target shadow journal; the source uses non-force trash/archive retirement and the target remains active.
+* Compatibility: Validated Merge with WooCommerce 11.0.1 across legacy, HPOS-only, and HPOS compatibility/synchronization storage, with WordPress 7.1 compatibility evidence.
+* Architecture/UI: Added a shared WooCommerce Backbone modal flow for hardened Merge review and confirmation.
+* Safety boundary: Return, Bulk Return, Category Split, and Stock-status Split remain disabled; unsupported Merge pairs fail closed.
 
 = 1.4.14 (Aug 19, 2026) =
 * New: Enabled the hardened single-order Duplicate workflow for supported WooCommerce orders.
@@ -155,5 +191,5 @@ Older release notes are available in `changelog.txt`.
 
 == Upgrade Notice ==
 
-= 1.4.14 =
-Hardened Duplicate is now production-enabled alongside manual quantity Split. Merge, Return, and Bulk Return remain fail-closed.
+= 1.4.15 =
+Hardened Merge is now production-enabled for supported order pairs alongside manual quantity Split and hardened Duplicate. Return, Bulk Return, Category Split, and Stock-status Split remain fail-closed.

--- a/wc-order-splitter.php
+++ b/wc-order-splitter.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: Order Splitter for WooCommerce
  * Plugin URI: https://github.com/yoohwz/wc-order-splitter
- * Description: Safely split and duplicate WooCommerce orders with server-side review, idempotency, HPOS support, and preserved historical order values.
- * Version: 1.4.14
+ * Description: Safely split, duplicate, and merge supported WooCommerce orders with server-side review, idempotency, HPOS support, and preserved historical order values.
+ * Version: 1.4.15
  * Author: YoOhw.com
  * Author URI: https://yoohw.com
  * Requires at least: 6.5


### PR DESCRIPTION
## Classification

`RELEASE_BOOKKEEPING_1_4_15`

Tracks #51.

## Authority

- Exact base SHA: `6f896613a3e6de4569c11ce88cc697eb187fbbe6`
- Exact head SHA: `4257db6073e227884596bba81b9c15c07f911f2c`
- Branch: `release/order-splitter-1.4.15`

## Release bookkeeping

- Plugin version and Stable tag: `1.4.15`
- Release date: Aug 24, 2026
- WordPress Tested up to: `7.1`
- Requires at least `6.5`, Requires PHP `7.4`, and WC tested up to `11.0` remain unchanged.
- Public documentation now describes hardened Merge without claiming support for unsupported participant pairs or disabled Split strategies.

## Package hardening

- Brings release ZIP assertions to parity for Merge Review/Confirmation stores, Admin Controller, Order Service, WooCommerce Adapter, Merge assets, and the existing plan/context/journal/participation/recovery/commit-guard/compensator/preflight/retirement-policy files.
- Asserts the exact workflow and Split-strategy gate maps inside the built ZIP.
- Asserts legacy Merge handlers/assets, `wc-merged`, tests, docs, `AGENTS.md`, `inc/mutation-v2`, and symlinks remain excluded.

## Exact production gates

- `SPLIT=true`
- `DUPLICATE=true`
- `MERGE=true`
- `RETURN_ORDER=false`
- `BULK_RETURN=false`

Split strategies:

- `manual_quantity=true`
- `category=false`
- `stock_status=false`

The workflow gate array is semantically unchanged; the feature-gate edit is docblock-only. The Split-strategy gate file is unchanged.

## Validation

Local:

- `git diff --check`: pass
- Full PHP lint: pass
- `php tests/unit/run.php`: 25/25 pass
- Metadata and exact gate assertions: pass
- Reproducible package simulation and Merge ZIP assertions: pass
- Full `origin/main...HEAD` self-review: only the five Issue #51 allowlisted files; no runtime behavior change

Exact-head canonical CI run [32697839846](https://github.com/yoohwz/wc-order-splitter/actions/runs/32697839846) for `4257db6073e227884596bba81b9c15c07f911f2c`: success.

- PHP 7.4: pass
- PHP 8.1: pass
- PHP 8.3: pass
- Package safety: pass
- Architecture and approved production gate contract: pass
- WooCommerce 11.0.1 legacy: pass
- WooCommerce 11.0.1 HPOS-only: pass
- WooCommerce 11.0.1 HPOS-sync: pass
- Required CI: pass

## Release boundary

No runtime mutation behavior or gate state changed. No tag, GitHub Release, publication, deployment, WordPress.org SVN change, or published ZIP was performed.