### PR TITLE
WOS-STRAT-003: Correct Split modal focus return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
       - name: Run strategy modal feedback lifecycle regression
         run: node tests/js/p2-strategy-modal-feedback-lifecycle.js
 
+      - name: Run Split method focus lifecycle regression
+        run: node tests/js/p2-split-method-focus-lifecycle.js
+
   package-check:
     name: Package safety contract
     runs-on: ubuntu-latest

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -629,6 +629,14 @@
 
     function openMethodChooser() {
         var handle = null;
+
+        function openFromVisibleLauncher(openStage) {
+            handle.close(false, function () {
+                launcher.focus();
+                openStage();
+            });
+        }
+
         handle = window.WCOSBackboneModal.open({
             trigger: launcher,
             title: 'Split order',
@@ -641,8 +649,7 @@
                     'By quantity',
                     'Move exact quantities from one or more product lines into child orders.',
                     function () {
-                        handle.close(false);
-                        window.setTimeout(function () { openQuantityDialog(launcher); }, 0);
+                        openFromVisibleLauncher(function () { openQuantityDialog(launcher); });
                     }
                 ));
                 strategyLaunchers.forEach(function (strategyLauncher) {
@@ -650,8 +657,7 @@
                         methodLabel(strategyLauncher.textContent),
                         strategyLauncher._wcosDescription || 'Build child orders from the reviewed product classification.',
                         function () {
-                            handle.close(false);
-                            window.setTimeout(function () { strategyLauncher.click(); }, 0);
+                            openFromVisibleLauncher(function () { strategyLauncher.click(); });
                         }
                     ));
                 });

--- a/tests/js/p2-split-method-focus-lifecycle.js
+++ b/tests/js/p2-split-method-focus-lifecycle.js
@@ -1,0 +1,240 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '../..');
+const client = fs.readFileSync(path.join(root, 'js/p2-split-admin.js'), 'utf8');
+
+class Element {
+    constructor(tagName, ownerDocument) {
+        this.tagName = String(tagName).toUpperCase();
+        this.ownerDocument = ownerDocument;
+        this.parentNode = null;
+        this.children = [];
+        this.attributes = new Map();
+        this.listeners = new Map();
+        this.hidden = false;
+        this.textContent = '';
+        this.type = '';
+        this.classes = new Set();
+    }
+
+    set className(value) {
+        this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+    }
+
+    get className() {
+        return Array.from(this.classes).join(' ');
+    }
+
+    appendChild(child) {
+        if (child.parentNode) {
+            child.parentNode.removeChild(child);
+        }
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    }
+
+    removeChild(child) {
+        const index = this.children.indexOf(child);
+        assert.notEqual(index, -1, 'removeChild target must belong to the parent');
+        this.children.splice(index, 1);
+        child.parentNode = null;
+        return child;
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(String(name), String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.has(name) ? this.attributes.get(name) : null;
+    }
+
+    removeAttribute(name) {
+        this.attributes.delete(name);
+    }
+
+    addEventListener(type, listener) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, []);
+        }
+        this.listeners.get(type).push(listener);
+    }
+
+    click() {
+        (this.listeners.get('click') || []).forEach((listener) => listener.call(this, { target: this }));
+    }
+
+    focus() {
+        this.ownerDocument.activeElement = this;
+    }
+
+    querySelector() {
+        return null;
+    }
+
+    querySelectorAll() {
+        return [];
+    }
+}
+
+class Document {
+    constructor() {
+        this.body = new Element('body', this);
+        this.activeElement = this.body;
+        this.elementsById = new Map();
+        this.launcher = null;
+        this.strategyLaunchers = [];
+    }
+
+    createElement(tagName) {
+        return new Element(tagName, this);
+    }
+
+    getElementById(id) {
+        return this.elementsById.get(id) || null;
+    }
+
+    querySelector(selector) {
+        return selector === '.wcos-split-launcher' ? this.launcher : null;
+    }
+
+    querySelectorAll(selector) {
+        return selector === '.wcos-strategy-launcher' ? this.strategyLaunchers : [];
+    }
+}
+
+function appendDescription(document, button, id, text) {
+    const description = document.createElement('span');
+    description.textContent = text;
+    description.setAttribute('id', id);
+    document.elementsById.set(id, description);
+    document.body.appendChild(description);
+    button.setAttribute('aria-describedby', id);
+}
+
+function createHarness() {
+    const document = new Document();
+    const sourceDialog = document.createElement('div');
+    document.elementsById.set('wcos-split-source', sourceDialog);
+    document.body.appendChild(sourceDialog);
+
+    const launcher = document.createElement('button');
+    launcher.className = 'wcos-split-launcher';
+    launcher.setAttribute('aria-controls', 'wcos-split-source');
+    appendDescription(document, launcher, 'wcos-split-description', 'Choose a Split method.');
+    document.launcher = launcher;
+    document.body.appendChild(launcher);
+
+    ['Split by category', 'Split by stock status'].forEach((label, index) => {
+        const strategy = document.createElement('button');
+        strategy.className = 'wcos-strategy-launcher';
+        strategy.textContent = label;
+        appendDescription(document, strategy, `wcos-strategy-description-${index}`, `${label} description.`);
+        document.strategyLaunchers.push(strategy);
+        document.body.appendChild(strategy);
+    });
+
+    let methodHandle = null;
+    let methodOptions = [];
+    let stageHandle = null;
+
+    function createModalHandle(previousFocus, onClose) {
+        return {
+            previousFocus,
+            close(restoreFocus = true, callback) {
+                document.activeElement = document.body;
+                if (restoreFocus && previousFocus) {
+                    previousFocus.focus();
+                }
+                if (onClose) {
+                    onClose();
+                }
+                if (callback) {
+                    callback();
+                }
+            }
+        };
+    }
+
+    const modal = {
+        open(options) {
+            const previousFocus = document.activeElement;
+            if (options.modalClass === 'wcos-split-method-backbone-modal') {
+                const body = document.createElement('div');
+                const footer = document.createElement('div');
+                methodHandle = createModalHandle(previousFocus);
+                options.build(body, footer);
+                methodOptions = body.children[0].children;
+                return methodHandle;
+            }
+
+            stageHandle = createModalHandle(previousFocus);
+            return stageHandle;
+        }
+    };
+
+    document.strategyLaunchers.forEach((strategy) => {
+        strategy.addEventListener('click', () => {
+            stageHandle = createModalHandle(document.activeElement);
+        });
+    });
+
+    vm.runInNewContext(client, {
+        window: {
+            WCOSBackboneModal: modal,
+            wcosSplitAdminStrings: {},
+            setTimeout(callback) {
+                callback();
+            }
+        },
+        document,
+        Array,
+        String
+    });
+
+    return {
+        document,
+        launcher,
+        strategyLaunchers: document.strategyLaunchers,
+        openChooser() {
+            launcher.focus();
+            launcher.click();
+            return { handle: methodHandle, options: methodOptions };
+        },
+        getStageHandle() {
+            return stageHandle;
+        }
+    };
+}
+
+{
+    const harness = createHarness();
+    const chooser = harness.openChooser();
+    chooser.options[0].focus();
+    chooser.handle.close();
+    assert.equal(harness.document.activeElement, harness.launcher, 'direct chooser close must restore the visible launcher');
+}
+
+['quantity', 'category', 'stock status'].forEach((method, index) => {
+    const harness = createHarness();
+    const chooser = harness.openChooser();
+    const option = chooser.options[index];
+    option.focus();
+    option.click();
+
+    const stage = harness.getStageHandle();
+    assert.ok(stage, `${method} must open its stage-2 modal`);
+    assert.equal(stage.previousFocus, harness.launcher, `${method} must capture the visible launcher as its focus origin`);
+    assert.notEqual(stage.previousFocus, harness.strategyLaunchers[index - 1], `${method} must not capture a hidden strategy launcher`);
+
+    stage.close();
+    assert.equal(harness.document.activeElement, harness.launcher, `${method} close must restore the visible launcher`);
+});
+
+console.log('Split method focus lifecycle regression passed.');


