### PR TITLE
WOS-RETURN-005: Return Review / Confirm / Execute Authority

### DIFF
--- a/.github/scripts/validate-distribution-contract.sh
+++ b/.github/scripts/validate-distribution-contract.sh
@@ -69,7 +69,6 @@ for forbidden_path in \
   'inc/backend/orders-bulk-return.php' \
   'inc/backend/order-split-button.php' \
   'inc/backend/order-return-option.php' \
-  'inc/backend/class-wcos-return-admin-controller.php' \
   'inc/backend/order-duplicate-option.php' \
   'inc/backend/order-merge-option.php' \
   'js/bulk-return-action.js' \
@@ -141,6 +140,9 @@ for required_path in \
   'inc/domain/class-wcos-return-compensator.php' \
   'inc/domain/class-wcos-return-order-service.php' \
   'inc/domain/class-wcos-return-woocommerce-adapter.php' \
+  'inc/backend/class-wcos-return-review-store.php' \
+  'inc/backend/class-wcos-return-confirmation-store.php' \
+  'inc/backend/class-wcos-return-admin-controller.php' \
   'css/p2-split-strategy-admin.css' \
   'js/p2-split-strategy-admin.js'; do
   if test ! -e "$distribution_root/$required_path"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
             fi
           done
 
-          if grep -R --line-number -E 'new[[:space:]]+WCOS_((Split|Duplicate)_Order_Service|Merge_(Order_Service|WooCommerce_Adapter))' inc/backend inc/cores; then
+          if grep -R --line-number -E 'new[[:space:]]+WCOS_((Split|Duplicate|Return)_Order_Service|Merge_(Order_Service|WooCommerce_Adapter))' inc/backend inc/cores; then
             echo 'A production controller bypasses WCOS_Mutation_Gateway.' >&2
             exit 1
           fi
@@ -186,10 +186,13 @@ jobs:
           grep -Fq 'class-wcos-return-source-evolution-authority.php' inc/cores/script.php
           grep -Fq "'return' === \$type" inc/domain/class-wcos-mutation-recovery-coordinator.php
           grep -Fq 'const APPROVED = self::NON_FORCE_TRASH_ARCHIVE;' inc/domain/class-wcos-return-retirement-policy.php
-          test ! -e inc/backend/class-wcos-return-admin-controller.php
           grep -Fq 'class-wcos-return-order-service.php' inc/cores/script.php
           grep -Fq 'class-wcos-return-woocommerce-adapter.php' inc/cores/script.php
           grep -Fq 'new WCOS_Return_WooCommerce_Adapter' inc/domain/class-wcos-mutation-gateway.php
+          grep -Fq 'class-wcos-return-review-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-return-confirmation-store.php' inc/cores/script.php
+          grep -Fq 'class-wcos-return-admin-controller.php' inc/cores/script.php
+          grep -Fq 'WCOS_Return_Admin_Controller::bootstrap();' inc/cores/script.php
           test ! -e js/p2-return-admin.js
           test ! -e css/p2-return-admin.css
           grep -Fq "const SEARCH_ACTION = 'wcos_merge_target_search';" inc/backend/class-wcos-merge-admin-controller.php
@@ -315,6 +318,14 @@ jobs:
             ) as $disabled_workflow) {
               if (WCOS_Feature_Gates::enabled($disabled_workflow)) { exit(1); }
             }
+            if (null !== WCOS_Return_Admin_Controller::bootstrap()) { exit(1); }
+            foreach (array(
+              WCOS_Return_Admin_Controller::REVIEW_ACTION,
+              WCOS_Return_Admin_Controller::CONFIRM_ACTION,
+              WCOS_Return_Admin_Controller::EXECUTE_ACTION
+            ) as $return_action) {
+              if (false !== has_action("wp_ajax_" . $return_action)) { exit(1); }
+            }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY)) { exit(1); }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::STOCK_STATUS)) { exit(1); }
@@ -400,6 +411,9 @@ jobs:
 
       - name: Verify hard-off Return service and WooCommerce adapter contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-service-adapter-smoke.php
+
+      - name: Verify hard-off Return Review Confirm Execute authority
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-review-confirm-authority-smoke.php
 
       - name: Verify Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php
@@ -559,6 +573,55 @@ jobs:
             if (WCOS_Split_Strategy_Gates::CATEGORY !== $record["strategy"]) { exit(1); }
             WCOS_Split_Strategy_Confirmation_Store::delete("'"$operation_id"'");
             echo "strategy-confirm-race-authority-ok\n";
+          '
+
+          cleanup_race
+          trap - EXIT
+
+      - name: Verify real concurrent Return Confirm single-consumption authority
+        if: matrix.storage == 'hpos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture='wp-content/plugins/wc-order-splitter/tests/integration/return-confirm-race-fixture.php'
+          worker='wp-content/plugins/wc-order-splitter/tests/integration/return-confirm-race-worker.php'
+          cleanup='wp-content/plugins/wc-order-splitter/tests/integration/return-confirm-race-cleanup.php'
+
+          cleanup_race() {
+            npx wp-env run cli wp eval-file "$cleanup" || true
+          }
+          trap cleanup_race EXIT
+
+          npx wp-env run cli wp eval-file "$fixture"
+          npx wp-env run cli wp eval-file "$worker" worker-a > /tmp/wcos-return-confirm-worker-a.log 2>&1 &
+          worker_a_pid=$!
+          npx wp-env run cli wp eval-file "$worker" worker-b > /tmp/wcos-return-confirm-worker-b.log 2>&1 &
+          worker_b_pid=$!
+          wait "$worker_a_pid"
+          wait "$worker_b_pid"
+
+          cat /tmp/wcos-return-confirm-worker-a.log
+          cat /tmp/wcos-return-confirm-worker-b.log
+          success_count="$(awk '/^CONFIRMED / { count++ } END { print count + 0 }' /tmp/wcos-return-confirm-worker-a.log /tmp/wcos-return-confirm-worker-b.log)"
+          rejected_count="$(awk '/^REJECTED / { count++ } END { print count + 0 }' /tmp/wcos-return-confirm-worker-a.log /tmp/wcos-return-confirm-worker-b.log)"
+          test "$success_count" -eq 1
+          test "$rejected_count" -eq 1
+
+          confirmed_line="$(awk '/^CONFIRMED / { print; exit }' /tmp/wcos-return-confirm-worker-a.log /tmp/wcos-return-confirm-worker-b.log)"
+          operation_id="$(printf '%s\n' "$confirmed_line" | awk '{ print $3 }')"
+          confirmation_token="$(printf '%s\n' "$confirmed_line" | awk '{ print $4 }')"
+          test -n "$operation_id"
+          test -n "$confirmation_token"
+
+          npx wp-env run cli wp eval '
+            $fixture = get_option("wcos_return_confirm_race_fixture", array());
+            $child = isset($fixture["child_id"]) ? wc_get_order(absint($fixture["child_id"])) : false;
+            if (!$child instanceof WC_Order) { exit(1); }
+            if (WCOS_Operation_Journal::get($child, "'"$operation_id"'")) { exit(1); }
+            $record = WCOS_Return_Confirmation_Store::verify($child, "'"$operation_id"'", "'"$confirmation_token"'", absint($fixture["user_id"]));
+            if (!is_array($record) || "confirmation" !== $record["replay_authority"]) { exit(1); }
+            WCOS_Return_Confirmation_Store::delete("'"$operation_id"'");
+            echo "return-confirm-race-authority-ok\n";
           '
 
           cleanup_race

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,6 +615,7 @@ jobs:
 
           npx wp-env run cli wp eval '
             $fixture = get_option("wcos_return_confirm_race_fixture", array());
+            wp_set_current_user(absint($fixture["user_id"]));
             $child = isset($fixture["child_id"]) ? wc_get_order(absint($fixture["child_id"])) : false;
             if (!$child instanceof WC_Order) { exit(1); }
             if (WCOS_Operation_Journal::get($child, "'"$operation_id"'")) { exit(1); }

--- a/inc/backend/class-wcos-return-admin-controller.php
+++ b/inc/backend/class-wcos-return-admin-controller.php
@@ -1,0 +1,237 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Return_Transport_Exception extends RuntimeException {
+	private $error_code;
+	private $http_status;
+	private $retryable;
+
+	public function __construct($error_code, $message, $http_status = 400, $retryable = false) {
+		$this->error_code = sanitize_key((string) $error_code);
+		$this->http_status = absint($http_status);
+		$this->retryable = (bool) $retryable;
+		parent::__construct((string) $message);
+	}
+
+	public function get_error_code() { return $this->error_code; }
+	public function get_http_status() { return $this->http_status; }
+	public function is_retryable() { return $this->retryable; }
+}
+
+/** Gate-aware request authority for future Return UI; no UI hooks belong here. */
+final class WCOS_Return_Admin_Controller {
+	const REVIEW_ACTION = 'wcos_return_review';
+	const CONFIRM_ACTION = 'wcos_return_confirm';
+	const EXECUTE_ACTION = 'wcos_return_execute';
+
+	private static $instance = null;
+	private $registered = false;
+
+	public static function bootstrap() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) {
+			return null;
+		}
+		if (!self::$instance instanceof self) {
+			self::$instance = new self();
+		}
+		self::$instance->register_hooks();
+		return self::$instance;
+	}
+
+	public function register_hooks() {
+		if ($this->registered || !WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) {
+			return false;
+		}
+		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		$this->registered = true;
+		return true;
+	}
+
+	public function unregister_hooks() {
+		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
+		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
+		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		$this->registered = false;
+		return true;
+	}
+
+	public function review_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'child_order_id'));
+		$child = $this->authorized_child($request);
+		$report = (new WCOS_Return_WooCommerce_Adapter())->preflight($child);
+		if (empty($report['supported'])) {
+			throw new WCOS_Return_Transport_Exception(
+				'preflight_' . sanitize_key(isset($report['reason']) ? (string) $report['reason'] : 'unsupported'),
+				isset($report['message']) ? (string) $report['message'] : __('This child is not supported by hardened Return.', 'wc-order-splitter'),
+				409,
+				false
+			);
+		}
+		try {
+			$stored = WCOS_Return_Review_Store::create($child, $report, get_current_user_id());
+		} catch (WCOS_Return_Review_Exception $exception) {
+			throw $this->review_exception($exception);
+		}
+		$original = wc_get_order(absint($report['source_order_id']));
+		if (!$original instanceof WC_Order) {
+			throw new WCOS_Return_Transport_Exception('participant_not_found', __('The server-resolved Return original is unavailable.', 'wc-order-splitter'), 404, false);
+		}
+		return array(
+			'review_id' => $stored['review_id'],
+			'review_token' => $stored['review_token'],
+			'expires_at' => $stored['expires_at'],
+			'summary' => $this->review_summary($child, $original, $report),
+		);
+	}
+
+	public function confirm_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'child_order_id', 'review_id', 'review_token'));
+		$child = $this->authorized_child($request);
+		$review_id = isset($request['review_id']) ? sanitize_key((string) $request['review_id']) : '';
+		$review_token = isset($request['review_token']) ? (string) $request['review_token'] : '';
+		try {
+			$authority = WCOS_Return_Review_Store::verify($child, $review_id, $review_token, get_current_user_id());
+			$confirmation = WCOS_Return_Confirmation_Store::create($child, $authority, get_current_user_id());
+			if (!WCOS_Return_Review_Store::consume($child, $review_id, $review_token, get_current_user_id())) {
+				WCOS_Return_Confirmation_Store::delete($confirmation['operation_id']);
+				throw new WCOS_Return_Review_Exception('already_consumed', __('This Return Review was already consumed by another Confirm request.', 'wc-order-splitter'));
+			}
+		} catch (WCOS_Return_Review_Exception $exception) {
+			throw $this->review_exception($exception);
+		} catch (WCOS_Return_Confirmation_Exception $exception) {
+			throw $this->confirmation_exception($exception);
+		}
+
+		return array(
+			'operation_id' => $confirmation['operation_id'],
+			'confirmation_token' => $confirmation['confirmation_token'],
+			'expires_at' => $confirmation['expires_at'],
+			'child_order_id' => absint($authority['child_order_id']),
+			'original_order_id' => absint($authority['original_order_id']),
+		);
+	}
+
+	public function execute_request(array $request) {
+		$this->reject_client_authority($request, array('action', 'nonce', 'child_order_id', 'operation_id', 'confirmation_token'));
+		$child = $this->authorized_child($request);
+		$operation_id = isset($request['operation_id']) ? sanitize_key((string) $request['operation_id']) : '';
+		$token = isset($request['confirmation_token']) ? (string) $request['confirmation_token'] : '';
+		try {
+			$confirmation = WCOS_Return_Confirmation_Store::verify($child, $operation_id, $token, get_current_user_id());
+		} catch (WCOS_Return_Confirmation_Exception $exception) {
+			throw $this->confirmation_exception($exception);
+		}
+
+		try {
+			$result = (new WCOS_Mutation_Gateway())->return_order(
+				$child,
+				$operation_id,
+				$confirmation['price_precision'],
+				WCOS_Return_Confirmation_Store::operation_authority($confirmation)
+			);
+		} catch (WCOS_Return_Adapter_Exception $exception) {
+			throw new WCOS_Return_Transport_Exception($exception->get_error_code(), __('The hardened Return request did not complete automatically.', 'wc-order-splitter'), 409, true);
+		} catch (RuntimeException $exception) {
+			if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) {
+				throw new WCOS_Return_Transport_Exception('workflow_disabled', __('Hardened Return is not enabled for production use yet.', 'wc-order-splitter'), 503, false);
+			}
+			throw new WCOS_Return_Transport_Exception('return_failed', __('The hardened Return request did not complete automatically.', 'wc-order-splitter'), 409, true);
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'status' => sanitize_key(isset($result['status']) ? (string) $result['status'] : 'completed'),
+			'child_order_id' => absint(isset($result['child_order_id']) ? $result['child_order_id'] : $child->get_id()),
+			'original_order_id' => absint(isset($result['original_order_id']) ? $result['original_order_id'] : $confirmation['original_order_id']),
+			'retirement_policy' => sanitize_key(isset($result['retirement_policy']) ? (string) $result['retirement_policy'] : WCOS_Return_Retirement_Policy::approved_identifier()),
+		);
+	}
+
+	public function ajax_review() { $this->send_ajax('review_request'); }
+	public function ajax_confirm() { $this->send_ajax('confirm_request'); }
+	public function ajax_execute() { $this->send_ajax('execute_request'); }
+
+	private function authorized_child(array $request) {
+		$child_id = isset($request['child_order_id']) ? absint($request['child_order_id']) : 0;
+		if (!$child_id) {
+			throw new WCOS_Return_Transport_Exception('invalid_child', __('A valid Return child order is required.', 'wc-order-splitter'), 400, false);
+		}
+		$nonce = isset($request['nonce']) ? sanitize_text_field((string) $request['nonce']) : '';
+		if (!wp_verify_nonce($nonce, 'wcos_return_order_' . $child_id)) {
+			throw new WCOS_Return_Transport_Exception('invalid_nonce', __('The Return request failed nonce verification.', 'wc-order-splitter'), 403, false);
+		}
+		$child = wc_get_order($child_id);
+		if (!$child instanceof WC_Order) {
+			throw new WCOS_Return_Transport_Exception('participant_not_found', __('The Return child could not be found.', 'wc-order-splitter'), 404, false);
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_can_edit($child);
+			WCOS_Order_Mutation_Authorizer::assert_can_delete($child);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Return_Transport_Exception('authorization_failed', __('You are not allowed to Return this child.', 'wc-order-splitter'), 403, false);
+		}
+		return $child;
+	}
+
+	private function reject_client_authority(array $request, array $allowed) {
+		foreach (array_keys($request) as $field) {
+			if (!in_array((string) $field, $allowed, true)) {
+				throw new WCOS_Return_Transport_Exception('unexpected_field', __('The Return request contains unsupported client authority.', 'wc-order-splitter'), 400, false);
+			}
+		}
+	}
+
+	private function review_summary(WC_Order $child, WC_Order $original, array $report) {
+		$plan = $report['return_plan'];
+		$precision = (int) $plan['price_precision'];
+		$quantity_units = 0;
+		$subtotal_units = 0;
+		$total_units = 0;
+		$tax_units = 0;
+		foreach ($plan['lines'] as $line) {
+			$quantity_units += WCOS_Decimal::to_units($line['quantity'], 6);
+			$subtotal_units += WCOS_Decimal::to_units($line['subtotal'], $precision);
+			$total_units += WCOS_Decimal::to_units($line['total'], $precision);
+			$tax_units += WCOS_Decimal::to_units($line['total_tax'], $precision);
+		}
+		return array(
+			'child' => array('id' => $child->get_id(), 'number' => (string) $child->get_order_number(), 'status' => (string) $child->get_status()),
+			'original' => array('id' => $original->get_id(), 'number' => (string) $original->get_order_number(), 'status' => (string) $original->get_status()),
+			'strategy' => sanitize_key((string) $plan['strategy']),
+			'returned_line_count' => count($plan['lines']),
+			'quantity' => WCOS_Decimal::from_units($quantity_units, 6),
+			'historical_subtotal' => WCOS_Decimal::from_units($subtotal_units, $precision),
+			'historical_total' => WCOS_Decimal::from_units($total_units, $precision),
+			'historical_tax' => WCOS_Decimal::from_units($tax_units, $precision),
+			'currency' => (string) $plan['currency'],
+			'price_precision' => $precision,
+			'retirement' => array('policy' => WCOS_Return_Retirement_Policy::approved_identifier(), 'child_status_after' => 'trash'),
+			'compatibility' => array('supported' => true, 'reason' => 'supported'),
+		);
+	}
+
+	private function review_exception(WCOS_Return_Review_Exception $exception) {
+		$reason = $exception->get_reason();
+		$status = 'invalid_identity' === $reason ? 400 : (in_array($reason, array('invalid_token', 'owner_mismatch'), true) ? 403 : (in_array($reason, array('expired', 'already_consumed'), true) ? 410 : 409));
+		return new WCOS_Return_Transport_Exception('review_' . $reason, $exception->getMessage(), $status, false);
+	}
+
+	private function confirmation_exception(WCOS_Return_Confirmation_Exception $exception) {
+		$reason = $exception->get_reason();
+		$status = 'invalid_identity' === $reason ? 400 : (in_array($reason, array('invalid_token', 'owner_mismatch'), true) ? 403 : ('expired' === $reason ? 410 : 409));
+		return new WCOS_Return_Transport_Exception('confirmation_' . $reason, $exception->getMessage(), $status, false);
+	}
+
+	private function send_ajax($method) {
+		try {
+			wp_send_json_success($this->{$method}(wp_unslash($_POST)));
+		} catch (WCOS_Return_Transport_Exception $exception) {
+			wp_send_json_error(array('code' => $exception->get_error_code(), 'message' => $exception->getMessage(), 'retryable' => $exception->is_retryable()), $exception->get_http_status());
+		} catch (Throwable $throwable) {
+			wp_send_json_error(array('code' => 'return_request_failed', 'message' => __('The Return request could not be completed.', 'wc-order-splitter'), 'retryable' => true), 500);
+		}
+	}
+}

