### PR TITLE
WOS-STRAT-004 — Enable Category Split production strategy

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -46,7 +46,7 @@ jobs:
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
@@ -185,7 +185,7 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
-          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
 
           for forbidden_archive_path in \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'Legacy mutation handlers are deliberately never loaded here.' inc/cores/script.php
 
@@ -188,7 +188,7 @@ jobs:
           grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::CATEGORY => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
@@ -326,7 +326,7 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::RETURN_ORDER => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
-          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-duplicate-admin-controller.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-duplicate-woocommerce-adapter.php'
@@ -455,11 +455,11 @@ jobs:
               if (WCOS_Feature_Gates::enabled($disabled_workflow)) { exit(1); }
             }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY)) { exit(1); }
-            if (WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
+            if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
             if (WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
-            if (false !== has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
+            if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }
             foreach (array(
               WCOS_Merge_Admin_Controller::SEARCH_ACTION,
               WCOS_Merge_Admin_Controller::REVIEW_ACTION,

--- a/inc/domain/class-wcos-split-strategy-gates.php
+++ b/inc/domain/class-wcos-split-strategy-gates.php
@@ -17,7 +17,7 @@ final class WCOS_Split_Strategy_Gates {
 
 	private static $states = array(
 		self::MANUAL_QUANTITY => true,
-		self::CATEGORY => false,
+		self::CATEGORY => true,
 		self::STOCK_STATUS => false,
 	);
 

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -88,7 +88,7 @@ $target_id = $target->get_id();
 /* Production enablement preserves the accepted domain and strategy contracts. */
 wcos_merge_foundation_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production MERGE gate is not enabled.');
 wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual strategy gate changed.');
-wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate changed.');
+wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
 wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock strategy gate changed.');
 wcos_merge_foundation_assert(class_exists('WCOS_Mutation_Gateway'), 'Mandatory production gateway is unavailable.');
 

--- a/tests/integration/p2-strategy-adapter-smoke.php
+++ b/tests/integration/p2-strategy-adapter-smoke.php
@@ -6,13 +6,13 @@ if (!defined('ABSPATH')) {
 
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_WooCommerce_Adapter'), 'Strategy Split adapter was not loaded by the plugin bootstrap.');
 wcos_p2_adapter_assert(method_exists('WCOS_Mutation_Gateway', 'split_strategy'), 'Strategy Split gateway boundary is missing.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy was enabled by the adapter foundation.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
 wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was enabled by the adapter foundation.');
 
 $strategy_adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
 $strategy_gateway = new WCOS_Mutation_Gateway();
 
-/* Production gateway must remain hard-off for both future strategies. */
+/* Production gateway must remain hard-off for Stock-status. */
 $gateway_product_a = wcos_p2_adapter_product('WCOS strategy gateway A', '5.00');
 $gateway_product_b = wcos_p2_adapter_product('WCOS strategy gateway B', '4.00');
 $gateway_order = wc_create_order();
@@ -23,7 +23,7 @@ $gateway_item_b = $gateway_order->add_product($gateway_product_b, 1);
 $gateway_order->calculate_totals(false);
 $gateway_order->save();
 
-foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $blocked_strategy) {
+$blocked_strategy = WCOS_Split_Strategy_Gates::STOCK_STATUS;
 	$blocked_operation = 'p2-strategy-gateway-' . $blocked_strategy . '-' . wp_generate_uuid4();
 	$blocked = false;
 	try {
@@ -39,7 +39,6 @@ foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::S
 	wcos_p2_adapter_assert($blocked, 'Strategy gateway allowed a hard-off production strategy: ' . $blocked_strategy);
 	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($gateway_order, $blocked_operation), 'Hard-off strategy gateway created a mutation journal.');
 	wcos_p2_adapter_assert(0 === count(wcos_p2_adapter_children($gateway_order->get_id(), $blocked_operation)), 'Hard-off strategy gateway created a child order.');
-}
 $gateway_order->delete(true);
 wp_delete_post($gateway_product_a->get_id(), true);
 wp_delete_post($gateway_product_b->get_id(), true);

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Global Split workflow is not production-enabled while planner foundation is tested.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Hardened Duplicate production gate was lost while planner foundation is tested.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual quantity Split strategy gate is not enabled.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy was production-enabled by the planner foundation.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
 wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was production-enabled by the planner foundation.');
 wcos_p2_adapter_assert(!class_exists('WCOS_Category_Split_Admin_Controller'), 'Category planner foundation unexpectedly exposed an admin controller.');
 wcos_p2_adapter_assert(!class_exists('WCOS_Stock_Status_Split_Admin_Controller'), 'Stock-status planner foundation unexpectedly exposed an admin controller.');

--- a/tests/integration/p2-strategy-transport-smoke.php
+++ b/tests/integration/p2-strategy-transport-smoke.php
@@ -17,14 +17,13 @@ function wcos_strategy_transport_expect($code, $http_status, callable $callback,
 
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Review_Store'), 'Strategy Review store was not loaded.');
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Admin_Controller'), 'Strategy transport controller contract was not loaded.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Hard-off strategy Review AJAX route was registered.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Hard-off strategy Confirm AJAX route was registered.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Hard-off strategy Execute AJAX route was registered.');
-
-$transport_controller = new WCOS_Split_Strategy_Admin_Controller();
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Instantiating the hard-off strategy controller registered Review AJAX.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Instantiating the hard-off strategy controller registered Confirm AJAX.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Instantiating the hard-off strategy controller registered Execute AJAX.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not hard-off.');
+$transport_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
+wcos_p2_adapter_assert($transport_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production Category transport controller did not bootstrap.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production Category Review AJAX route was not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production Category Confirm AJAX route was not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production Category Execute AJAX route was not registered.');
 
 $transport_previous_user = get_current_user_id();
 $transport_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
@@ -93,27 +92,19 @@ try {
 	wp_set_current_user($transport_admin_id);
 	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
 
-	/* Real release state blocks both future strategies before any transport write. */
-	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $hard_off_strategy) {
-		wcos_strategy_transport_expect(
-			'strategy_disabled',
-			503,
-			static function() use ($transport_controller, $transport_order_id, $transport_nonce, $hard_off_strategy) {
-				$transport_controller->review_request(array(
-					'order_id' => $transport_order_id,
-					'nonce' => $transport_nonce,
-					'strategy' => $hard_off_strategy,
-				));
-			},
-			'Hard-off strategy transport was directly usable: ' . $hard_off_strategy
-		);
-	}
-
-	/* Test-only scope exercises the future transport contract without changing source gates. */
-	$test_strategy_states = $release_strategy_states;
-	$test_strategy_states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
-	$test_strategy_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
-	$strategy_states_property->setValue(null, $test_strategy_states);
+	/* Real production state blocks Stock-status before any transport write. */
+	wcos_strategy_transport_expect(
+		'strategy_disabled',
+		503,
+		static function() use ($transport_controller, $transport_order_id, $transport_nonce) {
+			$transport_controller->review_request(array(
+				'order_id' => $transport_order_id,
+				'nonce' => $transport_nonce,
+				'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
+			));
+		},
+		'Hard-off Stock-status transport was directly usable.'
+	);
 
 	wcos_strategy_transport_expect(
 		'invalid_nonce',
@@ -294,8 +285,8 @@ try {
 	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($transport_order_id, $confirm_response['operation_id'])), 'Category transport replay created duplicate children.');
 
 	wcos_strategy_transport_expect(
-		'confirmation_strategy_mismatch',
-		409,
+		'strategy_disabled',
+		503,
 		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $confirm_response) {
 			$transport_controller->execute_request(array(
 				'order_id' => $transport_order_id,
@@ -305,8 +296,13 @@ try {
 				'confirmation_token' => '',
 			));
 		},
-		'Durable Category operation was replayable as Stock-status.'
+		'Durable Category operation bypassed the hard-off Stock-status gate.'
 	);
+
+	/* Test-only scope retains future Stock-status transport coverage after proving production fail-closed state. */
+	$future_strategy_states = $release_strategy_states;
+	$future_strategy_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
+	$strategy_states_property->setValue(null, $future_strategy_states);
 
 	/* Stock-status goes through the same Review -> Confirm -> Execute transport. */
 	$stock_nonce = wp_create_nonce('wcos_split_strategy_order_' . $stock_order_id);
@@ -401,10 +397,10 @@ try {
 	}
 }
 
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category strategy gate was not restored after transport acceptance.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate was not restored after transport acceptance.');
 wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy gate was not restored after transport acceptance.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX route was registered after transport acceptance.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX route was registered after transport acceptance.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX route was registered after transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production Category Review AJAX route was lost after transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production Category Confirm AJAX route was lost after transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production Category Execute AJAX route was lost after transport acceptance.');
 
-echo "p2-strategy-transport-hard-off-ok\n";
+echo "p2-category-production-transport-ok\n";

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -5,10 +5,13 @@ if (!defined('ABSPATH')) {
 }
 
 wcos_p2_adapter_assert(method_exists('WCOS_Split_Strategy_Admin_Controller', 'bootstrap'), 'Strategy UI gate-aware bootstrap is missing.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review route is registered in the real hard-off release state.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm route is registered in the real hard-off release state.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute route is registered in the real hard-off release state.');
-wcos_p2_adapter_assert(null === WCOS_Split_Strategy_Admin_Controller::bootstrap(), 'Hard-off strategy UI bootstrap returned an active controller.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not hard-off.');
+$ui_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
+wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production Category strategy UI did not bootstrap.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($ui_controller, 'ajax_review')), 'Production Category Review route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($ui_controller, 'ajax_confirm')), 'Production Category Confirm route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($ui_controller, 'ajax_execute')), 'Production Category Execute route is not registered.');
 
 $ui_previous_user = get_current_user_id();
 $ui_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
@@ -31,38 +34,24 @@ $ui_order->calculate_totals(false);
 $ui_order->save();
 $ui_order_id = $ui_order->get_id();
 
-$ui_strategy_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
-$ui_states_property = $ui_strategy_reflection->getProperty('states');
-$ui_states_property->setAccessible(true);
-$ui_release_states = $ui_states_property->getValue();
-$ui_controller = null;
-
 try {
-	$ui_test_states = $ui_release_states;
-	$ui_test_states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
-	$ui_test_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
-	$ui_states_property->setValue(null, $ui_test_states);
 	update_option('order_splitter_status_allowed', array('wc-pending'));
 	wp_set_current_user($ui_admin_id);
 
-	$ui_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
-	wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Enabled test-only strategy UI did not bootstrap.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($ui_controller, 'ajax_review')), 'Enabled strategy UI did not register Review AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($ui_controller, 'ajax_confirm')), 'Enabled strategy UI did not register Confirm AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($ui_controller, 'ajax_execute')), 'Enabled strategy UI did not register Execute AJAX.');
-	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons', array($ui_controller, 'render_launcher')), 'Enabled strategy UI did not register its order launcher callback.');
+	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons', array($ui_controller, 'render_launcher')), 'Production Category UI did not register its order launcher callback.');
 
 	ob_start();
 	$ui_controller->render_launcher(wc_get_order($ui_order_id));
 	$launcher_html = (string) ob_get_clean();
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'wcos-strategy-launcher'), 'Strategy launcher markup is missing.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by category'), 'Category strategy launcher is missing.');
-	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by stock status'), 'Stock-status strategy launcher is missing.');
+	wcos_p2_adapter_assert(false === strpos($launcher_html, 'Split by stock status'), 'Hard-off Stock-status strategy launcher was exposed.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-haspopup="dialog"'), 'Strategy launchers do not expose dialog semantics.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-category"'), 'Category launcher is not bound to its source dialog.');
-	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Stock-status launcher is not bound to its source dialog.');
+	wcos_p2_adapter_assert(false === strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Hard-off Stock-status launcher retained dialog authority.');
+	wcos_p2_adapter_assert('' === $ui_controller->dialog_html(wc_get_order($ui_order_id), WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Hard-off Stock-status source dialog was exposed.');
 
-	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $ui_strategy) {
+	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY) as $ui_strategy) {
 		$dialog_html = $ui_controller->dialog_html(wc_get_order($ui_order_id), $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Strategy source dialog is missing role=dialog: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-modal="true"'), 'Strategy source dialog is missing aria-modal: ' . $ui_strategy);
@@ -128,7 +117,6 @@ try {
 	if ($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller) {
 		$ui_controller->unregister_hooks();
 	}
-	$ui_states_property->setValue(null, $ui_release_states);
 	wp_set_current_user($ui_previous_user);
 	update_option('order_splitter_status_allowed', $ui_allowed_statuses);
 	$cleanup_ui_order = wc_get_order($ui_order_id);
@@ -142,10 +130,10 @@ try {
 	}
 }
 
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Category gate was not restored after strategy UI readiness acceptance.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status gate was not restored after strategy UI readiness acceptance.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX remained registered after test-only UI scope.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX remained registered after test-only UI scope.');
-wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX remained registered after test-only UI scope.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category gate changed during strategy UI acceptance.');
+wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status gate changed during strategy UI acceptance.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX remained registered after UI test cleanup.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX remained registered after UI test cleanup.');
+wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX remained registered after UI test cleanup.');
 
 echo "p2-strategy-ui-readiness-ok\n";

--- a/tests/integration/strategy-confirm-race-worker.php
+++ b/tests/integration/strategy-confirm-race-worker.php
@@ -11,13 +11,6 @@ if ('' === $label || !is_array($fixture) || empty($fixture['order_id']) || empty
 	exit(2);
 }
 
-$reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
-$states_property = $reflection->getProperty('states');
-$states_property->setAccessible(true);
-$states = $states_property->getValue();
-$states[WCOS_Split_Strategy_Gates::CATEGORY] = true;
-$states_property->setValue(null, $states);
-
 wp_set_current_user(absint($fixture['user_id']));
 $order_id = absint($fixture['order_id']);
 $nonce = wp_create_nonce('wcos_split_strategy_order_' . $order_id);


### PR DESCRIPTION
## Classification

`P1_PRODUCTION_ENABLEMENT / CATEGORY_SPLIT`

Closes #64.

## Summary

- changes only `WCOS_Split_Strategy_Gates::CATEGORY` from `false` to `true` in production runtime;
- keeps Manual Quantity enabled and Stock-status hard-off;
- updates exact-state CI/package assertions for `category=true`, `stock_status=false`;
- runs Category planner, gateway, Review → Confirm → Execute transport, UI, and concurrency evidence through the production gate rather than a Category test override;
- preserves future Stock-status internal coverage while proving its production transport remains fail-closed and its launcher/dialog remain absent.

## Exact target gate map

- workflows: Split=true, Duplicate=true, Merge=true, Return=false, Bulk Return=false;
- strategies: Manual Quantity=true, Category=true, Stock-status=false.

## Local evidence

- all PHP syntax checks passed;
- `php tests/unit/run.php` passed (25 contracts);
- focused Local WooCommerce strategy suite passed: planners, adapter, confirmation authority, Category production transport, UI readiness, modal feedback;
- Merge domain regression passed;
- strategy modal feedback and Split method focus lifecycle JS tests passed;
- workflow YAML parsed successfully;
- local package ZIP passed syntax, exclusion, and exact Category/Stock-status gate inspection;
- hands-on Local UI proved chooser exposes By quantity + By category only, Stock-status has no launcher/dialog, Review → Confirm → Execute completed one child, modal-local status/alert remained available, and focus returned to the visible Split launcher;
- test fixtures were removed after validation.

Canonical exact-head CI remains merge authority. Keep this PR Draft through CI and executor complete-diff review.

No version bump, release, publication, deployment, Technical Acceptance, or Human Gate is requested by this PR.