### PR TITLE
WOS-RETURN-006: Return UI + Sandbox Readiness

### DIFF
--- a/.github/scripts/validate-distribution-contract.sh
+++ b/.github/scripts/validate-distribution-contract.sh
@@ -75,8 +75,6 @@ for forbidden_path in \
   'js/merge-action.js' \
   'js/post-action-tip.js' \
   'js/split-table.js' \
-  'js/p2-return-admin.js' \
-  'css/p2-return-admin.css' \
   'inc/mutation-v2'; do
   if test -e "$distribution_root/$forbidden_path"; then
     fail "unsafe or development-only path entered distribution: $forbidden_path"
@@ -143,6 +141,8 @@ for required_path in \
   'inc/backend/class-wcos-return-review-store.php' \
   'inc/backend/class-wcos-return-confirmation-store.php' \
   'inc/backend/class-wcos-return-admin-controller.php' \
+  'css/p2-return-admin.css' \
+  'js/p2-return-admin.js' \
   'css/p2-split-strategy-admin.css' \
   'js/p2-split-strategy-admin.js'; do
   if test ! -e "$distribution_root/$required_path"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,10 @@ jobs:
           grep -Fq 'class-wcos-return-confirmation-store.php' inc/cores/script.php
           grep -Fq 'class-wcos-return-admin-controller.php' inc/cores/script.php
           grep -Fq 'WCOS_Return_Admin_Controller::bootstrap();' inc/cores/script.php
-          test ! -e js/p2-return-admin.js
-          test ! -e css/p2-return-admin.css
+          test -e js/p2-return-admin.js
+          test -e css/p2-return-admin.css
+          grep -Fq "'wcos-return-admin'" inc/backend/class-wcos-admin-backbone-modal-assets.php
+          grep -Fq 'window.WCOSBackboneModal.open' js/p2-return-admin.js
           grep -Fq "const SEARCH_ACTION = 'wcos_merge_target_search';" inc/backend/class-wcos-merge-admin-controller.php
           grep -Fq "'wcos-merge-admin'" inc/backend/class-wcos-admin-backbone-modal-assets.php
           grep -Fq 'window.WCOSBackboneModal.open' js/p2-merge-admin.js
@@ -206,6 +208,9 @@ jobs:
 
       - name: Run Split method focus lifecycle regression
         run: node tests/js/p2-split-method-focus-lifecycle.js
+
+      - name: Verify Return admin client syntax
+        run: node --check js/p2-return-admin.js
 
   package-check:
     name: Package safety contract
@@ -414,6 +419,9 @@ jobs:
 
       - name: Verify hard-off Return Review Confirm Execute authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-review-confirm-authority-smoke.php
+
+      - name: Verify hard-off Return UI readiness
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-ui-readiness-smoke.php
 
       - name: Verify Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php