--- a/inc/backend/class-wcos-return-confirmation-store.php
+++ b/inc/backend/class-wcos-return-confirmation-store.php
@@ -157,6 +157,42 @@ final class WCOS_Return_Confirmation_Store {
 		} catch (Throwable $throwable) {
 			throw new WCOS_Return_Confirmation_Exception('owner_mismatch', __('The operator is no longer authorized for this durable Return pair.', 'wc-order-splitter'));
 		}
+		$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		$recoverable = array('recovery_required', 'recovering', 'started', 'committed', 'failed', 'compensating');
+		if (in_array($status, $recoverable, true)) {
+			WCOS_Operation_Journal::require_recovery($child, $operation_id, array('reason' => 'return_confirmation_replay'));
+			$child = wc_get_order($child->get_id());
+			$journal = $child instanceof WC_Order ? WCOS_Operation_Journal::get($child, $operation_id) : null;
+			if (!is_array($journal)) {
+				throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The authoritative Return journal disappeared during recovery dispatch.', 'wc-order-splitter'));
+			}
+			try {
+				$reloaded = WCOS_Return_Journal_Context::confirmation_handoff_from_record($journal);
+			} catch (Throwable $throwable) {
+				throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The reloaded durable Return Confirmation authority is invalid.', 'wc-order-splitter'));
+			}
+			if ($confirmed !== $reloaded) {
+				throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The durable Return Confirmation authority changed during recovery dispatch.', 'wc-order-splitter'));
+			}
+			$status = sanitize_key(isset($journal['status']) ? (string) $journal['status'] : '');
+		}
+		if ('manual_reconciliation' === $status) {
+			throw new WCOS_Return_Confirmation_Exception('manual_reconciliation', __('This Return operation requires manual reconciliation.', 'wc-order-splitter'));
+		}
+		if (in_array($status, array('compensated', 'manual_reconciled'), true)) {
+			throw new WCOS_Return_Confirmation_Exception('operation_closed', __('This Return operation is closed and cannot be replayed.', 'wc-order-splitter'));
+		}
+		if ('completed' === $status) {
+			try {
+				$terminal_result = WCOS_Return_Journal_Context::terminal_result_from_record($journal);
+			} catch (Throwable $throwable) {
+				throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The durable Return terminal result failed authority verification.', 'wc-order-splitter'));
+			}
+		} elseif (in_array($status, $recoverable, true)) {
+			$terminal_result = array();
+		} else {
+			throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The durable Return journal has an unsupported state.', 'wc-order-splitter'));
+		}
 		$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
 		$record = array_merge($confirmed, array(
 			'schema_version' => self::SCHEMA_VERSION,
@@ -164,6 +200,10 @@ final class WCOS_Return_Confirmation_Store {
 			'plan' => isset($context['return_plan']) && is_array($context['return_plan']) ? $context['return_plan'] : array(),
 			'pair_authority' => isset($context['return_pair']['authority']) && is_array($context['return_pair']['authority']) ? $context['return_pair']['authority'] : array(),
 			'replay_authority' => 'journal',
+			'journal_status' => $status,
+			'terminal_result' => $terminal_result,
+			'recovery_state' => 'completed' === $status ? 'terminal' : 'recovery_pending',
+			'retryable' => 'completed' !== $status,
 		));
 		self::assert_complete($record);
 		return $record;

--- a/inc/backend/class-wcos-return-confirmation-store.php
+++ b/inc/backend/class-wcos-return-confirmation-store.php
@@ -199,6 +199,7 @@ final class WCOS_Return_Confirmation_Store {
 			'user_id' => $user_id,
 			'plan' => isset($context['return_plan']) && is_array($context['return_plan']) ? $context['return_plan'] : array(),
 			'pair_authority' => isset($context['return_pair']['authority']) && is_array($context['return_pair']['authority']) ? $context['return_pair']['authority'] : array(),
+			'confirmation_provenance' => isset($context['return_pair']['confirmation_provenance']) && is_array($context['return_pair']['confirmation_provenance']) ? $context['return_pair']['confirmation_provenance'] : array(),
 			'replay_authority' => 'journal',
 			'journal_status' => $status,
 			'terminal_result' => $terminal_result,
@@ -211,7 +212,7 @@ final class WCOS_Return_Confirmation_Store {
 
 	private static function assert_complete(array $record) {
 		$required = array(
-			'operation_id', 'user_id', 'child_order_id', 'original_order_id', 'plan', 'pair_authority',
+			'operation_id', 'user_id', 'child_order_id', 'original_order_id', 'plan', 'pair_authority', 'confirmation_provenance',
 			'plan_fingerprint', 'pair_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
 			'price_precision', 'currency', 'prices_include_tax', 'return_service_policy_version', 'preflight_policy_version',
 			'plan_schema_version', 'plan_policy_version', 'lineage_schema_version', 'lineage_policy_version',
@@ -225,13 +226,14 @@ final class WCOS_Return_Confirmation_Store {
 		}
 		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
 			|| !self::is_uuid($record['operation_id']) || !absint($record['user_id'])
-			|| !is_array($record['plan']) || !is_array($record['pair_authority'])
+			|| !is_array($record['plan']) || !is_array($record['pair_authority']) || !is_array($record['confirmation_provenance'])
 			|| !hash_equals((string) $record['plan_fingerprint'], WCOS_Return_Plan::fingerprint($record['plan']))) {
 			throw new WCOS_Return_Confirmation_Exception('confirmation_invalid', __('The stored Return Confirmation plan is malformed.', 'wc-order-splitter'));
 		}
 		$context = array('return_pair' => array(
 			'schema_version' => WCOS_Return_Journal_Context::SCHEMA_VERSION,
 			'authority' => $record['pair_authority'],
+			'confirmation_provenance' => $record['confirmation_provenance'],
 			'pair_fingerprint' => $record['pair_fingerprint'],
 		));
 		try {

--- a/inc/backend/class-wcos-return-confirmation-store.php
+++ b/inc/backend/class-wcos-return-confirmation-store.php
@@ -1,0 +1,261 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Return_Confirmation_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/** Temporary Return authority until the exact child-keyed journal exists. */
+final class WCOS_Return_Confirmation_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 1800;
+
+	public static function create(WC_Order $child, array $review_authority, $user_id) {
+		$child_id = absint($child->get_id());
+		$user_id = absint($user_id);
+		if (!$child_id || !$user_id || 'shop_order' !== $child->get_type()) {
+			throw new WCOS_Return_Confirmation_Exception('invalid_identity', __('Return Confirmation requires one persisted child and a signed-in operator.', 'wc-order-splitter'));
+		}
+		if (absint(isset($review_authority['child_order_id']) ? $review_authority['child_order_id'] : 0) !== $child_id) {
+			throw new WCOS_Return_Confirmation_Exception('review_mismatch', __('The Return Review does not match this child.', 'wc-order-splitter'));
+		}
+		try {
+			WCOS_Return_Review_Store::assert_matches_current($child, $review_authority);
+		} catch (WCOS_Return_Review_Exception $exception) {
+			throw new WCOS_Return_Confirmation_Exception('authority_changed', $exception->getMessage());
+		}
+
+		$operation_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$now = time();
+		$record = array_merge($review_authority, array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => $operation_id,
+			'token_hash' => self::token_hash($token),
+			'user_id' => $user_id,
+			'created_at' => $now,
+			'expires_at' => $now + self::TTL,
+		));
+		self::assert_complete($record);
+		if (!set_transient(self::key($operation_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to store the temporary Return Confirmation.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'operation_id' => $operation_id,
+			'confirmation_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'record' => $record,
+		);
+	}
+
+	public static function verify(WC_Order $child, $operation_id, $token, $user_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($operation_id) || !$user_id) {
+			throw new WCOS_Return_Confirmation_Exception('invalid_identity', __('The Return Confirmation identity is invalid.', 'wc-order-splitter'));
+		}
+		$journal = WCOS_Operation_Journal::get($child, $operation_id);
+		$record = get_transient(self::key($operation_id));
+		if (is_array($journal)) {
+			$durable = self::durable_replay($child, $operation_id, $user_id, $journal);
+			if (is_array($record)) {
+				self::assert_confirmation_matches_durable($record, $durable);
+			}
+			return $durable;
+		}
+		if (!is_array($record)) {
+			throw new WCOS_Return_Confirmation_Exception('expired', __('The Return Confirmation expired before a journal existed. Review the child again.', 'wc-order-splitter'));
+		}
+		if ('' === (string) $token || empty($record['token_hash'])
+			|| !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Return_Confirmation_Exception('invalid_token', __('The Return Confirmation token is invalid.', 'wc-order-splitter'));
+		}
+		if (absint(isset($record['user_id']) ? $record['user_id'] : 0) !== $user_id
+			|| absint(isset($record['child_order_id']) ? $record['child_order_id'] : 0) !== $child->get_id()) {
+			throw new WCOS_Return_Confirmation_Exception('owner_mismatch', __('The Return Confirmation does not belong to this operator and child.', 'wc-order-splitter'));
+		}
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($operation_id);
+			throw new WCOS_Return_Confirmation_Exception('expired', __('The Return Confirmation expired before a journal existed. Review the child again.', 'wc-order-splitter'));
+		}
+		self::assert_complete($record);
+		try {
+			WCOS_Return_Review_Store::assert_matches_current($child, self::review_authority($record));
+		} catch (WCOS_Return_Review_Exception $exception) {
+			throw new WCOS_Return_Confirmation_Exception('authority_changed', __('The frozen Return authority changed after Confirmation. Review the child again.', 'wc-order-splitter'));
+		}
+		$record['replay_authority'] = 'confirmation';
+		return $record;
+	}
+
+	/** PII-free authority passed from the controller/gateway into the existing Return journal. */
+	public static function operation_authority(array $record) {
+		self::assert_complete($record);
+		return array(
+			'confirmation_schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => sanitize_key((string) $record['operation_id']),
+			'operator_user_id' => absint($record['user_id']),
+			'child_order_id' => absint($record['child_order_id']),
+			'original_order_id' => absint($record['original_order_id']),
+			'split_operation_id' => sanitize_key((string) $record['split_operation_id']),
+			'split_child_key' => sanitize_key((string) $record['split_child_key']),
+			'pair_fingerprint' => sanitize_key((string) $record['pair_fingerprint']),
+			'plan_fingerprint' => sanitize_key((string) $record['plan_fingerprint']),
+			'lineage_authority_fingerprint' => sanitize_key((string) $record['lineage_authority_fingerprint']),
+			'source_evolution_authority_fingerprint' => sanitize_key((string) $record['source_evolution_authority_fingerprint']),
+			'price_precision' => WCOS_Price_Precision_Scope::validate($record['price_precision']),
+			'currency' => (string) $record['currency'],
+			'prices_include_tax' => (bool) $record['prices_include_tax'],
+			'return_service_policy_version' => absint($record['return_service_policy_version']),
+			'preflight_policy_version' => absint($record['preflight_policy_version']),
+			'plan_schema_version' => absint($record['plan_schema_version']),
+			'plan_policy_version' => absint($record['plan_policy_version']),
+			'lineage_schema_version' => absint($record['lineage_schema_version']),
+			'lineage_policy_version' => absint($record['lineage_policy_version']),
+			'journal_context_schema_version' => absint($record['journal_context_schema_version']),
+			'retirement_policy_schema_version' => absint($record['retirement_policy_schema_version']),
+			'retirement_policy_identifier' => sanitize_key((string) $record['retirement_policy_identifier']),
+			'stock_ownership_policy' => sanitize_key((string) $record['stock_ownership_policy']),
+			'order_stock_flag_policy' => sanitize_key((string) $record['order_stock_flag_policy']),
+		);
+	}
+
+	public static function delete($operation_id) {
+		$operation_id = sanitize_key((string) $operation_id);
+		return self::is_uuid($operation_id) ? delete_transient(self::key($operation_id)) : false;
+	}
+
+	private static function durable_replay(WC_Order $child, $operation_id, $user_id, array $journal) {
+		try {
+			$confirmed = WCOS_Return_Journal_Context::confirmation_handoff_from_record($journal);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The durable Return Confirmation authority is invalid.', 'wc-order-splitter'));
+		}
+		if (absint($confirmed['child_order_id']) !== $child->get_id()
+			|| sanitize_key((string) $confirmed['operation_id']) !== $operation_id
+			|| absint($confirmed['operator_user_id']) !== $user_id
+			|| (int) $confirmed['confirmation_schema_version'] !== self::SCHEMA_VERSION) {
+			throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The durable Return journal does not match this operation, operator, and child.', 'wc-order-splitter'));
+		}
+		$original = wc_get_order(absint($confirmed['original_order_id']));
+		if (!$original instanceof WC_Order) {
+			throw new WCOS_Return_Confirmation_Exception('participant_missing', __('The durable Return original is unavailable.', 'wc-order-splitter'));
+		}
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_return($child, $original);
+		} catch (Throwable $throwable) {
+			throw new WCOS_Return_Confirmation_Exception('owner_mismatch', __('The operator is no longer authorized for this durable Return pair.', 'wc-order-splitter'));
+		}
+		$context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
+		$record = array_merge($confirmed, array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'user_id' => $user_id,
+			'plan' => isset($context['return_plan']) && is_array($context['return_plan']) ? $context['return_plan'] : array(),
+			'pair_authority' => isset($context['return_pair']['authority']) && is_array($context['return_pair']['authority']) ? $context['return_pair']['authority'] : array(),
+			'replay_authority' => 'journal',
+		));
+		self::assert_complete($record);
+		return $record;
+	}
+
+	private static function assert_complete(array $record) {
+		$required = array(
+			'operation_id', 'user_id', 'child_order_id', 'original_order_id', 'plan', 'pair_authority',
+			'plan_fingerprint', 'pair_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
+			'price_precision', 'currency', 'prices_include_tax', 'return_service_policy_version', 'preflight_policy_version',
+			'plan_schema_version', 'plan_policy_version', 'lineage_schema_version', 'lineage_policy_version',
+			'journal_context_schema_version', 'retirement_policy_schema_version', 'retirement_policy_identifier',
+			'split_operation_id', 'split_child_key', 'stock_ownership_policy', 'order_stock_flag_policy',
+		);
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $record)) {
+				throw new WCOS_Return_Confirmation_Exception('confirmation_invalid', __('The stored Return Confirmation authority is incomplete.', 'wc-order-splitter'));
+			}
+		}
+		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| !self::is_uuid($record['operation_id']) || !absint($record['user_id'])
+			|| !is_array($record['plan']) || !is_array($record['pair_authority'])
+			|| !hash_equals((string) $record['plan_fingerprint'], WCOS_Return_Plan::fingerprint($record['plan']))) {
+			throw new WCOS_Return_Confirmation_Exception('confirmation_invalid', __('The stored Return Confirmation plan is malformed.', 'wc-order-splitter'));
+		}
+		$context = array('return_pair' => array(
+			'schema_version' => WCOS_Return_Journal_Context::SCHEMA_VERSION,
+			'authority' => $record['pair_authority'],
+			'pair_fingerprint' => $record['pair_fingerprint'],
+		));
+		try {
+			WCOS_Return_Journal_Context::create_confirmation_handoff($context, $record['operation_id'], self::operation_authority_unchecked($record));
+		} catch (Throwable $throwable) {
+			throw new WCOS_Return_Confirmation_Exception('authority_changed', __('The stored Return Confirmation no longer matches current policy authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function operation_authority_unchecked(array $record) {
+		return array(
+			'confirmation_schema_version' => self::SCHEMA_VERSION,
+			'operation_id' => sanitize_key((string) $record['operation_id']),
+			'operator_user_id' => absint($record['user_id']),
+			'child_order_id' => absint($record['child_order_id']),
+			'original_order_id' => absint($record['original_order_id']),
+			'split_operation_id' => sanitize_key((string) $record['split_operation_id']),
+			'split_child_key' => sanitize_key((string) $record['split_child_key']),
+			'pair_fingerprint' => sanitize_key((string) $record['pair_fingerprint']),
+			'plan_fingerprint' => sanitize_key((string) $record['plan_fingerprint']),
+			'lineage_authority_fingerprint' => sanitize_key((string) $record['lineage_authority_fingerprint']),
+			'source_evolution_authority_fingerprint' => sanitize_key((string) $record['source_evolution_authority_fingerprint']),
+			'price_precision' => (int) $record['price_precision'],
+			'currency' => (string) $record['currency'],
+			'prices_include_tax' => (bool) $record['prices_include_tax'],
+			'return_service_policy_version' => (int) $record['return_service_policy_version'],
+			'preflight_policy_version' => (int) $record['preflight_policy_version'],
+			'plan_schema_version' => (int) $record['plan_schema_version'],
+			'plan_policy_version' => (int) $record['plan_policy_version'],
+			'lineage_schema_version' => (int) $record['lineage_schema_version'],
+			'lineage_policy_version' => (int) $record['lineage_policy_version'],
+			'journal_context_schema_version' => (int) $record['journal_context_schema_version'],
+			'retirement_policy_schema_version' => (int) $record['retirement_policy_schema_version'],
+			'retirement_policy_identifier' => sanitize_key((string) $record['retirement_policy_identifier']),
+			'stock_ownership_policy' => sanitize_key((string) $record['stock_ownership_policy']),
+			'order_stock_flag_policy' => sanitize_key((string) $record['order_stock_flag_policy']),
+		);
+	}
+
+	private static function review_authority(array $record) {
+		$review = $record;
+		foreach (array('schema_version', 'operation_id', 'token_hash', 'user_id', 'created_at', 'expires_at', 'replay_authority', 'confirmation_schema_version', 'operator_user_id', 'authority_fingerprint') as $field) {
+			unset($review[$field]);
+		}
+		return $review;
+	}
+
+	private static function assert_confirmation_matches_durable(array $record, array $durable) {
+		$temporary = self::operation_authority($record);
+		$journal = self::operation_authority($durable);
+		if ($temporary !== $journal) {
+			throw new WCOS_Return_Confirmation_Exception('journal_mismatch', __('The temporary Return Confirmation conflicts with durable journal authority.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($operation_id) {
+		return 'wcos_return_confirm_' . hash('sha256', sanitize_key((string) $operation_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/backend/class-wcos-return-review-store.php
+++ b/inc/backend/class-wcos-return-review-store.php
@@ -137,7 +137,7 @@ final class WCOS_Return_Review_Store {
 		}
 		$plan = $report['return_plan'];
 		$lineage = $report['lineage_authority'];
-		$context = WCOS_Return_Journal_Context::create($child, $original, $plan, $lineage, $lineage['source_evolution_authority']);
+		$context = WCOS_Return_Journal_Context::create($child, $original, $plan, $lineage, $lineage['source_evolution_authority'], '', array(), true);
 		$pair = WCOS_Return_Journal_Context::pair_from_context($context);
 		if (!is_array($pair)) {
 			throw new WCOS_Return_Review_Exception('review_invalid', __('The canonical Return pair authority could not be frozen.', 'wc-order-splitter'));
@@ -150,6 +150,7 @@ final class WCOS_Return_Review_Store {
 			'plan' => $plan,
 			'plan_fingerprint' => $pair['plan_fingerprint'],
 			'pair_authority' => $context['return_pair']['authority'],
+			'confirmation_provenance' => $context['return_pair']['confirmation_provenance'],
 			'pair_fingerprint' => $pair['pair_fingerprint'],
 			'lineage_authority_fingerprint' => $pair['lineage_authority_fingerprint'],
 			'source_evolution_authority_fingerprint' => $pair['source_evolution_authority_fingerprint'],
@@ -197,7 +198,7 @@ final class WCOS_Return_Review_Store {
 	private static function assert_authority_complete(array $authority) {
 		$required = array(
 			'child_order_id', 'original_order_id', 'split_operation_id', 'split_child_key', 'plan', 'plan_fingerprint',
-			'pair_authority', 'pair_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
+			'pair_authority', 'confirmation_provenance', 'pair_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
 			'price_precision', 'currency', 'prices_include_tax', 'return_service_policy_version', 'preflight_policy_version',
 			'plan_schema_version', 'plan_policy_version', 'lineage_schema_version', 'lineage_policy_version',
 			'journal_context_schema_version', 'retirement_policy_schema_version', 'retirement_policy_identifier',
@@ -208,13 +209,14 @@ final class WCOS_Return_Review_Store {
 				throw new WCOS_Return_Review_Exception('review_invalid', __('The stored Return Review authority is incomplete.', 'wc-order-splitter'));
 			}
 		}
-		if (!is_array($authority['plan']) || !is_array($authority['pair_authority'])
+		if (!is_array($authority['plan']) || !is_array($authority['pair_authority']) || !is_array($authority['confirmation_provenance'])
 			|| !hash_equals((string) $authority['plan_fingerprint'], WCOS_Return_Plan::fingerprint($authority['plan']))) {
 			throw new WCOS_Return_Review_Exception('review_invalid', __('The stored Return Review plan authority is malformed.', 'wc-order-splitter'));
 		}
 		$context = array('return_pair' => array(
 			'schema_version' => WCOS_Return_Journal_Context::SCHEMA_VERSION,
 			'authority' => $authority['pair_authority'],
+			'confirmation_provenance' => $authority['confirmation_provenance'],
 			'pair_fingerprint' => $authority['pair_fingerprint'],
 		));
 		$pair = WCOS_Return_Journal_Context::pair_from_context($context);

--- a/inc/backend/class-wcos-return-review-store.php
+++ b/inc/backend/class-wcos-return-review-store.php
@@ -1,0 +1,254 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Return_Review_Exception extends RuntimeException {
+	private $reason;
+
+	public function __construct($reason, $message) {
+		$this->reason = sanitize_key((string) $reason);
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+}
+
+/** Short-lived, PII-free authority for one server-resolved Return Review. */
+final class WCOS_Return_Review_Store {
+	const SCHEMA_VERSION = 1;
+	const TTL = 900;
+
+	public static function create(WC_Order $child, array $report, $user_id) {
+		$child_id = absint($child->get_id());
+		$user_id = absint($user_id);
+		if (!$child_id || !$user_id || 'shop_order' !== $child->get_type()) {
+			throw new WCOS_Return_Review_Exception('invalid_identity', __('Return Review requires one persisted child and a signed-in operator.', 'wc-order-splitter'));
+		}
+		$authority = self::authority_from_report($report, $child_id);
+		self::assert_current($child, $authority);
+
+		$review_id = wp_generate_uuid4();
+		$token = wp_generate_password(48, false, false);
+		$now = time();
+		$record = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'review_id' => $review_id,
+			'token_hash' => self::token_hash($token),
+			'user_id' => $user_id,
+			'authority' => $authority,
+			'created_at' => $now,
+			'expires_at' => $now + self::TTL,
+		);
+		if (!set_transient(self::key($review_id), $record, self::TTL)) {
+			throw new RuntimeException(__('Unable to store the temporary Return Review.', 'wc-order-splitter'));
+		}
+
+		return array(
+			'review_id' => $review_id,
+			'review_token' => $token,
+			'expires_at' => $record['expires_at'],
+			'authority' => $authority,
+		);
+	}
+
+	public static function verify(WC_Order $child, $review_id, $token, $user_id) {
+		$review_id = sanitize_key((string) $review_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($review_id) || !$user_id) {
+			throw new WCOS_Return_Review_Exception('invalid_identity', __('The Return Review identity is invalid.', 'wc-order-splitter'));
+		}
+		$record = get_transient(self::key($review_id));
+		if (!is_array($record)) {
+			throw new WCOS_Return_Review_Exception('expired', __('The Return Review expired or was already consumed. Review the child again.', 'wc-order-splitter'));
+		}
+		self::assert_record_owner($record, $child, $token, $user_id);
+		if (empty($record['expires_at']) || (int) $record['expires_at'] < time()) {
+			self::delete($review_id);
+			throw new WCOS_Return_Review_Exception('expired', __('The Return Review expired. Review the child again.', 'wc-order-splitter'));
+		}
+		$authority = isset($record['authority']) && is_array($record['authority']) ? $record['authority'] : array();
+		self::assert_current($child, $authority);
+		return $authority;
+	}
+
+	public static function assert_matches_current(WC_Order $child, array $authority) {
+		self::assert_current($child, $authority);
+		return true;
+	}
+
+	/**
+	 * Atomically compare-and-delete the exact DB-backed transient record.
+	 *
+	 * Two Confirm workers may both finish read-only verification and create an
+	 * unexposed candidate. Only one can delete the exact reviewed record; every
+	 * loser must delete its candidate before returning it to a client.
+	 */
+	public static function consume(WC_Order $child, $review_id, $token, $user_id) {
+		$review_id = sanitize_key((string) $review_id);
+		$user_id = absint($user_id);
+		if (!self::is_uuid($review_id) || !$user_id || wp_using_ext_object_cache()) {
+			throw new WCOS_Return_Review_Exception('atomic_storage_unavailable', __('The current Review storage cannot prove single-consumption safely.', 'wc-order-splitter'));
+		}
+		$transient_key = self::key($review_id);
+		$record = get_transient($transient_key);
+		if (!is_array($record)) {
+			return false;
+		}
+		self::assert_record_owner($record, $child, $token, $user_id);
+
+		global $wpdb;
+		$option_name = '_transient_' . $transient_key;
+		$deleted = $wpdb->query($wpdb->prepare(
+			"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+			$option_name,
+			maybe_serialize($record)
+		));
+		if (1 !== (int) $deleted) {
+			wp_cache_delete($option_name, 'options');
+			return false;
+		}
+		$timeout_name = '_transient_timeout_' . $transient_key;
+		$wpdb->delete($wpdb->options, array('option_name' => $timeout_name), array('%s'));
+		wp_cache_delete($option_name, 'options');
+		wp_cache_delete($timeout_name, 'options');
+		wp_cache_delete($transient_key, 'transient');
+		return true;
+	}
+
+	public static function delete($review_id) {
+		$review_id = sanitize_key((string) $review_id);
+		return self::is_uuid($review_id) ? delete_transient(self::key($review_id)) : false;
+	}
+
+	private static function authority_from_report(array $report, $child_id) {
+		if (empty($report['supported'])
+			|| absint(isset($report['child_order_id']) ? $report['child_order_id'] : 0) !== $child_id
+			|| empty($report['source_order_id'])
+			|| empty($report['return_plan']) || !is_array($report['return_plan'])
+			|| empty($report['lineage_authority']) || !is_array($report['lineage_authority'])) {
+			throw new WCOS_Return_Review_Exception('review_invalid', __('The server Return Review is incomplete or mismatched.', 'wc-order-splitter'));
+		}
+		$child = wc_get_order($child_id);
+		$original = wc_get_order(absint($report['source_order_id']));
+		if (!$child instanceof WC_Order || !$original instanceof WC_Order) {
+			throw new WCOS_Return_Review_Exception('participant_missing', __('A Return participant is no longer available.', 'wc-order-splitter'));
+		}
+		$plan = $report['return_plan'];
+		$lineage = $report['lineage_authority'];
+		$context = WCOS_Return_Journal_Context::create($child, $original, $plan, $lineage, $lineage['source_evolution_authority']);
+		$pair = WCOS_Return_Journal_Context::pair_from_context($context);
+		if (!is_array($pair)) {
+			throw new WCOS_Return_Review_Exception('review_invalid', __('The canonical Return pair authority could not be frozen.', 'wc-order-splitter'));
+		}
+		return array(
+			'child_order_id' => $child_id,
+			'original_order_id' => $original->get_id(),
+			'split_operation_id' => $pair['split_operation_id'],
+			'split_child_key' => $pair['split_child_key'],
+			'plan' => $plan,
+			'plan_fingerprint' => $pair['plan_fingerprint'],
+			'pair_authority' => $context['return_pair']['authority'],
+			'pair_fingerprint' => $pair['pair_fingerprint'],
+			'lineage_authority_fingerprint' => $pair['lineage_authority_fingerprint'],
+			'source_evolution_authority_fingerprint' => $pair['source_evolution_authority_fingerprint'],
+			'price_precision' => $pair['price_precision'],
+			'currency' => $pair['currency'],
+			'prices_include_tax' => $pair['prices_include_tax'],
+			'return_service_policy_version' => WCOS_Return_Order_Service::POLICY_VERSION,
+			'preflight_policy_version' => $pair['preflight_policy_version'],
+			'plan_schema_version' => $pair['plan_schema_version'],
+			'plan_policy_version' => $pair['plan_policy_version'],
+			'lineage_schema_version' => $pair['lineage_schema_version'],
+			'lineage_policy_version' => $pair['lineage_policy_version'],
+			'journal_context_schema_version' => WCOS_Return_Journal_Context::SCHEMA_VERSION,
+			'retirement_policy_schema_version' => $pair['retirement_policy_schema_version'],
+			'retirement_policy_identifier' => $pair['retirement_policy_identifier'],
+			'stock_ownership_policy' => $pair['stock_ownership_policy'],
+			'order_stock_flag_policy' => $pair['order_stock_flag_policy'],
+		);
+	}
+
+	private static function assert_current(WC_Order $child, array $authority) {
+		self::assert_authority_complete($authority);
+		$current_child = wc_get_order($child->get_id());
+		if (!$current_child instanceof WC_Order) {
+			throw new WCOS_Return_Review_Exception('participant_missing', __('The Return child is no longer available.', 'wc-order-splitter'));
+		}
+		$report = (new WCOS_Return_WooCommerce_Adapter())->preflight($current_child);
+		if (empty($report['supported'])) {
+			throw new WCOS_Return_Review_Exception('pair_changed', __('The Return pair is no longer supported. Review the child again.', 'wc-order-splitter'));
+		}
+		$current = self::authority_from_report($report, $current_child->get_id());
+		foreach ($authority as $field => $value) {
+			if (!array_key_exists($field, $current) || $value !== $current[$field]) {
+				$reason = 'authority_changed';
+				if ('pair_authority' === $field && is_array($value) && is_array($current[$field])) {
+					if ((string) $value['child_signature_before'] !== (string) $current[$field]['child_signature_before']) { $reason = 'child_changed'; }
+					elseif ((string) $value['original_signature_before'] !== (string) $current[$field]['original_signature_before']) { $reason = 'original_changed'; }
+					elseif ((string) $value['original_relation_signature_before'] !== (string) $current[$field]['original_relation_signature_before']) { $reason = 'relation_changed'; }
+				}
+				throw new WCOS_Return_Review_Exception($reason, __('The Return authority changed after Review. Review the child again.', 'wc-order-splitter'));
+			}
+		}
+	}
+
+	private static function assert_authority_complete(array $authority) {
+		$required = array(
+			'child_order_id', 'original_order_id', 'split_operation_id', 'split_child_key', 'plan', 'plan_fingerprint',
+			'pair_authority', 'pair_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
+			'price_precision', 'currency', 'prices_include_tax', 'return_service_policy_version', 'preflight_policy_version',
+			'plan_schema_version', 'plan_policy_version', 'lineage_schema_version', 'lineage_policy_version',
+			'journal_context_schema_version', 'retirement_policy_schema_version', 'retirement_policy_identifier',
+			'stock_ownership_policy', 'order_stock_flag_policy',
+		);
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $authority)) {
+				throw new WCOS_Return_Review_Exception('review_invalid', __('The stored Return Review authority is incomplete.', 'wc-order-splitter'));
+			}
+		}
+		if (!is_array($authority['plan']) || !is_array($authority['pair_authority'])
+			|| !hash_equals((string) $authority['plan_fingerprint'], WCOS_Return_Plan::fingerprint($authority['plan']))) {
+			throw new WCOS_Return_Review_Exception('review_invalid', __('The stored Return Review plan authority is malformed.', 'wc-order-splitter'));
+		}
+		$context = array('return_pair' => array(
+			'schema_version' => WCOS_Return_Journal_Context::SCHEMA_VERSION,
+			'authority' => $authority['pair_authority'],
+			'pair_fingerprint' => $authority['pair_fingerprint'],
+		));
+		$pair = WCOS_Return_Journal_Context::pair_from_context($context);
+		if (!is_array($pair)
+			|| absint($authority['child_order_id']) !== $pair['child_order_id']
+			|| absint($authority['original_order_id']) !== $pair['original_order_id']
+			|| (int) $authority['return_service_policy_version'] !== WCOS_Return_Order_Service::POLICY_VERSION
+			|| (int) $authority['journal_context_schema_version'] !== WCOS_Return_Journal_Context::SCHEMA_VERSION) {
+			throw new WCOS_Return_Review_Exception('authority_changed', __('The stored Return Review policy authority is no longer current.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function assert_record_owner(array $record, WC_Order $child, $token, $user_id) {
+		if ((int) (isset($record['schema_version']) ? $record['schema_version'] : 0) !== self::SCHEMA_VERSION
+			|| empty($record['token_hash']) || '' === (string) $token
+			|| !hash_equals((string) $record['token_hash'], self::token_hash($token))) {
+			throw new WCOS_Return_Review_Exception('invalid_token', __('The Return Review token is invalid.', 'wc-order-splitter'));
+		}
+		$authority = isset($record['authority']) && is_array($record['authority']) ? $record['authority'] : array();
+		if (absint(isset($record['user_id']) ? $record['user_id'] : 0) !== absint($user_id)
+			|| absint(isset($authority['child_order_id']) ? $authority['child_order_id'] : 0) !== $child->get_id()) {
+			throw new WCOS_Return_Review_Exception('owner_mismatch', __('The Return Review does not belong to this operator and child.', 'wc-order-splitter'));
+		}
+	}
+
+	private static function token_hash($token) {
+		return hash_hmac('sha256', (string) $token, wp_salt('auth'));
+	}
+
+	private static function key($review_id) {
+		return 'wcos_return_review_' . hash('sha256', sanitize_key((string) $review_id));
+	}
+
+	private static function is_uuid($value) {
+		return 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/D', (string) $value);
+	}
+}

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -109,8 +109,13 @@ class WC_Order_Splitter_Script {
 
 		include_once $root . 'backend/class-wcos-merge-review-store.php';
 		include_once $root . 'backend/class-wcos-merge-confirmation-store.php';
-		include_once $root . 'backend/class-wcos-merge-admin-controller.php';
-		WCOS_Merge_Admin_Controller::bootstrap();
+			include_once $root . 'backend/class-wcos-merge-admin-controller.php';
+			WCOS_Merge_Admin_Controller::bootstrap();
+
+			include_once $root . 'backend/class-wcos-return-review-store.php';
+			include_once $root . 'backend/class-wcos-return-confirmation-store.php';
+			include_once $root . 'backend/class-wcos-return-admin-controller.php';
+			WCOS_Return_Admin_Controller::bootstrap();
 
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -59,14 +59,24 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Merge_WooCommerce_Adapter())->preflight($source, $target, $operation_id, $confirmed_precision);
 	}
 
-	public function return_order(WC_Order $child, $operation_id, $confirmed_precision = null) {
+	public function return_order(WC_Order $child, $operation_id, $confirmed_precision = null, array $confirmation_authority = array()) {
 		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::RETURN_ORDER);
-		$report = WCOS_Return_Preflight::assert_supported($child, false);
-		$original = wc_get_order(absint($report['source_order_id']));
+		if (empty($confirmation_authority)) {
+			throw new RuntimeException(__('A verified server Return Confirmation is required.', 'wc-order-splitter'));
+		}
+		$operation_id = sanitize_key((string) $operation_id);
+		$journal = WCOS_Operation_Journal::get($child, $operation_id);
+		if (is_array($journal)) {
+			$durable = WCOS_Return_Journal_Context::assert_confirmation_matches_record($journal, $confirmation_authority);
+			$original = wc_get_order(absint($durable['original_order_id']));
+		} else {
+			$report = WCOS_Return_Preflight::assert_supported($child, false);
+			$original = wc_get_order(absint($report['source_order_id']));
+		}
 		if (!$original instanceof WC_Order) {
 			throw new RuntimeException(__('The server-resolved Return original is unavailable.', 'wc-order-splitter'));
 		}
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $child, $original);
-		return (new WCOS_Return_WooCommerce_Adapter())->return_order($child, $operation_id, $confirmed_precision);
+		return (new WCOS_Return_WooCommerce_Adapter())->return_order($child, $operation_id, $confirmed_precision, $confirmation_authority);
 	}
 }

--- a/inc/domain/class-wcos-mutation-recovery-coordinator.php
+++ b/inc/domain/class-wcos-mutation-recovery-coordinator.php
@@ -108,6 +108,12 @@ final class WCOS_Mutation_Recovery_Coordinator {
 				WCOS_Return_Compensator::manual_reconciliation($fresh_child, null, $fresh_record, 'missing_return_peer');
 				return;
 			}
+			try {
+				WCOS_Return_Journal_Context::confirmation_handoff_if_required($fresh_record);
+			} catch (Throwable $throwable) {
+				WCOS_Return_Compensator::manual_reconciliation($fresh_child, $original, $fresh_record, 'corrupt_return_confirmation_authority');
+				return;
+			}
 			$participant_ids = array($pair['child_order_id'], $pair['original_order_id']);
 			$owned = array_filter($participant_ids, static function($order_id) use ($operation_id) {
 				return WCOS_Operation_Lock::is_current_owned_for($order_id, $operation_id);

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -504,10 +504,17 @@ final class WCOS_Operation_Journal {
             }
         }
 
+		foreach (array('return_confirmation_required', 'return_confirmation') as $field) {
+			if (array_key_exists($field, $current_context) !== array_key_exists($field, $replacement_context)
+				|| (array_key_exists($field, $current_context) && $current_context[$field] !== $replacement_context[$field])) {
+				return false;
+			}
+		}
+
         foreach (array(
             'execution_policy', 'fully_moved_item_ids', 'strategy_authority', 'merge_pair',
             'merge_recovery_snapshot', 'merge_recovery_snapshot_fingerprint', 'return_pair',
-            'return_plan', 'return_confirmation_required', 'return_confirmation',
+			'return_plan',
             'return_recovery_snapshot', 'return_recovery_snapshot_fingerprint',
         ) as $field) {
             if (array_key_exists($field, $current_context)) {

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -507,7 +507,8 @@ final class WCOS_Operation_Journal {
         foreach (array(
             'execution_policy', 'fully_moved_item_ids', 'strategy_authority', 'merge_pair',
             'merge_recovery_snapshot', 'merge_recovery_snapshot_fingerprint', 'return_pair',
-            'return_plan', 'return_recovery_snapshot', 'return_recovery_snapshot_fingerprint',
+            'return_plan', 'return_confirmation_required', 'return_confirmation',
+            'return_recovery_snapshot', 'return_recovery_snapshot_fingerprint',
         ) as $field) {
             if (array_key_exists($field, $current_context)) {
                 if (!array_key_exists($field, $replacement_context)

--- a/inc/domain/class-wcos-return-journal-context.php
+++ b/inc/domain/class-wcos-return-journal-context.php
@@ -5,11 +5,13 @@ defined('ABSPATH') || exit;
 /** Self-verifying, PII-free authority for one child-keyed Return journal. */
 final class WCOS_Return_Journal_Context {
 
-	const SCHEMA_VERSION = 1;
+	const SCHEMA_VERSION = 2;
+	const LEGACY_SCHEMA_VERSION = 1;
 	const TERMINAL_RESULT_SCHEMA_VERSION = 1;
 	const CONFIRMATION_SCHEMA_VERSION = 1;
+	const CONFIRMATION_PROVENANCE_SCHEMA_VERSION = 1;
 
-	public static function create(WC_Order $child, WC_Order $original, array $plan, array $lineage_authority, array $source_evolution_authority, $operation_id = '', array $confirmation_authority = array()) {
+	public static function create(WC_Order $child, WC_Order $original, array $plan, array $lineage_authority, array $source_evolution_authority, $operation_id = '', array $confirmation_authority = array(), $confirmation_required = null) {
 		$child_id = absint($child->get_id());
 		$original_id = absint($original->get_id());
 		if (!$child_id || !$original_id || $child_id === $original_id
@@ -60,11 +62,19 @@ final class WCOS_Return_Journal_Context {
 		if (!is_array($authority)) {
 			throw new RuntimeException(__('The canonical Return pair authority could not be constructed.', 'wc-order-splitter'));
 		}
+		if (null === $confirmation_required) {
+			$confirmation_required = !empty($confirmation_authority);
+		}
+		if (!is_bool($confirmation_required) || (!empty($confirmation_authority) && true !== $confirmation_required)) {
+			throw new InvalidArgumentException(__('Return Confirmation provenance is invalid.', 'wc-order-splitter'));
+		}
+		$confirmation_provenance = self::create_confirmation_provenance($child_id, $original_id, $confirmation_required);
 		$context = array(
 			'return_pair' => array(
 				'schema_version' => self::SCHEMA_VERSION,
 				'authority' => $authority,
-				'pair_fingerprint' => self::authority_fingerprint($authority),
+				'confirmation_provenance' => $confirmation_provenance,
+				'pair_fingerprint' => self::authority_fingerprint($authority, $confirmation_provenance),
 			),
 			'return_plan' => $plan,
 		);
@@ -80,7 +90,7 @@ final class WCOS_Return_Journal_Context {
 		$operation_id = sanitize_key((string) $operation_id);
 		$pair = self::pair_from_context($context);
 		$authority = self::canonical_confirmation_authority($confirmation_authority);
-		if ('' === $operation_id || !is_array($pair) || !is_array($authority)
+		if ('' === $operation_id || !is_array($pair) || true !== $pair['confirmation_required'] || !is_array($authority)
 			|| $operation_id !== $authority['operation_id']
 			|| !self::confirmation_matches_pair($authority, $pair)) {
 			throw new RuntimeException(__('Return Confirmation authority does not match the locked server Return pair.', 'wc-order-splitter'));
@@ -98,7 +108,7 @@ final class WCOS_Return_Journal_Context {
 		$authority = self::canonical_confirmation_authority($stored);
 		$fingerprint = self::fingerprint(isset($stored['authority_fingerprint']) ? $stored['authority_fingerprint'] : '');
 		$operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
-		if (!is_array($pair) || !is_array($authority) || '' === $fingerprint
+		if (!is_array($pair) || true !== $pair['confirmation_required'] || !is_array($authority) || '' === $fingerprint
 			|| !hash_equals($fingerprint, self::confirmation_fingerprint($authority))
 			|| $operation_id !== $authority['operation_id']
 			|| !self::confirmation_matches_pair($authority, $pair)) {
@@ -108,15 +118,22 @@ final class WCOS_Return_Journal_Context {
 		return $authority;
 	}
 
-	/** Preserve pre-Confirmation journals while failing closed for every journal that declares or carries a handoff. */
+	/** Preserve genuine schema-v1 journals while enforcing the sealed schema-v2 Confirmation provenance. */
 	public static function confirmation_handoff_if_required(array $record) {
+		$pair = self::pair_from_record($record);
+		if (!is_array($pair)) {
+			throw new RuntimeException(__('The durable Return pair failed integrity verification.', 'wc-order-splitter'));
+		}
 		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
 		$declared = array_key_exists('return_confirmation_required', $context);
 		$stored = array_key_exists('return_confirmation', $context);
-		if (!$declared && !$stored) {
+		if (true !== $pair['confirmation_required']) {
+			if ($declared || $stored) {
+				throw new RuntimeException(__('A legacy or unconfirmed Return journal cannot acquire Confirmation authority.', 'wc-order-splitter'));
+			}
 			return null;
 		}
-		if (($declared && true !== $context['return_confirmation_required']) || !$stored || !is_array($context['return_confirmation'])) {
+		if (!$declared || true !== $context['return_confirmation_required'] || !$stored || !is_array($context['return_confirmation'])) {
 			throw new RuntimeException(__('The durable Return journal is missing its required Confirmation handoff.', 'wc-order-splitter'));
 		}
 		return self::confirmation_handoff_from_record($record);
@@ -136,17 +153,11 @@ final class WCOS_Return_Journal_Context {
 			return null;
 		}
 		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
-		$pair = isset($context['return_pair']) && is_array($context['return_pair']) ? $context['return_pair'] : array();
-		if (self::SCHEMA_VERSION !== (int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0)
-			|| !isset($pair['authority']) || !is_array($pair['authority'])) {
+		$authority = self::pair_from_context($context);
+		if (!is_array($authority)) {
 			return null;
 		}
-		$authority = self::canonical_authority($pair['authority']);
-		if (!is_array($authority) || $authority !== $pair['authority']) {
-			return null;
-		}
-		$computed = self::authority_fingerprint($authority);
-		$stored = self::fingerprint(isset($pair['pair_fingerprint']) ? $pair['pair_fingerprint'] : '');
+		$computed = $authority['pair_fingerprint'];
 		$journal = self::fingerprint(isset($record['fingerprint']) ? $record['fingerprint'] : '');
 		$plan = isset($context['return_plan']) && is_array($context['return_plan']) ? $context['return_plan'] : array();
 		try {
@@ -159,13 +170,12 @@ final class WCOS_Return_Journal_Context {
 		} catch (Throwable $throwable) {
 			return null;
 		}
-		if ('' === $stored || '' === $journal || !hash_equals($computed, $stored) || !hash_equals($computed, $journal)
+		if ('' === $journal || !hash_equals($computed, $journal)
 			|| !hash_equals($authority['plan_fingerprint'], $plan_actual)
 			|| $authority['child_order_id'] !== absint(isset($record['source_order_id']) ? $record['source_order_id'] : 0)
 			|| $authority['price_precision'] !== (int) (isset($context['price_precision']) ? $context['price_precision'] : -1)) {
 			return null;
 		}
-		$authority['pair_fingerprint'] = $computed;
 		return $authority;
 	}
 
@@ -311,9 +321,32 @@ final class WCOS_Return_Journal_Context {
 		$pair = isset($context['return_pair']) && is_array($context['return_pair']) ? $context['return_pair'] : array();
 		$authority = isset($pair['authority']) && is_array($pair['authority']) ? self::canonical_authority($pair['authority']) : null;
 		$fingerprint = self::fingerprint(isset($pair['pair_fingerprint']) ? $pair['pair_fingerprint'] : '');
-		if (self::SCHEMA_VERSION !== (int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0)
-			|| !is_array($authority) || '' === $fingerprint
-			|| !hash_equals($fingerprint, self::authority_fingerprint($authority))) {
+		$schema_version = (int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0);
+		$expected_keys = self::SCHEMA_VERSION === $schema_version
+			? array('authority', 'confirmation_provenance', 'pair_fingerprint', 'schema_version')
+			: array('authority', 'pair_fingerprint', 'schema_version');
+		$actual_keys = array_keys($pair);
+		sort($actual_keys, SORT_STRING);
+		sort($expected_keys, SORT_STRING);
+		if (!is_array($authority) || $authority !== $pair['authority'] || '' === $fingerprint || $actual_keys !== $expected_keys) {
+			return null;
+		}
+		if (self::LEGACY_SCHEMA_VERSION === $schema_version) {
+			if (!hash_equals($fingerprint, self::legacy_authority_fingerprint($authority))) {
+				return null;
+			}
+			$authority['confirmation_required'] = false;
+			$authority['confirmation_provenance'] = null;
+		} elseif (self::SCHEMA_VERSION === $schema_version) {
+			$provenance = is_array($pair['confirmation_provenance'])
+				? self::canonical_confirmation_provenance($pair['confirmation_provenance'], $authority) : null;
+			if (!is_array($provenance) || $provenance !== $pair['confirmation_provenance']
+				|| !hash_equals($fingerprint, self::authority_fingerprint($authority, $provenance))) {
+				return null;
+			}
+			$authority['confirmation_required'] = $provenance['confirmation_required'];
+			$authority['confirmation_provenance'] = $provenance;
+		} else {
 			return null;
 		}
 		$authority['pair_fingerprint'] = $fingerprint;
@@ -404,7 +437,8 @@ final class WCOS_Return_Journal_Context {
 				return false;
 			}
 		}
-		return self::SCHEMA_VERSION === (int) $confirmation['journal_context_schema_version']
+		return true === $pair['confirmation_required']
+			&& self::SCHEMA_VERSION === (int) $confirmation['journal_context_schema_version']
 			&& WCOS_Return_Order_Service::POLICY_VERSION === (int) $confirmation['return_service_policy_version'];
 	}
 
@@ -416,7 +450,53 @@ final class WCOS_Return_Journal_Context {
 		return WCOS_Mutation_Fingerprint::create('return_confirmation_handoff_v1', $canonical['child_order_id'], $canonical);
 	}
 
-	private static function authority_fingerprint(array $authority) {
+	private static function create_confirmation_provenance($child_id, $original_id, $confirmation_required) {
+		$provenance = array(
+			'schema_version' => self::CONFIRMATION_PROVENANCE_SCHEMA_VERSION,
+			'child_order_id' => absint($child_id),
+			'original_order_id' => absint($original_id),
+			'confirmation_required' => (bool) $confirmation_required,
+		);
+		$provenance['provenance_fingerprint'] = self::confirmation_provenance_fingerprint($provenance);
+		return $provenance;
+	}
+
+	private static function canonical_confirmation_provenance(array $provenance, array $authority) {
+		$expected = array('schema_version', 'child_order_id', 'original_order_id', 'confirmation_required', 'provenance_fingerprint');
+		$actual = array_keys($provenance);
+		sort($actual, SORT_STRING);
+		sort($expected, SORT_STRING);
+		$fingerprint = self::fingerprint(isset($provenance['provenance_fingerprint']) ? $provenance['provenance_fingerprint'] : '');
+		$canonical = array(
+			'schema_version' => (int) (isset($provenance['schema_version']) ? $provenance['schema_version'] : 0),
+			'child_order_id' => absint(isset($provenance['child_order_id']) ? $provenance['child_order_id'] : 0),
+			'original_order_id' => absint(isset($provenance['original_order_id']) ? $provenance['original_order_id'] : 0),
+			'confirmation_required' => isset($provenance['confirmation_required']) ? $provenance['confirmation_required'] : null,
+			'provenance_fingerprint' => $fingerprint,
+		);
+		if ($actual !== $expected || self::CONFIRMATION_PROVENANCE_SCHEMA_VERSION !== $canonical['schema_version']
+			|| $canonical['child_order_id'] !== $authority['child_order_id']
+			|| $canonical['original_order_id'] !== $authority['original_order_id']
+			|| !is_bool($canonical['confirmation_required']) || '' === $fingerprint
+			|| !hash_equals($fingerprint, self::confirmation_provenance_fingerprint($canonical))) {
+			return null;
+		}
+		return $canonical;
+	}
+
+	private static function confirmation_provenance_fingerprint(array $provenance) {
+		unset($provenance['provenance_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create('return_confirmation_provenance_v1', absint($provenance['child_order_id']), $provenance);
+	}
+
+	private static function authority_fingerprint(array $authority, array $confirmation_provenance) {
+		return WCOS_Mutation_Fingerprint::create('return_pair_authority_v2', $authority['child_order_id'], array(
+			'authority' => $authority,
+			'confirmation_provenance' => $confirmation_provenance,
+		));
+	}
+
+	private static function legacy_authority_fingerprint(array $authority) {
 		return WCOS_Mutation_Fingerprint::create('return_pair_authority_v1', $authority['child_order_id'], $authority);
 	}
 

--- a/inc/domain/class-wcos-return-journal-context.php
+++ b/inc/domain/class-wcos-return-journal-context.php
@@ -69,6 +69,7 @@ final class WCOS_Return_Journal_Context {
 			'return_plan' => $plan,
 		);
 		if (!empty($confirmation_authority)) {
+			$context['return_confirmation_required'] = true;
 			$context['return_confirmation'] = self::create_confirmation_handoff($context, $operation_id, $confirmation_authority);
 		}
 		return $context;
@@ -105,6 +106,20 @@ final class WCOS_Return_Journal_Context {
 		}
 		$authority['authority_fingerprint'] = $fingerprint;
 		return $authority;
+	}
+
+	/** Preserve pre-Confirmation journals while failing closed for every journal that declares or carries a handoff. */
+	public static function confirmation_handoff_if_required(array $record) {
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$declared = array_key_exists('return_confirmation_required', $context);
+		$stored = array_key_exists('return_confirmation', $context);
+		if (!$declared && !$stored) {
+			return null;
+		}
+		if (($declared && true !== $context['return_confirmation_required']) || !$stored || !is_array($context['return_confirmation'])) {
+			throw new RuntimeException(__('The durable Return journal is missing its required Confirmation handoff.', 'wc-order-splitter'));
+		}
+		return self::confirmation_handoff_from_record($record);
 	}
 
 	public static function assert_confirmation_matches_record(array $record, array $confirmation_authority) {

--- a/inc/domain/class-wcos-return-journal-context.php
+++ b/inc/domain/class-wcos-return-journal-context.php
@@ -7,8 +7,9 @@ final class WCOS_Return_Journal_Context {
 
 	const SCHEMA_VERSION = 1;
 	const TERMINAL_RESULT_SCHEMA_VERSION = 1;
+	const CONFIRMATION_SCHEMA_VERSION = 1;
 
-	public static function create(WC_Order $child, WC_Order $original, array $plan, array $lineage_authority, array $source_evolution_authority) {
+	public static function create(WC_Order $child, WC_Order $original, array $plan, array $lineage_authority, array $source_evolution_authority, $operation_id = '', array $confirmation_authority = array()) {
 		$child_id = absint($child->get_id());
 		$original_id = absint($original->get_id());
 		if (!$child_id || !$original_id || $child_id === $original_id
@@ -59,7 +60,7 @@ final class WCOS_Return_Journal_Context {
 		if (!is_array($authority)) {
 			throw new RuntimeException(__('The canonical Return pair authority could not be constructed.', 'wc-order-splitter'));
 		}
-		return array(
+		$context = array(
 			'return_pair' => array(
 				'schema_version' => self::SCHEMA_VERSION,
 				'authority' => $authority,
@@ -67,6 +68,52 @@ final class WCOS_Return_Journal_Context {
 			),
 			'return_plan' => $plan,
 		);
+		if (!empty($confirmation_authority)) {
+			$context['return_confirmation'] = self::create_confirmation_handoff($context, $operation_id, $confirmation_authority);
+		}
+		return $context;
+	}
+
+	/** Bind temporary server Confirmation authority into the existing Return journal context. */
+	public static function create_confirmation_handoff(array $context, $operation_id, array $confirmation_authority) {
+		$operation_id = sanitize_key((string) $operation_id);
+		$pair = self::pair_from_context($context);
+		$authority = self::canonical_confirmation_authority($confirmation_authority);
+		if ('' === $operation_id || !is_array($pair) || !is_array($authority)
+			|| $operation_id !== $authority['operation_id']
+			|| !self::confirmation_matches_pair($authority, $pair)) {
+			throw new RuntimeException(__('Return Confirmation authority does not match the locked server Return pair.', 'wc-order-splitter'));
+		}
+		$authority['authority_fingerprint'] = self::confirmation_fingerprint($authority);
+		return $authority;
+	}
+
+	/** Recover and self-verify the durable Confirmation handoff without any transient. */
+	public static function confirmation_handoff_from_record(array $record) {
+		$pair = self::pair_from_record($record);
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		$stored = isset($context['return_confirmation']) && is_array($context['return_confirmation'])
+			? $context['return_confirmation'] : array();
+		$authority = self::canonical_confirmation_authority($stored);
+		$fingerprint = self::fingerprint(isset($stored['authority_fingerprint']) ? $stored['authority_fingerprint'] : '');
+		$operation_id = sanitize_key(isset($record['operation_id']) ? (string) $record['operation_id'] : '');
+		if (!is_array($pair) || !is_array($authority) || '' === $fingerprint
+			|| !hash_equals($fingerprint, self::confirmation_fingerprint($authority))
+			|| $operation_id !== $authority['operation_id']
+			|| !self::confirmation_matches_pair($authority, $pair)) {
+			throw new RuntimeException(__('The durable Return Confirmation handoff failed integrity verification.', 'wc-order-splitter'));
+		}
+		$authority['authority_fingerprint'] = $fingerprint;
+		return $authority;
+	}
+
+	public static function assert_confirmation_matches_record(array $record, array $confirmation_authority) {
+		$durable = self::confirmation_handoff_from_record($record);
+		$current = self::canonical_confirmation_authority($confirmation_authority);
+		if (!is_array($current) || !hash_equals($durable['authority_fingerprint'], self::confirmation_fingerprint($current))) {
+			throw new RuntimeException(__('Temporary Return Confirmation authority conflicts with the durable Return journal.', 'wc-order-splitter'));
+		}
+		return $durable;
 	}
 
 	public static function pair_from_record(array $record) {
@@ -243,6 +290,115 @@ final class WCOS_Return_Journal_Context {
 			$canonical[$field] = self::fingerprint($authority[$field]);
 		}
 		return '' === $canonical['split_operation_id'] || '' === $canonical['split_child_key'] ? null : $canonical;
+	}
+
+	public static function pair_from_context(array $context) {
+		$pair = isset($context['return_pair']) && is_array($context['return_pair']) ? $context['return_pair'] : array();
+		$authority = isset($pair['authority']) && is_array($pair['authority']) ? self::canonical_authority($pair['authority']) : null;
+		$fingerprint = self::fingerprint(isset($pair['pair_fingerprint']) ? $pair['pair_fingerprint'] : '');
+		if (self::SCHEMA_VERSION !== (int) (isset($pair['schema_version']) ? $pair['schema_version'] : 0)
+			|| !is_array($authority) || '' === $fingerprint
+			|| !hash_equals($fingerprint, self::authority_fingerprint($authority))) {
+			return null;
+		}
+		$authority['pair_fingerprint'] = $fingerprint;
+		return $authority;
+	}
+
+	private static function canonical_confirmation_authority(array $authority) {
+		$copy = $authority;
+		unset($copy['authority_fingerprint'], $copy['token_hash'], $copy['confirmation_token'], $copy['created_at'], $copy['expires_at'], $copy['replay_authority']);
+		$expected = array(
+			'child_order_id', 'confirmation_schema_version', 'currency', 'journal_context_schema_version',
+			'lineage_authority_fingerprint', 'lineage_policy_version', 'lineage_schema_version', 'operation_id',
+			'operator_user_id', 'order_stock_flag_policy', 'original_order_id', 'pair_fingerprint',
+			'plan_fingerprint', 'plan_policy_version', 'plan_schema_version', 'preflight_policy_version',
+			'price_precision', 'prices_include_tax', 'retirement_policy_identifier',
+			'retirement_policy_schema_version', 'return_service_policy_version',
+			'source_evolution_authority_fingerprint', 'split_child_key', 'split_operation_id', 'stock_ownership_policy',
+		);
+		$actual = array_keys($copy);
+		sort($actual, SORT_STRING);
+		sort($expected, SORT_STRING);
+		if ($actual !== $expected) {
+			return null;
+		}
+		$canonical = array(
+			'confirmation_schema_version' => (int) $copy['confirmation_schema_version'],
+			'operation_id' => sanitize_key((string) $copy['operation_id']),
+			'operator_user_id' => absint($copy['operator_user_id']),
+			'child_order_id' => absint($copy['child_order_id']),
+			'original_order_id' => absint($copy['original_order_id']),
+			'split_operation_id' => sanitize_key((string) $copy['split_operation_id']),
+			'split_child_key' => sanitize_key((string) $copy['split_child_key']),
+			'pair_fingerprint' => self::fingerprint($copy['pair_fingerprint']),
+			'plan_fingerprint' => self::fingerprint($copy['plan_fingerprint']),
+			'lineage_authority_fingerprint' => self::fingerprint($copy['lineage_authority_fingerprint']),
+			'source_evolution_authority_fingerprint' => self::fingerprint($copy['source_evolution_authority_fingerprint']),
+			'price_precision' => (int) $copy['price_precision'],
+			'currency' => (string) $copy['currency'],
+			'prices_include_tax' => $copy['prices_include_tax'],
+			'return_service_policy_version' => (int) $copy['return_service_policy_version'],
+			'preflight_policy_version' => (int) $copy['preflight_policy_version'],
+			'plan_schema_version' => (int) $copy['plan_schema_version'],
+			'plan_policy_version' => (int) $copy['plan_policy_version'],
+			'lineage_schema_version' => (int) $copy['lineage_schema_version'],
+			'lineage_policy_version' => (int) $copy['lineage_policy_version'],
+			'journal_context_schema_version' => (int) $copy['journal_context_schema_version'],
+			'retirement_policy_schema_version' => (int) $copy['retirement_policy_schema_version'],
+			'retirement_policy_identifier' => sanitize_key((string) $copy['retirement_policy_identifier']),
+			'stock_ownership_policy' => sanitize_key((string) $copy['stock_ownership_policy']),
+			'order_stock_flag_policy' => sanitize_key((string) $copy['order_stock_flag_policy']),
+		);
+		if (self::CONFIRMATION_SCHEMA_VERSION !== $canonical['confirmation_schema_version']
+			|| '' === $canonical['operation_id'] || !$canonical['operator_user_id']
+			|| !$canonical['child_order_id'] || !$canonical['original_order_id']
+			|| $canonical['child_order_id'] === $canonical['original_order_id']
+			|| '' === $canonical['split_operation_id'] || '' === $canonical['split_child_key']
+			|| in_array('', array($canonical['pair_fingerprint'], $canonical['plan_fingerprint'], $canonical['lineage_authority_fingerprint'], $canonical['source_evolution_authority_fingerprint']), true)
+			|| WCOS_Price_Precision_Scope::validate($canonical['price_precision']) !== $canonical['price_precision']
+			|| 1 !== preg_match('/^[A-Z]{3}$/D', $canonical['currency'])
+			|| !in_array($canonical['prices_include_tax'], array(true, false), true)
+			|| WCOS_Return_Order_Service::POLICY_VERSION !== $canonical['return_service_policy_version']
+			|| WCOS_Return_Preflight::POLICY_VERSION !== $canonical['preflight_policy_version']
+			|| WCOS_Return_Plan::SCHEMA_VERSION !== $canonical['plan_schema_version']
+			|| WCOS_Return_Plan::POLICY_VERSION !== $canonical['plan_policy_version']
+			|| WCOS_Return_Lineage_Authority::SCHEMA_VERSION !== $canonical['lineage_schema_version']
+			|| WCOS_Return_Lineage_Authority::POLICY_VERSION !== $canonical['lineage_policy_version']
+			|| self::SCHEMA_VERSION !== $canonical['journal_context_schema_version']
+			|| WCOS_Return_Retirement_Policy::SCHEMA_VERSION !== $canonical['retirement_policy_schema_version']
+			|| WCOS_Return_Retirement_Policy::approved_identifier() !== $canonical['retirement_policy_identifier']
+			|| WCOS_Return_Retirement_Policy::STOCK_OWNERSHIP_POLICY !== $canonical['stock_ownership_policy']
+			|| WCOS_Return_Retirement_Policy::ORDER_STOCK_FLAG_POLICY !== $canonical['order_stock_flag_policy']) {
+			return null;
+		}
+		return $canonical;
+	}
+
+	private static function confirmation_matches_pair(array $confirmation, array $pair) {
+		$fields = array(
+			'child_order_id', 'original_order_id', 'split_operation_id', 'split_child_key', 'pair_fingerprint',
+			'plan_fingerprint', 'lineage_authority_fingerprint', 'source_evolution_authority_fingerprint',
+			'price_precision', 'currency', 'prices_include_tax', 'preflight_policy_version', 'plan_schema_version',
+			'plan_policy_version', 'lineage_schema_version', 'lineage_policy_version',
+			'retirement_policy_schema_version', 'retirement_policy_identifier', 'stock_ownership_policy', 'order_stock_flag_policy',
+		);
+		foreach ($fields as $field) {
+			if (!array_key_exists($field, $confirmation) || !array_key_exists($field, $pair)
+				|| (string) $confirmation[$field] !== (string) $pair[$field]) {
+				return false;
+			}
+		}
+		return self::SCHEMA_VERSION === (int) $confirmation['journal_context_schema_version']
+			&& WCOS_Return_Order_Service::POLICY_VERSION === (int) $confirmation['return_service_policy_version'];
+	}
+
+	private static function confirmation_fingerprint(array $authority) {
+		$canonical = self::canonical_confirmation_authority($authority);
+		if (!is_array($canonical)) {
+			return '';
+		}
+		return WCOS_Mutation_Fingerprint::create('return_confirmation_handoff_v1', $canonical['child_order_id'], $canonical);
 	}
 
 	private static function authority_fingerprint(array $authority) {

--- a/inc/domain/class-wcos-return-order-service.php
+++ b/inc/domain/class-wcos-return-order-service.php
@@ -201,19 +201,14 @@ final class WCOS_Return_Order_Service {
 		if ((int) $pair['price_precision'] !== (int) $precision) {
 			throw new RuntimeException(__('This Return operation carries conflicting precision authority.', 'wc-order-splitter'));
 		}
-		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
-		if (array_key_exists('return_confirmation_required', $context)
-			|| array_key_exists('return_confirmation', $context) || !empty($confirmation_authority)) {
-			try {
-				if (empty($confirmation_authority)) {
-					WCOS_Return_Journal_Context::confirmation_handoff_if_required($record);
-				} else {
-					WCOS_Return_Journal_Context::assert_confirmation_matches_record($record, $confirmation_authority);
-				}
-			} catch (Throwable $throwable) {
-				$this->quarantine_replay_authority($child_id, $operation_id, 'return_confirmation_replay_integrity_failed');
-				throw new RuntimeException(__('The Return pair requires manual reconciliation.', 'wc-order-splitter'), 0, $throwable);
+		try {
+			WCOS_Return_Journal_Context::confirmation_handoff_if_required($record);
+			if (!empty($confirmation_authority)) {
+				WCOS_Return_Journal_Context::assert_confirmation_matches_record($record, $confirmation_authority);
 			}
+		} catch (Throwable $throwable) {
+			$this->quarantine_replay_authority($child_id, $operation_id, 'return_confirmation_replay_integrity_failed');
+			throw new RuntimeException(__('The Return pair requires manual reconciliation.', 'wc-order-splitter'), 0, $throwable);
 		}
 		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		if ('completed' !== $status) {

--- a/inc/domain/class-wcos-return-order-service.php
+++ b/inc/domain/class-wcos-return-order-service.php
@@ -8,7 +8,7 @@ final class WCOS_Return_Order_Service {
 	const TYPE = 'return';
 	const POLICY_VERSION = 1;
 
-	public function return_order(WC_Order $child, $operation_id, $precision) {
+	public function return_order(WC_Order $child, $operation_id, $precision, array $confirmation_authority = array()) {
 		$operation_id = sanitize_key((string) $operation_id);
 		$child_id = absint($child->get_id());
 		$precision = WCOS_Price_Precision_Scope::validate($precision);
@@ -18,7 +18,7 @@ final class WCOS_Return_Order_Service {
 
 		$existing = WCOS_Operation_Journal::get($child, $operation_id);
 		if (is_array($existing)) {
-			return $this->replay_existing($child_id, $operation_id, $precision, $existing);
+			return $this->replay_existing($child_id, $operation_id, $precision, $existing, $confirmation_authority);
 		}
 
 		$report = WCOS_Return_Preflight::assert_supported($child, true);
@@ -42,7 +42,7 @@ final class WCOS_Return_Order_Service {
 			$original = $this->load_order($original_id, 'original');
 			$existing = WCOS_Operation_Journal::get($child, $operation_id);
 			if (is_array($existing)) {
-				return $this->replay_existing($child_id, $operation_id, $precision, $existing);
+				return $this->replay_existing($child_id, $operation_id, $precision, $existing, $confirmation_authority);
 			}
 			$lease->assert_owned();
 			$locked_report = WCOS_Return_Preflight::assert_supported($child, true);
@@ -59,7 +59,9 @@ final class WCOS_Return_Order_Service {
 				$original,
 				$plan,
 				$lineage,
-				$lineage['source_evolution_authority']
+				$lineage['source_evolution_authority'],
+				$operation_id,
+				$confirmation_authority
 			);
 			$fingerprint = (string) $context['return_pair']['pair_fingerprint'];
 
@@ -191,13 +193,26 @@ final class WCOS_Return_Order_Service {
 		}
 	}
 
-	private function replay_existing($child_id, $operation_id, $precision, array $record) {
+	private function replay_existing($child_id, $operation_id, $precision, array $record, array $confirmation_authority = array()) {
 		$pair = WCOS_Return_Journal_Context::pair_from_record($record);
 		if (!is_array($pair) || (int) $pair['child_order_id'] !== (int) $child_id) {
 			$this->recover_invalid_replay_authority($child_id, $operation_id, $record);
 		}
 		if ((int) $pair['price_precision'] !== (int) $precision) {
 			throw new RuntimeException(__('This Return operation carries conflicting precision authority.', 'wc-order-splitter'));
+		}
+		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
+		if (!empty($context['return_confirmation']) || !empty($confirmation_authority)) {
+			try {
+				if (empty($confirmation_authority)) {
+					WCOS_Return_Journal_Context::confirmation_handoff_from_record($record);
+				} else {
+					WCOS_Return_Journal_Context::assert_confirmation_matches_record($record, $confirmation_authority);
+				}
+			} catch (Throwable $throwable) {
+				$this->quarantine_replay_authority($child_id, $operation_id, 'return_confirmation_replay_integrity_failed');
+				throw new RuntimeException(__('The Return pair requires manual reconciliation.', 'wc-order-splitter'), 0, $throwable);
+			}
 		}
 		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		if ('completed' !== $status) {
@@ -220,7 +235,7 @@ final class WCOS_Return_Order_Service {
 		$child = $this->load_order($child_id, 'child');
 		$status = sanitize_key(isset($record['status']) ? (string) $record['status'] : '');
 		if ('completed' === $status) {
-			$this->quarantine_completed_replay($child_id, $operation_id, 'invalid_completed_return_pair_authority');
+			$this->quarantine_replay_authority($child_id, $operation_id, 'invalid_completed_return_pair_authority');
 			$status = 'manual_reconciliation';
 		} elseif (!in_array($status, array('compensated', 'manual_reconciliation', 'manual_reconciled'), true)) {
 			WCOS_Operation_Journal::require_recovery($child, $operation_id, array('reason' => 'invalid_return_replay_authority'));
@@ -245,24 +260,24 @@ final class WCOS_Return_Order_Service {
 			return WCOS_Return_Journal_Context::terminal_result_from_record($record);
 		} catch (Throwable $throwable) {
 			if (is_array($record) && 'completed' === sanitize_key(isset($record['status']) ? (string) $record['status'] : '')) {
-				$this->quarantine_completed_replay($child_id, $operation_id, 'completed_return_replay_integrity_failed');
+				$this->quarantine_replay_authority($child_id, $operation_id, 'completed_return_replay_integrity_failed');
 				throw new RuntimeException(__('The Return pair requires manual reconciliation.', 'wc-order-splitter'), 0, $throwable);
 			}
 			throw $throwable;
 		}
 	}
 
-	private function quarantine_completed_replay($child_id, $operation_id, $reason) {
+	private function quarantine_replay_authority($child_id, $operation_id, $reason) {
 		$child = $this->load_order($child_id, 'child');
 		$record = WCOS_Operation_Journal::get($child, $operation_id);
 		if (!is_array($record)) {
-			throw new RuntimeException(__('Completed Return authority disappeared before reconciliation quarantine.', 'wc-order-splitter'));
+			throw new RuntimeException(__('Return authority disappeared before reconciliation quarantine.', 'wc-order-splitter'));
 		}
 		$pair = WCOS_Return_Journal_Context::pair_from_record($record);
 		$original = is_array($pair) ? wc_get_order($pair['original_order_id']) : null;
 		if (!$original instanceof WC_Order || 'shop_order' !== $original->get_type()) { $original = null; }
 		if ('manual_reconciliation' !== WCOS_Return_Compensator::manual_reconciliation($child, $original, $record, $reason)) {
-			throw new RuntimeException(__('Completed Return authority could not be quarantined.', 'wc-order-splitter'));
+			throw new RuntimeException(__('Return authority could not be quarantined.', 'wc-order-splitter'));
 		}
 	}
 

--- a/inc/domain/class-wcos-return-order-service.php
+++ b/inc/domain/class-wcos-return-order-service.php
@@ -202,10 +202,11 @@ final class WCOS_Return_Order_Service {
 			throw new RuntimeException(__('This Return operation carries conflicting precision authority.', 'wc-order-splitter'));
 		}
 		$context = isset($record['context']) && is_array($record['context']) ? $record['context'] : array();
-		if (!empty($context['return_confirmation']) || !empty($confirmation_authority)) {
+		if (array_key_exists('return_confirmation_required', $context)
+			|| array_key_exists('return_confirmation', $context) || !empty($confirmation_authority)) {
 			try {
 				if (empty($confirmation_authority)) {
-					WCOS_Return_Journal_Context::confirmation_handoff_from_record($record);
+					WCOS_Return_Journal_Context::confirmation_handoff_if_required($record);
 				} else {
 					WCOS_Return_Journal_Context::assert_confirmation_matches_record($record, $confirmation_authority);
 				}

--- a/inc/domain/class-wcos-return-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-return-woocommerce-adapter.php
@@ -19,7 +19,7 @@ final class WCOS_Return_Adapter_Exception extends RuntimeException {
 /** WooCommerce-facing, transport-free adapter for the hardened Return service. */
 final class WCOS_Return_WooCommerce_Adapter {
 
-	public function return_order(WC_Order $child, $operation_id, $confirmed_precision = null) {
+	public function return_order(WC_Order $child, $operation_id, $confirmed_precision = null, array $confirmation_authority = array()) {
 		$operation_id = sanitize_key((string) $operation_id);
 		$child_id = absint($child->get_id());
 		if ('' === $operation_id) { throw new WCOS_Return_Adapter_Exception('invalid_operation_id', __('A Return operation ID is required.', 'wc-order-splitter')); }
@@ -63,7 +63,7 @@ final class WCOS_Return_WooCommerce_Adapter {
 			add_action('wcos_return_mutation_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
 			add_action('wcos_return_recovery_checkpoint', $boundary_guard, PHP_INT_MAX, 4);
 			try {
-				$result = (new WCOS_Return_Order_Service())->return_order($child, $operation_id, $precision);
+				$result = (new WCOS_Return_Order_Service())->return_order($child, $operation_id, $precision, $confirmation_authority);
 				WCOS_Stock_Side_Effect_Guard::assert_clean($stock_token);
 				return $result;
 			} catch (WCOS_Return_Adapter_Exception $exception) {

--- a/tests/integration/return-confirm-race-cleanup.php
+++ b/tests/integration/return-confirm-race-cleanup.php
@@ -1,0 +1,24 @@
+<?php
+
+if (!defined('ABSPATH')) { exit(1); }
+
+$fixture_key = 'wcos_return_confirm_race_fixture';
+$fixture = get_option($fixture_key, array());
+if (!is_array($fixture) || empty($fixture)) { echo "RETURN_RACE_ALREADY_CLEAN\n"; exit(0); }
+if (!empty($fixture['review_id'])) { WCOS_Return_Review_Store::delete($fixture['review_id']); }
+foreach (array('child_id', 'original_id') as $key) {
+	$order = !empty($fixture[$key]) ? wc_get_order(absint($fixture[$key])) : false;
+	if ($order instanceof WC_Order) {
+		$summary = $order->get_meta(WCOS_Operation_Journal::SUMMARY_META_KEY, true);
+		foreach (is_array($summary) ? $summary : array() as $entry) {
+			if (!empty($entry['operation_id'])) { WCOS_Operation_Journal::delete($order, $entry['operation_id']); }
+		}
+		$order->delete(true);
+	}
+}
+$product = !empty($fixture['product_id']) ? wc_get_product(absint($fixture['product_id'])) : false;
+if ($product instanceof WC_Product) { $product->delete(true); }
+if (!function_exists('wp_delete_user')) { require_once ABSPATH . 'wp-admin/includes/user.php'; }
+if (!empty($fixture['user_id'])) { wp_delete_user(absint($fixture['user_id'])); }
+delete_option($fixture_key);
+echo "RETURN_RACE_CLEAN\n";

--- a/tests/integration/return-confirm-race-fixture.php
+++ b/tests/integration/return-confirm-race-fixture.php
@@ -1,0 +1,40 @@
+<?php
+
+if (!defined('ABSPATH')) { exit(1); }
+
+$fixture_key = 'wcos_return_confirm_race_fixture';
+if (!function_exists('wp_delete_user')) { require_once ABSPATH . 'wp-admin/includes/user.php'; }
+$user_id = wp_insert_user(array(
+	'user_login' => 'wcos_return_confirm_race_' . wp_generate_password(8, false),
+	'user_pass' => wp_generate_password(24, true),
+	'user_email' => 'wcos-return-confirm-race-' . wp_generate_uuid4() . '@example.test',
+	'role' => 'administrator',
+));
+if (is_wp_error($user_id)) { fwrite(STDERR, "RETURN_RACE_USER_FAILED\n"); exit(2); }
+wp_set_current_user($user_id);
+
+$product = new WC_Product_Simple(); $product->set_name('WCOS Return Confirm Race'); $product->set_regular_price('8.00'); $product->set_price('8.00'); $product->save();
+$order = wc_create_order(); $order->set_status('pending'); $order->set_currency('USD');
+$item_id = $order->add_product($product, 2); $order->calculate_totals(false); $order->save();
+$children = (new WCOS_Mutation_Gateway())->split(
+	wc_get_order($order->get_id()),
+	array('return-race-child' => array($item_id => '1.000000')),
+	'return-race-split-' . wp_generate_uuid4(),
+	2
+);
+if (1 !== count($children)) { fwrite(STDERR, "RETURN_RACE_SPLIT_FAILED\n"); exit(3); }
+$child = $children[0];
+$controller = new WCOS_Return_Admin_Controller();
+$review = $controller->review_request(array(
+	'child_order_id' => $child->get_id(),
+	'nonce' => wp_create_nonce('wcos_return_order_' . $child->get_id()),
+));
+update_option($fixture_key, array(
+	'user_id' => absint($user_id),
+	'product_id' => $product->get_id(),
+	'original_id' => $order->get_id(),
+	'child_id' => $child->get_id(),
+	'review_id' => sanitize_key((string) $review['review_id']),
+	'review_token' => (string) $review['review_token'],
+), false);
+echo 'RETURN_RACE_FIXTURE_READY child=' . $child->get_id() . ' review=' . $review['review_id'] . "\n";

--- a/tests/integration/return-confirm-race-worker.php
+++ b/tests/integration/return-confirm-race-worker.php
@@ -1,0 +1,27 @@
+<?php
+
+if (!defined('ABSPATH')) { exit(1); }
+
+$label = isset($args[0]) ? sanitize_key((string) $args[0]) : '';
+$fixture = get_option('wcos_return_confirm_race_fixture', array());
+if ('' === $label || empty($fixture['child_id']) || empty($fixture['review_id']) || empty($fixture['review_token'])) {
+	fwrite(STDERR, "RETURN_RACE_WORKER_INVALID_INPUT\n"); exit(2);
+}
+wp_set_current_user(absint($fixture['user_id']));
+$controller = new WCOS_Return_Admin_Controller();
+try {
+	$result = $controller->confirm_request(array(
+		'child_order_id' => absint($fixture['child_id']),
+		'nonce' => wp_create_nonce('wcos_return_order_' . absint($fixture['child_id'])),
+		'review_id' => sanitize_key((string) $fixture['review_id']),
+		'review_token' => (string) $fixture['review_token'],
+	));
+	echo 'CONFIRMED ' . $label . ' ' . sanitize_key((string) $result['operation_id']) . ' ' . (string) $result['confirmation_token'] . "\n";
+	exit(0);
+} catch (WCOS_Return_Transport_Exception $exception) {
+	echo 'REJECTED ' . $label . ' ' . $exception->get_error_code() . "\n";
+	exit(0);
+} catch (Throwable $throwable) {
+	fwrite(STDERR, 'RETURN_RACE_WORKER_FAILED ' . $label . ' ' . get_class($throwable) . ': ' . $throwable->getMessage() . "\n");
+	exit(3);
+}

--- a/tests/integration/return-review-confirm-authority-smoke.php
+++ b/tests/integration/return-review-confirm-authority-smoke.php
@@ -240,6 +240,13 @@ try {
 	wcos_return_authority_assert('completed' === $result['status'], 'Confirmed lower-level Return did not complete.');
 	$journal = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
 	$handoff = WCOS_Return_Journal_Context::confirmation_handoff_from_record($journal);
+	$sealed_pair = WCOS_Return_Journal_Context::pair_from_record($journal);
+	wcos_return_authority_assert(
+		is_array($sealed_pair) && true === $sealed_pair['confirmation_required']
+		&& WCOS_Return_Journal_Context::SCHEMA_VERSION === (int) $journal['context']['return_pair']['schema_version']
+		&& WCOS_Return_Journal_Context::CONFIRMATION_PROVENANCE_SCHEMA_VERSION === (int) $sealed_pair['confirmation_provenance']['schema_version'],
+		'Confirmed Return journal did not seal versioned Confirmation provenance into its pair authority.'
+	);
 	wcos_return_authority_assert(true === $journal['context']['return_confirmation_required'], 'Confirmed Return journal did not declare mandatory handoff authority.');
 	wcos_return_authority_assert($confirm['operation_id'] === $handoff['operation_id'] && $operator_id === $handoff['operator_user_id'], 'Return journal did not bind exact operation/operator Confirmation authority.');
 	wcos_return_authority_assert($confirmed['pair_fingerprint'] === $handoff['pair_fingerprint'] && $confirmed['plan_fingerprint'] === $handoff['plan_fingerprint'], 'Return journal handoff changed frozen pair/plan authority.');
@@ -258,6 +265,33 @@ try {
 	$removed_marker = $journal;
 	unset($removed_marker['context']['return_confirmation_required']);
 	wcos_return_authority_assert(false === $immutable_method->invoke(null, $journal, $removed_marker), 'Return journal accepted Confirmation requirement removal.');
+	$legacy_fingerprint_method = (new ReflectionClass('WCOS_Return_Journal_Context'))->getMethod('legacy_authority_fingerprint');
+	$legacy_fingerprint_method->setAccessible(true);
+	$legacy_journal = $journal;
+	unset(
+		$legacy_journal['context']['return_pair']['confirmation_provenance'],
+		$legacy_journal['context']['return_confirmation_required'],
+		$legacy_journal['context']['return_confirmation']
+	);
+	$legacy_journal['context']['return_pair']['schema_version'] = WCOS_Return_Journal_Context::LEGACY_SCHEMA_VERSION;
+	$legacy_journal['context']['return_pair']['pair_fingerprint'] = $legacy_fingerprint_method->invoke(
+		null,
+		$legacy_journal['context']['return_pair']['authority']
+	);
+	$legacy_journal['fingerprint'] = $legacy_journal['context']['return_pair']['pair_fingerprint'];
+	wcos_return_authority_assert(is_array(WCOS_Return_Journal_Context::pair_from_record($legacy_journal)), 'Genuine schema-v1 Return journal compatibility was not preserved.');
+	wcos_return_authority_assert(null === WCOS_Return_Journal_Context::confirmation_handoff_if_required($legacy_journal), 'Genuine schema-v1 Return journal was incorrectly treated as Confirmation-required.');
+	$legacy_with_confirmation = $legacy_journal;
+	$legacy_with_confirmation['context']['return_confirmation_required'] = true;
+	$legacy_with_confirmation['context']['return_confirmation'] = $journal['context']['return_confirmation'];
+	wcos_return_authority_assert(
+		false === $immutable_method->invoke(null, $legacy_journal, $legacy_with_confirmation),
+		'Legacy Return journal accepted addition of both Confirmation fields.'
+	);
+	$legacy_addition_rejected = false;
+	try { WCOS_Return_Journal_Context::confirmation_handoff_if_required($legacy_with_confirmation); }
+	catch (Throwable $throwable) { $legacy_addition_rejected = true; }
+	wcos_return_authority_assert($legacy_addition_rejected, 'Legacy Return journal addition was treated as valid Confirmation authority.');
 
 	WCOS_Return_Confirmation_Store::delete($confirm['operation_id']);
 	$durable = WCOS_Return_Confirmation_Store::verify(wc_get_order($primary['child_id']), $confirm['operation_id'], '', $operator_id);
@@ -324,14 +358,16 @@ try {
 	}
 	wcos_return_authority_assert($manual_reconciled_closed, 'Manual-reconciled confirmed Return journal remained replayable.');
 
-	foreach (array('corrupt' => false, 'missing' => true) as $confirmation_fault => $remove_handoff) {
+	foreach (array('corrupt', 'missing', 'stripped') as $confirmation_fault) {
 		$fault = wcos_return_authority_fixture('confirmed-recovery-' . $confirmation_fault, 'manual_quantity');
 		$fixtures[] = $fault; $fault_index = count($fixtures) - 1;
 		list($fault_confirm, $fault_confirmation, $fault_journal) = wcos_return_authority_freeze_recovery($controller, $fault, $operator_id);
 		$fixtures[$fault_index]['operation_ids'][] = $fault_confirm['operation_id'];
 		WCOS_Return_Confirmation_Store::delete($fault_confirm['operation_id']);
-		if ($remove_handoff) {
+		if ('missing' === $confirmation_fault) {
 			unset($fault_journal['context']['return_confirmation']);
+		} elseif ('stripped' === $confirmation_fault) {
+			unset($fault_journal['context']['return_confirmation_required'], $fault_journal['context']['return_confirmation']);
 		} else {
 			$fault_journal['context']['return_confirmation']['authority_fingerprint'] = hash('sha256', 'confirmed-recovery-corruption');
 		}
@@ -461,7 +497,7 @@ try {
 	wcos_return_authority_assert($legacy_rejected, 'Legacy yoos_* metadata minted Return Review authority.');
 	$legacy_child->delete(true); $legacy_original->delete(true); $legacy_product->delete(true);
 
-	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 immutable_handoff=1 confirmed_states=4 corrupt_recovery=2 cas_single_consume=1\n";
+	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 immutable_handoff=1 legacy_addition_rejected=1 confirmed_states=4 corrupt_recovery=3 stripped_confirmed_quarantined=1 cas_single_consume=1\n";
 } finally {
 	foreach (array_reverse($fixtures) as $fixture) {
 		try { wcos_return_authority_cleanup($fixture); } catch (Throwable $throwable) {}

--- a/tests/integration/return-review-confirm-authority-smoke.php
+++ b/tests/integration/return-review-confirm-authority-smoke.php
@@ -1,0 +1,341 @@
+<?php
+
+if (!defined('ABSPATH')) { exit(1); }
+
+function wcos_return_authority_assert($condition, $message) {
+	if (!$condition) { throw new RuntimeException($message); }
+}
+
+function wcos_return_authority_fixture($label, $strategy = 'manual_quantity') {
+	$product = new WC_Product_Simple();
+	$product->set_name('WCOS Return authority ' . $label);
+	$product->set_regular_price('10.00'); $product->set_price('10.00'); $product->set_manage_stock(false);
+	wcos_return_authority_assert($product->save() > 0, 'Return authority product fixture could not be saved.');
+	$keep = new WC_Product_Simple();
+	$keep->set_name('WCOS Return authority keep ' . $label);
+	$keep->set_regular_price('3.00'); $keep->set_price('3.00'); $keep->set_manage_stock(false);
+	wcos_return_authority_assert($keep->save() > 0, 'Return authority keep product could not be saved.');
+
+	$original = wc_create_order();
+	$original->set_status('pending'); $original->set_currency('USD'); $original->set_prices_include_tax(false);
+	$original->set_billing_first_name('Private'); $original->set_billing_last_name('Return');
+	$original->set_billing_email('return-authority-' . wp_generate_uuid4() . '@example.test');
+	$original->set_billing_address_1('99 Private Return Street'); $original->set_payment_method('cod');
+	$item_id = $original->add_product($product, 2);
+	$keep_item_id = $original->add_product($keep, 1);
+	$original->calculate_totals(false); $original->save();
+	$split_operation = 'return-authority-split-' . wp_generate_uuid4();
+
+	if ('manual_quantity' === $strategy) {
+		$children = (new WCOS_Mutation_Gateway())->split(
+			wc_get_order($original->get_id()),
+			array('return-authority-child' => array($item_id => '1.000000')),
+			$split_operation,
+			2
+		);
+	} else {
+		$children = (new WCOS_Split_WooCommerce_Adapter())->split(
+			wc_get_order($original->get_id()),
+			array('return-authority-child' => array($item_id => '2.000000')),
+			$split_operation,
+			2,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			array('strategy_authority' => array(
+				'strategy' => $strategy,
+				'planner_policy_version' => 'category' === $strategy ? WCOS_Category_Split_Planner::POLICY_VERSION : WCOS_Stock_Status_Split_Planner::POLICY_VERSION,
+				'classification_fingerprint' => hash('sha256', 'return-authority-' . $strategy . '-' . $label),
+				'source_bucket_key' => $strategy . '-source',
+				'review_source_signature' => WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($original->get_id())),
+			))
+		);
+	}
+	wcos_return_authority_assert(1 === count($children), 'Return authority Split did not create exactly one child.');
+	return array(
+		'product_ids' => array($product->get_id(), $keep->get_id()),
+		'original_id' => $original->get_id(),
+		'child_id' => $children[0]->get_id(),
+		'item_id' => $item_id,
+		'keep_item_id' => $keep_item_id,
+		'strategy' => $strategy,
+		'review_ids' => array(),
+		'operation_ids' => array(),
+	);
+}
+
+function wcos_return_authority_request(array $fixture) {
+	return array(
+		'child_order_id' => $fixture['child_id'],
+		'nonce' => wp_create_nonce('wcos_return_order_' . $fixture['child_id']),
+	);
+}
+
+function wcos_return_authority_cleanup(array $fixture) {
+	delete_option('wcos_manual_reconcile_block_' . absint($fixture['child_id']));
+	delete_option('wcos_manual_reconcile_block_' . absint($fixture['original_id']));
+	foreach (isset($fixture['review_ids']) ? $fixture['review_ids'] : array() as $review_id) {
+		WCOS_Return_Review_Store::delete($review_id);
+	}
+	foreach (isset($fixture['operation_ids']) ? $fixture['operation_ids'] : array() as $operation_id) {
+		WCOS_Return_Confirmation_Store::delete($operation_id);
+		$child = wc_get_order($fixture['child_id']);
+		if ($child instanceof WC_Order) { WCOS_Operation_Journal::delete($child, $operation_id); }
+	}
+	foreach (array($fixture['child_id'], $fixture['original_id']) as $order_id) {
+		$order = wc_get_order($order_id);
+		if ($order instanceof WC_Order) {
+			$summary = $order->get_meta(WCOS_Operation_Journal::SUMMARY_META_KEY, true);
+			foreach (is_array($summary) ? $summary : array() as $entry) {
+				if (!empty($entry['operation_id'])) { WCOS_Operation_Journal::delete($order, $entry['operation_id']); }
+			}
+			$order->delete(true);
+		}
+	}
+	foreach ($fixture['product_ids'] as $product_id) {
+		$product = wc_get_product($product_id);
+		if ($product instanceof WC_Product) { $product->delete(true); }
+	}
+}
+
+function wcos_return_authority_transient($prefix, $id) {
+	return $prefix . hash('sha256', sanitize_key((string) $id));
+}
+
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_return_authority_assert(!empty($admins), 'Return authority smoke requires an administrator.');
+$operator_id = absint($admins[0]);
+wp_set_current_user($operator_id);
+$controller = new WCOS_Return_Admin_Controller();
+$fixtures = array();
+
+wcos_return_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return production gate drifted on.');
+wcos_return_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return production gate drifted on.');
+wcos_return_authority_assert(null === WCOS_Return_Admin_Controller::bootstrap(), 'Hard-off Return bootstrap returned a controller.');
+wcos_return_authority_assert(false === $controller->register_hooks(), 'Hard-off Return controller registered hooks.');
+foreach (array(WCOS_Return_Admin_Controller::REVIEW_ACTION, WCOS_Return_Admin_Controller::CONFIRM_ACTION, WCOS_Return_Admin_Controller::EXECUTE_ACTION) as $action) {
+	wcos_return_authority_assert(false === has_action('wp_ajax_' . $action), 'Hard-off Return AJAX hook was registered: ' . $action);
+}
+
+try {
+	foreach (array('manual_quantity', 'category', 'stock_status') as $strategy) {
+		$fixture = wcos_return_authority_fixture('strategy-' . $strategy, $strategy);
+		$fixtures[] = $fixture;
+		$index = count($fixtures) - 1;
+		$request = wcos_return_authority_request($fixture);
+		$child_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id']));
+		$original_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id']));
+		$review = $controller->review_request($request);
+		$fixtures[$index]['review_ids'][] = $review['review_id'];
+		wcos_return_authority_assert($strategy === $review['summary']['strategy'], 'Return Review lost exact Split strategy display authority.');
+		wcos_return_authority_assert($fixture['original_id'] === $review['summary']['original']['id'], 'Return Review did not server-resolve the exact original.');
+		$review_json = wp_json_encode($review);
+		wcos_return_authority_assert(false === strpos($review_json, '@example.test') && false === strpos($review_json, 'Private Return Street'), 'Return Review payload exposed customer PII.');
+
+		$review_record = get_transient(wcos_return_authority_transient('wcos_return_review_', $review['review_id']));
+		wcos_return_authority_assert(is_array($review_record) && !empty($review_record['token_hash']), 'Return Review did not persist hash-only token authority.');
+		wcos_return_authority_assert(false === strpos(wp_json_encode($review_record), $review['review_token']), 'Raw Return Review token was persisted.');
+
+		$confirm = $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		$fixtures[$index]['operation_ids'][] = $confirm['operation_id'];
+		wcos_return_authority_assert($fixture['original_id'] === $confirm['original_order_id'], 'Return Confirm changed server-resolved original authority.');
+		$confirmation = WCOS_Return_Confirmation_Store::verify(wc_get_order($fixture['child_id']), $confirm['operation_id'], $confirm['confirmation_token'], $operator_id);
+		$confirmation_again = WCOS_Return_Confirmation_Store::verify(wc_get_order($fixture['child_id']), $confirm['operation_id'], $confirm['confirmation_token'], $operator_id);
+		wcos_return_authority_assert($confirmation['operation_id'] === $confirmation_again['operation_id'], 'Repeated Return Confirmation verification minted another operation.');
+
+		$confirm_record = get_transient(wcos_return_authority_transient('wcos_return_confirm_', $confirm['operation_id']));
+		wcos_return_authority_assert(is_array($confirm_record) && false === strpos(wp_json_encode($confirm_record), $confirm['confirmation_token']), 'Return Confirmation persisted its raw token.');
+		wcos_return_authority_assert(false === strpos(wp_json_encode($confirm_record), '@example.test'), 'Return Confirmation persisted customer PII.');
+
+		for ($attempt = 0; $attempt < 2; $attempt++) {
+			$disabled = false;
+			try {
+				$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
+			} catch (WCOS_Return_Transport_Exception $exception) {
+				$disabled = 'workflow_disabled' === $exception->get_error_code();
+			}
+			wcos_return_authority_assert($disabled, 'Hard-off Return controller Execute did not return workflow_disabled.');
+		}
+		wcos_return_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($fixture['child_id']), $confirm['operation_id']), 'Hard-off Return controller Execute created a journal.');
+		wcos_return_authority_assert($child_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id'])), 'Hard-off Return controller Execute changed child commercial state.');
+		wcos_return_authority_assert($original_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id'])), 'Hard-off Return controller Execute changed original commercial state.');
+	}
+
+	$primary = wcos_return_authority_fixture('handoff', 'manual_quantity');
+	$fixtures[] = $primary; $primary_index = count($fixtures) - 1;
+	$request = wcos_return_authority_request($primary);
+	$unexpected = $request; $unexpected['original_order_id'] = $primary['original_id'];
+	$client_original_rejected = false;
+	try { $controller->review_request($unexpected); }
+	catch (WCOS_Return_Transport_Exception $exception) { $client_original_rejected = 'unexpected_field' === $exception->get_error_code(); }
+	wcos_return_authority_assert($client_original_rejected, 'Client-supplied Return original authority was not rejected.');
+
+	$review = $controller->review_request($request);
+	$fixtures[$primary_index]['review_ids'][] = $review['review_id'];
+	$wrong_token = false;
+	try { WCOS_Return_Review_Store::verify(wc_get_order($primary['child_id']), $review['review_id'], 'wrong', $operator_id); }
+	catch (WCOS_Return_Review_Exception $exception) { $wrong_token = 'invalid_token' === $exception->get_reason(); }
+	wcos_return_authority_assert($wrong_token, 'Return Review accepted an invalid token.');
+	$wrong_user = false;
+	try { WCOS_Return_Review_Store::verify(wc_get_order($primary['child_id']), $review['review_id'], $review['review_token'], $operator_id + 99999); }
+	catch (WCOS_Return_Review_Exception $exception) { $wrong_user = 'owner_mismatch' === $exception->get_reason(); }
+	wcos_return_authority_assert($wrong_user, 'Return Review accepted the wrong operator.');
+
+	$confirm = $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+	$fixtures[$primary_index]['operation_ids'][] = $confirm['operation_id'];
+	$replayed_review = false;
+	try { $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token']))); }
+	catch (WCOS_Return_Transport_Exception $exception) { $replayed_review = in_array($exception->get_error_code(), array('review_expired', 'review_already_consumed'), true); }
+	wcos_return_authority_assert($replayed_review, 'Consumed Return Review minted another Confirmation.');
+
+	$wrong_confirmation = false;
+	try { WCOS_Return_Confirmation_Store::verify(wc_get_order($primary['child_id']), $confirm['operation_id'], 'wrong', $operator_id); }
+	catch (WCOS_Return_Confirmation_Exception $exception) { $wrong_confirmation = 'invalid_token' === $exception->get_reason(); }
+	wcos_return_authority_assert($wrong_confirmation, 'Return Confirmation accepted an invalid token.');
+	$confirmed = WCOS_Return_Confirmation_Store::verify(wc_get_order($primary['child_id']), $confirm['operation_id'], $confirm['confirmation_token'], $operator_id);
+	$operation_authority = WCOS_Return_Confirmation_Store::operation_authority($confirmed);
+	$result = (new WCOS_Return_WooCommerce_Adapter())->return_order(wc_get_order($primary['child_id']), $confirm['operation_id'], $confirmed['price_precision'], $operation_authority);
+	wcos_return_authority_assert('completed' === $result['status'], 'Confirmed lower-level Return did not complete.');
+	$journal = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
+	$handoff = WCOS_Return_Journal_Context::confirmation_handoff_from_record($journal);
+	wcos_return_authority_assert($confirm['operation_id'] === $handoff['operation_id'] && $operator_id === $handoff['operator_user_id'], 'Return journal did not bind exact operation/operator Confirmation authority.');
+	wcos_return_authority_assert($confirmed['pair_fingerprint'] === $handoff['pair_fingerprint'] && $confirmed['plan_fingerprint'] === $handoff['plan_fingerprint'], 'Return journal handoff changed frozen pair/plan authority.');
+	wcos_return_authority_assert(false === strpos(wp_json_encode($journal['context']['return_confirmation']), $confirm['confirmation_token']), 'Return journal stored the raw Confirmation token.');
+
+	WCOS_Return_Confirmation_Store::delete($confirm['operation_id']);
+	$durable = WCOS_Return_Confirmation_Store::verify(wc_get_order($primary['child_id']), $confirm['operation_id'], '', $operator_id);
+	wcos_return_authority_assert('journal' === $durable['replay_authority'], 'Transient loss after journal start did not use durable Return authority.');
+	$journal_before = wp_json_encode($journal);
+	$result_replay = (new WCOS_Return_WooCommerce_Adapter())->return_order(wc_get_order($primary['child_id']), $confirm['operation_id'], $durable['price_precision'], WCOS_Return_Confirmation_Store::operation_authority($durable));
+	wcos_return_authority_assert($result === $result_replay, 'Durable confirmed Return replay did not return the stable terminal result.');
+	wcos_return_authority_assert($journal_before === wp_json_encode(WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id'])), 'Durable confirmed replay changed journal authority.');
+
+	$corrupt = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
+	$corrupt['context']['return_confirmation']['authority_fingerprint'] = hash('sha256', 'corrupt-confirmation-handoff');
+	update_option('wcos_mutation_op_' . hash('sha256', absint($primary['child_id']) . '|' . sanitize_key($confirm['operation_id'])), $corrupt, false);
+	$child_before_quarantine = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['child_id']));
+	$original_before_quarantine = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['original_id']));
+	$handoff_quarantined = false;
+	try { (new WCOS_Return_WooCommerce_Adapter())->return_order(wc_get_order($primary['child_id']), $confirm['operation_id'], $durable['price_precision']); }
+	catch (WCOS_Return_Adapter_Exception $exception) { $handoff_quarantined = 'return_manual_reconciliation' === $exception->get_error_code(); }
+	$quarantined_journal = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
+	wcos_return_authority_assert($handoff_quarantined && 'manual_reconciliation' === $quarantined_journal['status'], 'Corrupt durable Return Confirmation handoff was not quarantined.');
+	wcos_return_authority_assert($child_before_quarantine === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['child_id'])) && $original_before_quarantine === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['original_id'])), 'Confirmation handoff quarantine changed commercial state.');
+
+	$race = wcos_return_authority_fixture('sequential-race', 'manual_quantity');
+	$fixtures[] = $race; $race_index = count($fixtures) - 1;
+	$race_request = wcos_return_authority_request($race);
+	$race_review = $controller->review_request($race_request);
+	$fixtures[$race_index]['review_ids'][] = $race_review['review_id'];
+	$authority_one = WCOS_Return_Review_Store::verify(wc_get_order($race['child_id']), $race_review['review_id'], $race_review['review_token'], $operator_id);
+	$authority_two = WCOS_Return_Review_Store::verify(wc_get_order($race['child_id']), $race_review['review_id'], $race_review['review_token'], $operator_id);
+	$candidate_one = WCOS_Return_Confirmation_Store::create(wc_get_order($race['child_id']), $authority_one, $operator_id);
+	$candidate_two = WCOS_Return_Confirmation_Store::create(wc_get_order($race['child_id']), $authority_two, $operator_id);
+	$fixtures[$race_index]['operation_ids'][] = $candidate_one['operation_id'];
+	$fixtures[$race_index]['operation_ids'][] = $candidate_two['operation_id'];
+	wcos_return_authority_assert(WCOS_Return_Review_Store::consume(wc_get_order($race['child_id']), $race_review['review_id'], $race_review['review_token'], $operator_id), 'First Return Review CAS consumption failed.');
+	$second_consumed = WCOS_Return_Review_Store::consume(wc_get_order($race['child_id']), $race_review['review_id'], $race_review['review_token'], $operator_id);
+	if (!$second_consumed) { WCOS_Return_Confirmation_Store::delete($candidate_two['operation_id']); }
+	wcos_return_authority_assert(false === $second_consumed, 'One Return Review was consumed twice.');
+	wcos_return_authority_assert(is_array(get_transient(wcos_return_authority_transient('wcos_return_confirm_', $candidate_one['operation_id']))), 'Winning Return Confirmation disappeared.');
+	wcos_return_authority_assert(false === get_transient(wcos_return_authority_transient('wcos_return_confirm_', $candidate_two['operation_id'])), 'Losing Return Confirmation remained usable.');
+
+	$expiry = wcos_return_authority_fixture('expiry-integrity', 'manual_quantity');
+	$fixtures[] = $expiry; $expiry_index = count($fixtures) - 1;
+	$expiry_request = wcos_return_authority_request($expiry);
+	$expiry_review = $controller->review_request($expiry_request);
+	$fixtures[$expiry_index]['review_ids'][] = $expiry_review['review_id'];
+	$expiry_review_key = wcos_return_authority_transient('wcos_return_review_', $expiry_review['review_id']);
+	$expiry_record = get_transient($expiry_review_key); $expiry_record['expires_at'] = time() - 1;
+	set_transient($expiry_review_key, $expiry_record, WCOS_Return_Review_Store::TTL);
+	$review_expired = false;
+	try { WCOS_Return_Review_Store::verify(wc_get_order($expiry['child_id']), $expiry_review['review_id'], $expiry_review['review_token'], $operator_id); }
+	catch (WCOS_Return_Review_Exception $exception) { $review_expired = 'expired' === $exception->get_reason(); }
+	wcos_return_authority_assert($review_expired, 'Expired Return Review remained usable.');
+
+	$fresh_review = $controller->review_request($expiry_request);
+	$fixtures[$expiry_index]['review_ids'][] = $fresh_review['review_id'];
+	$expiry_confirm = $controller->confirm_request(array_merge($expiry_request, array('review_id' => $fresh_review['review_id'], 'review_token' => $fresh_review['review_token'])));
+	$fixtures[$expiry_index]['operation_ids'][] = $expiry_confirm['operation_id'];
+	$expiry_confirm_key = wcos_return_authority_transient('wcos_return_confirm_', $expiry_confirm['operation_id']);
+	$expiry_confirmation_record = get_transient($expiry_confirm_key);
+	$expiry_confirmation_record['expires_at'] = time() - 1;
+	set_transient($expiry_confirm_key, $expiry_confirmation_record, WCOS_Return_Confirmation_Store::TTL);
+	$confirmation_expired = false;
+	try { WCOS_Return_Confirmation_Store::verify(wc_get_order($expiry['child_id']), $expiry_confirm['operation_id'], $expiry_confirm['confirmation_token'], $operator_id); }
+	catch (WCOS_Return_Confirmation_Exception $exception) { $confirmation_expired = 'expired' === $exception->get_reason(); }
+	wcos_return_authority_assert($confirmation_expired && null === WCOS_Operation_Journal::get(wc_get_order($expiry['child_id']), $expiry_confirm['operation_id']), 'Expired Return Confirmation created or reused journal authority.');
+
+	$conflict = wcos_return_authority_fixture('confirmation-conflict', 'manual_quantity');
+	$fixtures[] = $conflict; $conflict_index = count($fixtures) - 1;
+	$conflict_request = wcos_return_authority_request($conflict);
+	$conflict_review = $controller->review_request($conflict_request);
+	$fixtures[$conflict_index]['review_ids'][] = $conflict_review['review_id'];
+	$conflict_confirm = $controller->confirm_request(array_merge($conflict_request, array('review_id' => $conflict_review['review_id'], 'review_token' => $conflict_review['review_token'])));
+	$fixtures[$conflict_index]['operation_ids'][] = $conflict_confirm['operation_id'];
+	$conflict_record = WCOS_Return_Confirmation_Store::verify(wc_get_order($conflict['child_id']), $conflict_confirm['operation_id'], $conflict_confirm['confirmation_token'], $operator_id);
+	$conflict_authority = WCOS_Return_Confirmation_Store::operation_authority($conflict_record);
+	$conflict_authority['plan_fingerprint'] = hash('sha256', 'client-conflict');
+	$child_before_conflict = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($conflict['child_id']));
+	$original_before_conflict = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($conflict['original_id']));
+	$handoff_conflict_rejected = false;
+	try { (new WCOS_Return_WooCommerce_Adapter())->return_order(wc_get_order($conflict['child_id']), $conflict_confirm['operation_id'], $conflict_record['price_precision'], $conflict_authority); }
+	catch (WCOS_Return_Adapter_Exception $exception) { $handoff_conflict_rejected = true; }
+	wcos_return_authority_assert($handoff_conflict_rejected && null === WCOS_Operation_Journal::get(wc_get_order($conflict['child_id']), $conflict_confirm['operation_id']), 'Conflicting Return Confirmation handoff reached journal start.');
+	wcos_return_authority_assert($child_before_conflict === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($conflict['child_id'])) && $original_before_conflict === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($conflict['original_id'])), 'Conflicting Return Confirmation changed commercial state.');
+
+	$precision_record = get_transient(wcos_return_authority_transient('wcos_return_confirm_', $conflict_confirm['operation_id']));
+	$precision_record['price_precision'] = 3;
+	set_transient(wcos_return_authority_transient('wcos_return_confirm_', $conflict_confirm['operation_id']), $precision_record, WCOS_Return_Confirmation_Store::TTL);
+	$precision_rejected = false;
+	try { WCOS_Return_Confirmation_Store::verify(wc_get_order($conflict['child_id']), $conflict_confirm['operation_id'], $conflict_confirm['confirmation_token'], $operator_id); }
+	catch (WCOS_Return_Confirmation_Exception $exception) { $precision_rejected = in_array($exception->get_reason(), array('authority_changed', 'confirmation_invalid'), true); }
+	wcos_return_authority_assert($precision_rejected, 'Return Confirmation precision/policy drift was accepted.');
+
+	$drift = wcos_return_authority_fixture('drift', 'manual_quantity');
+	$fixtures[] = $drift; $drift_index = count($fixtures) - 1;
+	$drift_request = wcos_return_authority_request($drift);
+	$drift_review = $controller->review_request($drift_request);
+	$fixtures[$drift_index]['review_ids'][] = $drift_review['review_id'];
+	$child = wc_get_order($drift['child_id']); $line = current($child->get_items('line_item'));
+	$line->set_quantity(2); $line->save();
+	$child_drift_rejected = false;
+	try { $controller->confirm_request(array_merge($drift_request, array('review_id' => $drift_review['review_id'], 'review_token' => $drift_review['review_token']))); }
+	catch (WCOS_Return_Transport_Exception $exception) { $child_drift_rejected = 0 === strpos($exception->get_error_code(), 'review_'); }
+	wcos_return_authority_assert($child_drift_rejected, 'Child drift after Return Review was accepted.');
+
+	$original_drift = wcos_return_authority_fixture('original-drift', 'manual_quantity');
+	$fixtures[] = $original_drift; $original_drift_index = count($fixtures) - 1;
+	$original_drift_request = wcos_return_authority_request($original_drift);
+	$original_drift_review = $controller->review_request($original_drift_request);
+	$fixtures[$original_drift_index]['review_ids'][] = $original_drift_review['review_id'];
+	$original = wc_get_order($original_drift['original_id']); $original_line = current($original->get_items('line_item'));
+	$original_line->add_meta_data('Unauthenticated original drift', 'reject', true); $original_line->save();
+	$original_drift_rejected = false;
+	try { $controller->confirm_request(array_merge($original_drift_request, array('review_id' => $original_drift_review['review_id'], 'review_token' => $original_drift_review['review_token']))); }
+	catch (WCOS_Return_Transport_Exception $exception) { $original_drift_rejected = 0 === strpos($exception->get_error_code(), 'review_'); }
+	wcos_return_authority_assert($original_drift_rejected, 'Original commercial/source-evolution drift after Return Review was accepted.');
+
+	$wrong_child = wcos_return_authority_fixture('wrong-child', 'manual_quantity');
+	$fixtures[] = $wrong_child; $wrong_child_index = count($fixtures) - 1;
+	$wrong_child_request = wcos_return_authority_request($wrong_child);
+	$wrong_child_review = $controller->review_request($wrong_child_request);
+	$fixtures[$wrong_child_index]['review_ids'][] = $wrong_child_review['review_id'];
+	$wrong_child_rejected = false;
+	try { WCOS_Return_Review_Store::verify(wc_get_order($expiry['child_id']), $wrong_child_review['review_id'], $wrong_child_review['review_token'], $operator_id); }
+	catch (WCOS_Return_Review_Exception $exception) { $wrong_child_rejected = 'owner_mismatch' === $exception->get_reason(); }
+	wcos_return_authority_assert($wrong_child_rejected, 'Return Review accepted the wrong child participant.');
+
+	$legacy_product = new WC_Product_Simple(); $legacy_product->set_name('WCOS Return legacy authority'); $legacy_product->set_regular_price('2.00'); $legacy_product->save();
+	$legacy_original = wc_create_order(); $legacy_original->add_product($legacy_product, 1); $legacy_original->calculate_totals(false); $legacy_original->save();
+	$legacy_child = wc_create_order(); $legacy_child->add_product($legacy_product, 1); $legacy_child->update_meta_data('yoos_original_order', $legacy_original->get_id()); $legacy_child->calculate_totals(false); $legacy_child->save();
+	$legacy_rejected = false;
+	try { $controller->review_request(array('child_order_id' => $legacy_child->get_id(), 'nonce' => wp_create_nonce('wcos_return_order_' . $legacy_child->get_id()))); }
+	catch (WCOS_Return_Transport_Exception $exception) { $legacy_rejected = 0 === strpos($exception->get_error_code(), 'preflight_'); }
+	wcos_return_authority_assert($legacy_rejected, 'Legacy yoos_* metadata minted Return Review authority.');
+	$legacy_child->delete(true); $legacy_original->delete(true); $legacy_product->delete(true);
+
+	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 cas_single_consume=1\n";
+} finally {
+	foreach (array_reverse($fixtures) as $fixture) {
+		try { wcos_return_authority_cleanup($fixture); } catch (Throwable $throwable) {}
+	}
+}

--- a/tests/integration/return-review-confirm-authority-smoke.php
+++ b/tests/integration/return-review-confirm-authority-smoke.php
@@ -100,6 +100,50 @@ function wcos_return_authority_transient($prefix, $id) {
 	return $prefix . hash('sha256', sanitize_key((string) $id));
 }
 
+function wcos_return_authority_write_journal(WC_Order $child, $operation_id, array $record) {
+	$key = 'wcos_mutation_op_' . hash('sha256', absint($child->get_id()) . '|' . sanitize_key((string) $operation_id));
+	update_option($key, $record, false);
+	wp_cache_delete($key, 'options');
+}
+
+function wcos_return_authority_freeze_recovery(WCOS_Return_Admin_Controller $controller, array $fixture, $operator_id) {
+	$request = wcos_return_authority_request($fixture);
+	$review = $controller->review_request($request);
+	$confirm = $controller->confirm_request(array_merge($request, array(
+		'review_id' => $review['review_id'],
+		'review_token' => $review['review_token'],
+	)));
+	$confirmation = WCOS_Return_Confirmation_Store::verify(
+		wc_get_order($fixture['child_id']),
+		$confirm['operation_id'],
+		$confirm['confirmation_token'],
+		$operator_id
+	);
+	$interrupt = static function($stage) {
+		if ('after_durable_preparation' === $stage) {
+			throw new RuntimeException('deterministic-confirmed-return-recovery');
+		}
+	};
+	remove_action('wcos_mutation_recovery_required', array('WCOS_Mutation_Recovery_Coordinator', 'handle'), 10);
+	add_action('wcos_return_mutation_checkpoint', $interrupt, PHP_INT_MAX, 1);
+	try {
+		(new WCOS_Return_WooCommerce_Adapter())->return_order(
+			wc_get_order($fixture['child_id']),
+			$confirm['operation_id'],
+			$confirmation['price_precision'],
+			WCOS_Return_Confirmation_Store::operation_authority($confirmation)
+		);
+	} catch (Throwable $throwable) {
+		// Expected after the confirmed journal and recovery snapshot are durable, before commercial writes.
+	} finally {
+		remove_action('wcos_return_mutation_checkpoint', $interrupt, PHP_INT_MAX);
+		add_action('wcos_mutation_recovery_required', array('WCOS_Mutation_Recovery_Coordinator', 'handle'), 10, 3);
+	}
+	$journal = WCOS_Operation_Journal::get(wc_get_order($fixture['child_id']), $confirm['operation_id']);
+	wcos_return_authority_assert(is_array($journal) && 'recovery_required' === $journal['status'], 'Confirmed Return fixture did not freeze at recovery_required.');
+	return array($confirm, $confirmation, $journal);
+}
+
 $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
 wcos_return_authority_assert(!empty($admins), 'Return authority smoke requires an administrator.');
 $operator_id = absint($admins[0]);
@@ -196,9 +240,24 @@ try {
 	wcos_return_authority_assert('completed' === $result['status'], 'Confirmed lower-level Return did not complete.');
 	$journal = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
 	$handoff = WCOS_Return_Journal_Context::confirmation_handoff_from_record($journal);
+	wcos_return_authority_assert(true === $journal['context']['return_confirmation_required'], 'Confirmed Return journal did not declare mandatory handoff authority.');
 	wcos_return_authority_assert($confirm['operation_id'] === $handoff['operation_id'] && $operator_id === $handoff['operator_user_id'], 'Return journal did not bind exact operation/operator Confirmation authority.');
 	wcos_return_authority_assert($confirmed['pair_fingerprint'] === $handoff['pair_fingerprint'] && $confirmed['plan_fingerprint'] === $handoff['plan_fingerprint'], 'Return journal handoff changed frozen pair/plan authority.');
 	wcos_return_authority_assert(false === strpos(wp_json_encode($journal['context']['return_confirmation']), $confirm['confirmation_token']), 'Return journal stored the raw Confirmation token.');
+	$tampered_handoff = $journal['context']['return_confirmation'];
+	$tampered_handoff['authority_fingerprint'] = hash('sha256', 'immutable-overwrite-probe');
+	wcos_return_authority_assert(
+		false === WCOS_Operation_Journal::checkpoint(wc_get_order($primary['child_id']), $confirm['operation_id'], 'confirmation_overwrite_probe', array('return_confirmation' => $tampered_handoff)),
+		'Return journal accepted a Confirmation handoff overwrite.'
+	);
+	$immutable_method = (new ReflectionClass('WCOS_Operation_Journal'))->getMethod('immutable_fields_match');
+	$immutable_method->setAccessible(true);
+	$removed_handoff = $journal;
+	unset($removed_handoff['context']['return_confirmation']);
+	wcos_return_authority_assert(false === $immutable_method->invoke(null, $journal, $removed_handoff), 'Return journal accepted Confirmation handoff removal.');
+	$removed_marker = $journal;
+	unset($removed_marker['context']['return_confirmation_required']);
+	wcos_return_authority_assert(false === $immutable_method->invoke(null, $journal, $removed_marker), 'Return journal accepted Confirmation requirement removal.');
 
 	WCOS_Return_Confirmation_Store::delete($confirm['operation_id']);
 	$durable = WCOS_Return_Confirmation_Store::verify(wc_get_order($primary['child_id']), $confirm['operation_id'], '', $operator_id);
@@ -219,6 +278,75 @@ try {
 	$quarantined_journal = WCOS_Operation_Journal::get(wc_get_order($primary['child_id']), $confirm['operation_id']);
 	wcos_return_authority_assert($handoff_quarantined && 'manual_reconciliation' === $quarantined_journal['status'], 'Corrupt durable Return Confirmation handoff was not quarantined.');
 	wcos_return_authority_assert($child_before_quarantine === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['child_id'])) && $original_before_quarantine === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($primary['original_id'])), 'Confirmation handoff quarantine changed commercial state.');
+
+	$recovery = wcos_return_authority_fixture('confirmed-recovery-states', 'manual_quantity');
+	$fixtures[] = $recovery; $recovery_index = count($fixtures) - 1;
+	list($recovery_confirm, $recovery_confirmation, $recovery_journal) = wcos_return_authority_freeze_recovery($controller, $recovery, $operator_id);
+	$fixtures[$recovery_index]['operation_ids'][] = $recovery_confirm['operation_id'];
+	wcos_return_authority_assert(true === $recovery_journal['context']['return_confirmation_required'], 'Confirmed recovery journal lost mandatory handoff authority.');
+	WCOS_Return_Confirmation_Store::delete($recovery_confirm['operation_id']);
+	$recovery_closed = false;
+	try {
+		WCOS_Return_Confirmation_Store::verify(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Return_Confirmation_Exception $exception) {
+		$recovery_closed = 'operation_closed' === $exception->get_reason();
+	}
+	$recovery_after = WCOS_Operation_Journal::get(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id']);
+	wcos_return_authority_assert($recovery_closed && 'compensated' === $recovery_after['status'], 'Transient-loss confirmed recovery did not deterministically compensate and close.');
+	$compensated_closed = false;
+	try {
+		WCOS_Return_Confirmation_Store::verify(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Return_Confirmation_Exception $exception) {
+		$compensated_closed = 'operation_closed' === $exception->get_reason();
+	}
+	wcos_return_authority_assert($compensated_closed, 'Compensated confirmed Return journal remained replayable.');
+	$recovery_child = wc_get_order($recovery['child_id']);
+	wcos_return_authority_assert(
+		WCOS_Operation_Journal::mark_manual_reconciliation($recovery_child, $recovery_confirm['operation_id'], array('reason' => 'confirmed_return_manual_fixture')),
+		'Unable to establish confirmed Return manual-reconciliation authority.'
+	);
+	$manual_closed = false;
+	try {
+		WCOS_Return_Confirmation_Store::verify(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Return_Confirmation_Exception $exception) {
+		$manual_closed = 'manual_reconciliation' === $exception->get_reason();
+	}
+	wcos_return_authority_assert($manual_closed, 'Manual-reconciliation confirmed Return journal did not fail closed.');
+	wcos_return_authority_assert(
+		WCOS_Operation_Journal::mark_manual_reconciled(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id'], array('reason' => 'confirmed_return_manual_fixture_closed')),
+		'Unable to close confirmed Return manual-reconciliation authority.'
+	);
+	$manual_reconciled_closed = false;
+	try {
+		WCOS_Return_Confirmation_Store::verify(wc_get_order($recovery['child_id']), $recovery_confirm['operation_id'], '', $operator_id);
+	} catch (WCOS_Return_Confirmation_Exception $exception) {
+		$manual_reconciled_closed = 'operation_closed' === $exception->get_reason();
+	}
+	wcos_return_authority_assert($manual_reconciled_closed, 'Manual-reconciled confirmed Return journal remained replayable.');
+
+	foreach (array('corrupt' => false, 'missing' => true) as $confirmation_fault => $remove_handoff) {
+		$fault = wcos_return_authority_fixture('confirmed-recovery-' . $confirmation_fault, 'manual_quantity');
+		$fixtures[] = $fault; $fault_index = count($fixtures) - 1;
+		list($fault_confirm, $fault_confirmation, $fault_journal) = wcos_return_authority_freeze_recovery($controller, $fault, $operator_id);
+		$fixtures[$fault_index]['operation_ids'][] = $fault_confirm['operation_id'];
+		WCOS_Return_Confirmation_Store::delete($fault_confirm['operation_id']);
+		if ($remove_handoff) {
+			unset($fault_journal['context']['return_confirmation']);
+		} else {
+			$fault_journal['context']['return_confirmation']['authority_fingerprint'] = hash('sha256', 'confirmed-recovery-corruption');
+		}
+		wcos_return_authority_write_journal(wc_get_order($fault['child_id']), $fault_confirm['operation_id'], $fault_journal);
+		$fault_child_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fault['child_id']));
+		$fault_original_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fault['original_id']));
+		WCOS_Mutation_Recovery_Coordinator::handle(wc_get_order($fault['child_id']), $fault_confirm['operation_id'], $fault_journal);
+		$fault_after = WCOS_Operation_Journal::get(wc_get_order($fault['child_id']), $fault_confirm['operation_id']);
+		wcos_return_authority_assert('manual_reconciliation' === $fault_after['status'], 'Confirmed recovery did not quarantine ' . $confirmation_fault . ' handoff authority.');
+		wcos_return_authority_assert(
+			$fault_child_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fault['child_id']))
+			&& $fault_original_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fault['original_id'])),
+			'Confirmed recovery handoff quarantine changed commercial state: ' . $confirmation_fault
+		);
+	}
 
 	$race = wcos_return_authority_fixture('sequential-race', 'manual_quantity');
 	$fixtures[] = $race; $race_index = count($fixtures) - 1;
@@ -333,7 +461,7 @@ try {
 	wcos_return_authority_assert($legacy_rejected, 'Legacy yoos_* metadata minted Return Review authority.');
 	$legacy_child->delete(true); $legacy_original->delete(true); $legacy_product->delete(true);
 
-	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 cas_single_consume=1\n";
+	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 immutable_handoff=1 confirmed_states=4 corrupt_recovery=2 cas_single_consume=1\n";
 } finally {
 	foreach (array_reverse($fixtures) as $fixture) {
 		try { wcos_return_authority_cleanup($fixture); } catch (Throwable $throwable) {}


### PR DESCRIPTION
## Task

WOS-RETURN-005 / Issue #79

Classification: `P2_WOOCOMMERCE_ADAPTER / RETURN_REVIEW_CONFIRM_EXECUTE`

## Summary

- add PII-free, operator-bound Return Review and Confirmation stores;
- atomically single-consume DB-backed Review transients with compare-and-delete race authority;
- add a gate-aware Return request controller whose direct Review / Confirm / Execute methods are testable while production hooks remain absent;
- bind a self-verifying Confirmation handoff into the existing child-keyed Return journal before commercial writes;
- require verified Confirmation authority at the future production gateway boundary while preserving the accepted transport-free WOS-RETURN-004 harness;
- keep `RETURN_ORDER=false` and `BULK_RETURN=false`, with no Return UI, launcher, asset, REST route, order action, or production AJAX hook.

## Local evidence at exact head

- head: `f73de70b6715ca61f600ea0c868260412354efc1` / tree `5831b8b6b4ede77d13c45664d6d26a87e53b898f`;
- source: `db3ffd47788a2679287d07652fb3d9ec7c2c3cc0` / tree `b3ab6f83349a7ed27b398c184add131796e4b447`;
- changed-file PHP syntax: PHP 7.4.30 / 8.1.29 / 8.3.23 pass;
- `php tests/unit/run.php` pass;
- distribution contract pass, version/stable tag unchanged at `1.4.15`;
- `return-domain-lineage-smoke.php` pass;
- `return-recovery-foundation-smoke.php` pass;
- existing `return-service-adapter-smoke.php`: all 37 cases pass;
- new `return-review-confirm-authority-smoke.php`: Manual Quantity / Category / Stock-status Review authority, gate-off Execute, schema-v2 self-verifying Confirmation provenance, symmetric immutable handoff presence, schema-v1 legacy compatibility/addition rejection, transient-loss durable replay/recovery, confirmed `recovery_required` / `compensated` / `manual_reconciliation` / `manual_reconciled` states, expiry/drift/integrity/privacy/legacy rejection, and missing/corrupt/fully-stripped recovery-handoff quarantine pass;
- real two-worker Confirm race: exactly one `CONFIRMED`, one `REJECTED`;
- post-run fixture inventory: orders=0, reviews=0, confirmations=0, race_fixture=0;
- `git diff --check`, workflow YAML parse, and distribution shell syntax pass.

## Canonical CI

- run: `32921936669` / attempt `1` / event `pull_request` / conclusion `success`;
- exact head: `f73de70b6715ca61f600ea0c868260412354efc1`;
- exact base: `db3ffd47788a2679287d07652fb3d9ec7c2c3cc0`;
- merge candidate: `afcde510a155b2120a6884a92b71ce45fbe873b8` / tree `5831b8b6b4ede77d13c45664d6d26a87e53b898f`;
- merge parents: base `db3ffd47788a2679287d07652fb3d9ec7c2c3cc0`, head `f73de70b6715ca61f600ea0c868260412354efc1`;
- all nine required jobs pass: PHP 7.4 / 8.1 / 8.3, architecture and gate contract, package safety, WooCommerce 11.0.1 legacy / HPOS-only / HPOS-sync, and `Required CI`;
- artifacts: `0`.

## Technical correction tranche

- resolves the latest Independent Technical Review comment `5419557300` at prior head `13bdf3cebbd65591ba74f161de7b19f8a864ea9d`, following the earlier correction for comment `5419281174`;
- upgrades the Return pair root to schema v2 and binds a versioned, self-verifying `confirmation_provenance` into the pair/journal fingerprint;
- preserves explicit schema-v1 compatibility only for genuinely legacy journals carrying no Confirmation authority;
- enforces symmetric immutable presence for `return_confirmation_required` and `return_confirmation`, so legacy absence cannot acquire both and confirmed presence cannot be removed;
- derives replay/recovery requirements from the sealed root, so stripping both top-level fields enters pair-wide `manual_reconciliation` before commercial writes;
- focused legacy-addition and fully-stripped-confirmed regressions run in canonical legacy / HPOS-only / HPOS-sync CI.

Relates to #79.
