### PR TITLE
WOS-STRAT-005 — Enable Stock-status Split production strategy

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -47,7 +47,7 @@ jobs:
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => true' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
           telemetry_host='yoexpress''.''top'
@@ -186,7 +186,7 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
-          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => true'
 
           for forbidden_archive_path in \
             'wc-order-splitter/inc/backend/order-merge-option.php' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'Legacy mutation handlers are deliberately never loaded here.' inc/cores/script.php
 
           if grep -R --line-number -E 'WC_ORDER_SPLITTER_(MUTATIONS|SPLIT|DUPLICATE|MERGE|RETURN|BULK_RETURN)_ENABLED' \
@@ -189,7 +189,7 @@ jobs:
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
-          grep -Fq 'self::STOCK_STATUS => false' inc/domain/class-wcos-split-strategy-gates.php
+          grep -Fq 'self::STOCK_STATUS => true' inc/domain/class-wcos-split-strategy-gates.php
           test ! -d inc/mutation-v2
 
           telemetry_host='yoexpress''.''top'
@@ -327,7 +327,7 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-feature-gates.php | grep -Fq 'self::BULK_RETURN => false'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
-          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => false'
+          unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => true'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/backend/class-wcos-duplicate-admin-controller.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-duplicate-woocommerce-adapter.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-duplicate-admin.js'
@@ -456,7 +456,7 @@ jobs:
             }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY)) { exit(1); }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
-            if (WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS)) { exit(1); }
+            if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS)) { exit(1); }
             if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION)) { exit(1); }
             if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION)) { exit(1); }
             if (false === has_action("wp_ajax_" . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION)) { exit(1); }

--- a/inc/domain/class-wcos-split-strategy-gates.php
+++ b/inc/domain/class-wcos-split-strategy-gates.php
@@ -18,7 +18,7 @@ final class WCOS_Split_Strategy_Gates {
 	private static $states = array(
 		self::MANUAL_QUANTITY => true,
 		self::CATEGORY => true,
-		self::STOCK_STATUS => false,
+		self::STOCK_STATUS => true,
 	);
 
 	public static function enabled($strategy) {

--- a/tests/integration/merge-domain-foundation-smoke.php
+++ b/tests/integration/merge-domain-foundation-smoke.php
@@ -89,7 +89,7 @@ $target_id = $target->get_id();
 wcos_merge_foundation_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production MERGE gate is not enabled.');
 wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual strategy gate changed.');
 wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
-wcos_merge_foundation_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock strategy gate changed.');
+wcos_merge_foundation_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not enabled.');
 wcos_merge_foundation_assert(class_exists('WCOS_Mutation_Gateway'), 'Mandatory production gateway is unavailable.');
 
 /* Canonical historical-state planning is read-only and never coalesces lines. */

--- a/tests/integration/p2-strategy-adapter-smoke.php
+++ b/tests/integration/p2-strategy-adapter-smoke.php
@@ -7,41 +7,9 @@ if (!defined('ABSPATH')) {
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_WooCommerce_Adapter'), 'Strategy Split adapter was not loaded by the plugin bootstrap.');
 wcos_p2_adapter_assert(method_exists('WCOS_Mutation_Gateway', 'split_strategy'), 'Strategy Split gateway boundary is missing.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was enabled by the adapter foundation.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not enabled.');
 
 $strategy_adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
-$strategy_gateway = new WCOS_Mutation_Gateway();
-
-/* Production gateway must remain hard-off for Stock-status. */
-$gateway_product_a = wcos_p2_adapter_product('WCOS strategy gateway A', '5.00');
-$gateway_product_b = wcos_p2_adapter_product('WCOS strategy gateway B', '4.00');
-$gateway_order = wc_create_order();
-$gateway_order->set_status('pending');
-$gateway_order->set_currency('USD');
-$gateway_item_a = $gateway_order->add_product($gateway_product_a, 2);
-$gateway_item_b = $gateway_order->add_product($gateway_product_b, 1);
-$gateway_order->calculate_totals(false);
-$gateway_order->save();
-
-$blocked_strategy = WCOS_Split_Strategy_Gates::STOCK_STATUS;
-	$blocked_operation = 'p2-strategy-gateway-' . $blocked_strategy . '-' . wp_generate_uuid4();
-	$blocked = false;
-	try {
-		$strategy_gateway->split_strategy(
-			wc_get_order($gateway_order->get_id()),
-			$blocked_strategy,
-			array('child-1' => array($gateway_item_a => '2.000000')),
-			$blocked_operation
-		);
-	} catch (RuntimeException $exception) {
-		$blocked = false !== strpos($exception->getMessage(), 'not enabled for production use');
-	}
-	wcos_p2_adapter_assert($blocked, 'Strategy gateway allowed a hard-off production strategy: ' . $blocked_strategy);
-	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($gateway_order, $blocked_operation), 'Hard-off strategy gateway created a mutation journal.');
-	wcos_p2_adapter_assert(0 === count(wcos_p2_adapter_children($gateway_order->get_id(), $blocked_operation)), 'Hard-off strategy gateway created a child order.');
-$gateway_order->delete(true);
-wp_delete_post($gateway_product_a->get_id(), true);
-wp_delete_post($gateway_product_b->get_id(), true);
 
 /* Category Review -> frozen plan -> whole-line adapter execution. */
 $category_suffix = strtolower(wp_generate_password(6, false, false));

--- a/tests/integration/p2-strategy-planners-smoke.php
+++ b/tests/integration/p2-strategy-planners-smoke.php
@@ -8,7 +8,7 @@ wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), '
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Hardened Duplicate production gate was lost while planner foundation is tested.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY), 'Manual quantity Split strategy gate is not enabled.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy was production-enabled by the planner foundation.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not enabled.');
 wcos_p2_adapter_assert(!class_exists('WCOS_Category_Split_Admin_Controller'), 'Category planner foundation unexpectedly exposed an admin controller.');
 wcos_p2_adapter_assert(!class_exists('WCOS_Stock_Status_Split_Admin_Controller'), 'Stock-status planner foundation unexpectedly exposed an admin controller.');
 wcos_p2_adapter_assert(!method_exists('WCOS_Mutation_Gateway', 'category_split'), 'Category planner foundation unexpectedly exposed a mutation gateway method.');