--- a/css/p2-return-admin.css
+++ b/css/p2-return-admin.css
@@ -1,0 +1,94 @@
+.wcos-return-launcher-description {
+	display: inline-block;
+	margin: 6px 0 0 8px;
+	vertical-align: middle;
+}
+
+.wcos-return-launcher {
+	margin-left: 8px !important;
+}
+
+.wcos-return-backbone-modal .wc-backbone-modal-content {
+	width: min(720px, calc(100vw - 32px));
+	max-width: 720px;
+}
+
+.wcos-return-backbone-modal .wcos-admin-backbone-modal__description {
+	margin: 0;
+}
+
+.wcos-return-backbone-modal .wcos-return-policy,
+.wcos-return-backbone-modal .wcos-return-review {
+	margin: 0 0 20px;
+	padding: 16px;
+	border: 1px solid #dcdcde;
+	background: #f6f7f7;
+}
+
+.wcos-return-backbone-modal .wcos-return-policy h3,
+.wcos-return-backbone-modal .wcos-return-review h3 {
+	margin-top: 0;
+}
+
+.wcos-return-backbone-modal .wcos-return-policy ul {
+	margin-bottom: 0;
+	padding-left: 20px;
+	list-style: disc;
+}
+
+.wcos-return-backbone-modal .wcos-return-review-summary {
+	display: grid;
+	grid-template-columns: minmax(150px, 0.8fr) minmax(220px, 1.4fr);
+	gap: 8px 16px;
+	margin: 0 0 16px;
+}
+
+.wcos-return-backbone-modal .wcos-return-review-summary dt {
+	font-weight: 600;
+}
+
+.wcos-return-backbone-modal .wcos-return-review-summary dd {
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.wcos-return-backbone-modal .wcos-return-confirm-label {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	font-weight: 600;
+}
+
+.wcos-return-backbone-modal .wcos-return-confirm-label input {
+	margin-top: 2px;
+}
+
+.wcos-return-backbone-modal .wcos-return-status {
+	min-height: 20px;
+	margin: 0 0 12px;
+}
+
+.wcos-return-backbone-modal .wcos-return-error,
+.wcos-return-backbone-modal .wcos-return-result {
+	margin: 0 0 12px;
+	padding: 10px 12px;
+}
+
+.wcos-return-backbone-modal .wcos-return-result p {
+	margin: 0 0 8px;
+}
+
+.wcos-return-backbone-modal .wcos-return-result p:last-child {
+	margin-bottom: 0;
+}
+
+@media (max-width: 600px) {
+	.wcos-return-backbone-modal .wcos-return-review-summary {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
+
+	.wcos-return-backbone-modal .wcos-return-review-summary dd {
+		margin-bottom: 8px;
+	}
+}

--- a/inc/backend/class-wcos-admin-backbone-modal-assets.php
+++ b/inc/backend/class-wcos-admin-backbone-modal-assets.php
@@ -47,7 +47,7 @@ final class WCOS_Admin_Backbone_Modal_Assets {
 			return;
 		}
 
-		foreach (array('wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin', 'wcos-merge-admin') as $handle) {
+		foreach (array('wcos-split-admin', 'wcos-duplicate-admin', 'wcos-split-strategy-admin', 'wcos-merge-admin', 'wcos-return-admin') as $handle) {
 			if (!isset($scripts->registered[$handle])) {
 				continue;
 			}

--- a/inc/backend/class-wcos-return-admin-controller.php
+++ b/inc/backend/class-wcos-return-admin-controller.php
@@ -19,7 +19,7 @@ final class WCOS_Return_Transport_Exception extends RuntimeException {
 	public function is_retryable() { return $this->retryable; }
 }
 
-/** Gate-aware request authority for future Return UI; no UI hooks belong here. */
+/** Gate-aware request and presentation authority for hardened single-order Return. */
 final class WCOS_Return_Admin_Controller {
 	const REVIEW_ACTION = 'wcos_return_review';
 	const CONFIRM_ACTION = 'wcos_return_confirm';
@@ -27,6 +27,7 @@ final class WCOS_Return_Admin_Controller {
 
 	private static $instance = null;
 	private $registered = false;
+	private $current_child = null;
 
 	public static function bootstrap() {
 		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) {
@@ -46,6 +47,9 @@ final class WCOS_Return_Admin_Controller {
 		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 23, 1);
+		add_action('admin_footer', array($this, 'render_dialog'));
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = true;
 		return true;
 	}
@@ -54,7 +58,11 @@ final class WCOS_Return_Admin_Controller {
 		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
+		remove_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 23);
+		remove_action('admin_footer', array($this, 'render_dialog'));
+		remove_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = false;
+		$this->current_child = null;
 		return true;
 	}
 
@@ -133,7 +141,9 @@ final class WCOS_Return_Admin_Controller {
 				WCOS_Return_Confirmation_Store::operation_authority($confirmation)
 			);
 		} catch (WCOS_Return_Adapter_Exception $exception) {
-			throw new WCOS_Return_Transport_Exception($exception->get_error_code(), __('The hardened Return request did not complete automatically.', 'wc-order-splitter'), 409, true);
+			$error_code = $exception->get_error_code();
+			$retryable = !in_array($error_code, array('return_manual_reconciliation', 'return_compensated', 'return_operation_closed'), true);
+			throw new WCOS_Return_Transport_Exception($error_code, __('The hardened Return request did not complete automatically.', 'wc-order-splitter'), 409, $retryable);
 		} catch (RuntimeException $exception) {
 			if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) {
 				throw new WCOS_Return_Transport_Exception('workflow_disabled', __('Hardened Return is not enabled for production use yet.', 'wc-order-splitter'), 503, false);
@@ -141,11 +151,19 @@ final class WCOS_Return_Admin_Controller {
 			throw new WCOS_Return_Transport_Exception('return_failed', __('The hardened Return request did not complete automatically.', 'wc-order-splitter'), 409, true);
 		}
 
+		$original_id = absint(isset($result['original_order_id']) ? $result['original_order_id'] : $confirmation['original_order_id']);
+		$persisted_original = wc_get_order($original_id);
 		return array(
 			'operation_id' => $operation_id,
 			'status' => sanitize_key(isset($result['status']) ? (string) $result['status'] : 'completed'),
 			'child_order_id' => absint(isset($result['child_order_id']) ? $result['child_order_id'] : $child->get_id()),
-			'original_order_id' => absint(isset($result['original_order_id']) ? $result['original_order_id'] : $confirmation['original_order_id']),
+			'original_order_id' => $original_id,
+			'original' => $persisted_original instanceof WC_Order ? array(
+				'id' => $persisted_original->get_id(),
+				'number' => (string) $persisted_original->get_order_number(),
+				'status' => (string) $persisted_original->get_status(),
+				'edit_url' => method_exists($persisted_original, 'get_edit_order_url') ? esc_url_raw((string) $persisted_original->get_edit_order_url()) : '',
+			) : array('id' => $original_id, 'number' => (string) $original_id, 'status' => '', 'edit_url' => ''),
 			'retirement_policy' => sanitize_key(isset($result['retirement_policy']) ? (string) $result['retirement_policy'] : WCOS_Return_Retirement_Policy::approved_identifier()),
 		);
 	}
@@ -153,6 +171,131 @@ final class WCOS_Return_Admin_Controller {
 	public function ajax_review() { $this->send_ajax('review_request'); }
 	public function ajax_confirm() { $this->send_ajax('confirm_request'); }
 	public function ajax_execute() { $this->send_ajax('execute_request'); }
+
+	public function render_launcher($order) {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER) || !$order instanceof WC_Order) {
+			return;
+		}
+		try {
+			$report = (new WCOS_Return_WooCommerce_Adapter())->preflight($order);
+			if (empty($report['supported'])) {
+				return;
+			}
+			$original = wc_get_order(absint($report['source_order_id']));
+			if (!$original instanceof WC_Order) {
+				return;
+			}
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $order, $original);
+		} catch (Throwable $throwable) {
+			return;
+		}
+
+		$this->current_child = $order;
+		$dialog_id = 'wcos-return-dialog-' . $order->get_id();
+		$description_id = 'wcos-return-launcher-description-' . $order->get_id();
+		echo '<button type="button" class="button wcos-return-launcher" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '">';
+		echo esc_html__('Return to original order', 'wc-order-splitter');
+		echo '</button>';
+		echo '<span id="' . esc_attr($description_id) . '" class="description wcos-return-launcher-description">';
+		echo esc_html__('Review the server-resolved original and historical Return summary before confirming.', 'wc-order-splitter');
+		echo '</span>';
+	}
+
+	public function enqueue_assets() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER) || !$this->is_order_edit_screen()) {
+			return;
+		}
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_style('wcos-return-admin', plugins_url('css/p2-return-admin.css', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION);
+		wp_enqueue_script('wcos-return-admin', plugins_url('js/p2-return-admin.js', $plugin_file), array(), WC_ORDER_SPLITTER_VERSION, true);
+		wp_localize_script('wcos-return-admin', 'wcosReturnAdminStrings', array(
+			'reviewing' => __('Reviewing Return authority…', 'wc-order-splitter'),
+			'reviewReady' => __('The child passed server review. Acknowledge the immutable summary to confirm Return.', 'wc-order-splitter'),
+			'confirming' => __('Confirming reviewed Return authority…', 'wc-order-splitter'),
+			'confirmReady' => __('Return is confirmed. Execute this exact operation when ready.', 'wc-order-splitter'),
+			'executing' => __('Returning operational ownership to the original order…', 'wc-order-splitter'),
+			'retrying' => __('Retrying the same Return operation…', 'wc-order-splitter'),
+			'completed' => __('Return completed. The child is retired and the original is active.', 'wc-order-splitter'),
+			'requestFailed' => __('The Return request could not be completed.', 'wc-order-splitter'),
+			'reviewReturn' => __('Review return', 'wc-order-splitter'),
+			'confirmReturn' => __('Confirm return', 'wc-order-splitter'),
+			'executeReturn' => __('Execute return', 'wc-order-splitter'),
+			'retryReturn' => __('Retry same return', 'wc-order-splitter'),
+			'newReviewRequired' => __('This Review is no longer valid. Close or explicitly review the child again.', 'wc-order-splitter'),
+			'closedOperation' => __('This Return operation did not complete and cannot be restarted from this modal. Review the orders before taking another action.', 'wc-order-splitter'),
+			'originalOrder' => __('Active original order', 'wc-order-splitter'),
+			'childOrder' => __('Current child', 'wc-order-splitter'),
+			'strategy' => __('Split strategy', 'wc-order-splitter'),
+			'linesQuantity' => __('Returned lines / quantity', 'wc-order-splitter'),
+			'historicalValues' => __('Historical subtotal / total / tax', 'wc-order-splitter'),
+			'retirement' => __('Child retirement', 'wc-order-splitter'),
+		));
+	}
+
+	public function render_dialog() {
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER) || !$this->current_child instanceof WC_Order) {
+			return;
+		}
+		echo $this->dialog_html($this->current_child); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/** Direct presentation harness; production rendering remains guarded by render_dialog(). */
+	public function dialog_html(WC_Order $child) {
+		if (!$child->get_id() || 'shop_order' !== $child->get_type()) {
+			return '';
+		}
+		$dialog_id = 'wcos-return-dialog-' . $child->get_id();
+		$title_id = $dialog_id . '-title';
+		$description_id = $dialog_id . '-description';
+		$nonce = wp_create_nonce('wcos_return_order_' . $child->get_id());
+
+		ob_start();
+		?>
+		<div id="<?php echo esc_attr($dialog_id); ?>" class="wcos-return-dialog" role="dialog" aria-modal="true" aria-labelledby="<?php echo esc_attr($title_id); ?>" aria-describedby="<?php echo esc_attr($description_id); ?>" data-child-order-id="<?php echo esc_attr($child->get_id()); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" data-ajax-url="<?php echo esc_url(admin_url('admin-ajax.php')); ?>" data-review-action="<?php echo esc_attr(self::REVIEW_ACTION); ?>" data-confirm-action="<?php echo esc_attr(self::CONFIRM_ACTION); ?>" data-execute-action="<?php echo esc_attr(self::EXECUTE_ACTION); ?>" hidden>
+			<div class="wcos-return-dialog__backdrop" aria-hidden="true"></div>
+			<div class="wcos-return-dialog__panel" tabindex="-1">
+				<div class="wcos-return-dialog__header">
+					<div>
+						<h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Return to original order', 'wc-order-splitter'); ?></h2>
+						<p id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html(sprintf(__('Current child: order #%1$s (ID %2$d). The original is resolved only by server-held Split lineage during Review.', 'wc-order-splitter'), $child->get_order_number(), $child->get_id())); ?></p>
+					</div>
+					<button type="button" class="button-link wcos-return-close" aria-label="<?php esc_attr_e('Close Return dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
+				</div>
+
+				<div class="wcos-return-policy" aria-labelledby="<?php echo esc_attr($dialog_id . '-policy-title'); ?>">
+					<h3 id="<?php echo esc_attr($dialog_id . '-policy-title'); ?>"><?php esc_html_e('Return safety policy', 'wc-order-splitter'); ?></h3>
+					<ul>
+						<li><?php esc_html_e('The server resolves the proven original order; this screen cannot select or replace it.', 'wc-order-splitter'); ?></li>
+						<li><?php esc_html_e('Operational ownership moves back to the original using preserved historical line values and taxes; current catalog values are not reconstructed.', 'wc-order-splitter'); ?></li>
+						<li><?php esc_html_e('Return is designed to be physical-stock neutral and transfers only accepted stock-reduction ownership markers.', 'wc-order-splitter'); ?></li>
+						<li><?php esc_html_e('After completion, the child becomes non-owning and is archived/trash under non_force_trash_archive while its history remains preserved.', 'wc-order-splitter'); ?></li>
+					</ul>
+				</div>
+
+				<div class="wcos-return-review" hidden>
+					<h3><?php esc_html_e('Immutable server Review', 'wc-order-splitter'); ?></h3>
+					<dl class="wcos-return-review-summary"></dl>
+					<label class="wcos-return-confirm-label">
+						<input type="checkbox" class="wcos-return-confirm-checkbox" />
+						<span><?php esc_html_e('I reviewed the server-resolved original, historical values, physical-stock neutrality, and child retirement policy.', 'wc-order-splitter'); ?></span>
+					</label>
+				</div>
+
+				<div class="wcos-return-status" role="status" aria-live="polite" aria-atomic="true" tabindex="-1"></div>
+				<div class="wcos-return-error notice notice-error inline" role="alert" tabindex="-1" hidden></div>
+				<div class="wcos-return-result notice notice-success inline" role="status" tabindex="-1" hidden></div>
+
+				<div class="wcos-return-dialog__actions">
+					<button type="button" class="button wcos-return-cancel"><?php esc_html_e('Close', 'wc-order-splitter'); ?></button>
+					<button type="button" class="button button-secondary wcos-return-review-button"><?php esc_html_e('Review return', 'wc-order-splitter'); ?></button>
+					<button type="button" class="button button-secondary wcos-return-confirm-button" hidden disabled><?php esc_html_e('Confirm return', 'wc-order-splitter'); ?></button>
+					<button type="button" class="button button-primary wcos-return-execute-button" hidden disabled><?php esc_html_e('Execute return', 'wc-order-splitter'); ?></button>
+				</div>
+			</div>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
 
 	private function authorized_child(array $request) {
 		$child_id = isset($request['child_order_id']) ? absint($request['child_order_id']) : 0;
@@ -233,5 +376,15 @@ final class WCOS_Return_Admin_Controller {
 		} catch (Throwable $throwable) {
 			wp_send_json_error(array('code' => 'return_request_failed', 'message' => __('The Return request could not be completed.', 'wc-order-splitter'), 'retryable' => true), 500);
 		}
+	}
+
+	private function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
 	}
 }

