### PR TITLE
WOS-RETURN-002: Return domain and lineage foundation

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -86,12 +86,15 @@ jobs:
             'inc/backend/orders-bulk-return.php' \
             'inc/backend/order-split-button.php' \
             'inc/backend/order-return-option.php' \
+            'inc/backend/class-wcos-return-admin-controller.php' \
             'inc/backend/order-duplicate-option.php' \
             'inc/backend/order-merge-option.php' \
             'js/bulk-return-action.js' \
             'js/merge-action.js' \
             'js/post-action-tip.js' \
             'js/split-table.js' \
+            'js/p2-return-admin.js' \
+            'css/p2-return-admin.css' \
             'inc/mutation-v2' \
             'tests' \
             'docs' \
@@ -144,6 +147,10 @@ jobs:
             'inc/domain/class-wcos-merge-retirement-policy.php' \
             'inc/domain/class-wcos-merge-order-service.php' \
             'inc/domain/class-wcos-merge-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-return-participation.php' \
+            'inc/domain/class-wcos-return-plan.php' \
+            'inc/domain/class-wcos-return-lineage-authority.php' \
+            'inc/domain/class-wcos-return-preflight.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -187,10 +194,17 @@ jobs:
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::MANUAL_QUANTITY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::CATEGORY => true'
           unzip -p wc-order-splitter.zip wc-order-splitter/inc/domain/class-wcos-split-strategy-gates.php | grep -Fq 'self::STOCK_STATUS => true'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-participation.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-plan.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-lineage-authority.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-preflight.php'
 
           for forbidden_archive_path in \
             'wc-order-splitter/inc/backend/order-merge-option.php' \
-            'wc-order-splitter/js/merge-action.js'; do
+            'wc-order-splitter/js/merge-action.js' \
+            'wc-order-splitter/inc/backend/class-wcos-return-admin-controller.php' \
+            'wc-order-splitter/js/p2-return-admin.js' \
+            'wc-order-splitter/css/p2-return-admin.css'; do
             if unzip -Z1 wc-order-splitter.zip | grep -Fxq "$forbidden_archive_path"; then
               echo "Legacy Merge path entered the ZIP: $forbidden_archive_path" >&2
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,13 @@ jobs:
           grep -Fq 'class-wcos-merge-confirmation-store.php' inc/cores/script.php
           grep -Fq 'class-wcos-merge-admin-controller.php' inc/cores/script.php
           grep -Fq 'WCOS_Merge_Admin_Controller::bootstrap();' inc/cores/script.php
+          grep -Fq 'class-wcos-return-participation.php' inc/cores/script.php
+          grep -Fq 'class-wcos-return-plan.php' inc/cores/script.php
+          grep -Fq 'class-wcos-return-lineage-authority.php' inc/cores/script.php
+          grep -Fq 'class-wcos-return-preflight.php' inc/cores/script.php
+          test ! -e inc/backend/class-wcos-return-admin-controller.php
+          test ! -e js/p2-return-admin.js
+          test ! -e css/p2-return-admin.css
           grep -Fq "const SEARCH_ACTION = 'wcos_merge_target_search';" inc/backend/class-wcos-merge-admin-controller.php
           grep -Fq "'wcos-merge-admin'" inc/backend/class-wcos-admin-backbone-modal-assets.php
           grep -Fq 'window.WCOSBackboneModal.open' js/p2-merge-admin.js
@@ -228,12 +235,15 @@ jobs:
             'inc/backend/orders-bulk-return.php' \
             'inc/backend/order-split-button.php' \
             'inc/backend/order-return-option.php' \
+            'inc/backend/class-wcos-return-admin-controller.php' \
             'inc/backend/order-duplicate-option.php' \
             'inc/backend/order-merge-option.php' \
             'js/bulk-return-action.js' \
             'js/merge-action.js' \
             'js/post-action-tip.js' \
             'js/split-table.js' \
+            'js/p2-return-admin.js' \
+            'css/p2-return-admin.css' \
             'inc/mutation-v2' \
             'tests' \
             'docs' \
@@ -286,6 +296,10 @@ jobs:
             'inc/domain/class-wcos-merge-retirement-policy.php' \
             'inc/domain/class-wcos-merge-order-service.php' \
             'inc/domain/class-wcos-merge-woocommerce-adapter.php' \
+            'inc/domain/class-wcos-return-participation.php' \
+            'inc/domain/class-wcos-return-plan.php' \
+            'inc/domain/class-wcos-return-lineage-authority.php' \
+            'inc/domain/class-wcos-return-preflight.php' \
             'css/p2-split-strategy-admin.css' \
             'js/p2-split-strategy-admin.js'; do
             if test ! -e "$package_root/$required_path"; then
@@ -356,6 +370,10 @@ jobs:
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-retirement-policy.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-order-service.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-merge-woocommerce-adapter.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-participation.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-plan.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-lineage-authority.php'
+          unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/inc/domain/class-wcos-return-preflight.php'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/js/p2-split-strategy-admin.js'
           unzip -Z1 wc-order-splitter.zip | grep -Fq 'wc-order-splitter/css/p2-split-strategy-admin.css'
           if unzip -Z1 wc-order-splitter.zip | grep -E '(^|/)(tests|docs|node_modules|inc/mutation-v2)(/|$)|(^|/)AGENTS\.md$'; then
@@ -530,6 +548,9 @@ jobs:
 
       - name: Verify governance, authorization, and metadata policy
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
+
+      - name: Verify hard-off Return domain and hardened Split lineage authority
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-domain-lineage-smoke.php
 
       - name: Verify Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -73,6 +73,10 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-category-split-planner.php';
 		include_once $root . 'domain/class-wcos-stock-status-split-planner.php';
 		include_once $root . 'domain/class-wcos-split-strategy-woocommerce-adapter.php';