--- a/tests/integration/p2-strategy-transport-smoke.php
+++ b/tests/integration/p2-strategy-transport-smoke.php
@@ -18,12 +18,12 @@ function wcos_strategy_transport_expect($code, $http_status, callable $callback,
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Review_Store'), 'Strategy Review store was not loaded.');
 wcos_p2_adapter_assert(class_exists('WCOS_Split_Strategy_Admin_Controller'), 'Strategy transport controller contract was not loaded.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not hard-off.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not enabled.');
 $transport_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
-wcos_p2_adapter_assert($transport_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production Category transport controller did not bootstrap.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production Category Review AJAX route was not registered.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production Category Confirm AJAX route was not registered.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production Category Execute AJAX route was not registered.');
+wcos_p2_adapter_assert($transport_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production strategy transport controller did not bootstrap.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production strategy Review AJAX route was not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production strategy Confirm AJAX route was not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production strategy Execute AJAX route was not registered.');
 
 $transport_previous_user = get_current_user_id();
 $transport_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
@@ -81,30 +81,11 @@ $stock_order->calculate_totals(false);
 $stock_order->save();
 $stock_order_id = $stock_order->get_id();
 
-$strategy_reflection = new ReflectionClass('WCOS_Split_Strategy_Gates');
-$strategy_states_property = $strategy_reflection->getProperty('states');
-$strategy_states_property->setAccessible(true);
-$release_strategy_states = $strategy_states_property->getValue();
-
 try {
 	update_option('order_splitter_status_allowed', array('wc-pending'));
 	update_option('order_splitter_shop_manager_permission', 'no');
 	wp_set_current_user($transport_admin_id);
 	$transport_nonce = wp_create_nonce('wcos_split_strategy_order_' . $transport_order_id);
-
-	/* Real production state blocks Stock-status before any transport write. */
-	wcos_strategy_transport_expect(
-		'strategy_disabled',
-		503,
-		static function() use ($transport_controller, $transport_order_id, $transport_nonce) {
-			$transport_controller->review_request(array(
-				'order_id' => $transport_order_id,
-				'nonce' => $transport_nonce,
-				'strategy' => WCOS_Split_Strategy_Gates::STOCK_STATUS,
-			));
-		},
-		'Hard-off Stock-status transport was directly usable.'
-	);
 
 	wcos_strategy_transport_expect(
 		'invalid_nonce',
@@ -285,8 +266,8 @@ try {
 	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($transport_order_id, $confirm_response['operation_id'])), 'Category transport replay created duplicate children.');
 
 	wcos_strategy_transport_expect(
-		'strategy_disabled',
-		503,
+		'confirmation_strategy_mismatch',
+		409,
 		static function() use ($transport_controller, $transport_order_id, $transport_nonce, $confirm_response) {
 			$transport_controller->execute_request(array(
 				'order_id' => $transport_order_id,
@@ -296,15 +277,10 @@ try {
 				'confirmation_token' => '',
 			));
 		},
-		'Durable Category operation bypassed the hard-off Stock-status gate.'
+		'Durable Category operation was replayable as Stock-status.'
 	);
 
-	/* Test-only scope retains future Stock-status transport coverage after proving production fail-closed state. */
-	$future_strategy_states = $release_strategy_states;
-	$future_strategy_states[WCOS_Split_Strategy_Gates::STOCK_STATUS] = true;
-	$strategy_states_property->setValue(null, $future_strategy_states);
-
-	/* Stock-status goes through the same Review -> Confirm -> Execute transport. */
+	/* Production Stock-status goes through the same Review -> Confirm -> Execute transport. */
 	$stock_nonce = wp_create_nonce('wcos_split_strategy_order_' . $stock_order_id);
 	$stock_review_response = $transport_controller->review_request(array(
 		'order_id' => $stock_order_id,
@@ -339,7 +315,6 @@ try {
 	$stock_journal = WCOS_Operation_Journal::get($stock_source, $stock_confirm_response['operation_id']);
 	wcos_p2_adapter_assert(is_array($stock_journal) && WCOS_Split_Strategy_Gates::STOCK_STATUS === $stock_journal['context']['strategy_authority']['strategy'], 'Stock-status transport journal lost semantic strategy authority.');
 } finally {
-	$strategy_states_property->setValue(null, $release_strategy_states);
 	wp_set_current_user($transport_previous_user);
 	update_option('order_splitter_status_allowed', $transport_allowed_statuses);
 	update_option('order_splitter_shop_manager_permission', $transport_manager_permission);
@@ -397,10 +372,10 @@ try {
 	}
 }
 
-wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate was not restored after transport acceptance.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status strategy gate was not restored after transport acceptance.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production Category Review AJAX route was lost after transport acceptance.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production Category Confirm AJAX route was lost after transport acceptance.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production Category Execute AJAX route was lost after transport acceptance.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate changed during transport acceptance.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate changed during transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($transport_controller, 'ajax_review')), 'Production strategy Review AJAX route was lost after transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($transport_controller, 'ajax_confirm')), 'Production strategy Confirm AJAX route was lost after transport acceptance.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($transport_controller, 'ajax_execute')), 'Production strategy Execute AJAX route was lost after transport acceptance.');
 
-echo "p2-category-production-transport-ok\n";
+echo "p2-production-strategy-transport-ok\n";

--- a/tests/integration/p2-strategy-ui-readiness-smoke.php
+++ b/tests/integration/p2-strategy-ui-readiness-smoke.php
@@ -6,12 +6,12 @@ if (!defined('ABSPATH')) {
 
 wcos_p2_adapter_assert(method_exists('WCOS_Split_Strategy_Admin_Controller', 'bootstrap'), 'Strategy UI gate-aware bootstrap is missing.');
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category strategy gate is not enabled.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not hard-off.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status strategy gate is not enabled.');
 $ui_controller = WCOS_Split_Strategy_Admin_Controller::bootstrap();
-wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production Category strategy UI did not bootstrap.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($ui_controller, 'ajax_review')), 'Production Category Review route is not registered.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($ui_controller, 'ajax_confirm')), 'Production Category Confirm route is not registered.');
-wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($ui_controller, 'ajax_execute')), 'Production Category Execute route is not registered.');
+wcos_p2_adapter_assert($ui_controller instanceof WCOS_Split_Strategy_Admin_Controller, 'Production strategy UI did not bootstrap.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION, array($ui_controller, 'ajax_review')), 'Production strategy Review route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION, array($ui_controller, 'ajax_confirm')), 'Production strategy Confirm route is not registered.');
+wcos_p2_adapter_assert(false !== has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION, array($ui_controller, 'ajax_execute')), 'Production strategy Execute route is not registered.');
 
 $ui_previous_user = get_current_user_id();
 $ui_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