--- a/js/p2-return-admin.js
+++ b/js/p2-return-admin.js
@@ -1,0 +1,379 @@
+(function () {
+	'use strict';
+
+	var strings = window.wcosReturnAdminStrings || {};
+	var launcher = document.querySelector('.wcos-return-launcher');
+	if (!launcher || !window.WCOSBackboneModal) {
+		return;
+	}
+
+	var sourceDialogId = launcher.getAttribute('aria-controls');
+	var sourceDialog = sourceDialogId ? document.getElementById(sourceDialogId) : null;
+	if (!sourceDialog) {
+		return;
+	}
+
+	function text(key, fallback) {
+		return typeof strings[key] === 'string' && strings[key] ? strings[key] : fallback;
+	}
+
+	function removeExternalDescription(button) {
+		var descriptionId = button.getAttribute('aria-describedby');
+		var description = descriptionId ? document.getElementById(descriptionId) : null;
+		var value = description ? description.textContent.trim() : '';
+		if (description && description.parentNode) {
+			description.parentNode.removeChild(description);
+		}
+		button.removeAttribute('aria-describedby');
+		return value;
+	}
+
+	var launcherDescription = removeExternalDescription(launcher);
+	launcher.removeAttribute('aria-controls');
+
+	function cloneBody(sourcePanel, body) {
+		Array.prototype.forEach.call(sourcePanel.children, function (child) {
+			if (child.classList.contains('wcos-return-dialog__header') || child.classList.contains('wcos-return-dialog__actions')) {
+				return;
+			}
+			body.appendChild(child.cloneNode(true));
+		});
+	}
+
+	function cloneFooter(sourceActions, footer) {
+		Array.prototype.forEach.call(sourceActions ? sourceActions.children : [], function (sourceButton) {
+			var button = sourceButton.cloneNode(true);
+			if (button.classList.contains('wcos-return-cancel')) {
+				button.classList.add('modal-close');
+				button.classList.add('button-large');
+			}
+			footer.appendChild(button);
+		});
+	}
+
+	function openReturnModal() {
+		var phase = 'initial';
+		var busy = false;
+		var reviewAuthority = null;
+		var confirmationAuthority = null;
+		var retryReady = false;
+		var dialog;
+		var closeButton;
+		var cancelButton;
+		var reviewButton;
+		var confirmButton;
+		var executeButton;
+		var confirmCheckbox;
+		var reviewBox;
+		var reviewSummary;
+		var statusBox;
+		var errorBox;
+		var resultBox;
+
+		function request(action, data) {
+			var body = new URLSearchParams();
+			body.set('action', action);
+			Object.keys(data).forEach(function (key) {
+				body.set(key, String(data[key]));
+			});
+			return window.fetch(sourceDialog.getAttribute('data-ajax-url'), {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+				body: body.toString()
+			}).then(function (response) {
+				return response.json().catch(function () {
+					var parseError = new Error(text('requestFailed', 'The Return request could not be completed.'));
+					parseError.retryable = true;
+					parseError.transportFailure = true;
+					throw parseError;
+				});
+			}).then(function (payload) {
+				if (!payload || payload.success !== true) {
+					var failure = payload && payload.data ? payload.data : {};
+					var error = new Error(failure.message || text('requestFailed', 'The Return request could not be completed.'));
+					error.code = failure.code || 'request_failed';
+					error.retryable = !!failure.retryable;
+					throw error;
+				}
+				return payload.data || {};
+			}).catch(function (error) {
+				if (typeof error.retryable !== 'boolean') {
+					error.retryable = true;
+					error.transportFailure = true;
+				}
+				throw error;
+			});
+		}
+
+		function clearError() {
+			errorBox.hidden = true;
+			errorBox.textContent = '';
+		}
+
+		function showError(message) {
+			errorBox.textContent = message || text('requestFailed', 'The Return request could not be completed.');
+			errorBox.hidden = false;
+			errorBox.focus();
+		}
+
+		function setStatus(message) {
+			statusBox.textContent = message || '';
+		}
+
+		function addSummary(label, value) {
+			var term = document.createElement('dt');
+			var detail = document.createElement('dd');
+			term.textContent = label;
+			detail.textContent = value;
+			reviewSummary.appendChild(term);
+			reviewSummary.appendChild(detail);
+		}
+
+		function renderReview(summary) {
+			var child = summary.child || {};
+			var original = summary.original || {};
+			var retirement = summary.retirement || {};
+			var currency = String(summary.currency || '');
+			reviewSummary.textContent = '';
+			addSummary(text('childOrder', 'Current child'), '#' + String(child.number || child.id || ''));
+			addSummary(text('originalOrder', 'Server-resolved original'), '#' + String(original.number || original.id || ''));
+			addSummary(text('strategy', 'Split strategy'), String(summary.strategy || ''));
+			addSummary(text('linesQuantity', 'Returned lines / quantity'), String(summary.returned_line_count || 0) + ' / ' + String(summary.quantity || '0'));
+			addSummary(text('historicalValues', 'Historical subtotal / total / tax'), String(summary.historical_subtotal || '0') + ' / ' + String(summary.historical_total || '0') + ' / ' + String(summary.historical_tax || '0') + ' ' + currency);
+			addSummary(text('retirement', 'Child retirement'), String(retirement.policy || 'non_force_trash_archive') + ' / ' + String(retirement.child_status_after || 'trash'));
+			reviewBox.hidden = false;
+		}
+
+		function clearResult() {
+			resultBox.hidden = true;
+			resultBox.textContent = '';
+		}
+
+		function setPhase(nextPhase) {
+			phase = nextPhase;
+			reviewButton.hidden = 'initial' !== phase;
+			confirmButton.hidden = 'reviewed' !== phase;
+			executeButton.hidden = 'confirmed' !== phase && 'executing' !== phase;
+			if ('reviewed' === phase) {
+				confirmCheckbox.disabled = busy;
+			} else {
+				confirmCheckbox.disabled = true;
+			}
+		}
+
+		function updateControls() {
+			dialog.setAttribute('aria-busy', busy ? 'true' : 'false');
+			cancelButton.disabled = busy;
+			closeButton.disabled = busy;
+			reviewButton.disabled = busy || 'initial' !== phase;
+			confirmButton.disabled = busy || 'reviewed' !== phase || !reviewAuthority || !confirmCheckbox.checked;
+			executeButton.disabled = busy || ('confirmed' !== phase && 'executing' !== phase) || !confirmationAuthority;
+			confirmCheckbox.disabled = busy || 'reviewed' !== phase;
+		}
+
+		function setBusy(nextBusy) {
+			busy = !!nextBusy;
+			updateControls();
+		}
+
+		function resetForExplicitReview() {
+			reviewAuthority = null;
+			confirmationAuthority = null;
+			retryReady = false;
+			reviewBox.hidden = true;
+			reviewSummary.textContent = '';
+			confirmCheckbox.checked = false;
+			executeButton.textContent = text('executeReturn', 'Execute return');
+			clearResult();
+			setPhase('initial');
+			updateControls();
+		}
+
+		function reviewReturn() {
+			if (busy || 'initial' !== phase) {
+				return;
+			}
+			clearError();
+			clearResult();
+			setBusy(true);
+			setStatus(text('reviewing', 'Reviewing Return authority…'));
+			request(sourceDialog.getAttribute('data-review-action'), {
+				child_order_id: sourceDialog.getAttribute('data-child-order-id'),
+				nonce: sourceDialog.getAttribute('data-nonce')
+			}).then(function (data) {
+				reviewAuthority = { reviewId: data.review_id, token: data.review_token };
+				renderReview(data.summary || {});
+				confirmCheckbox.checked = false;
+				setPhase('reviewed');
+				setStatus(text('reviewReady', 'The child passed server review. Acknowledge the immutable summary to confirm Return.'));
+				confirmCheckbox.focus();
+			}).catch(function (error) {
+				resetForExplicitReview();
+				setStatus('');
+				showError(error.message);
+			}).finally(function () {
+				setBusy(false);
+			});
+		}
+
+		function confirmReturn() {
+			if (busy || 'reviewed' !== phase || !reviewAuthority || !confirmCheckbox.checked) {
+				return;
+			}
+			clearError();
+			setBusy(true);
+			setStatus(text('confirming', 'Confirming reviewed Return authority…'));
+			request(sourceDialog.getAttribute('data-confirm-action'), {
+				child_order_id: sourceDialog.getAttribute('data-child-order-id'),
+				nonce: sourceDialog.getAttribute('data-nonce'),
+				review_id: reviewAuthority.reviewId,
+				review_token: reviewAuthority.token
+			}).then(function (data) {
+				confirmationAuthority = { operationId: data.operation_id, token: data.confirmation_token };
+				reviewAuthority = null;
+				retryReady = false;
+				setPhase('confirmed');
+				setStatus(text('confirmReady', 'Return is confirmed. Execute this exact operation when ready.'));
+				executeButton.focus();
+			}).catch(function (error) {
+				reviewAuthority = null;
+				confirmationAuthority = null;
+				retryReady = false;
+				confirmCheckbox.disabled = true;
+				setPhase('closed');
+				setStatus(text('newReviewRequired', 'This Review is no longer valid. Close or explicitly review the child again.'));
+				showError(error.message);
+			}).finally(function () {
+				setBusy(false);
+			});
+		}
+
+		function executeSameOperation() {
+			return request(sourceDialog.getAttribute('data-execute-action'), {
+				child_order_id: sourceDialog.getAttribute('data-child-order-id'),
+				nonce: sourceDialog.getAttribute('data-nonce'),
+				operation_id: confirmationAuthority.operationId,
+				confirmation_token: confirmationAuthority.token
+			});
+		}
+
+		function renderSuccess(data) {
+			if (!data || data.status !== 'completed') {
+				var terminalError = new Error(text('closedOperation', 'This Return operation did not complete.'));
+				terminalError.retryable = false;
+				throw terminalError;
+			}
+			resultBox.textContent = '';
+			var message = document.createElement('p');
+			message.textContent = text('completed', 'Return completed. The child is retired and the original is active.');
+			resultBox.appendChild(message);
+			var original = data.original || null;
+			if (original) {
+				var detail = document.createElement('p');
+				if (original.edit_url) {
+					var link = document.createElement('a');
+					link.href = original.edit_url;
+					link.textContent = text('originalOrder', 'Active original order') + ' #' + String(original.number || original.id || '');
+					detail.appendChild(link);
+				} else {
+					detail.textContent = text('originalOrder', 'Active original order') + ' #' + String(original.number || original.id || '');
+				}
+				resultBox.appendChild(detail);
+			}
+			resultBox.hidden = false;
+			resultBox.focus();
+		}
+
+		function executeReturn() {
+			if (busy || 'confirmed' !== phase || !confirmationAuthority) {
+				return;
+			}
+			clearError();
+			setPhase('executing');
+			setBusy(true);
+			setStatus(retryReady ? text('retrying', 'Retrying the same Return operation…') : text('executing', 'Returning operational ownership to the original order…'));
+			executeSameOperation().then(function (data) {
+				renderSuccess(data);
+				confirmationAuthority = null;
+				retryReady = false;
+				setPhase('completed');
+				setStatus('');
+			}).catch(function (error) {
+				if (error.retryable && confirmationAuthority) {
+					retryReady = true;
+					executeButton.textContent = text('retryReturn', 'Retry same return');
+					setPhase('confirmed');
+					setStatus(text('retrying', 'Retry the same Return operation; Review and Confirm will not be repeated.'));
+				} else {
+					confirmationAuthority = null;
+					retryReady = false;
+					setPhase('closed');
+					setStatus(text('closedOperation', 'This Return operation did not complete and cannot be restarted from this modal.'));
+				}
+				showError(error.message);
+			}).finally(function () {
+				setBusy(false);
+			});
+		}
+
+		var sourcePanel = sourceDialog.querySelector('.wcos-return-dialog__panel');
+		var sourceActions = sourceDialog.querySelector('.wcos-return-dialog__actions');
+		var modal = window.WCOSBackboneModal.open({
+			trigger: launcher,
+			title: (sourceDialog.querySelector('.wcos-return-dialog__header h2') || {}).textContent || launcher.textContent.trim(),
+			description: (sourceDialog.querySelector('.wcos-return-dialog__header p') || {}).textContent || launcherDescription,
+			modalClass: 'wcos-return-backbone-modal',
+			isBusy: function () { return busy; },
+			build: function (body, footer, root, handle) {
+				cloneBody(sourcePanel, body);
+				cloneFooter(sourceActions, footer);
+				dialog = root;
+				closeButton = root.querySelector('.wc-backbone-modal-header .modal-close');
+				cancelButton = root.querySelector('.wcos-return-cancel');
+				reviewButton = root.querySelector('.wcos-return-review-button');
+				confirmButton = root.querySelector('.wcos-return-confirm-button');
+				executeButton = root.querySelector('.wcos-return-execute-button');
+				confirmCheckbox = root.querySelector('.wcos-return-confirm-checkbox');
+				reviewBox = root.querySelector('.wcos-return-review');
+				reviewSummary = root.querySelector('.wcos-return-review-summary');
+				statusBox = root.querySelector('.wcos-return-status');
+				errorBox = root.querySelector('.wcos-return-error');
+				resultBox = root.querySelector('.wcos-return-result');
+				reviewButton.addEventListener('click', reviewReturn);
+				confirmButton.addEventListener('click', confirmReturn);
+				executeButton.addEventListener('click', executeReturn);
+				confirmCheckbox.addEventListener('change', updateControls);
+				root.addEventListener('keydown', function (event) {
+					if ('Escape' === event.key && busy) {
+						event.preventDefault();
+						event.stopImmediatePropagation();
+					}
+				}, true);
+				setPhase('initial');
+				updateControls();
+				handle.focusContent();
+			},
+			onReady: function (root) {
+				var content = root.querySelector('.wc-backbone-modal-content');
+				var title = root.querySelector('.wcos-admin-backbone-modal__title');
+				var description = root.querySelector('.wcos-admin-backbone-modal__description');
+				var identity = String(sourceDialog.getAttribute('data-child-order-id') || 'return');
+				if (title && description && content) {
+					title.id = 'wcos-return-modal-title-' + identity;
+					description.id = 'wcos-return-modal-description-' + identity;
+					content.setAttribute('role', 'dialog');
+					content.setAttribute('aria-modal', 'true');
+					content.setAttribute('aria-labelledby', title.id);
+					content.setAttribute('aria-describedby', description.id);
+					content.setAttribute('tabindex', '-1');
+					content.focus();
+				}
+			}
+		});
+
+		return modal;
+	}
+
+	launcher.addEventListener('click', openReturnModal);
+})();