### PR DESCRIPTION
## Classification

`P3_PRODUCT_QUALITY / ACCESSIBILITY_CORRECTION`

Closes #61.

## Summary

- hand off from the Split method chooser only after its modal has been removed;
- focus the visible `.wcos-split-launcher` before opening Quantity, Category, or Stock-status stage 2;
- add an executable lifecycle regression proving direct chooser return and every stage-2 focus origin/return.

## Scope and invariants

- runtime change is limited to `js/p2-split-admin.js`;
- no planner, classification, confirmation, mutation, stock, tax, money, Merge, version, release, or publication behavior changes;
- production workflow gates remain Split/Duplicate/Merge on and Return/Bulk Return off;
- production strategy gates remain manual quantity on and Category/Stock-status off;
- WOS-STRAT-001 remains stopped.

## Local evidence

- `node tests/js/p2-split-method-focus-lifecycle.js`
- `node tests/js/p2-strategy-modal-feedback-lifecycle.js`
- `php tests/unit/run.php`
- `find . -type f -name '*.php' -print0 | xargs -0 -n1 php -l`
- `git diff --check`

## Exact-head canonical CI

- correction head: `0cd72d76447c3ee69035ef02d3b8d16299b908b7`
- CI run: `32719877796` (`pull_request`, attempt 1, completed/success)
- PHP 7.4 / 8.1 / 8.3, Architecture and approved gate contract, Package safety, WooCommerce 11.0.1 legacy / HPOS-only / HPOS-sync, and Required CI all passed.

## Hands-on Local-runtime evidence

The active WordPress Local worktree used disposable validation child SHA `2cd07c0`, created directly from correction head `0cd72d7`. Its complete diff from the correction head was exactly two gate values in `inc/domain/class-wcos-split-strategy-gates.php`: Category and Stock-status `false -> true`. It was never pushed or targeted at `main`.

On disposable orders `#23106` (two category and stock-status buckets) and `#23107` (single-bucket/no-split), verified:

- direct method chooser Escape, header close, Cancel, and backdrop close -> visible `.wcos-split-launcher` focused;
- Quantity Escape, header close, and Cancel -> visible launcher focused;
- Category initial, reviewed, confirmed, and no-split close paths -> visible launcher focused;
- Stock-status initial, reviewed, confirmed, and no-split close paths -> visible launcher focused;
- Review -> Confirm lifecycle remained intact without Execute;
- focus remained inside the open chooser and exactly one modal existed;
- Split, Duplicate, and Merge launchers coexisted;
- no site/plugin console error occurred (only unrelated Chrome-extension transport messages were observed).

Cleanup was verified after permanently deleting only the disposable orders `#23106`, `#23107`, products `#23104`, `#23105`, and categories `#247`, `#248`. The active Local worktree was then restored cleanly to canonical correction head `0cd72d7`, where production strategy gates remain hard-off, and the local validation branch was deleted to prevent reuse.

Keep this PR Draft pending independent technical review.