@@ -38,20 +38,19 @@ try {
 	update_option('order_splitter_status_allowed', array('wc-pending'));
 	wp_set_current_user($ui_admin_id);
 
-	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons', array($ui_controller, 'render_launcher')), 'Production Category UI did not register its order launcher callback.');
+	wcos_p2_adapter_assert(false !== has_action('woocommerce_order_item_add_action_buttons', array($ui_controller, 'render_launcher')), 'Production strategy UI did not register its order launcher callback.');
 
 	ob_start();
 	$ui_controller->render_launcher(wc_get_order($ui_order_id));
 	$launcher_html = (string) ob_get_clean();
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'wcos-strategy-launcher'), 'Strategy launcher markup is missing.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by category'), 'Category strategy launcher is missing.');
-	wcos_p2_adapter_assert(false === strpos($launcher_html, 'Split by stock status'), 'Hard-off Stock-status strategy launcher was exposed.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'Split by stock status'), 'Stock-status strategy launcher is missing.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-haspopup="dialog"'), 'Strategy launchers do not expose dialog semantics.');
 	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-category"'), 'Category launcher is not bound to its source dialog.');
-	wcos_p2_adapter_assert(false === strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Hard-off Stock-status launcher retained dialog authority.');
-	wcos_p2_adapter_assert('' === $ui_controller->dialog_html(wc_get_order($ui_order_id), WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Hard-off Stock-status source dialog was exposed.');
+	wcos_p2_adapter_assert(false !== strpos($launcher_html, 'aria-controls="wcos-strategy-dialog-' . $ui_order_id . '-stock_status"'), 'Stock-status launcher is not bound to its source dialog.');
 
-	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY) as $ui_strategy) {
+	foreach (array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS) as $ui_strategy) {
 		$dialog_html = $ui_controller->dialog_html(wc_get_order($ui_order_id), $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'role="dialog"'), 'Strategy source dialog is missing role=dialog: ' . $ui_strategy);
 		wcos_p2_adapter_assert(false !== strpos($dialog_html, 'aria-modal="true"'), 'Strategy source dialog is missing aria-modal: ' . $ui_strategy);
@@ -131,7 +130,7 @@ try {
 }
 
 wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY), 'Production Category gate changed during strategy UI acceptance.');