--- a/tests/integration/return-ui-readiness-smoke.php
+++ b/tests/integration/return-ui-readiness-smoke.php
@@ -1,0 +1,137 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_return_ui_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+$root = dirname(__DIR__, 2);
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_return_ui_assert(!empty($admins), 'Return UI readiness requires an administrator fixture.');
+wp_set_current_user(absint($admins[0]));
+
+wcos_return_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate drifted on.');
+wcos_return_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate drifted on.');
+wcos_return_ui_assert(null === WCOS_Return_Admin_Controller::bootstrap(), 'Hard-off Return bootstrap returned a controller.');
+
+$controller = new WCOS_Return_Admin_Controller();
+wcos_return_ui_assert(false === $controller->register_hooks(), 'Hard-off Return controller registered hooks.');
+$hook_contracts = array(
+	'wp_ajax_' . WCOS_Return_Admin_Controller::REVIEW_ACTION => 'ajax_review',
+	'wp_ajax_' . WCOS_Return_Admin_Controller::CONFIRM_ACTION => 'ajax_confirm',
+	'wp_ajax_' . WCOS_Return_Admin_Controller::EXECUTE_ACTION => 'ajax_execute',
+	'woocommerce_order_item_add_action_buttons' => 'render_launcher',
+	'admin_footer' => 'render_dialog',
+	'admin_enqueue_scripts' => 'enqueue_assets',
+);
+foreach ($hook_contracts as $hook => $method) {
+	wcos_return_ui_assert(false === has_action($hook, array($controller, $method)), 'Hard-off Return hook was registered: ' . $hook);
+}
+wcos_return_ui_assert(!wp_script_is('wcos-return-admin', 'registered'), 'Return client was registered through an ungated path.');
+wcos_return_ui_assert(!wp_style_is('wcos-return-admin', 'registered'), 'Return stylesheet was registered through an ungated path.');
+
+$order = wc_create_order();
+$order->set_status('pending');
+$order->set_currency('USD');
+$order->set_billing_first_name('Private');
+$order->set_billing_last_name('Return UI');
+$order->set_billing_email('return-ui-' . wp_generate_uuid4() . '@example.test');
+$order->set_billing_phone('555-0060');
+$order->set_billing_address_1('60 Private Return Street');
+$order->set_payment_method('cod');
+$order->set_payment_method_title('Private Return Payment');
+$order->save();
+
+try {
+	$template = $controller->dialog_html($order);
+	wcos_return_ui_assert(false !== strpos($template, 'role="dialog"'), 'Return source template is not a dialog.');
+	wcos_return_ui_assert(false !== strpos($template, 'aria-modal="true"'), 'Return source template is not modal.');
+	wcos_return_ui_assert(false !== strpos($template, 'aria-labelledby="wcos-return-dialog-' . $order->get_id() . '-title"'), 'Return source template is not title-labelled.');
+	wcos_return_ui_assert(false !== strpos($template, 'aria-describedby="wcos-return-dialog-' . $order->get_id() . '-description"'), 'Return source template is not description-labelled.');
+	wcos_return_ui_assert(false !== strpos($template, 'data-child-order-id="' . $order->get_id() . '"'), 'Return source template does not freeze current child identity.');
+	wcos_return_ui_assert(false !== strpos($template, 'wcos-return-review-summary'), 'Return Review summary surface is missing.');
+	wcos_return_ui_assert(false !== strpos($template, 'wcos-return-confirm-checkbox'), 'Return explicit acknowledgement is missing.');
+	wcos_return_ui_assert(false !== strpos($template, 'aria-live="polite"'), 'Return modal-local status is not announced.');
+	wcos_return_ui_assert(false !== strpos($template, 'role="alert"'), 'Return modal-local errors lack alert semantics.');
+	wcos_return_ui_assert(false !== strpos($template, 'non_force_trash_archive'), 'Return child retirement policy is not explicit.');
+	wcos_return_ui_assert(false !== strpos($template, 'physical-stock neutral'), 'Return physical-stock neutrality is not explicit.');
+	wcos_return_ui_assert(false === strpos($template, 'data-original'), 'Return template exposed client-selectable original authority.');
+	foreach (array('@example.test', 'Private Return Street', '555-0060', 'Private Return Payment') as $private_value) {
+		wcos_return_ui_assert(false === strpos($template, $private_value), 'Return template exposed customer/payment PII: ' . $private_value);
+	}
+
+	ob_start();
+	$controller->render_launcher($order);
+	$launcher = (string) ob_get_clean();
+	wcos_return_ui_assert('' === $launcher, 'Hard-off Return launcher rendered.');
+
+	$order_screen_id = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+	set_current_screen($order_screen_id);
+	$_GET['id'] = (string) $order->get_id();
+	$controller->enqueue_assets();
+	wcos_return_ui_assert(!wp_script_is('wcos-return-admin', 'enqueued'), 'Hard-off Return script was enqueued on an order screen.');
+	wcos_return_ui_assert(!wp_style_is('wcos-return-admin', 'enqueued'), 'Hard-off Return stylesheet was enqueued on an order screen.');
+
+	$client = file_get_contents($root . '/js/p2-return-admin.js');
+	wcos_return_ui_assert(is_string($client) && '' !== $client, 'Return admin client is missing.');
+	foreach (array(
+		'window.WCOSBackboneModal.open',
+		"var phase = 'initial';",
+		'var reviewAuthority = null;',
+		'var confirmationAuthority = null;',
+		'function reviewReturn()',
+		'function confirmReturn()',
+		'function executeSameOperation()',
+		'function executeReturn()',
+		'review_id: reviewAuthority.reviewId',
+		'review_token: reviewAuthority.token',
+		'operation_id: confirmationAuthority.operationId',
+		'confirmation_token: confirmationAuthority.token',
+		"setPhase('confirmed');",
+		"setPhase('completed');",
+		"setPhase('closed');",
+		'if (error.retryable && confirmationAuthority)',
+		"data.status !== 'completed'",
+		"if ('Escape' === event.key && busy)",
+		"content.setAttribute('role', 'dialog');",
+		"content.setAttribute('aria-modal', 'true');",
+		"content.setAttribute('aria-labelledby', title.id);",
+		"content.setAttribute('aria-describedby', description.id);",
+	) as $needle) {
+		wcos_return_ui_assert(false !== strpos($client, $needle), 'Return client state/accessibility contract is missing: ' . $needle);
+	}
+	wcos_return_ui_assert(1 === substr_count($client, "getAttribute('data-review-action')"), 'Return client has more than one Review request site.');
+	wcos_return_ui_assert(1 === substr_count($client, "getAttribute('data-confirm-action')"), 'Return client has more than one Confirm request site.');
+	wcos_return_ui_assert(1 === substr_count($client, "getAttribute('data-execute-action')"), 'Return client has more than one Execute request site.');
+	foreach (array('original_order_id:', 'source_order_id:', 'plan:', 'amount:', 'tax:', 'precision:', 'fingerprint:', 'retirement_policy:', 'stock:', 'line:', 'localStorage', 'sessionStorage', 'document.cookie', '.innerHTML', 'console.') as $forbidden) {
+		wcos_return_ui_assert(false === strpos($client, $forbidden), 'Return client authors or stores forbidden authority: ' . $forbidden);
+	}
+
+	$controller_source = file_get_contents($root . '/inc/backend/class-wcos-return-admin-controller.php');
+	wcos_return_ui_assert(false === strpos($controller_source, 'new WCOS_Return_Order_Service'), 'Return controller directly instantiates the Return service.');
+	wcos_return_ui_assert(false !== strpos($controller_source, 'new WCOS_Mutation_Gateway())->return_order('), 'Return Execute does not enter through the mutation gateway.');
+	wcos_return_ui_assert(false !== strpos($controller_source, "add_action('woocommerce_order_item_add_action_buttons', array(\$this, 'render_launcher'), 23, 1);"), 'Return launcher hook is missing from the gated controller.');
+	wcos_return_ui_assert(false !== strpos($controller_source, 'WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $order, $original);'), 'Return launcher does not use server-resolved pair authorization.');
+
+	$asset_contract = file_get_contents($root . '/inc/backend/class-wcos-admin-backbone-modal-assets.php');
+	wcos_return_ui_assert(false !== strpos($asset_contract, "'wcos-return-admin'"), 'Return client is not bound to the shared Backbone modal dependency.');
+	$css = file_get_contents($root . '/css/p2-return-admin.css');
+	wcos_return_ui_assert(is_string($css) && false !== strpos($css, '.wcos-return-backbone-modal .wc-backbone-modal-content'), 'Return CSS does not target the shared WooCommerce Backbone shell.');
+
+	foreach (array(
+		$root . '/inc/backend/actions/return-order.php',
+		$root . '/inc/backend/actions/return-order-bulk-action.php',
+		$root . '/js/bulk-return-action.js',
+	) as $legacy_path) {
+		wcos_return_ui_assert(false === strpos(file_get_contents($root . '/inc/cores/script.php'), basename($legacy_path)), 'Legacy Return runtime path was reintroduced: ' . basename($legacy_path));
+	}
+} finally {
+	$order->delete(true);
+}
+
+echo "return-ui-readiness-ok hard_off_hooks=0 shared_modal=1 pii_free=1 client_authority=bounded\n";