+		include_once $root . 'domain/class-wcos-return-participation.php';
+		include_once $root . 'domain/class-wcos-return-plan.php';
+		include_once $root . 'domain/class-wcos-return-lineage-authority.php';
+		include_once $root . 'domain/class-wcos-return-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-preflight.php';
 		include_once $root . 'domain/class-wcos-merge-preflight.php';
 		include_once $root . 'domain/class-wcos-duplicate-woocommerce-adapter.php';

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -16,6 +16,7 @@ final class WCOS_Order_Item_Meta_Policy {
 	const CONTEXT_DUPLICATE = 'duplicate';
 	const CONTEXT_SPLIT = 'split';
 	const CONTEXT_MERGE = 'merge';
+	const CONTEXT_RETURN = 'return';
 	const CONTEXT_IDENTITY = 'identity';
 
 	const CLASS_BUSINESS = 'business';

--- a/inc/domain/class-wcos-return-lineage-authority.php
+++ b/inc/domain/class-wcos-return-lineage-authority.php
@@ -1,0 +1,645 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Return_Lineage_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/**
+ * Read-only proof that one current order is an exact hardened Split child.
+ *
+ * Authority is derived from the completed source-keyed Split journal, its
+ * integrity-checked pre-Split source snapshot, the immutable Split request
+ * fingerprint, and current persisted participant state. Legacy relation meta
+ * is corroboration only and never mints executable authority.
+ */
+final class WCOS_Return_Lineage_Authority {
+
+	const SCHEMA_VERSION = 1;
+	const POLICY_VERSION = 1;
+
+	public static function resolve(WC_Order $child) {
+		$child_id = absint($child->get_id());
+		if (!$child_id || 'shop_order' !== $child->get_type()) {
+			self::reject('invalid_child', __('Return lineage requires a persisted WooCommerce shop order child.', 'wc-order-splitter'));
+		}
+
+		$raw_source_id = $child->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true);
+		if ('' === $raw_source_id || null === $raw_source_id) {
+			$legacy = self::legacy_candidate($child);
+			if (!empty($legacy['legacy_parent_id'])) {
+				self::reject('legacy_lineage_not_authoritative', __('Legacy Split metadata is diagnostic only and cannot authorize Return.', 'wc-order-splitter'));
+			}
+			self::reject('lineage_missing', __('This order does not carry hardened Split parent authority.', 'wc-order-splitter'));
+		}
+		$source_id = self::positive_int_scalar($raw_source_id, 'parent_order_id');
+		if ($source_id === $child_id) {
+			self::reject('same_participant', __('A Return child cannot be its own original order.', 'wc-order-splitter'));
+		}
+
+		$raw_operation_id = $child->get_meta(WCOS_Split_Order_Service::OPERATION_META, true);
+		$operation_id = self::canonical_key_scalar($raw_operation_id, 'split_operation_id');
+		$raw_child_key = $child->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true);
+		$child_key = self::canonical_key_scalar($raw_child_key, 'split_child_key');
+
+		$source = wc_get_order($source_id);
+		if (!$source instanceof WC_Order || 'shop_order' !== $source->get_type()) {
+			self::reject('source_missing', __('The hardened Split original order is unavailable.', 'wc-order-splitter'));
+		}
+
+		self::assert_structured_relation($source, $child_id);
+		$legacy = self::legacy_candidate($child, $source);
+		if (!empty($legacy['conflict'])) {
+			self::reject('legacy_lineage_conflict', __('Legacy relation metadata conflicts with hardened Split authority.', 'wc-order-splitter'));
+		}
+
+		$record = WCOS_Operation_Journal::get($source, $operation_id);
+		self::assert_journal_identity($record, $source_id, $operation_id);
+		$context = $record['context'];
+		$plan = self::canonical_split_plan($context);
+		if (!isset($plan[$child_key])) {
+			self::reject('child_key_not_in_plan', __('The Split child key is absent from the durable Split plan.', 'wc-order-splitter'));
+		}
+
+		$execution_policy = self::execution_policy($context);
+		$fully_moved = self::canonical_id_list(isset($context['fully_moved_item_ids']) ? $context['fully_moved_item_ids'] : array(), 'fully_moved_item_ids');
+		$price_precision = WCOS_Price_Precision_Scope::validate(isset($context['price_precision']) ? $context['price_precision'] : null);
+		$snapshot = self::source_snapshot($context, $source_id);
+		$derived_fully_moved = self::derive_fully_moved_ids($snapshot, $plan);
+		if ($derived_fully_moved !== $fully_moved) {
+			self::reject('fully_moved_authority_mismatch', __('The durable Split whole-line provenance does not match its source snapshot and plan.', 'wc-order-splitter'));
+		}
+		if (WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === $execution_policy && !empty($fully_moved)) {
+			self::reject('execution_policy_mismatch', __('A partial-line Split journal contains whole-line provenance.', 'wc-order-splitter'));
+		}
+
+		$strategy = self::assert_strategy_authority($context, $execution_policy, $snapshot);
+		self::assert_split_fingerprint($record, $plan, $execution_policy, $context);
+		self::assert_target_set($source, $context, $plan, $source_id, $operation_id, $child_id, $child_key);
+
+		$expected_source_signature = self::fingerprint_value(isset($context['source_signature_after']) ? $context['source_signature_after'] : '', 'source_signature_after');
+		$expected_source_recovery_signature = self::fingerprint_value(isset($context['source_recovery_signature_after']) ? $context['source_recovery_signature_after'] : '', 'source_recovery_signature_after');
+		if (!hash_equals($expected_source_signature, WCOS_Order_Contract_Snapshot::source_signature($source))
+			|| !hash_equals($expected_source_recovery_signature, WCOS_Order_Mutation_Snapshot::split_owned_signature($source))) {
+			self::reject('source_drift', __('The original order changed after the completed Split operation.', 'wc-order-splitter'));
+		}
+
+		try {
+			WCOS_Order_Copy_Context::assert_matches($snapshot['copy_context_signature'], $child);
+			WCOS_Order_Totals_Rebuilder::assert_consistent($source, $price_precision);
+			WCOS_Order_Totals_Rebuilder::assert_consistent($child, $price_precision);
+		} catch (Throwable $throwable) {
+			self::reject('commercial_context_drift', __('The Return participant commercial context no longer matches durable Split evidence.', 'wc-order-splitter'));
+		}
+
+		$lines = self::prove_child_lines($source, $child, $snapshot, $plan, $child_key, $fully_moved, $price_precision);
+		$child_signature = WCOS_Order_Contract_Snapshot::source_signature($child);
+		$authority = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'policy_version' => self::POLICY_VERSION,
+			'child_order_id' => $child_id,
+			'source_order_id' => $source_id,
+			'split_operation_id' => $operation_id,
+			'split_child_key' => $child_key,
+			'split_operation_fingerprint' => self::fingerprint_value($record['fingerprint'], 'split_operation_fingerprint'),
+			'split_plan_fingerprint' => WCOS_Mutation_Fingerprint::create('split_plan', $source_id, $plan),
+			'source_snapshot_authority' => self::sealed_fingerprint('source_snapshot', $snapshot['recovery_fingerprint']),
+			'execution_policy' => $execution_policy,
+			'strategy' => $strategy,
+			'price_precision' => $price_precision,
+			'currency' => (string) $source->get_currency(),
+			'prices_include_tax' => (bool) $source->get_prices_include_tax(),
+			'source_commercial_authority' => self::sealed_fingerprint('source_commercial', $expected_source_signature),
+			'source_relation_authority' => self::sealed_fingerprint('source_relation', $expected_source_recovery_signature),
+			'child_commercial_authority' => self::sealed_fingerprint('child_commercial', $child_signature),
+			'lines' => $lines,
+			'legacy_diagnosis' => $legacy,
+		);
+		$authority['authority_fingerprint'] = self::fingerprint($authority);
+		return $authority;
+	}
+
+	public static function fingerprint(array $authority) {
+		$copy = $authority;
+		unset($copy['authority_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create(
+			'return_lineage_authority',
+			absint(isset($copy['child_order_id']) ? $copy['child_order_id'] : 0),
+			self::canonicalize($copy)
+		);
+	}
+
+	public static function legacy_candidate(WC_Order $child, ?WC_Order $source = null) {
+		$legacy_parent_raw = $child->get_meta('yoos_original_order', true);
+		$legacy_parent_id = 0;
+		$malformed = false;
+		if ('' !== $legacy_parent_raw && null !== $legacy_parent_raw) {
+			try {
+				$legacy_parent_id = self::positive_int_scalar($legacy_parent_raw, 'legacy_parent_id');
+			} catch (WCOS_Return_Lineage_Exception $exception) {
+				$malformed = true;
+			}
+		}
+
+		$reciprocal = null;
+		if ($source instanceof WC_Order) {
+			try {
+				$legacy_children = self::legacy_id_list($source->get_meta('yoos_splitted_order', true));
+				$reciprocal = in_array($child->get_id(), $legacy_children, true);
+			} catch (WCOS_Return_Lineage_Exception $exception) {
+				$malformed = true;
+				$reciprocal = false;
+			}
+		}
+
+		$structured_parent = 0;
+		try {
+			$raw = $child->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true);
+			if ('' !== $raw && null !== $raw) {
+				$structured_parent = self::positive_int_scalar($raw, 'parent_order_id');
+			}
+		} catch (WCOS_Return_Lineage_Exception $exception) {
+			$malformed = true;
+		}
+
+		$conflict = $malformed
+			|| ($legacy_parent_id && $structured_parent && $legacy_parent_id !== $structured_parent)
+			|| (null !== $reciprocal && $legacy_parent_id && !$reciprocal);
+
+		return array(
+			'executable' => false,
+			'reason' => 'legacy_lineage_not_authoritative',
+			'legacy_parent_id' => $legacy_parent_id,
+			'source_exists' => $source instanceof WC_Order,
+			'reciprocal_legacy_relation' => $reciprocal,
+			'conflict' => $conflict,
+			'migration_required' => $legacy_parent_id > 0,
+		);
+	}
+
+	private static function assert_journal_identity($record, $source_id, $operation_id) {
+		if (!is_array($record)) {
+			self::reject('journal_missing', __('The authoritative Split journal is missing.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0) !== $source_id
+			|| sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '') !== $operation_id) {
+			self::reject('journal_identity_mismatch', __('The Split journal does not belong to this source and operation.', 'wc-order-splitter'));
+		}
+		if ('split' !== sanitize_key(isset($record['type']) ? (string) $record['type'] : '')) {
+			self::reject('journal_wrong_type', __('The durable operation is not a Split journal.', 'wc-order-splitter'));
+		}
+		if ('completed' !== sanitize_key(isset($record['status']) ? (string) $record['status'] : '')) {
+			self::reject('journal_not_completed', __('Return requires a completed Split journal.', 'wc-order-splitter'));
+		}
+		if (empty($record['context']) || !is_array($record['context'])) {
+			self::reject('journal_context_missing', __('The completed Split journal is missing durable context.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function canonical_split_plan(array $context) {
+		if (empty($context['plan']) || !is_array($context['plan'])) {
+			self::reject('split_plan_missing', __('The Split journal is missing its normalized plan.', 'wc-order-splitter'));
+		}
+		try {
+			$plan = WCOS_Split_Plan::canonicalize_request($context['plan']);
+		} catch (Throwable $throwable) {
+			self::reject('split_plan_malformed', __('The durable Split plan is malformed.', 'wc-order-splitter'));
+		}
+		if ($plan !== $context['plan']) {
+			self::reject('split_plan_not_canonical', __('The durable Split plan is not canonical.', 'wc-order-splitter'));
+		}
+		$child_keys = isset($context['child_keys']) ? array_values($context['child_keys']) : array();
+		if (WCOS_Split_Plan::child_keys($plan) !== $child_keys) {
+			self::reject('child_key_set_mismatch', __('The Split journal child-key set does not match its plan.', 'wc-order-splitter'));
+		}
+		return $plan;
+	}
+
+	private static function source_snapshot(array $context, $source_id) {
+		if (empty($context['source_snapshot']) || !is_array($context['source_snapshot'])) {
+			self::reject('source_snapshot_missing', __('The Split journal is missing its pre-Split source snapshot.', 'wc-order-splitter'));
+		}
+		$snapshot = $context['source_snapshot'];
+		try {
+			WCOS_Order_Mutation_Snapshot::assert_valid($snapshot);
+		} catch (Throwable $throwable) {
+			self::reject('source_snapshot_invalid', __('The pre-Split source snapshot failed integrity verification.', 'wc-order-splitter'));
+		}
+		if (absint(isset($snapshot['order_id']) ? $snapshot['order_id'] : 0) !== $source_id
+			|| empty($snapshot['line_items']) || !is_array($snapshot['line_items'])) {
+			self::reject('source_snapshot_mismatch', __('The pre-Split snapshot does not match this source order.', 'wc-order-splitter'));
+		}
+		$stored = self::fingerprint_value(isset($context['source_snapshot_fingerprint']) ? $context['source_snapshot_fingerprint'] : '', 'source_snapshot_fingerprint');
+		if (!hash_equals($stored, (string) $snapshot['recovery_fingerprint'])) {
+			self::reject('source_snapshot_fingerprint_mismatch', __('The Split snapshot pointer does not match its integrity fingerprint.', 'wc-order-splitter'));
+		}
+		if (!empty($context['source_signature']) && !hash_equals((string) $context['source_signature'], (string) $snapshot['source_signature'])) {
+			self::reject('source_snapshot_signature_mismatch', __('The Split source signature does not match its recovery snapshot.', 'wc-order-splitter'));
+		}
+		return $snapshot;
+	}
+
+	private static function execution_policy(array $context) {
+		try {
+			return WCOS_Split_Execution_Policy::normalize(isset($context['execution_policy']) ? $context['execution_policy'] : '');
+		} catch (Throwable $throwable) {
+			self::reject('execution_policy_invalid', __('The Split journal execution policy is invalid.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function assert_strategy_authority(array $context, $execution_policy, array $snapshot) {
+		$has_strategy = isset($context['strategy_authority']) && is_array($context['strategy_authority']);
+		if (WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === $execution_policy) {
+			if ($has_strategy) {
+				self::reject('strategy_policy_mismatch', __('A manual partial Split unexpectedly carries strategy authority.', 'wc-order-splitter'));
+			}
+			return 'manual_quantity';
+		}
+		if (!$has_strategy) {
+			self::reject('strategy_authority_missing', __('Whole-line Return provenance requires durable Split strategy authority.', 'wc-order-splitter'));
+		}
+		$authority = $context['strategy_authority'];
+		$strategy = sanitize_key(isset($authority['strategy']) ? (string) $authority['strategy'] : '');
+		if (!in_array($strategy, array(WCOS_Split_Strategy_Gates::CATEGORY, WCOS_Split_Strategy_Gates::STOCK_STATUS), true)) {
+			self::reject('strategy_authority_invalid', __('The Split strategy identity is unsupported.', 'wc-order-splitter'));
+		}
+		$expected_policy = WCOS_Split_Strategy_Gates::CATEGORY === $strategy
+			? WCOS_Category_Split_Planner::POLICY_VERSION
+			: WCOS_Stock_Status_Split_Planner::POLICY_VERSION;
+		if (absint(isset($authority['planner_policy_version']) ? $authority['planner_policy_version'] : 0) !== $expected_policy
+			|| empty($authority['classification_fingerprint']) || empty($authority['source_bucket_key'])
+			|| empty($authority['review_source_signature'])
+			|| !hash_equals((string) $authority['review_source_signature'], (string) $snapshot['source_signature'])) {
+			self::reject('strategy_authority_invalid', __('The durable Split strategy authority is incomplete or inconsistent.', 'wc-order-splitter'));
+		}
+		return $strategy;
+	}
+
+	private static function assert_split_fingerprint(array $record, array $plan, $execution_policy, array $context) {
+		$fingerprint_context = array(
+			'policy_version' => WCOS_Split_Order_Service::POLICY_VERSION,
+			'plan' => $plan,
+			'shipping_policy' => 'keep_on_source',
+			'fee_policy' => 'keep_on_source',
+			'child_status' => 'pending',
+			'execution_policy' => $execution_policy,
+		);
+		if (isset($context['strategy_authority'])) {
+			$fingerprint_context['strategy_authority'] = $context['strategy_authority'];
+		}
+		$expected = WCOS_Mutation_Fingerprint::create('split', absint($record['source_order_id']), $fingerprint_context);
+		$stored = self::fingerprint_value(isset($record['fingerprint']) ? $record['fingerprint'] : '', 'split_operation_fingerprint');
+		if (!hash_equals($stored, $expected)) {
+			self::reject('split_fingerprint_mismatch', __('The Split journal request fingerprint does not match its durable plan and policy.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function assert_target_set(WC_Order $source, array $context, array $plan, $source_id, $operation_id, $child_id, $child_key) {
+		$target_ids = self::canonical_id_list(isset($context['target_order_ids']) ? $context['target_order_ids'] : array(), 'target_order_ids');
+		if (count($target_ids) !== count($plan) || 1 !== count(array_keys($target_ids, $child_id, true))) {
+			self::reject('journal_target_set_mismatch', __('The completed Split target set does not contain this child exactly once.', 'wc-order-splitter'));
+		}
+		$relation_ids = self::canonical_id_list($source->get_meta(WCOS_Split_Order_Service::RELATION_CHILDREN_META, true), 'source_child_relations');
+		if ($relation_ids !== $target_ids) {
+			self::reject('source_relation_target_mismatch', __('The original order child relation set does not match the completed Split target set.', 'wc-order-splitter'));
+		}
+		$seen_keys = array();
+		foreach ($target_ids as $target_id) {
+			$target = wc_get_order($target_id);
+			if (!$target instanceof WC_Order || 'shop_order' !== $target->get_type()) {
+				self::reject('journal_target_missing', __('A completed Split target is unavailable.', 'wc-order-splitter'));
+			}
+			$key = self::canonical_key_scalar($target->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true), 'target_child_key');
+			if (isset($seen_keys[$key]) || !isset($plan[$key])
+				|| self::positive_int_scalar($target->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true), 'target_parent') !== $source_id
+				|| self::canonical_key_scalar($target->get_meta(WCOS_Split_Order_Service::OPERATION_META, true), 'target_operation') !== $operation_id) {
+				self::reject('journal_target_provenance_mismatch', __('The completed Split target set has conflicting child provenance.', 'wc-order-splitter'));
+			}
+			$seen_keys[$key] = true;
+			if ($target_id === $child_id && $key !== $child_key) {
+				self::reject('child_key_mismatch', __('The current child key does not match its target-set authority.', 'wc-order-splitter'));
+			}
+		}
+		$keys = array_keys($seen_keys);
+		sort($keys, SORT_STRING);
+		if ($keys !== array_keys($plan)) {
+			self::reject('journal_target_key_set_mismatch', __('The target child-key set does not match the durable Split plan.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function prove_child_lines(WC_Order $source, WC_Order $child, array $snapshot, array $plan, $child_key, array $fully_moved, $precision) {
+		$expected = self::expected_allocations($snapshot, $plan, $child_key, $precision);
+		$actual = array();
+		foreach ($child->get_items('line_item') as $child_item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				self::reject('child_line_type_invalid', __('A Return child contains an unsupported product-line type.', 'wc-order-splitter'));
+			}
+			try {
+				$source_item_id = self::positive_int_scalar($item->get_meta('_wcos_source_item_id', true), 'source_item_id');
+			} catch (WCOS_Return_Lineage_Exception $exception) {
+				self::reject('child_line_provenance_invalid', __('A child line has missing or malformed Split source-item provenance.', 'wc-order-splitter'));
+			}
+			if (isset($actual[$source_item_id]) || !isset($expected[$source_item_id])) {
+				self::reject('child_line_provenance_mismatch', __('Child line provenance is duplicated or absent from the durable Split plan.', 'wc-order-splitter'));
+			}
+			self::assert_line_matches($item, $expected[$source_item_id], $precision, 'child');
+			$line = $expected[$source_item_id];
+			$line['source_item_id'] = $source_item_id;
+			$line['child_item_id'] = absint($child_item_id);
+			$line['product_id'] = absint($item->get_product_id());
+			$line['variation_id'] = absint($item->get_variation_id());
+			$line['tax_class'] = (string) $item->get_tax_class();
+			$line['destination'] = in_array($source_item_id, $fully_moved, true)
+				? WCOS_Return_Plan::DESTINATION_FRESH_SOURCE_ITEM
+				: WCOS_Return_Plan::DESTINATION_RESIDUAL_SOURCE_ITEM;
+			$line['destination_source_item_id'] = in_array($source_item_id, $fully_moved, true) ? 0 : $source_item_id;
+			$actual[$source_item_id] = $line;
+		}
+		ksort($actual, SORT_NUMERIC);
+		if (array_keys($actual) !== array_keys($expected)) {
+			self::reject('child_line_set_mismatch', __('The child line set does not exactly match its durable Split allocation.', 'wc-order-splitter'));
+		}
+
+		foreach ($actual as $source_item_id => $line) {
+			$source_item = $source->get_item($source_item_id);
+			if (in_array($source_item_id, $fully_moved, true)) {
+				if ($source_item instanceof WC_Order_Item_Product) {
+					self::reject('whole_line_source_drift', __('A fully moved Split source line unexpectedly exists on the original order.', 'wc-order-splitter'));
+				}
+				continue;
+			}
+			if (!$source_item instanceof WC_Order_Item_Product || empty($line['expected_source'])) {
+				self::reject('residual_source_line_missing', __('A partial Split residual source line is missing.', 'wc-order-splitter'));
+			}
+			self::assert_line_matches($source_item, $line['expected_source'], $precision, 'source');
+			unset($actual[$source_item_id]['expected_source']);
+		}
+		foreach ($actual as $source_item_id => $line) {
+			unset($actual[$source_item_id]['expected_source']);
+			$actual[$source_item_id]['line_identity_authority'] = self::sealed_fingerprint('line_identity', $line['line_identity']);
+			unset($actual[$source_item_id]['line_identity']);
+		}
+		return $actual;
+	}
+
+	private static function expected_allocations(array $snapshot, array $plan, $child_key, $precision) {
+		$expected = array();
+		foreach ($plan[$child_key] as $source_item_id => $child_quantity) {
+			$source_item_id = absint($source_item_id);
+			if (!isset($snapshot['line_items'][$source_item_id]) || !is_array($snapshot['line_items'][$source_item_id])) {
+				self::reject('source_item_snapshot_missing', __('The Split plan references a source item absent from its pre-Split snapshot.', 'wc-order-splitter'));
+			}
+			$before = $snapshot['line_items'][$source_item_id];
+			$before_units = WCOS_Decimal::to_units($before['quantity'], 6);
+			$allocated_units = 0;
+			$weights = array();
+			foreach ($plan as $key => $items) {
+				if (!isset($items[$source_item_id])) {
+					continue;
+				}
+				$units = WCOS_Decimal::to_units($items[$source_item_id], 6);
+				$allocated_units += $units;
+				$weights[$key] = WCOS_Decimal::from_units($units, 6);
+			}
+			$residual_units = $before_units - $allocated_units;
+			if ($residual_units < 0) {
+				self::reject('split_allocation_invalid', __('The durable Split plan over-allocates a source line.', 'wc-order-splitter'));
+			}
+			if ($residual_units > 0) {
+				$weights = array_merge(array('source' => WCOS_Decimal::from_units($residual_units, 6)), $weights);
+			}
+
+			$parts = array();
+			foreach (array('subtotal', 'total', 'subtotal_tax', 'total_tax') as $field) {
+				$allocated = WCOS_Amount_Allocator::allocate((string) $before[$field], $weights, $precision);
+				$parts[$field] = $allocated[$child_key];
+				if ($residual_units > 0) {
+					$parts['source_' . $field] = $allocated['source'];
+				}
+			}
+			$taxes = self::allocate_taxes(isset($before['taxes']) ? (array) $before['taxes'] : array(), $weights, $child_key, $precision);
+			$source_taxes = $residual_units > 0
+				? self::allocate_taxes(isset($before['taxes']) ? (array) $before['taxes'] : array(), $weights, 'source', $precision)
+				: array('subtotal' => array(), 'total' => array());
+			$reduced = null;
+			$source_reduced = null;
+			if (isset($before['reduced_stock']) && null !== $before['reduced_stock']) {
+				$reduced_parts = WCOS_Amount_Allocator::allocate((string) $before['reduced_stock'], $weights, 6);
+				$reduced = self::nullable_decimal($reduced_parts[$child_key], 6);
+				$source_reduced = $residual_units > 0 ? self::nullable_decimal($reduced_parts['source'], 6) : null;
+			}
+
+			$expected[$source_item_id] = array(
+				'line_identity' => self::fingerprint_value(isset($before['identity']) ? $before['identity'] : '', 'line_identity'),
+				'quantity' => WCOS_Decimal::normalize($child_quantity, 6),
+				'subtotal' => $parts['subtotal'],
+				'total' => $parts['total'],
+				'subtotal_tax' => $parts['subtotal_tax'],
+				'total_tax' => $parts['total_tax'],
+				'taxes' => $taxes,
+				'reduced_stock' => $reduced,
+				'expected_source' => $residual_units > 0 ? array(
+					'line_identity' => self::fingerprint_value(isset($before['identity']) ? $before['identity'] : '', 'line_identity'),
+					'quantity' => WCOS_Decimal::from_units($residual_units, 6),
+					'subtotal' => $parts['source_subtotal'],
+					'total' => $parts['source_total'],
+					'subtotal_tax' => $parts['source_subtotal_tax'],
+					'total_tax' => $parts['source_total_tax'],
+					'taxes' => $source_taxes,
+					'reduced_stock' => $source_reduced,
+				) : null,
+			);
+		}
+		ksort($expected, SORT_NUMERIC);
+		return $expected;
+	}
+
+	private static function allocate_taxes(array $taxes, array $weights, $destination, $precision) {
+		$result = array('subtotal' => array(), 'total' => array());
+		foreach (array('subtotal', 'total') as $bucket) {
+			foreach (isset($taxes[$bucket]) ? (array) $taxes[$bucket] : array() as $rate_id => $amount) {
+				$parts = WCOS_Amount_Allocator::allocate((string) $amount, $weights, $precision);
+				$result[$bucket][(int) $rate_id] = $parts[$destination];
+			}
+			ksort($result[$bucket], SORT_NUMERIC);
+		}
+		return $result;
+	}
+
+	private static function assert_line_matches(WC_Order_Item_Product $item, array $expected, $precision, $role) {
+		try {
+			$identity = WCOS_Line_Identity::from_item($item);
+			$unknown = WCOS_Order_Item_Meta_Policy::unknown_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_RETURN);
+			$inconsistent = WCOS_Order_Item_Meta_Policy::inconsistent_private_keys($item, WCOS_Order_Item_Meta_Policy::CONTEXT_RETURN);
+		} catch (Throwable $throwable) {
+			self::reject($role . '_line_identity_invalid', __('A Return participant line has non-canonical business metadata.', 'wc-order-splitter'));
+		}
+		if (!empty($unknown) || !empty($inconsistent)) {
+			self::reject($role . '_line_private_meta_unsupported', __('A Return participant line contains unclassified private metadata.', 'wc-order-splitter'));
+		}
+		$actual = array(
+			'line_identity' => $identity,
+			'quantity' => WCOS_Decimal::normalize($item->get_quantity(), 6),
+			'subtotal' => WCOS_Decimal::normalize($item->get_subtotal(), $precision),
+			'total' => WCOS_Decimal::normalize($item->get_total(), $precision),
+			'subtotal_tax' => WCOS_Decimal::normalize($item->get_subtotal_tax(), $precision),
+			'total_tax' => WCOS_Decimal::normalize($item->get_total_tax(), $precision),
+			'taxes' => self::normalize_taxes($item->get_taxes(), $precision),
+			'reduced_stock' => self::nullable_decimal($item->get_meta('_reduced_stock', true), 6),
+		);
+		$compare = $expected;
+		unset($compare['expected_source']);
+		if ($actual !== $compare) {
+			self::reject($role . '_line_drift', __('A Return participant line no longer matches its durable Split allocation.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function normalize_taxes(array $taxes, $precision) {
+		$result = array('subtotal' => array(), 'total' => array());
+		foreach (array('subtotal', 'total') as $bucket) {
+			foreach (isset($taxes[$bucket]) ? (array) $taxes[$bucket] : array() as $rate_id => $amount) {
+				$result[$bucket][(int) $rate_id] = WCOS_Decimal::normalize($amount, $precision);
+			}
+			ksort($result[$bucket], SORT_NUMERIC);
+		}
+		return $result;
+	}
+
+	private static function derive_fully_moved_ids(array $snapshot, array $plan) {
+		$allocated = array();
+		foreach ($plan as $items) {
+			foreach ($items as $source_item_id => $quantity) {
+				$source_item_id = absint($source_item_id);
+				$units = WCOS_Decimal::to_units($quantity, 6);
+				$allocated[$source_item_id] = isset($allocated[$source_item_id]) ? $allocated[$source_item_id] + $units : $units;
+			}
+		}
+		$fully = array();
+		foreach ($allocated as $source_item_id => $units) {
+			if (!isset($snapshot['line_items'][$source_item_id])) {
+				self::reject('source_item_snapshot_missing', __('A Split allocation references an unknown pre-Split source item.', 'wc-order-splitter'));
+			}
+			$before = WCOS_Decimal::to_units($snapshot['line_items'][$source_item_id]['quantity'], 6);
+			if ($units > $before) {
+				self::reject('split_allocation_invalid', __('The Split allocation exceeds its source quantity.', 'wc-order-splitter'));
+			}
+			if ($units === $before) {
+				$fully[] = $source_item_id;
+			}
+		}
+		sort($fully, SORT_NUMERIC);
+		return $fully;
+	}
+
+	private static function assert_structured_relation(WC_Order $source, $child_id) {
+		$ids = self::canonical_id_list($source->get_meta(WCOS_Split_Order_Service::RELATION_CHILDREN_META, true), 'source_child_relations');
+		if (1 !== count(array_keys($ids, $child_id, true))) {
+			self::reject('source_relation_mismatch', __('The original order does not contain this child exactly once in its hardened relation graph.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function canonical_id_list($value, $field) {
+		if (!is_array($value)) {
+			self::reject($field . '_malformed', __('A hardened Return authority ID list is malformed.', 'wc-order-splitter'));
+		}
+		$ids = array();
+		foreach ($value as $item) {
+			$id = self::positive_int_scalar($item, $field);
+			if (isset($ids[$id])) {
+				self::reject($field . '_duplicate', __('A hardened Return authority ID list contains duplicates.', 'wc-order-splitter'));
+			}
+			$ids[$id] = true;
+		}
+		$result = array_keys($ids);
+		sort($result, SORT_NUMERIC);
+		return $result;
+	}
+
+	private static function legacy_id_list($value) {
+		if ('' === $value || null === $value) {
+			return array();
+		}
+		if (!is_string($value) || !preg_match('/^[1-9][0-9]*(,[1-9][0-9]*)*$/D', $value)) {
+			self::reject('legacy_relation_malformed', __('Legacy Split relation metadata is malformed.', 'wc-order-splitter'));
+		}
+		$ids = array_map('intval', explode(',', $value));
+		if (count($ids) !== count(array_unique($ids))) {
+			self::reject('legacy_relation_duplicate', __('Legacy Split relation metadata contains duplicate IDs.', 'wc-order-splitter'));
+		}
+		sort($ids, SORT_NUMERIC);
+		return $ids;
+	}
+
+	private static function positive_int_scalar($value, $field) {
+		if (is_int($value) && $value > 0) {
+			return $value;
+		}
+		if (is_string($value) && preg_match('/^[1-9][0-9]*$/D', $value)) {
+			return (int) $value;
+		}
+		self::reject($field . '_malformed', __('A hardened Return authority order/item ID is malformed.', 'wc-order-splitter'));
+	}
+
+	private static function canonical_key_scalar($value, $field) {
+		if (!is_string($value) || '' === $value || sanitize_key($value) !== $value) {
+			self::reject($field . '_malformed', __('A hardened Return authority key is malformed.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function fingerprint_value($value, $field) {
+		$value = is_string($value) ? $value : '';
+		if (1 !== preg_match('/^[0-9a-f]{64}$/D', $value)) {
+			self::reject($field . '_malformed', __('A hardened Return authority fingerprint is malformed.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function sealed_fingerprint($domain, $value) {
+		$value = self::fingerprint_value($value, $domain);
+		return hash_hmac('sha256', 'wcos_return_' . sanitize_key($domain) . '|' . $value, wp_salt('auth'));
+	}
+
+	private static function nullable_decimal($value, $precision) {
+		if ('' === $value || null === $value) {
+			return null;
+		}
+		$normalized = WCOS_Decimal::normalize($value, $precision);
+		return 0 === WCOS_Decimal::to_units($normalized, $precision) ? null : $normalized;
+	}
+
+	private static function canonicalize($value) {
+		if (!is_array($value)) {
+			return $value;
+		}
+		$is_list = true;
+		$expected = 0;
+		foreach (array_keys($value) as $key) {
+			if ($key !== $expected++) {
+				$is_list = false;
+				break;
+			}
+		}
+		if (!$is_list) {
+			ksort($value, SORT_STRING);
+		}
+		foreach ($value as $key => $item) {
+			$value[$key] = self::canonicalize($item);
+		}
+		return $value;
+	}
+
+	private static function reject($reason, $message) {
+		throw new WCOS_Return_Lineage_Exception($reason, $message);
+	}
+}

--- a/inc/domain/class-wcos-return-participation.php
+++ b/inc/domain/class-wcos-return-participation.php
@@ -1,0 +1,79 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Non-executable Return relation vocabulary for later mutation milestones.
+ *
+ * WOS-RETURN-002 only reads and validates these keys. It never persists them.
+ */
+final class WCOS_Return_Participation {
+
+	const SCHEMA_VERSION = 1;
+	const CHILD_ORIGINAL_META = '_wcos_returned_to_order_id';
+	const CHILD_OPERATION_META = '_wcos_return_operation_id';
+	const CHILD_PAIR_FINGERPRINT_META = '_wcos_return_pair_fingerprint';
+	const ORIGINAL_CHILD_META = '_wcos_returned_child_order_id';
+	const ORIGINAL_OPERATION_META = '_wcos_returned_child_operation_id';
+
+	public static function inspect(WC_Order $order) {
+		$values = array(
+			'returned_to_order_id' => self::scalar_positive_int($order->get_meta(self::CHILD_ORIGINAL_META, true)),
+			'operation_id' => self::scalar_key($order->get_meta(self::CHILD_OPERATION_META, true)),
+			'pair_fingerprint' => self::scalar_fingerprint($order->get_meta(self::CHILD_PAIR_FINGERPRINT_META, true)),
+		);
+		$present = 0;
+		foreach ($values as $value) {
+			if (null !== $value) {
+				$present++;
+			}
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'present' => $present > 0,
+			'complete' => 3 === $present,
+			'values' => $values,
+		);
+	}
+
+	public static function assert_not_terminal(WC_Order $child) {
+		$state = self::inspect($child);
+		if (!empty($state['present'])) {
+			throw new RuntimeException(__('This Split child already carries Return participation evidence.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function scalar_positive_int($value) {
+		if ('' === $value || null === $value) {
+			return null;
+		}
+		if (is_int($value) && $value > 0) {
+			return $value;
+		}
+		if (is_string($value) && preg_match('/^[1-9][0-9]*$/D', $value)) {
+			return (int) $value;
+		}
+		throw new RuntimeException(__('Return participation contains a malformed order ID.', 'wc-order-splitter'));
+	}
+
+	private static function scalar_key($value) {
+		if ('' === $value || null === $value) {
+			return null;
+		}
+		if (!is_string($value) || sanitize_key($value) !== $value || '' === $value) {
+			throw new RuntimeException(__('Return participation contains a malformed operation ID.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function scalar_fingerprint($value) {
+		if ('' === $value || null === $value) {
+			return null;
+		}
+		if (!is_string($value) || 1 !== preg_match('/^[0-9a-f]{64}$/D', $value)) {
+			throw new RuntimeException(__('Return participation contains a malformed fingerprint.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+}

--- a/inc/domain/class-wcos-return-plan.php
+++ b/inc/domain/class-wcos-return-plan.php
@@ -1,0 +1,160 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/** Immutable, read-only all-or-nothing Return plan. */
+final class WCOS_Return_Plan {
+
+	const SCHEMA_VERSION = 1;
+	const POLICY_VERSION = 1;
+	const DESTINATION_RESIDUAL_SOURCE_ITEM = 'residual_source_item';
+	const DESTINATION_FRESH_SOURCE_ITEM = 'fresh_source_item';
+
+	public static function build(array $lineage_authority) {
+		if (empty($lineage_authority['authority_fingerprint'])) {
+			throw new InvalidArgumentException(__('A verified Return lineage authority is required.', 'wc-order-splitter'));
+		}
+
+		$price_precision = WCOS_Price_Precision_Scope::validate(isset($lineage_authority['price_precision']) ? $lineage_authority['price_precision'] : null);
+		$operation_id = isset($lineage_authority['split_operation_id']) ? $lineage_authority['split_operation_id'] : '';
+		$child_key = isset($lineage_authority['split_child_key']) ? $lineage_authority['split_child_key'] : '';
+		$currency = isset($lineage_authority['currency']) ? $lineage_authority['currency'] : '';
+		$execution_policy = isset($lineage_authority['execution_policy']) ? $lineage_authority['execution_policy'] : '';
+		$strategy = isset($lineage_authority['strategy']) ? $lineage_authority['strategy'] : '';
+		if (!is_string($operation_id) || sanitize_key($operation_id) !== $operation_id
+			|| !is_string($child_key) || sanitize_key($child_key) !== $child_key
+			|| !is_string($currency) || 1 !== preg_match('/^[A-Z]{3}$/D', $currency)
+			|| !is_string($execution_policy) || !in_array($execution_policy, array('partial_lines_only', 'allow_whole_line_transfer'), true)
+			|| !is_string($strategy) || !in_array($strategy, array('manual_quantity', 'category', 'stock_status'), true)
+			|| ('partial_lines_only' === $execution_policy) !== ('manual_quantity' === $strategy)) {
+			throw new InvalidArgumentException(__('Return plan Split identifiers are not canonical.', 'wc-order-splitter'));
+		}
+
+		$plan = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'policy_version' => self::POLICY_VERSION,
+			'child_order_id' => absint(isset($lineage_authority['child_order_id']) ? $lineage_authority['child_order_id'] : 0),
+			'source_order_id' => absint(isset($lineage_authority['source_order_id']) ? $lineage_authority['source_order_id'] : 0),
+			'split_operation_id' => $operation_id,
+			'split_child_key' => $child_key,
+			'lineage_authority_fingerprint' => self::fingerprint_value(isset($lineage_authority['authority_fingerprint']) ? $lineage_authority['authority_fingerprint'] : ''),
+			'price_precision' => $price_precision,
+			'currency' => $currency,
+			'prices_include_tax' => !empty($lineage_authority['prices_include_tax']),
+			'execution_policy' => $execution_policy,
+			'strategy' => $strategy,
+			'source_commercial_authority' => self::fingerprint_value(isset($lineage_authority['source_commercial_authority']) ? $lineage_authority['source_commercial_authority'] : ''),
+			'source_relation_authority' => self::fingerprint_value(isset($lineage_authority['source_relation_authority']) ? $lineage_authority['source_relation_authority'] : ''),
+			'child_commercial_authority' => self::fingerprint_value(isset($lineage_authority['child_commercial_authority']) ? $lineage_authority['child_commercial_authority'] : ''),
+			'lines' => self::canonical_lines(isset($lineage_authority['lines']) && is_array($lineage_authority['lines']) ? $lineage_authority['lines'] : array(), $price_precision),
+		);
+
+		if (!$plan['child_order_id'] || !$plan['source_order_id'] || $plan['child_order_id'] === $plan['source_order_id']
+			|| '' === $plan['split_operation_id'] || '' === $plan['split_child_key'] || '' === $plan['currency'] || empty($plan['lines'])) {
+			throw new InvalidArgumentException(__('Return plan authority is incomplete.', 'wc-order-splitter'));
+		}
+
+		$plan['plan_fingerprint'] = self::fingerprint($plan);
+		return $plan;
+	}
+
+	public static function fingerprint(array $plan) {
+		$copy = $plan;
+		unset($copy['plan_fingerprint']);
+		$child_id = absint(isset($copy['child_order_id']) ? $copy['child_order_id'] : 0);
+		return WCOS_Mutation_Fingerprint::create('return_plan', $child_id, self::canonicalize($copy));
+	}
+
+	private static function canonical_lines(array $lines, $price_precision) {
+		$canonical = array();
+		foreach ($lines as $raw_source_item_id => $line) {
+			if (!is_array($line)) {
+				throw new InvalidArgumentException(__('Every Return plan line must be structured.', 'wc-order-splitter'));
+			}
+			$source_item_id = absint($raw_source_item_id);
+			if (!$source_item_id || isset($canonical[$source_item_id])) {
+				throw new InvalidArgumentException(__('Return plan source item IDs must be unique and positive.', 'wc-order-splitter'));
+			}
+			$destination = sanitize_key(isset($line['destination']) ? (string) $line['destination'] : '');
+			if (!in_array($destination, array(self::DESTINATION_RESIDUAL_SOURCE_ITEM, self::DESTINATION_FRESH_SOURCE_ITEM), true)) {
+				throw new InvalidArgumentException(__('Return plan contains an unsupported destination policy.', 'wc-order-splitter'));
+			}
+			$destination_item_id = absint(isset($line['destination_source_item_id']) ? $line['destination_source_item_id'] : 0);
+			if ((self::DESTINATION_RESIDUAL_SOURCE_ITEM === $destination && $destination_item_id !== $source_item_id)
+				|| (self::DESTINATION_FRESH_SOURCE_ITEM === $destination && 0 !== $destination_item_id)) {
+				throw new InvalidArgumentException(__('Return plan destination provenance is inconsistent.', 'wc-order-splitter'));
+			}
+
+			$child_item_id = absint(isset($line['child_item_id']) ? $line['child_item_id'] : 0);
+			$product_id = absint(isset($line['product_id']) ? $line['product_id'] : 0);
+			if (!$child_item_id || !$product_id) {
+				throw new InvalidArgumentException(__('Return plan child item identity is missing.', 'wc-order-splitter'));
+			}
+			$canonical[$source_item_id] = array(
+				'source_item_id' => $source_item_id,
+				'child_item_id' => $child_item_id,
+				'product_id' => $product_id,
+				'variation_id' => absint(isset($line['variation_id']) ? $line['variation_id'] : 0),
+				'tax_class' => isset($line['tax_class']) && is_string($line['tax_class']) ? $line['tax_class'] : '',
+				'line_identity_authority' => self::fingerprint_value(isset($line['line_identity_authority']) ? $line['line_identity_authority'] : ''),
+				'destination' => $destination,
+				'destination_source_item_id' => $destination_item_id,
+				'quantity' => WCOS_Decimal::normalize(isset($line['quantity']) ? $line['quantity'] : '', 6),
+				'subtotal' => WCOS_Decimal::normalize(isset($line['subtotal']) ? $line['subtotal'] : '', $price_precision),
+				'total' => WCOS_Decimal::normalize(isset($line['total']) ? $line['total'] : '', $price_precision),
+				'subtotal_tax' => WCOS_Decimal::normalize(isset($line['subtotal_tax']) ? $line['subtotal_tax'] : '', $price_precision),
+				'total_tax' => WCOS_Decimal::normalize(isset($line['total_tax']) ? $line['total_tax'] : '', $price_precision),
+				'taxes' => self::canonical_taxes(isset($line['taxes']) && is_array($line['taxes']) ? $line['taxes'] : array(), $price_precision),
+				'reduced_stock' => null === (isset($line['reduced_stock']) ? $line['reduced_stock'] : null)
+					? null
+					: WCOS_Decimal::normalize($line['reduced_stock'], 6),
+			);
+		}
+		ksort($canonical, SORT_NUMERIC);
+		return $canonical;
+	}
+
+	private static function canonical_taxes(array $taxes, $price_precision) {
+		$result = array('subtotal' => array(), 'total' => array());
+		foreach (array('subtotal', 'total') as $kind) {
+			foreach (isset($taxes[$kind]) && is_array($taxes[$kind]) ? $taxes[$kind] : array() as $rate_id => $amount) {
+				$rate_id = absint($rate_id);
+				if (!$rate_id || isset($result[$kind][$rate_id])) {
+					throw new InvalidArgumentException(__('Return plan contains malformed per-rate tax authority.', 'wc-order-splitter'));
+				}
+				$result[$kind][$rate_id] = WCOS_Decimal::normalize($amount, $price_precision);
+			}
+			ksort($result[$kind], SORT_NUMERIC);
+		}
+		return $result;
+	}
+
+	private static function fingerprint_value($value) {
+		$value = sanitize_key((string) $value);
+		if (1 !== preg_match('/^[0-9a-f]{64}$/D', $value)) {
+			throw new InvalidArgumentException(__('Return authority contains a malformed fingerprint.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function canonicalize($value) {
+		if (!is_array($value)) {
+			return $value;
+		}
+		$is_list = true;
+		$expected = 0;
+		foreach (array_keys($value) as $key) {
+			if ($key !== $expected++) {
+				$is_list = false;
+				break;
+			}
+		}
+		if (!$is_list) {
+			ksort($value, SORT_STRING);
+		}
+		foreach ($value as $key => $item) {
+			$value[$key] = self::canonicalize($item);
+		}
+		return $value;
+	}
+}

--- a/inc/domain/class-wcos-return-preflight.php
+++ b/inc/domain/class-wcos-return-preflight.php
@@ -1,0 +1,173 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/** Read-only, PII-free eligibility boundary for future hardened Return. */
+final class WCOS_Return_Preflight {
+
+	const POLICY_VERSION = 1;
+
+	public static function policy() {
+		return array(
+			'policy_version' => self::POLICY_VERSION,
+			'lineage' => 'direct_hardened_split_child_only',
+			'scope' => 'all_child_product_lines',
+			'legacy_lineage' => 'diagnostic_only',
+			'child_shipping' => 'reject',
+			'child_fees' => 'reject',
+			'child_coupons' => 'reject',
+			'refunds' => 'reject',
+			'child_payment_transaction' => 'reject',
+			'physical_stock' => 'read_only_no_write',
+			'catalog_authority' => 'never',
+			'nested_child' => 'reject',
+		);
+	}
+
+	public static function assert_supported(WC_Order $child, $authorize = true) {
+		$report = self::report($child, $authorize);
+		if (empty($report['supported'])) {
+			throw new WCOS_Return_Lineage_Exception(
+				isset($report['reason']) ? $report['reason'] : 'unsupported',
+				isset($report['message']) ? $report['message'] : __('This Split child is not eligible for hardened Return.', 'wc-order-splitter')
+			);
+		}
+		return $report;
+	}
+
+	public static function report(WC_Order $child, $authorize = true) {
+		$report = array(
+			'supported' => false,
+			'reason' => '',
+			'message' => '',
+			'child_order_id' => absint($child->get_id()),
+			'source_order_id' => 0,
+			'policy' => self::policy(),
+			'lineage_authority' => array(),
+			'return_plan' => array(),
+		);
+
+		try {
+			$authority = WCOS_Return_Lineage_Authority::resolve($child);
+		} catch (WCOS_Return_Lineage_Exception $exception) {
+			return self::reject($report, $exception->get_reason(), $exception->getMessage());
+		} catch (Throwable $throwable) {
+			return self::reject($report, 'lineage_verification_failed', __('Return lineage could not be verified safely.', 'wc-order-splitter'));
+		}
+
+		$source = wc_get_order($authority['source_order_id']);
+		if (!$source instanceof WC_Order) {
+			return self::reject($report, 'source_missing', __('The Return original order is unavailable.', 'wc-order-splitter'));
+		}
+		$report['source_order_id'] = $source->get_id();
+
+		if ($authorize) {
+			try {
+				WCOS_Order_Mutation_Authorizer::assert_return($child, $source);
+			} catch (Throwable $throwable) {
+				return self::reject($report, 'authorization_failed', __('The current operator is not authorized to Return this order pair.', 'wc-order-splitter'));
+			}
+		}
+
+		try {
+			WCOS_Return_Participation::assert_not_terminal($child);
+		} catch (Throwable $throwable) {
+			return self::reject($report, 'already_returned', __('This Split child already carries terminal Return participation.', 'wc-order-splitter'));
+		}
+
+		if (self::has_descendants($child)) {
+			return self::reject($report, 'nested_or_parent_child', __('A Split child with descendant orders is outside the initial Return policy.', 'wc-order-splitter'));
+		}
+		if (self::has_unresolved_authority($child) || self::has_unresolved_authority($source)) {
+			return self::reject($report, 'unresolved_mutation_authority', __('A Return participant has unresolved mutation or reconciliation authority.', 'wc-order-splitter'));
+		}
+
+		$unsupported_statuses = array('trash', 'cancelled', 'refunded', 'failed', 'checkout-draft');
+		if (in_array(sanitize_key((string) $child->get_status()), $unsupported_statuses, true)) {
+			return self::reject($report, 'unsupported_child_status', __('The Split child status is outside the initial Return policy.', 'wc-order-splitter'));
+		}
+		if ($child->is_paid() || null !== $child->get_date_paid() || '' !== (string) $child->get_transaction_id()) {
+			return self::reject($report, 'child_payment_ownership', __('A paid or transaction-bearing Split child cannot be returned in the initial policy.', 'wc-order-splitter'));
+		}
+		if (self::has_refunds($child) || self::has_refunds($source)) {
+			return self::reject($report, 'refund_ownership_unsupported', __('Refund-bearing Return participants are outside the initial policy.', 'wc-order-splitter'));
+		}
+		if (!empty($child->get_items('shipping')) || !empty($child->get_items('fee')) || !empty($child->get_items('coupon'))
+			|| 0 !== WCOS_Decimal::to_units($child->get_shipping_total(), $authority['price_precision'])) {
+			return self::reject($report, 'child_charge_ownership', __('The Split child owns charges that the initial Return policy cannot transfer.', 'wc-order-splitter'));
+		}
+		if (self::has_inconsistent_stock_state($child)) {
+			return self::reject($report, 'child_stock_state_inconsistent', __('The Split child has inconsistent reduced-stock ownership evidence.', 'wc-order-splitter'));
+		}
+
+		try {
+			$plan = WCOS_Return_Plan::build($authority);
+		} catch (Throwable $throwable) {
+			return self::reject($report, 'return_plan_invalid', __('The exact all-or-nothing Return plan could not be built.', 'wc-order-splitter'));
+		}
+
+		$report['supported'] = true;
+		$report['reason'] = 'supported';
+		$report['message'] = __('This direct hardened Split child has exact read-only Return lineage and plan authority.', 'wc-order-splitter');
+		$report['lineage_authority'] = $authority;
+		$report['return_plan'] = $plan;
+		return $report;
+	}
+
+	private static function has_descendants(WC_Order $child) {
+		$structured = $child->get_meta(WCOS_Split_Order_Service::RELATION_CHILDREN_META, true);
+		if (is_array($structured) && !empty(array_filter(array_map('absint', $structured)))) {
+			return true;
+		}
+		$legacy = (string) $child->get_meta('yoos_splitted_order', true);
+		return '' !== trim($legacy, " ,\t\n\r\0\x0B");
+	}
+
+	private static function has_unresolved_authority(WC_Order $order) {
+		if (WCOS_Manual_Reconciliation_Blocker::has_active($order)) {
+			return true;
+		}
+		if (class_exists('WCOS_Merge_Participation') && !empty(WCOS_Merge_Participation::unresolved_operation_ids($order))) {
+			return true;
+		}
+		$summary = $order->get_meta(WCOS_Operation_Journal::SUMMARY_META_KEY, true);
+		foreach (is_array($summary) ? $summary : array() as $entry) {
+			$status = sanitize_key(isset($entry['status']) ? (string) $entry['status'] : '');
+			if (!in_array($status, array('completed', 'compensated', 'manual_reconciled'), true)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static function has_refunds(WC_Order $order) {
+		return $order->get_total_refunded() != 0 || !empty($order->get_refunds());
+	}
+
+	private static function has_inconsistent_stock_state(WC_Order $child) {
+		$order_reduced = (bool) $child->get_data_store()->get_stock_reduced($child->get_id());
+		foreach ($child->get_items('line_item') as $item) {
+			$value = $item->get_meta('_reduced_stock', true);
+			if ('' === $value || null === $value) {
+				continue;
+			}
+			try {
+				$reduced = WCOS_Decimal::to_units($value, 6);
+				$quantity = WCOS_Decimal::to_units($item->get_quantity(), 6);
+			} catch (Throwable $throwable) {
+				return true;
+			}
+			if (!$order_reduced || $reduced < 0 || $reduced > $quantity) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static function reject(array $report, $reason, $message) {
+		$report['supported'] = false;
+		$report['reason'] = sanitize_key((string) $reason);
+		$report['message'] = (string) $message;
+		return $report;
+	}
+}

--- a/tests/integration/return-domain-lineage-smoke.php
+++ b/tests/integration/return-domain-lineage-smoke.php
@@ -1,0 +1,609 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+$GLOBALS['wcos_return_foundation_manifest'] = array(
+	'orders' => array(),
+	'products' => array(),
+	'terms' => array(),
+	'users' => array(),
+	'journal_keys' => array(),
+	'tax_classes' => array(),
+);
+
+function wcos_return_foundation_record($kind, $value) {
+	$GLOBALS['wcos_return_foundation_manifest'][$kind][] = $value;
+}
+
+function wcos_return_foundation_assert_manifest_clean() {
+	$manifest = $GLOBALS['wcos_return_foundation_manifest'];
+	foreach (array_unique(array_map('absint', $manifest['orders'])) as $order_id) {
+		wcos_return_foundation_assert(!$order_id || false === wc_get_order($order_id), 'Fixture manifest retained order ' . $order_id . '.');
+	}
+	foreach (array_unique(array_map('absint', $manifest['products'])) as $product_id) {
+		wcos_return_foundation_assert(!$product_id || false === wc_get_product($product_id), 'Fixture manifest retained product ' . $product_id . '.');
+	}
+	foreach (array_unique(array_map('absint', $manifest['terms'])) as $term_id) {
+		wcos_return_foundation_assert(!$term_id || null === get_term($term_id, 'product_cat'), 'Fixture manifest retained product category ' . $term_id . '.');
+	}
+	foreach (array_unique(array_map('absint', $manifest['users'])) as $user_id) {
+		wcos_return_foundation_assert(!$user_id || false === get_user_by('id', $user_id), 'Fixture manifest retained user ' . $user_id . '.');
+	}
+	foreach (array_unique(array_map('strval', $manifest['journal_keys'])) as $journal_key) {
+		wcos_return_foundation_assert(false === get_option($journal_key, false), 'Fixture manifest retained journal ' . $journal_key . '.');
+	}
+	$remaining_tax_classes = WC_Tax::get_tax_class_slugs();
+	foreach (array_unique(array_map('strval', $manifest['tax_classes'])) as $tax_class) {
+		wcos_return_foundation_assert(!in_array($tax_class, $remaining_tax_classes, true), 'Fixture manifest retained tax class ' . $tax_class . '.');
+	}
+	return $manifest;
+}
+
+function wcos_return_foundation_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_return_foundation_product($name, $price = '10.00') {
+	$product = new WC_Product_Simple();
+	$product->set_name($name);
+	$product->set_regular_price($price);
+	$product->set_manage_stock(true);
+	$product->set_stock_quantity(50);
+	$product->save();
+	wcos_return_foundation_record('products', $product->get_id());
+	return $product;
+}
+
+function wcos_return_foundation_journal_key($source_id, $operation_id) {
+	return 'wcos_mutation_op_' . hash('sha256', absint($source_id) . '|' . sanitize_key($operation_id));
+}
+
+function wcos_return_foundation_reason(WC_Order $child) {
+	try {
+		WCOS_Return_Lineage_Authority::resolve($child);
+	} catch (WCOS_Return_Lineage_Exception $exception) {
+		return $exception->get_reason();
+	}
+	return 'accepted';
+}
+
+function wcos_return_foundation_assert_read_only(WC_Order $source, WC_Order $child, $operation_id, callable $callback, $message) {
+	$source_id = $source->get_id();
+	$child_id = $child->get_id();
+	$source_signature = WCOS_Order_Mutation_Snapshot::split_owned_signature($source);
+	$child_signature = WCOS_Order_Contract_Snapshot::source_signature($child);
+	$child_relations = array(
+		'parent' => $child->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true),
+		'operation' => $child->get_meta(WCOS_Split_Order_Service::OPERATION_META, true),
+		'key' => $child->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true),
+		'legacy_parent' => $child->get_meta('yoos_original_order', true),
+	);
+	$journal = WCOS_Operation_Journal::get($source, $operation_id);
+	$source_notes = count(wc_get_order_notes(array('order_id' => $source_id)));
+	$child_notes = count(wc_get_order_notes(array('order_id' => $child_id)));
+	$callback();
+	$source_after = wc_get_order($source_id);
+	$child_after = wc_get_order($child_id);
+	wcos_return_foundation_assert($source_signature === WCOS_Order_Mutation_Snapshot::split_owned_signature($source_after), $message . ': source changed during read-only verification.');
+	wcos_return_foundation_assert($child_signature === WCOS_Order_Contract_Snapshot::source_signature($child_after), $message . ': child changed during read-only verification.');
+	wcos_return_foundation_assert($child_relations === array(
+		'parent' => $child_after->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true),
+		'operation' => $child_after->get_meta(WCOS_Split_Order_Service::OPERATION_META, true),
+		'key' => $child_after->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true),
+		'legacy_parent' => $child_after->get_meta('yoos_original_order', true),
+	), $message . ': child relation meta changed during read-only verification.');
+	wcos_return_foundation_assert($journal === WCOS_Operation_Journal::get($source_after, $operation_id), $message . ': journal changed during read-only verification.');
+	wcos_return_foundation_assert($source_notes === count(wc_get_order_notes(array('order_id' => $source_id))), $message . ': source note was written.');
+	wcos_return_foundation_assert($child_notes === count(wc_get_order_notes(array('order_id' => $child_id))), $message . ': child note was written.');
+}
+
+function wcos_return_foundation_cleanup(WC_Order $source, WC_Order $child, $operation_id, array $products, array $term_ids = array()) {
+	WCOS_Operation_Journal::delete(wc_get_order($source->get_id()), $operation_id);
+	$child = wc_get_order($child->get_id());
+	if ($child) {
+		$child->delete(true);
+	}
+	$source = wc_get_order($source->get_id());
+	if ($source) {
+		$source->delete(true);
+	}
+	foreach ($products as $product) {
+		if ($product instanceof WC_Product) {
+			wp_delete_post($product->get_id(), true);
+		}
+	}
+	foreach ($term_ids as $term_id) {
+		wp_delete_term(absint($term_id), 'product_cat');
+	}
+}
+
+function wcos_return_foundation_strategy_case($strategy, $user_id) {
+	$keep = wcos_return_foundation_product('WCOS Return keep ' . $strategy, '12.00');
+	$move = wcos_return_foundation_product('WCOS Return move ' . $strategy, '7.00');
+	$term_ids = array();
+	if (WCOS_Split_Strategy_Gates::CATEGORY === $strategy) {
+		$suffix = strtolower(wp_generate_password(6, false, false));
+		$keep_term = wp_insert_term('WCOS Return Keep ' . $suffix, 'product_cat');
+		$move_term = wp_insert_term('WCOS Return Move ' . $suffix, 'product_cat');
+		wcos_return_foundation_assert(!is_wp_error($keep_term) && !is_wp_error($move_term), 'Unable to create Return Category terms.');
+		$term_ids = array(absint($keep_term['term_id']), absint($move_term['term_id']));
+		foreach ($term_ids as $term_id) {
+			wcos_return_foundation_record('terms', $term_id);
+		}
+		wp_set_object_terms($keep->get_id(), array($term_ids[0]), 'product_cat');
+		wp_set_object_terms($move->get_id(), array($term_ids[1]), 'product_cat');
+		$source_bucket = 'category-' . $term_ids[0];
+	} else {
+		$keep->set_stock_status('instock');
+		$keep->save();
+		$move->set_stock_quantity(0);
+		$move->set_stock_status('outofstock');
+		$move->save();
+		$source_bucket = 'stock-instock';
+	}
+
+	$source = wc_create_order();
+	wcos_return_foundation_record('orders', $source->get_id());
+	$source->set_status('pending');
+	$source->set_currency('USD');
+	$keep_item_id = $source->add_product($keep, 2);
+	$move_item_id = $source->add_product($move, 2);
+	$source->calculate_totals(false);
+	$source->save();
+
+	$adapter = new WCOS_Split_Strategy_WooCommerce_Adapter();
+	$review = $adapter->review($source, $strategy);
+	wcos_return_foundation_assert(!empty($review['supported']), 'Strategy review did not support Return provenance fixture: ' . wp_json_encode($review));
+	$confirmation = WCOS_Split_Strategy_Confirmation_Store::create($source, $strategy, $review, $source_bucket, $user_id);
+	$verified = WCOS_Split_Strategy_Confirmation_Store::verify(
+		wc_get_order($source->get_id()),
+		$confirmation['operation_id'],
+		$confirmation['confirmation_token'],
+		$user_id
+	);
+	$children = $adapter->split_confirmed(
+		wc_get_order($source->get_id()),
+		$strategy,
+		$verified['plan'],
+		$verified['operation_id'],
+		$verified['price_precision'],
+		$verified
+	);
+	wcos_return_foundation_assert(1 === count($children), 'Confirmed strategy Split did not produce one child.');
+	$source = wc_get_order($source->get_id());
+	$child = wc_get_order($children[0]->get_id());
+	wcos_return_foundation_record('orders', $child->get_id());
+	wcos_return_foundation_record('journal_keys', wcos_return_foundation_journal_key($source->get_id(), $verified['operation_id']));
+	wcos_return_foundation_assert(!$source->get_item($move_item_id), 'Whole-line strategy source item still exists.');
+	wcos_return_foundation_assert($source->get_item($keep_item_id) instanceof WC_Order_Item_Product, 'Strategy source residual item disappeared.');
+
+	$authority = WCOS_Return_Lineage_Authority::resolve($child);
+	wcos_return_foundation_assert($strategy === $authority['strategy'], 'Return lineage did not bind the exact strategy identity.');
+	wcos_return_foundation_assert(WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER === $authority['execution_policy'], 'Return lineage did not bind whole-line execution policy.');
+	$line = reset($authority['lines']);
+	wcos_return_foundation_assert(WCOS_Return_Plan::DESTINATION_FRESH_SOURCE_ITEM === $line['destination'], 'Whole-line Return plan did not require a fresh destination item.');
+	wcos_return_foundation_assert($move_item_id === $line['source_item_id'], 'Whole-line Return lineage lost original source-item provenance.');
+	$report = WCOS_Return_Preflight::report($child, true);
+	wcos_return_foundation_assert(!empty($report['supported']), 'Confirmed strategy child failed Return preflight.');
+	wcos_return_foundation_assert($authority['authority_fingerprint'] === $report['lineage_authority']['authority_fingerprint'], 'Return preflight changed strategy lineage authority.');
+
+	WCOS_Split_Strategy_Confirmation_Store::delete($verified['operation_id']);
+	wcos_return_foundation_cleanup($source, $child, $verified['operation_id'], array($keep, $move), $term_ids);
+}
+
+wcos_return_foundation_assert(class_exists('WCOS_Return_Lineage_Authority'), 'Return lineage class is not loaded.');
+wcos_return_foundation_assert(class_exists('WCOS_Return_Preflight'), 'Return preflight class is not loaded.');
+wcos_return_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return gate changed during hard-off foundation.');
+wcos_return_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate changed during hard-off foundation.');
+
+$user_id = wp_insert_user(array(
+	'user_login' => 'wcos_return_foundation_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-return-foundation-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+wcos_return_foundation_assert(!is_wp_error($user_id), 'Unable to create Return foundation user.');
+wcos_return_foundation_record('users', $user_id);
+wp_set_current_user($user_id);
+
+/* Manual Quantity: partial residual, per-rate tax, metadata and stock marker. */
+$product_a = wcos_return_foundation_product('WCOS Return manual A', '10.00');
+$product_b = wcos_return_foundation_product('WCOS Return manual B', '4.00');
+$source = wc_create_order();
+wcos_return_foundation_record('orders', $source->get_id());
+$source->set_status('pending');
+$source->set_currency('USD');
+$source->set_billing_email('return-private-' . wp_generate_uuid4() . '@example.test');
+$source->set_customer_note('return-private-customer-note');
+$item_a = new WC_Order_Item_Product();
+$item_a_result = $item_a->set_props(array(
+	'name' => $product_a->get_name(),
+	'product_id' => $product_a->get_id(),
+	'quantity' => '3.000000',
+	'subtotal' => '30.00',
+	'total' => '27.00',
+	'subtotal_tax' => '3.00',
+	'total_tax' => '2.70',
+	'taxes' => array('subtotal' => array(1 => '3.00'), 'total' => array(1 => '2.70')),
+));
+wcos_return_foundation_assert(!is_wp_error($item_a_result), 'Unable to construct Manual Return line A.');
+$item_a->add_meta_data('fulfillment_group', 'north', true);
+$item_a->add_meta_data('_reduced_stock', '2.400000', true);
+$source->add_item($item_a);
+$item_b = new WC_Order_Item_Product();
+$item_b_result = $item_b->set_props(array(
+	'name' => $product_b->get_name(),
+	'product_id' => $product_b->get_id(),
+	'quantity' => '2.000000',
+	'subtotal' => '8.00',
+	'total' => '8.00',
+	'subtotal_tax' => '0.00',
+	'total_tax' => '0.00',
+	'taxes' => array('subtotal' => array(), 'total' => array()),
+));
+wcos_return_foundation_assert(!is_wp_error($item_b_result), 'Unable to construct Manual Return line B.');
+$source->add_item($item_b);
+$tax = new WC_Order_Item_Tax();
+$tax->set_rate_id(1);
+$tax->set_label('Return historical rate');
+$tax->set_tax_total('2.70');
+$tax->set_shipping_tax_total('0.00');
+$source->add_item($tax);
+WCOS_Order_Totals_Rebuilder::rebuild($source, 2);
+$source->save();
+$item_a_id = $item_a->get_id();
+$item_b_id = $item_b->get_id();
+$source->get_data_store()->set_stock_reduced($source->get_id(), true);
+$source = wc_get_order($source->get_id());
+WCOS_Order_Totals_Rebuilder::assert_consistent($source, 2);
+$manual_split_preflight = WCOS_Split_Preflight::report($source, 2);
+wcos_return_foundation_assert(!empty($manual_split_preflight['supported']), 'Manual Return fixture failed Split preflight: ' . wp_json_encode($manual_split_preflight));
+$operation_id = 'return-lineage-manual-' . wp_generate_uuid4();
+$children = (new WCOS_Mutation_Gateway())->split(
+	$source,
+	array(
+		'manual-child' => array($item_a_id => '1.000000'),
+		'manual-sibling' => array($item_a_id => '1.000000'),
+	),
+	$operation_id,
+	2
+);
+wcos_return_foundation_assert(2 === count($children), 'Manual Split did not create the expected Return fixture children.');
+$source = wc_get_order($source->get_id());
+$child = null;
+$sibling = null;
+foreach ($children as $candidate) {
+	$candidate = wc_get_order($candidate->get_id());
+	if ('manual-child' === $candidate->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true)) {
+		$child = $candidate;
+	} else {
+		$sibling = $candidate;
+	}
+}
+wcos_return_foundation_assert($child instanceof WC_Order && $sibling instanceof WC_Order, 'Manual Split child keys were not persisted exactly.');
+wcos_return_foundation_record('orders', $child->get_id());
+wcos_return_foundation_record('orders', $sibling->get_id());
+wcos_return_foundation_record('journal_keys', wcos_return_foundation_journal_key($source->get_id(), $operation_id));
+$authority = WCOS_Return_Lineage_Authority::resolve($child);
+wcos_return_foundation_assert('manual_quantity' === $authority['strategy'], 'Manual Return lineage strategy is incorrect.');
+wcos_return_foundation_assert(WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === $authority['execution_policy'], 'Manual Return lineage execution policy is incorrect.');
+wcos_return_foundation_assert(isset($authority['lines'][$item_a_id]), 'Manual Return lineage omitted its source item.');
+$manual_line = $authority['lines'][$item_a_id];
+wcos_return_foundation_assert(WCOS_Return_Plan::DESTINATION_RESIDUAL_SOURCE_ITEM === $manual_line['destination'], 'Manual Return plan did not bind the residual source item.');
+wcos_return_foundation_assert('1.000000' === $manual_line['quantity'], 'Manual Return quantity authority is incorrect.');
+wcos_return_foundation_assert('10.00' === $manual_line['subtotal'], 'Manual Return subtotal allocation is incorrect.');
+wcos_return_foundation_assert('9.00' === $manual_line['total'], 'Manual Return total allocation is incorrect.');
+wcos_return_foundation_assert('1.00' === $manual_line['taxes']['subtotal'][1], 'Manual Return per-rate subtotal tax is incorrect.');
+wcos_return_foundation_assert('0.90' === $manual_line['taxes']['total'][1], 'Manual Return per-rate total tax is incorrect.');
+wcos_return_foundation_assert('0.800000' === $manual_line['reduced_stock'], 'Manual Return reduced-stock ownership allocation is incorrect.');
+$report = WCOS_Return_Preflight::report($child, true);
+wcos_return_foundation_assert(!empty($report['supported']), 'Manual hardened Split child failed Return preflight.');
+wcos_return_foundation_assert($authority['authority_fingerprint'] === $report['lineage_authority']['authority_fingerprint'], 'Return preflight changed Manual lineage authority.');
+$payload = wp_json_encode(array($authority, $report['return_plan']));
+wcos_return_foundation_assert(false === strpos($payload, 'return-private-'), 'Return authority leaked billing/customer plaintext.');
+wcos_return_foundation_assert(false === strpos($payload, 'customer-note'), 'Return authority leaked customer note plaintext.');
+$durable_split_record = WCOS_Operation_Journal::get($source, $operation_id);
+$raw_source_signature = $durable_split_record['context']['source_signature_after'];
+$raw_child_signature = WCOS_Order_Contract_Snapshot::source_signature($child);
+$raw_line_identity = $durable_split_record['context']['source_snapshot']['line_items'][$item_a_id]['identity'];
+$raw_snapshot_fingerprint = $durable_split_record['context']['source_snapshot']['recovery_fingerprint'];
+wcos_return_foundation_assert(false === strpos($payload, $raw_source_signature), 'Return authority exposed an unsalted source commercial digest.');
+wcos_return_foundation_assert(false === strpos($payload, $raw_child_signature), 'Return authority exposed an unsalted child commercial digest.');
+wcos_return_foundation_assert(false === strpos($payload, $raw_line_identity), 'Return authority exposed an unsalted business-metadata identity digest.');
+wcos_return_foundation_assert(false === strpos($payload, $raw_snapshot_fingerprint), 'Return authority exposed an unsalted source snapshot digest.');
+
+/* Current catalog is not authority: lineage resolution must not dereference order products. */
+$catalog_accesses = 0;
+$catalog_observer = static function($product) use (&$catalog_accesses) {
+	$catalog_accesses++;
+	return $product;
+};
+add_filter('woocommerce_order_item_product', $catalog_observer, 10, 1);
+$catalog_independent = WCOS_Return_Lineage_Authority::resolve(wc_get_order($child->get_id()));
+remove_filter('woocommerce_order_item_product', $catalog_observer, 10);
+wcos_return_foundation_assert(0 === $catalog_accesses, 'Return lineage dereferenced the current product catalog.');
+wcos_return_foundation_assert($authority['authority_fingerprint'] === $catalog_independent['authority_fingerprint'], 'Return lineage changed without current catalog authority.');
+
+/* Tamper matrix; every rejection is read-only. */
+$child_line = current($child->get_items('line_item'));
+$original_quantity = $child_line->get_quantity();
+$child_line->set_quantity('1.500000');
+$child_line->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+$child = wc_get_order($child->get_id());
+wcos_return_foundation_assert_read_only($source, $child, $operation_id, static function() use ($child) {
+	wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason($child), 'Changed child quantity was not rejected.');
+}, 'child quantity tamper');
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$child_line->set_quantity($original_quantity);
+$child_line->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+
+$child = wc_get_order($child->get_id());
+$child_line = current($child->get_items('line_item'));
+$original_subtotal = $child_line->get_subtotal();
+$original_total = $child_line->get_total();
+$child_line->set_subtotal('11.00');
+$child_line->set_total('10.00');
+$child_line->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Changed child money was not rejected.');
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$child_line->set_subtotal($original_subtotal);
+$child_line->set_total($original_total);
+$child_line->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+
+$child = wc_get_order($child->get_id());
+$child_line = current($child->get_items('line_item'));
+$child_tax = current($child->get_items('tax'));
+$child_line->set_taxes(array('subtotal' => array(1 => '1.01'), 'total' => array(1 => '0.91')));
+$child_line->save();
+$child_tax->set_tax_total('0.91');
+$child_tax->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Changed child per-rate tax was not rejected.');
+$child = wc_get_order($child->get_id());
+$child_line = current($child->get_items('line_item'));
+$child_tax = current($child->get_items('tax'));
+$child_line->set_taxes(array('subtotal' => array(1 => '1.00'), 'total' => array(1 => '0.90')));
+$child_line->save();
+$child_tax->set_tax_total('0.90');
+$child_tax->save();
+$child = wc_get_order($child->get_id());
+WCOS_Order_Totals_Rebuilder::rebuild($child, 2);
+$child->save();
+
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$child_line->add_meta_data('tampered_business_identity', 'changed', true);
+$child_line->save();
+wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Changed child business metadata was not rejected.');
+$child_line->delete_meta_data('tampered_business_identity');
+$child_line->save();
+
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$child_line->add_meta_data('_unknown_return_private', 'changed', true);
+$child_line->save();
+wcos_return_foundation_assert('child_line_private_meta_unsupported' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Unknown private child metadata was not rejected.');
+$child_line->delete_meta_data('_unknown_return_private');
+$child_line->save();
+
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$original_tax_class = $child_line->get_tax_class();
+$tampered_tax_class = WC_Tax::create_tax_class('WCOS Return Tampered ' . wp_generate_password(6, false, false));
+wcos_return_foundation_assert(!is_wp_error($tampered_tax_class), 'Unable to create a disposable tax class for lineage tamper evidence.');
+wcos_return_foundation_record('tax_classes', $tampered_tax_class['slug']);
+$child_line->set_tax_class($tampered_tax_class['slug']);
+$child_line->save();
+wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Changed child tax class was not rejected.');
+$child_line->set_tax_class($original_tax_class);
+$child_line->save();
+WC_Tax::delete_tax_class_by('slug', $tampered_tax_class['slug']);
+
+$child_line = current(wc_get_order($child->get_id())->get_items('line_item'));
+$original_variation_id = $child_line->get_variation_id();
+$tampered_variable = new WC_Product_Variable();
+$tampered_variable->set_name('WCOS Return tampered variation parent');
+$tampered_variable->save();
+wcos_return_foundation_record('products', $tampered_variable->get_id());
+$tampered_variation = new WC_Product_Variation();
+$tampered_variation->set_parent_id($tampered_variable->get_id());
+$tampered_variation->set_regular_price('1.00');
+$tampered_variation->save();
+wcos_return_foundation_record('products', $tampered_variation->get_id());
+$child_line->set_variation_id($tampered_variation->get_id());
+$child_line->save();
+wcos_return_foundation_assert('child_line_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Changed child variation was not rejected.');
+$child_line->set_variation_id($original_variation_id);
+$child_line->save();
+wp_delete_post($tampered_variation->get_id(), true);
+wp_delete_post($tampered_variable->get_id(), true);
+
+$child = wc_get_order($child->get_id());
+$child_line = current($child->get_items('line_item'));
+$child_line->delete_meta_data('_wcos_source_item_id');
+$child_line->save();
+wcos_return_foundation_assert('child_line_provenance_invalid' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Missing child source-item provenance was not rejected.');
+$child_line->add_meta_data('_wcos_source_item_id', $item_a_id, true);
+$child_line->save();
+
+$child = wc_get_order($child->get_id());
+$child_line = current($child->get_items('line_item'));
+$original_source_item_id = $child_line->get_meta('_wcos_source_item_id', true);
+$child_line->update_meta_data('_wcos_source_item_id', $item_b_id);
+$child_line->save();
+$child = wc_get_order($child->get_id());
+wcos_return_foundation_assert('child_line_provenance_mismatch' === wcos_return_foundation_reason($child), 'Wrong child source-item provenance was not rejected.');
+$child_line = current($child->get_items('line_item'));
+$child_line->update_meta_data('_wcos_source_item_id', $original_source_item_id);
+$child_line->save();
+
+$child = wc_get_order($child->get_id());
+$original_parent = $child->get_meta(WCOS_Split_Order_Service::RELATION_PARENT_META, true);
+$child->update_meta_data(WCOS_Split_Order_Service::RELATION_PARENT_META, 999999999);
+$child->save_meta_data();
+wcos_return_foundation_assert('source_missing' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Forged parent ID was not rejected.');
+$child->update_meta_data(WCOS_Split_Order_Service::RELATION_PARENT_META, $original_parent);
+$child->save_meta_data();
+
+$child = wc_get_order($child->get_id());
+$original_operation = $child->get_meta(WCOS_Split_Order_Service::OPERATION_META, true);
+$child->update_meta_data(WCOS_Split_Order_Service::OPERATION_META, 'wrong-operation');
+$child->save_meta_data();
+wcos_return_foundation_assert('journal_missing' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Wrong Split operation ID was not rejected.');
+$child->update_meta_data(WCOS_Split_Order_Service::OPERATION_META, $original_operation);
+$child->save_meta_data();
+
+$child = wc_get_order($child->get_id());
+$original_key = $child->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true);
+$child->update_meta_data(WCOS_Split_Order_Service::CHILD_KEY_META, 'wrong-child');
+$child->save_meta_data();
+wcos_return_foundation_assert('child_key_not_in_plan' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Wrong Split child key was not rejected.');
+$child->update_meta_data(WCOS_Split_Order_Service::CHILD_KEY_META, $original_key);
+$child->save_meta_data();
+
+$sibling = wc_get_order($sibling->get_id());
+$sibling_key = $sibling->get_meta(WCOS_Split_Order_Service::CHILD_KEY_META, true);
+$sibling->update_meta_data(WCOS_Split_Order_Service::CHILD_KEY_META, $original_key);
+$sibling->save_meta_data();
+wcos_return_foundation_assert('journal_target_provenance_mismatch' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Duplicate persisted Split child key was not rejected.');
+$sibling->update_meta_data(WCOS_Split_Order_Service::CHILD_KEY_META, $sibling_key);
+$sibling->save_meta_data();
+
+$source = wc_get_order($source->get_id());
+$relations = $source->get_meta(WCOS_Split_Order_Service::RELATION_CHILDREN_META, true);
+$source->update_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META, array());
+$source->save_meta_data();
+wcos_return_foundation_assert('source_relation_mismatch' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Missing source relation was not rejected.');
+$source->update_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META, $relations);
+$source->save_meta_data();
+
+$source = wc_get_order($source->get_id());
+$source->update_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META, array_merge($relations, array(999999996)));
+$source->save_meta_data();
+wcos_return_foundation_assert('source_relation_target_mismatch' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Unrelated source child relation was not rejected.');
+$source->update_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META, $relations);
+$source->save_meta_data();
+
+$source = wc_get_order($source->get_id());
+$residual_line = $source->get_item($item_a_id);
+$residual_quantity = $residual_line->get_quantity();
+$residual_line->set_quantity('0.500000');
+$residual_line->save();
+wcos_return_foundation_assert('source_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Residual source line drift was not rejected.');
+$residual_line->set_quantity($residual_quantity);
+$residual_line->save();
+
+$source = wc_get_order($source->get_id());
+$fee = new WC_Order_Item_Fee();
+$fee->set_props(array('name' => 'Return drift fee', 'amount' => '0.00', 'total' => '0.00', 'total_tax' => '0.00', 'taxes' => array('total' => array())));
+$source->add_item($fee);
+$source->save();
+wcos_return_foundation_assert('source_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Source fee context drift was not rejected.');
+$source->remove_item($fee->get_id());
+$source->save();
+
+$source = wc_get_order($source->get_id());
+$shipping = new WC_Order_Item_Shipping();
+$shipping->set_props(array('method_title' => 'Return drift shipping', 'method_id' => 'flat_rate', 'total' => '0.00', 'total_tax' => '0.00', 'taxes' => array('total' => array())));
+$source->add_item($shipping);
+$source->save();
+wcos_return_foundation_assert('source_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Source shipping context drift was not rejected.');
+$source->remove_item($shipping->get_id());
+$source->save();
+
+$source = wc_get_order($source->get_id());
+$coupon = new WC_Order_Item_Coupon();
+$coupon->set_props(array('code' => 'return-drift', 'discount' => '0.00', 'discount_tax' => '0.00'));
+$source->add_item($coupon);
+$source->save();
+wcos_return_foundation_assert('source_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Source coupon context drift was not rejected.');
+$source->remove_item($coupon->get_id());
+$source->save();
+
+$source = wc_get_order($source->get_id());
+$source->set_transaction_id('return-drift-transaction');
+$source->save();
+wcos_return_foundation_assert('source_drift' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Source payment context drift was not rejected.');
+$source->set_transaction_id('');
+$source->save();
+
+$child = wc_get_order($child->get_id());
+$legacy_parent = $child->get_meta('yoos_original_order', true);
+$child->update_meta_data('yoos_original_order', 999999998);
+$child->save_meta_data();
+wcos_return_foundation_assert('legacy_lineage_conflict' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Conflicting legacy parent was not rejected.');
+$child->update_meta_data('yoos_original_order', $legacy_parent);
+$child->save_meta_data();
+
+$journal_key = wcos_return_foundation_journal_key($source->get_id(), $operation_id);
+$journal = get_option($journal_key);
+delete_option($journal_key);
+wcos_return_foundation_assert('journal_missing' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Missing Split journal was not rejected.');
+add_option($journal_key, $journal, '', false);
+
+$tampered = $journal;
+$tampered['status'] = 'started';
+update_option($journal_key, $tampered, false);
+wcos_return_foundation_assert('journal_not_completed' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Nonterminal Split journal was not rejected.');
+update_option($journal_key, $journal, false);
+
+$tampered = $journal;
+$tampered['type'] = 'duplicate';
+update_option($journal_key, $tampered, false);
+wcos_return_foundation_assert('journal_wrong_type' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Wrong journal type was not rejected.');
+update_option($journal_key, $journal, false);
+
+$tampered = $journal;
+$tampered['context']['target_order_ids'] = array($child->get_id(), $child->get_id());
+update_option($journal_key, $tampered, false);
+wcos_return_foundation_assert('target_order_ids_duplicate' === wcos_return_foundation_reason(wc_get_order($child->get_id())), 'Duplicate journal target membership was not rejected.');
+update_option($journal_key, $journal, false);
+
+$child = wc_get_order($child->get_id());
+$child->update_meta_data(WCOS_Return_Participation::CHILD_ORIGINAL_META, $source->get_id());
+$child->update_meta_data(WCOS_Return_Participation::CHILD_OPERATION_META, 'return-operation');
+$child->update_meta_data(WCOS_Return_Participation::CHILD_PAIR_FINGERPRINT_META, str_repeat('a', 64));
+$child->save_meta_data();
+$terminal_report = WCOS_Return_Preflight::report(wc_get_order($child->get_id()), true);
+wcos_return_foundation_assert(empty($terminal_report['supported']) && 'already_returned' === $terminal_report['reason'], 'Terminal Return participation was not rejected.');
+$child->delete_meta_data(WCOS_Return_Participation::CHILD_ORIGINAL_META);
+$child->delete_meta_data(WCOS_Return_Participation::CHILD_OPERATION_META);
+$child->delete_meta_data(WCOS_Return_Participation::CHILD_PAIR_FINGERPRINT_META);
+$child->save_meta_data();
+
+/* Legacy-only metadata remains explicitly non-executable. */
+$legacy = wc_create_order();
+wcos_return_foundation_record('orders', $legacy->get_id());
+$legacy->update_meta_data('yoos_original_order', $source->get_id());
+$legacy->save();
+$legacy_report = WCOS_Return_Preflight::report(wc_get_order($legacy->get_id()), true);
+wcos_return_foundation_assert(empty($legacy_report['supported']) && 'legacy_lineage_not_authoritative' === $legacy_report['reason'], 'Legacy-only Return lineage became executable.');
+$legacy->delete(true);
+
+$sibling->delete(true);
+wcos_return_foundation_cleanup($source, wc_get_order($child->get_id()), $operation_id, array($product_a, $product_b));
+
+/* Current production Category and Stock-status authority after DB reread. */
+wcos_return_foundation_strategy_case(WCOS_Split_Strategy_Gates::CATEGORY, $user_id);
+wcos_return_foundation_strategy_case(WCOS_Split_Strategy_Gates::STOCK_STATUS, $user_id);
+
+wp_delete_user($user_id);
+
+$fixture_manifest = wcos_return_foundation_assert_manifest_clean();
+echo 'return-domain-lineage-fixture-manifest=' . hash('sha256', wp_json_encode($fixture_manifest)) . "\n";
+echo "return-domain-lineage-foundation-ok\n";

--- a/tests/integration/return-domain-lineage-smoke.php
+++ b/tests/integration/return-domain-lineage-smoke.php
@@ -63,6 +63,9 @@ function wcos_return_foundation_journal_key($source_id, $operation_id) {
 }
 
 function wcos_return_foundation_reason(WC_Order $child) {
+	$child_id = $child->get_id();
+	WC_Cache_Helper::invalidate_cache_group('orders');
+	$child = wc_get_order($child_id);
 	try {
 		WCOS_Return_Lineage_Authority::resolve($child);
 	} catch (WCOS_Return_Lineage_Exception $exception) {

--- a/tests/integration/return-domain-lineage-smoke.php
+++ b/tests/integration/return-domain-lineage-smoke.php
@@ -589,6 +589,40 @@ $child->delete_meta_data(WCOS_Return_Participation::CHILD_OPERATION_META);
 $child->delete_meta_data(WCOS_Return_Participation::CHILD_PAIR_FINGERPRINT_META);
 $child->save_meta_data();
 
+$child = wc_get_order($child->get_id());
+$child->update_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META, array(999999995));
+$child->save_meta_data();
+$nested_report = WCOS_Return_Preflight::report(wc_get_order($child->get_id()), true);
+wcos_return_foundation_assert(empty($nested_report['supported']) && 'nested_or_parent_child' === $nested_report['reason'], 'Nested/descendant Return participation was not rejected.');
+$child->delete_meta_data(WCOS_Split_Order_Service::RELATION_CHILDREN_META);
+$child->save_meta_data();
+
+$child = wc_get_order($child->get_id());
+$child->add_meta_data(WCOS_Merge_Participation::TARGET_OPERATION_META, 'conflicting-merge-operation', false);
+$child->save_meta_data();
+$merge_participation_report = WCOS_Return_Preflight::report(wc_get_order($child->get_id()), true);
+wcos_return_foundation_assert(empty($merge_participation_report['supported']) && 'unresolved_mutation_authority' === $merge_participation_report['reason'], 'Conflicting Merge participation was not rejected.');
+$child->delete_meta_data(WCOS_Merge_Participation::TARGET_OPERATION_META);
+$child->save_meta_data();
+
+$child = wc_get_order($child->get_id());
+$child->set_transaction_id('return-child-transaction');
+$child->save();
+$transaction_report = WCOS_Return_Preflight::report(wc_get_order($child->get_id()), true);
+wcos_return_foundation_assert(empty($transaction_report['supported']) && 'child_payment_ownership' === $transaction_report['reason'], 'Transaction-bearing Return child was not rejected.');
+$child->set_transaction_id('');
+$child->save();
+
+$child = wc_get_order($child->get_id());
+$child_fee = new WC_Order_Item_Fee();
+$child_fee->set_props(array('name' => 'Unsupported child fee', 'amount' => '0.00', 'total' => '0.00', 'total_tax' => '0.00', 'taxes' => array('total' => array())));
+$child->add_item($child_fee);
+$child->save();
+$charge_report = WCOS_Return_Preflight::report(wc_get_order($child->get_id()), true);
+wcos_return_foundation_assert(empty($charge_report['supported']) && 'child_charge_ownership' === $charge_report['reason'], 'Charge-owning Return child was not rejected.');
+$child->remove_item($child_fee->get_id());
+$child->save();
+
 /* Legacy-only metadata remains explicitly non-executable. */
 $legacy = wc_create_order();
 wcos_return_foundation_record('orders', $legacy->get_id());

--- a/tests/integration/return-domain-lineage-smoke.php
+++ b/tests/integration/return-domain-lineage-smoke.php
@@ -334,7 +334,7 @@ wcos_return_foundation_assert($authority['authority_fingerprint'] === $catalog_i
 /* Tamper matrix; every rejection is read-only. */
 $child_line = current($child->get_items('line_item'));
 $original_quantity = $child_line->get_quantity();
-$child_line->set_quantity('1.500000');
+$child_line->set_quantity('2.000000');
 $child_line->save();
 $child = wc_get_order($child->get_id());
 WCOS_Order_Totals_Rebuilder::rebuild($child, 2);

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -26,11 +26,14 @@ require_once $root . 'class-wcos-decimal.php';
 require_once $root . 'class-wcos-amount-allocator.php';
 require_once $root . 'class-wcos-line-identity.php';
 require_once $root . 'class-wcos-mutation-fingerprint.php';
+require_once $root . 'class-wcos-price-precision-scope.php';
 require_once $root . 'class-wcos-mutation-contract.php';
 require_once $root . 'class-wcos-split-plan.php';
 require_once $root . 'class-wcos-merge-retirement-policy.php';
 require_once $root . 'class-wcos-merge-plan.php';
 require_once $root . 'class-wcos-merge-recovery-state-graph.php';
+require_once $root . 'class-wcos-return-participation.php';
+require_once $root . 'class-wcos-return-plan.php';
 
 $tests = array();
 
@@ -249,6 +252,111 @@ $tests['merge plan rejects self merge and normalized item collisions'] = static 
 			'01' => array('source_item_id' => 1, 'line_identity' => str_repeat('a', 64)),
 			1 => array('source_item_id' => 1, 'line_identity' => str_repeat('b', 64)),
 		));
+	}, InvalidArgumentException::class);
+};
+
+$tests['return plan canonicalization ignores incidental line ordering'] = static function() {
+	$line_a = array(
+		'source_item_id' => 11,
+		'child_item_id' => 101,
+		'product_id' => 1001,
+		'variation_id' => 0,
+		'tax_class' => '',
+		'destination' => WCOS_Return_Plan::DESTINATION_RESIDUAL_SOURCE_ITEM,
+		'destination_source_item_id' => 11,
+		'line_identity_authority' => str_repeat('a', 64),
+		'quantity' => '1.000000',
+		'subtotal' => '5.00',
+		'total' => '4.50',
+		'subtotal_tax' => '0.50',
+		'total_tax' => '0.45',
+		'taxes' => array('total' => array(2 => '0.45'), 'subtotal' => array(2 => '0.50')),
+		'reduced_stock' => '1.000000',
+	);
+	$line_b = array(
+		'source_item_id' => 22,
+		'child_item_id' => 202,
+		'product_id' => 1002,
+		'variation_id' => 2002,
+		'tax_class' => 'reduced-rate',
+		'destination' => WCOS_Return_Plan::DESTINATION_FRESH_SOURCE_ITEM,
+		'destination_source_item_id' => 0,
+		'line_identity_authority' => str_repeat('b', 64),
+		'quantity' => '2.000000',
+		'subtotal' => '8.00',
+		'total' => '8.00',
+		'subtotal_tax' => '0.00',
+		'total_tax' => '0.00',
+		'taxes' => array('subtotal' => array(), 'total' => array()),
+		'reduced_stock' => null,
+	);
+	$base = array(
+		'authority_fingerprint' => str_repeat('c', 64),
+		'child_order_id' => 302,
+		'source_order_id' => 301,
+		'split_operation_id' => 'split-operation',
+		'split_child_key' => 'child-a',
+		'price_precision' => 2,
+		'currency' => 'USD',
+		'prices_include_tax' => false,
+		'execution_policy' => 'allow_whole_line_transfer',
+		'strategy' => 'category',
+		'source_commercial_authority' => str_repeat('d', 64),
+		'source_relation_authority' => str_repeat('f', 64),
+		'child_commercial_authority' => str_repeat('e', 64),
+	);
+	$first = $base;
+	$first['lines'] = array(22 => $line_b, 11 => $line_a);
+	$second = $base;
+	$second['lines'] = array(11 => $line_a, 22 => $line_b);
+	$first_plan = WCOS_Return_Plan::build($first);
+	$second_plan = WCOS_Return_Plan::build($second);
+	assert_same(array(11, 22), array_keys($first_plan['lines']));
+	assert_same($first_plan['plan_fingerprint'], $second_plan['plan_fingerprint']);
+};
+
+$tests['return plan binds destination and historical ownership evidence'] = static function() {
+	$authority = array(
+		'authority_fingerprint' => str_repeat('a', 64),
+		'child_order_id' => 42,
+		'source_order_id' => 41,
+		'split_operation_id' => 'split-operation',
+		'split_child_key' => 'child-a',
+		'price_precision' => 2,
+		'currency' => 'USD',
+		'prices_include_tax' => false,
+		'execution_policy' => 'partial_lines_only',
+		'strategy' => 'manual_quantity',
+		'source_commercial_authority' => str_repeat('b', 64),
+		'source_relation_authority' => str_repeat('e', 64),
+		'child_commercial_authority' => str_repeat('c', 64),
+		'lines' => array(9 => array(
+			'source_item_id' => 9,
+			'child_item_id' => 90,
+			'product_id' => 900,
+			'variation_id' => 0,
+			'tax_class' => '',
+			'destination' => WCOS_Return_Plan::DESTINATION_RESIDUAL_SOURCE_ITEM,
+			'destination_source_item_id' => 9,
+			'line_identity_authority' => str_repeat('d', 64),
+			'quantity' => '1.000000',
+			'subtotal' => '10.00',
+			'total' => '9.00',
+			'subtotal_tax' => '1.00',
+			'total_tax' => '0.90',
+			'taxes' => array('subtotal' => array(1 => '1.00'), 'total' => array(1 => '0.90')),
+			'reduced_stock' => '1.000000',
+			'customer_name' => 'must-not-enter-return-plan',
+		)),
+	);
+	$first = WCOS_Return_Plan::build($authority);
+	assert_true(false === strpos(json_encode($first), 'must-not-enter-return-plan'), 'Return plan copied an undeclared line field.');
+	$authority['lines'][9]['total'] = '8.99';
+	$second = WCOS_Return_Plan::build($authority);
+	assert_true($first['plan_fingerprint'] !== $second['plan_fingerprint'], 'Return plan fingerprint ignored historical money drift.');
+	$authority['lines'][9]['destination'] = WCOS_Return_Plan::DESTINATION_FRESH_SOURCE_ITEM;
+	assert_throws(static function() use ($authority) {
+		WCOS_Return_Plan::build($authority);
 	}, InvalidArgumentException::class);
 };
 


### PR DESCRIPTION
## Classification

`P1_DOMAIN_CONTRACT / RETURN_LINEAGE`

Closes #69.

## Scope

- adds read-only hardened Split lineage authority for direct Return candidates;
- adds immutable all-or-nothing Return plan, preflight, and non-executable participation vocabulary;
- proves Manual Quantity, Category, and Stock-status provenance after DB reread;
- adds fail-closed tamper, PII-safe authority, fixture-manifest, package, and hard-off CI evidence.

## Production boundary

- Split/Duplicate/Merge remain enabled;
- Return/Bulk Return remain hard-off;
- no Return service, controller, endpoint, UI, recovery writer, or gateway execution path;
- legacy Return handlers remain unloaded and excluded from the package.

## Local evidence before push

- full PHP syntax: pass;
- `php tests/unit/run.php`: pass;
- Local WooCommerce integration: `return-domain-lineage-foundation-ok`;
- fixture manifest cleanup: pass;
- hard-off package inspection: pass.

Exact-head CI and complete-diff self-review are pending; keep this PR Draft.