-wcos_p2_adapter_assert(!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Stock-status gate changed during strategy UI acceptance.');
+wcos_p2_adapter_assert(WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS), 'Production Stock-status gate changed during strategy UI acceptance.');
 wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::REVIEW_ACTION), 'Strategy Review AJAX remained registered after UI test cleanup.');
 wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::CONFIRM_ACTION), 'Strategy Confirm AJAX remained registered after UI test cleanup.');
 wcos_p2_adapter_assert(false === has_action('wp_ajax_' . WCOS_Split_Strategy_Admin_Controller::EXECUTE_ACTION), 'Strategy Execute AJAX remained registered after UI test cleanup.');


### PR DESCRIPTION
## Classification

`P2_WOOCOMMERCE_ADAPTER / STOCK_STATUS_SPLIT`

Closes #66.

## Summary

- changes only `WCOS_Split_Strategy_Gates::STOCK_STATUS` from `false` to `true` in production runtime;
- keeps Manual Quantity and Category enabled;
- updates exact-state CI/package assertions for `manual_quantity=true`, `category=true`, `stock_status=true`;
- runs Stock-status planner, adapter, Review → Confirm → Execute transport, and UI evidence through the real production gate without a Reflection override;
- retains Category production transport and rejects cross-strategy confirmation replay;
- does not change planner, classifier, controller, gateway, mutation, recovery, version, release, or publication runtime source.

## Exact target gate map

- workflows: Split=true, Duplicate=true, Merge=true, Return=false, Bulk Return=false;
- strategies: Manual Quantity=true, Category=true, Stock-status=true.

## Exact head and Local evidence

- exact source: `origin/main@e4bb429e75def5b61015934e7841562ab783c96f`;
- exact PR/Local head: `63029375f0e8a8e1733ab56dabd09d96098af1ca`;
- Local filesystem HEAD equals the pushed branch head;
- all PHP syntax checks passed;
- `php tests/unit/run.php` passed (25 contracts);
- workflow YAML parsed successfully;
- strategy modal-feedback and Split method focus lifecycle JS tests passed;
- exact-head focused Local WooCommerce suite passed: planners, adapter, confirmation authority, Category + Stock-status production transport, UI readiness, and modal feedback;
- hands-on Local UI exposed exactly By quantity + By category + By stock status, then completed Stock-status Review → Confirm → Execute with `In stock` retained and `Out of stock` moved to one child;
- database re-read proved source item `27033` retained, moved item `27034` removed, fresh child item `27035`, quantity `2`, combined total `22.73`, unchanged `instock/outofstock` product state, completed `stock_status` journal authority, and `fully_moved_item_ids=[27034]`;
- modal-local success remained visible and closing the modal returned focus to the visible `Split order` launcher;
- fixture manifest was recorded and exact source `23624`, child `23625`, products `23622/23623`, terms `318/319`, journal, and manifest option were deleted; post-cleanup audit passed;
- the aggregate Local `operation-control-smoke.php` entrypoint is not usable on this shared site because an external `woocommerce_stock_amount` integration preserves fractional quantity before the strategy suite; the exact-head focused strategy suite and hands-on evidence above are green, while canonical isolated CI remains authority for the full regression matrix.

Canonical exact-head CI remains merge authority. Keep this PR Draft through CI and executor complete-diff review.

No version bump, release, publication, deployment, Technical Acceptance, or Human Gate is requested by this PR.