### PR DESCRIPTION
## Task authority

Closes #83.

- Risk: `HIGH`
- Classification: `P2_WOOCOMMERCE_ADAPTER` (task contract: `P2_ADMIN_UI / RETURN_SANDBOX_READINESS`)
- Exact source: `f0af2534460b31b761be6b25544155f0fbd8b3f0`
- Production gate map remains exact: Split=true, Duplicate=true, Merge=true, Return=false, Bulk Return=false; Manual Quantity/Category/Stock-status=true.

## Production hard-off implementation

- Extends the existing `WCOS_Return_Admin_Controller` with gate-bound launcher, shared WooCommerce Backbone modal presentation, asset, Review, Confirm, and Execute hooks.
- Filters the launcher through server-side Return preflight and pair capability checks without minting temporary Review/Confirmation authority.
- Adds a PII-free Review -> Confirm -> Execute client state machine; Execute retry reuses the same operation and confirmation authority.
- Adds bounded server-derived original identity/edit-link output after successful Return.
- Packages the new Return UI assets for later minimal enablement while production bootstrap continues to register zero Return hooks.

## Local evidence

- All PHP syntax checks passed.
- `php tests/unit/run.php`: 30 passed.
- `tests/ci/workflow-contract.sh`: passed.
- `tests/ci/distribution-contract.sh`: passed.
- Shared modal JS lifecycle regressions: passed.
- `return-ui-readiness-smoke.php`: passed on the active WordPress Local worktree.
- `return-review-confirm-authority-smoke.php`: passed.
- `return-service-adapter-smoke.php`: passed, including strategy/stock/replay/recovery/sibling cases.
- `merge-ui-foundation-smoke.php`: passed.

The production PR intentionally does not enable Return. Exact-derived enabled sandbox evidence will be attached after this PR head is stable and canonical CI is green. No ZIP, release, publication, or deployment is authorized.