### PR TITLE
WOS-RETURN-007: enable production Return

### DIFF
--- a/.github/scripts/validate-distribution-contract.sh
+++ b/.github/scripts/validate-distribution-contract.sh
@@ -47,7 +47,7 @@ grep -Fq 'return WCOS_Feature_Gates::any_enabled();' "$distribution_root/inc/cor
 grep -Fq 'self::SPLIT => true' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Split gate drifted"
 grep -Fq 'self::DUPLICATE => true' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Duplicate gate drifted"
 grep -Fq 'self::MERGE => true' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Merge gate drifted"
-grep -Fq 'self::RETURN_ORDER => false' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Return gate drifted"
+grep -Fq 'self::RETURN_ORDER => true' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Return gate drifted"
 grep -Fq 'self::BULK_RETURN => false' "$distribution_root/inc/domain/class-wcos-feature-gates.php" || fail "Bulk Return gate drifted"
 grep -Fq 'self::MANUAL_QUANTITY => true' "$distribution_root/inc/domain/class-wcos-split-strategy-gates.php" || fail "Manual Quantity gate drifted"
 grep -Fq 'self::CATEGORY => true' "$distribution_root/inc/domain/class-wcos-split-strategy-gates.php" || fail "Category gate drifted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,9 @@ jobs:
       - name: Verify Return admin client syntax
         run: node --check js/p2-return-admin.js
 
+      - name: Run Return focus lifecycle regression
+        run: node tests/js/p2-return-focus-lifecycle.js
+
   package-check:
     name: Package safety contract
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MERGE => true' inc/domain/class-wcos-feature-gates.php
-          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php
@@ -317,19 +317,17 @@ jobs:
             if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE)) { exit(1); }
             if (!WCOS_Feature_Gates::any_enabled()) { exit(1); }
             if (!WC_Order_Splitter_Safety_Guard::mutations_enabled()) { exit(1); }
-            foreach (array(
-              WCOS_Feature_Gates::RETURN_ORDER,
-              WCOS_Feature_Gates::BULK_RETURN
-            ) as $disabled_workflow) {
+            if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER)) { exit(1); }
+            foreach (array(WCOS_Feature_Gates::BULK_RETURN) as $disabled_workflow) {
               if (WCOS_Feature_Gates::enabled($disabled_workflow)) { exit(1); }
             }
-            if (null !== WCOS_Return_Admin_Controller::bootstrap()) { exit(1); }
+            if (!(WCOS_Return_Admin_Controller::bootstrap() instanceof WCOS_Return_Admin_Controller)) { exit(1); }
             foreach (array(
               WCOS_Return_Admin_Controller::REVIEW_ACTION,
               WCOS_Return_Admin_Controller::CONFIRM_ACTION,
               WCOS_Return_Admin_Controller::EXECUTE_ACTION
             ) as $return_action) {
-              if (false !== has_action("wp_ajax_" . $return_action)) { exit(1); }
+              if (false === has_action("wp_ajax_" . $return_action)) { exit(1); }
             }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::MANUAL_QUANTITY)) { exit(1); }
             if (!WCOS_Split_Strategy_Gates::enabled(WCOS_Split_Strategy_Gates::CATEGORY)) { exit(1); }
@@ -408,20 +406,23 @@ jobs:
       - name: Verify governance, authorization, and metadata policy
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
 
-      - name: Verify hard-off Return domain and hardened Split lineage authority
+      - name: Verify enabled Return domain and hardened Split lineage authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-domain-lineage-smoke.php
 
-      - name: Verify hard-off Return recovery retirement stock and sibling-evolution foundation
+      - name: Verify enabled Return recovery retirement stock and sibling-evolution foundation
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-recovery-foundation-smoke.php
 
-      - name: Verify hard-off Return service and WooCommerce adapter contracts
+      - name: Verify enabled Return service and WooCommerce adapter contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-service-adapter-smoke.php
 
-      - name: Verify hard-off Return Review Confirm Execute authority
+      - name: Verify enabled Return Review Confirm Execute authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-review-confirm-authority-smoke.php
 
-      - name: Verify hard-off Return UI readiness
+      - name: Verify enabled Return UI readiness
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-ui-readiness-smoke.php
+
+      - name: Verify enabled production Return controller gateway and storage contracts
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-enabled-production-smoke.php
 
       - name: Verify Merge domain foundation contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-domain-foundation-smoke.php

--- a/.github/workflows/main-attestation.yml
+++ b/.github/workflows/main-attestation.yml
@@ -45,7 +45,7 @@ jobs:
           grep -Fq 'self::SPLIT => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::DUPLICATE => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MERGE => true' inc/domain/class-wcos-feature-gates.php
-          grep -Fq 'self::RETURN_ORDER => false' inc/domain/class-wcos-feature-gates.php
+          grep -Fq 'self::RETURN_ORDER => true' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php
           grep -Fq 'self::MANUAL_QUANTITY => true' inc/domain/class-wcos-split-strategy-gates.php
           grep -Fq 'self::CATEGORY => true' inc/domain/class-wcos-split-strategy-gates.php

--- a/inc/domain/class-wcos-feature-gates.php
+++ b/inc/domain/class-wcos-feature-gates.php
@@ -22,7 +22,7 @@ final class WCOS_Feature_Gates {
 		self::SPLIT => true,
 		self::DUPLICATE => true,
 		self::MERGE => true,
-		self::RETURN_ORDER => false,
+		self::RETURN_ORDER => true,
 		self::BULK_RETURN => false,
 	);
 

--- a/js/p2-return-admin.js
+++ b/js/p2-return-admin.js
@@ -207,13 +207,15 @@
 				confirmCheckbox.checked = false;
 				setPhase('reviewed');
 				setStatus(text('reviewReady', 'The child passed server review. Acknowledge the immutable summary to confirm Return.'));
-				confirmCheckbox.focus();
 			}).catch(function (error) {
 				resetForExplicitReview();
 				setStatus('');
 				showError(error.message);
 			}).finally(function () {
 				setBusy(false);
+				if ('reviewed' === phase && reviewAuthority) {
+					confirmCheckbox.focus();
+				}
 			});
 		}
 
@@ -235,7 +237,6 @@
 				retryReady = false;
 				setPhase('confirmed');
 				setStatus(text('confirmReady', 'Return is confirmed. Execute this exact operation when ready.'));
-				executeButton.focus();
 			}).catch(function (error) {
 				reviewAuthority = null;
 				confirmationAuthority = null;
@@ -246,6 +247,9 @@
 				showError(error.message);
 			}).finally(function () {
 				setBusy(false);
+				if ('confirmed' === phase && confirmationAuthority) {
+					executeButton.focus();
+				}
 			});
 		}
 

--- a/js/p2-return-admin.js
+++ b/js/p2-return-admin.js
@@ -175,6 +175,67 @@
 		function setBusy(nextBusy) {
 			busy = !!nextBusy;
 			updateControls();
+			if (busy && !focusableElements().length) {
+				focusDialogFallback();
+			}
+		}
+
+		function isUsableFocusTarget(element) {
+			if (!element || element.disabled || 'hidden' === element.getAttribute('type')) {
+				return false;
+			}
+			var tabindex = element.getAttribute('tabindex');
+			if (null !== tabindex && parseInt(tabindex, 10) < 0) {
+				return false;
+			}
+			var current = element;
+			while (current && current !== dialog) {
+				if (current.hidden || 'true' === current.getAttribute('aria-hidden')) {
+					return false;
+				}
+				if (typeof window.getComputedStyle === 'function') {
+					var style = window.getComputedStyle(current);
+					if (style && ('none' === style.display || 'hidden' === style.visibility)) {
+						return false;
+					}
+				}
+				current = current.parentNode;
+			}
+			return current === dialog;
+		}
+
+		function focusableElements() {
+			var selector = 'a[href], area[href], input, select, textarea, button, iframe, object, embed, [contenteditable="true"], [tabindex]';
+			return Array.prototype.filter.call(dialog.querySelectorAll(selector), isUsableFocusTarget);
+		}
+
+		function focusDialogFallback() {
+			var content = dialog.querySelector('.wc-backbone-modal-content');
+			if (content && typeof content.focus === 'function') {
+				content.focus();
+			}
+		}
+
+		function trapFocus(event) {
+			if ('Tab' !== event.key) {
+				return;
+			}
+			var targets = focusableElements();
+			if (!targets.length) {
+				event.preventDefault();
+				focusDialogFallback();
+				return;
+			}
+			var first = targets[0];
+			var last = targets[targets.length - 1];
+			var active = document.activeElement;
+			if (event.shiftKey && (active === first || !dialog.contains(active))) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+				event.preventDefault();
+				first.focus();
+			}
 		}
 
 		function resetForExplicitReview() {
@@ -349,6 +410,10 @@
 				executeButton.addEventListener('click', executeReturn);
 				confirmCheckbox.addEventListener('change', updateControls);
 				root.addEventListener('keydown', function (event) {
+					if ('Tab' === event.key) {
+						trapFocus(event);
+						return;
+					}
 					if ('Escape' === event.key && busy) {
 						event.preventDefault();
 						event.stopImmediatePropagation();

--- a/tests/integration/governance-smoke.php
+++ b/tests/integration/governance-smoke.php
@@ -35,14 +35,10 @@ foreach (array(
 wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Approved manual quantity Split gate is not enabled.');
 wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Approved hardened Duplicate gate is not enabled.');
 wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Approved hardened Merge gate is not enabled.');
+wcos_governance_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Approved hardened Return gate is not enabled.');
 wcos_governance_assert(WCOS_Feature_Gates::any_enabled(), 'Approved production workflow set was reported as entirely disabled.');
 wcos_governance_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved production gate set.');
-foreach (array(
-	WCOS_Feature_Gates::RETURN_ORDER,
-	WCOS_Feature_Gates::BULK_RETURN,
-) as $disabled_workflow) {
-	wcos_governance_assert(!WCOS_Feature_Gates::enabled($disabled_workflow), 'An unapproved mutation workflow became production-enabled.');
-}
+wcos_governance_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return became production-enabled.');
 
 $order = wc_create_order();
 $order->set_status('pending');

--- a/tests/integration/p2-production-duplicate-enabled-smoke.php
+++ b/tests/integration/p2-production-duplicate-enabled-smoke.php
@@ -18,14 +18,10 @@ function wcos_p2_duplicate_enabled_expect_transport($code, $http_status, callabl
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Production Split gate was lost while enabling Duplicate.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Hardened Duplicate is not production-enabled in the enablement contract.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate was lost while validating Duplicate.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate was lost while validating Duplicate.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::any_enabled(), 'Approved production gate set was reported as fully disabled.');
 wcos_p2_adapter_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved Duplicate gate.');
-foreach (array(
-	WCOS_Feature_Gates::RETURN_ORDER,
-	WCOS_Feature_Gates::BULK_RETURN,
-) as $disabled_workflow) {
-	wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled($disabled_workflow), 'An unapproved mutation workflow is enabled alongside Duplicate.');
-}
+wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return is enabled alongside Duplicate.');
 
 $duplicate_enabled_previous_user = get_current_user_id();
 $duplicate_enabled_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));

--- a/tests/integration/p2-production-split-enabled-smoke.php
+++ b/tests/integration/p2-production-split-enabled-smoke.php
@@ -17,14 +17,10 @@ function wcos_p2_enabled_expect_transport($code, $http_status, callable $callbac
 
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Manual quantity Split is not production-enabled in the enablement contract.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Production Merge gate was lost while validating Split.');
+wcos_p2_adapter_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate was lost while validating Split.');
 wcos_p2_adapter_assert(WCOS_Feature_Gates::any_enabled(), 'Production gate set was reported as fully disabled.');
 wcos_p2_adapter_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not reflect the approved Split gate.');
-foreach (array(
-	WCOS_Feature_Gates::RETURN_ORDER,
-	WCOS_Feature_Gates::BULK_RETURN,
-) as $disabled_workflow) {
-	wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled($disabled_workflow), 'An unapproved mutation workflow is enabled alongside Split.');
-}
+wcos_p2_adapter_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return is enabled alongside Split.');
 
 $enabled_previous_user = get_current_user_id();
 $enabled_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));

--- a/tests/integration/return-domain-lineage-smoke.php
+++ b/tests/integration/return-domain-lineage-smoke.php
@@ -200,8 +200,8 @@ function wcos_return_foundation_strategy_case($strategy, $user_id) {
 
 wcos_return_foundation_assert(class_exists('WCOS_Return_Lineage_Authority'), 'Return lineage class is not loaded.');
 wcos_return_foundation_assert(class_exists('WCOS_Return_Preflight'), 'Return preflight class is not loaded.');
-wcos_return_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return gate changed during hard-off foundation.');
-wcos_return_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate changed during hard-off foundation.');
+wcos_return_foundation_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate is not enabled.');
+wcos_return_foundation_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return production gate changed.');
 
 $user_id = wp_insert_user(array(
 	'user_login' => 'wcos_return_foundation_' . wp_generate_password(8, false),

--- a/tests/integration/return-enabled-production-smoke.php
+++ b/tests/integration/return-enabled-production-smoke.php
@@ -1,0 +1,225 @@
+<?php
+
+if (!defined('ABSPATH')) { exit(1); }
+
+function wcos_return_production_assert($condition, $message) {
+	if (!$condition) { throw new RuntimeException($message); }
+}
+
+function wcos_return_production_fixture($label, $strategy) {
+	$product = new WC_Product_Simple();
+	$product->set_name('WCOS Return production ' . $label);
+	$product->set_regular_price('10.00'); $product->set_price('10.00');
+	$product->set_manage_stock(true); $product->set_stock_quantity(40); $product->set_backorders('yes');
+	wcos_return_production_assert($product->save() > 0, 'Production Return product could not be saved.');
+	$keep = new WC_Product_Simple();
+	$keep->set_name('WCOS Return production keep ' . $label);
+	$keep->set_regular_price('3.00'); $keep->set_price('3.00'); $keep->set_manage_stock(false);
+	wcos_return_production_assert($keep->save() > 0, 'Production Return keep product could not be saved.');
+
+	$original = wc_create_order();
+	$original->set_status('pending'); $original->set_currency('USD'); $original->set_prices_include_tax(false);
+	$original->set_billing_email('production-private-' . wp_generate_uuid4() . '@example.test');
+	$original->set_billing_address_1('Production Private Street');
+	$item_id = $original->add_product($product, 2);
+	$original->add_product($keep, 1);
+	$original->calculate_totals(false); $original->save();
+	$item = $original->get_item($item_id);
+	$item->add_meta_data('Production identity', $strategy, true);
+	$item->add_meta_data('_reduced_stock', '2.000000', true);
+	$item->save();
+	$original->get_data_store()->set_stock_reduced($original->get_id(), true);
+	$stock_before = WCOS_Decimal::normalize(wc_get_product($product->get_id())->get_stock_quantity(), 6);
+	$split_operation = 'return-production-split-' . wp_generate_uuid4();
+	$source = wc_get_order($original->get_id());
+	if ('manual_quantity' === $strategy) {
+		$children = (new WCOS_Mutation_Gateway())->split($source, array('production-child' => array($item_id => '1.000000')), $split_operation, 2);
+	} else {
+		$children = (new WCOS_Split_WooCommerce_Adapter())->split(
+			$source,
+			array('production-child' => array($item_id => '2.000000')),
+			$split_operation,
+			2,
+			WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER,
+			array('strategy_authority' => array(
+				'strategy' => $strategy,
+				'planner_policy_version' => 'category' === $strategy ? WCOS_Category_Split_Planner::POLICY_VERSION : WCOS_Stock_Status_Split_Planner::POLICY_VERSION,
+				'classification_fingerprint' => hash('sha256', 'return-production-' . $strategy . '-' . $label),
+				'source_bucket_key' => $strategy . '-production-source',
+				'review_source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
+			))
+		);
+	}
+	wcos_return_production_assert(1 === count($children), 'Production Return Split did not create one child.');
+	return array(
+		'product_ids' => array($product->get_id(), $keep->get_id()),
+		'product_id' => $product->get_id(),
+		'original_id' => $original->get_id(),
+		'child_id' => $children[0]->get_id(),
+		'strategy' => $strategy,
+		'stock_before' => $stock_before,
+		'review_ids' => array(),
+		'operation_ids' => array(),
+	);
+}
+
+function wcos_return_production_request(array $fixture) {
+	return array(
+		'child_order_id' => $fixture['child_id'],
+		'nonce' => wp_create_nonce('wcos_return_order_' . $fixture['child_id']),
+	);
+}
+
+function wcos_return_production_cleanup(array $fixture) {
+	delete_option('wcos_manual_reconcile_block_' . absint($fixture['child_id']));
+	delete_option('wcos_manual_reconcile_block_' . absint($fixture['original_id']));
+	foreach ($fixture['review_ids'] as $review_id) { WCOS_Return_Review_Store::delete($review_id); }
+	foreach ($fixture['operation_ids'] as $operation_id) {
+		WCOS_Return_Confirmation_Store::delete($operation_id);
+		$child = wc_get_order($fixture['child_id']);
+		if ($child instanceof WC_Order) { WCOS_Operation_Journal::delete($child, $operation_id); }
+	}
+	foreach (array($fixture['child_id'], $fixture['original_id']) as $order_id) {
+		$order = wc_get_order($order_id);
+		if ($order instanceof WC_Order) {
+			$summary = $order->get_meta(WCOS_Operation_Journal::SUMMARY_META_KEY, true);
+			foreach (is_array($summary) ? $summary : array() as $entry) {
+				if (!empty($entry['operation_id'])) { WCOS_Operation_Journal::delete($order, $entry['operation_id']); }
+			}
+			$order->delete(true);
+		}
+	}
+	foreach ($fixture['product_ids'] as $product_id) {
+		$product = wc_get_product($product_id);
+		if ($product instanceof WC_Product) { $product->delete(true); }
+	}
+}
+
+function wcos_return_production_reduced_total(WC_Order $order) {
+	$total = 0;
+	foreach ($order->get_items('line_item') as $item) {
+		$value = $item->get_meta('_reduced_stock', true);
+		if ('' !== (string) $value) { $total += WCOS_Decimal::to_units($value, 6); }
+	}
+	return WCOS_Decimal::from_units($total, 6);
+}
+
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_return_production_assert(!empty($admins), 'Enabled Return production requires an administrator.');
+wp_set_current_user(absint($admins[0]));
+wcos_return_production_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate is not enabled.');
+wcos_return_production_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Production Bulk Return gate drifted on.');
+foreach (array(WCOS_Feature_Gates::SPLIT, WCOS_Feature_Gates::DUPLICATE, WCOS_Feature_Gates::MERGE) as $workflow) {
+	wcos_return_production_assert(WCOS_Feature_Gates::enabled($workflow), 'Accepted production workflow gate drifted off: ' . $workflow);
+}
+
+$controller = WCOS_Return_Admin_Controller::bootstrap();
+wcos_return_production_assert($controller instanceof WCOS_Return_Admin_Controller, 'Enabled Return controller did not bootstrap.');
+$hook_contracts = array(
+	'wp_ajax_' . WCOS_Return_Admin_Controller::REVIEW_ACTION => 'ajax_review',
+	'wp_ajax_' . WCOS_Return_Admin_Controller::CONFIRM_ACTION => 'ajax_confirm',
+	'wp_ajax_' . WCOS_Return_Admin_Controller::EXECUTE_ACTION => 'ajax_execute',
+	'woocommerce_order_item_add_action_buttons' => 'render_launcher',
+	'admin_footer' => 'render_dialog',
+	'admin_enqueue_scripts' => 'enqueue_assets',
+);
+foreach ($hook_contracts as $hook => $method) {
+	wcos_return_production_assert(false !== has_action($hook, array($controller, $method)), 'Enabled Return hook is missing: ' . $hook);
+}
+foreach (array('wp_ajax_return_order', 'wp_ajax_return_order_bulk', 'woocommerce_order_action_yoos_return_order') as $legacy_hook) {
+	wcos_return_production_assert(false === has_action($legacy_hook), 'Legacy or Bulk Return hook became reachable: ' . $legacy_hook);
+}
+
+$fixtures = array();
+try {
+	foreach (array('manual_quantity', 'category', 'stock_status') as $strategy) {
+		$fixture = wcos_return_production_fixture('controller-' . $strategy, $strategy);
+		$fixtures[] = $fixture; $index = count($fixtures) - 1;
+		$request = wcos_return_production_request($fixture);
+		$child = wc_get_order($fixture['child_id']);
+		$child_line_count = count($child->get_items('line_item'));
+
+		ob_start(); $controller->render_launcher($child); $launcher = (string) ob_get_clean();
+		wcos_return_production_assert(false !== strpos($launcher, 'Return to original order'), 'Eligible Return launcher did not render: ' . $strategy);
+		wcos_return_production_assert(false === strpos($launcher, '@example.test') && false === strpos($launcher, 'Private Street'), 'Return launcher exposed PII.');
+		ob_start(); $controller->render_dialog(); $dialog = (string) ob_get_clean();
+		wcos_return_production_assert(false !== strpos($dialog, 'data-child-order-id="' . $fixture['child_id'] . '"'), 'Eligible Return modal did not freeze the current child: ' . $strategy);
+		wcos_return_production_assert(false === strpos($dialog, '@example.test') && false === strpos($dialog, 'Private Street'), 'Return modal exposed PII.');
+
+		$unexpected = $request; $unexpected['original_order_id'] = $fixture['original_id'];
+		$client_original_rejected = false;
+		try { $controller->review_request($unexpected); }
+		catch (WCOS_Return_Transport_Exception $exception) { $client_original_rejected = 'unexpected_field' === $exception->get_error_code(); }
+		wcos_return_production_assert($client_original_rejected, 'Client-selected original was accepted: ' . $strategy);
+
+		$review = $controller->review_request($request);
+		$fixtures[$index]['review_ids'][] = $review['review_id'];
+		wcos_return_production_assert($strategy === $review['summary']['strategy'], 'Return Review lost strategy: ' . $strategy);
+		wcos_return_production_assert($fixture['original_id'] === $review['summary']['original']['id'], 'Return Review changed server-resolved original.');
+		wcos_return_production_assert($fixture['child_id'] === $review['summary']['child']['id'], 'Return Review changed child identity.');
+		wcos_return_production_assert(false === strpos(wp_json_encode($review['summary']), '@example.test'), 'Return Review summary exposed PII.');
+
+		$confirm = $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token'])));
+		$fixtures[$index]['operation_ids'][] = $confirm['operation_id'];
+		if ('category' === $strategy) {
+			$second_confirm_rejected = false;
+			try { $controller->confirm_request(array_merge($request, array('review_id' => $review['review_id'], 'review_token' => $review['review_token']))); }
+			catch (WCOS_Return_Transport_Exception $exception) { $second_confirm_rejected = 0 === strpos($exception->get_error_code(), 'review_'); }
+			wcos_return_production_assert($second_confirm_rejected, 'One Return Review created two Confirm results.');
+		}
+		$execute_request = array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token']));
+		if ('manual_quantity' === $strategy) {
+			$invalid_token_rejected = false;
+			try { $controller->execute_request(array_merge($execute_request, array('confirmation_token' => 'invalid'))); }
+			catch (WCOS_Return_Transport_Exception $exception) { $invalid_token_rejected = 'confirmation_invalid_token' === $exception->get_error_code(); }
+			wcos_return_production_assert($invalid_token_rejected, 'Invalid Return Confirmation reached Execute.');
+			wcos_return_production_assert(null === WCOS_Operation_Journal::get($child, $confirm['operation_id']), 'Invalid Confirmation created a journal.');
+		}
+
+		$result = $controller->execute_request($execute_request);
+		$child = wc_get_order($fixture['child_id']); $original = wc_get_order($fixture['original_id']);
+		wcos_return_production_assert('completed' === $result['status'] && 'trash' === $child->get_status(), 'Enabled Return did not complete/retire child: ' . $strategy);
+		wcos_return_production_assert($fixture['original_id'] === $result['original']['id'] && !empty($result['original']['edit_url']), 'Return result lacks bounded original navigation.');
+		wcos_return_production_assert($child_line_count === count($child->get_items('line_item')), 'Return retirement deleted child history.');
+		wcos_return_production_assert('2.000000' === wcos_return_production_reduced_total($original), 'Return did not restore exact reduced-stock ownership.');
+		wcos_return_production_assert('0.000000' === wcos_return_production_reduced_total($child), 'Retired child retained reduced-stock ownership.');
+		wcos_return_production_assert((bool) $original->get_data_store()->get_stock_reduced($original->get_id()), 'Original did not regain order stock flag.');
+		wcos_return_production_assert(!(bool) $child->get_data_store()->get_stock_reduced($child->get_id()), 'Retired child kept order stock flag.');
+		wcos_return_production_assert($fixture['stock_before'] === WCOS_Decimal::normalize(wc_get_product($fixture['product_id'])->get_stock_quantity(), 6), 'Controller Return changed physical stock.');
+
+		$child_signature = WCOS_Order_Contract_Snapshot::source_signature($child);
+		$original_signature = WCOS_Order_Contract_Snapshot::source_signature($original);
+		$replay = $controller->execute_request($execute_request);
+		wcos_return_production_assert($result === $replay, 'Response-loss retry did not replay the same terminal result.');
+		wcos_return_production_assert($child_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id'])), 'Replay repeated child commercial writes.');
+		wcos_return_production_assert($original_signature === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id'])), 'Replay repeated original commercial writes.');
+	}
+
+	$drift = wcos_return_production_fixture('drift', 'manual_quantity');
+	$fixtures[] = $drift; $drift_index = count($fixtures) - 1;
+	$drift_request = wcos_return_production_request($drift);
+	$drift_review = $controller->review_request($drift_request); $fixtures[$drift_index]['review_ids'][] = $drift_review['review_id'];
+	$drift_child = wc_get_order($drift['child_id']); $drift_line = current($drift_child->get_items('line_item'));
+	$drift_line->add_meta_data('Production drift', 'reject', true); $drift_line->save();
+	$drift_rejected = false;
+	try { $controller->confirm_request(array_merge($drift_request, array('review_id' => $drift_review['review_id'], 'review_token' => $drift_review['review_token']))); }
+	catch (WCOS_Return_Transport_Exception $exception) { $drift_rejected = 0 === strpos($exception->get_error_code(), 'review_'); }
+	wcos_return_production_assert($drift_rejected, 'Return Confirm accepted participant drift.');
+
+	$blocked = wcos_return_production_fixture('blocked', 'manual_quantity');
+	$fixtures[] = $blocked;
+	$blocked_child = wc_get_order($blocked['child_id']);
+	wcos_return_production_assert(WCOS_Manual_Reconciliation_Blocker::block($blocked_child, 'return-production-blocked'), 'Manual-reconciliation blocker fixture failed.');
+	ob_start(); $controller->render_launcher($blocked_child); $blocked_launcher = (string) ob_get_clean();
+	wcos_return_production_assert('' === $blocked_launcher, 'Blocked Return child exposed a launcher.');
+	$blocked_rejected = false;
+	try { $controller->review_request(wcos_return_production_request($blocked)); }
+	catch (WCOS_Return_Transport_Exception $exception) { $blocked_rejected = 0 === strpos($exception->get_error_code(), 'preflight_'); }
+	wcos_return_production_assert($blocked_rejected, 'Blocked Return child minted Review authority.');
+
+	echo "return-enabled-production-ok strategies=3 hooks=6 client_original_rejected=3 replay=3 drift=1 blocked=1 bulk_return=off\n";
+} finally {
+	foreach (array_reverse($fixtures) as $fixture) {
+		try { wcos_return_production_cleanup($fixture); } catch (Throwable $throwable) {}
+	}
+}

--- a/tests/integration/return-recovery-foundation-smoke.php
+++ b/tests/integration/return-recovery-foundation-smoke.php
@@ -666,7 +666,7 @@ function wcos_return_recovery_strategy_case($strategy, $user_id) {
 	foreach ($terms as $term_id) { wp_delete_term($term_id, 'product_cat'); }
 }
 
-wcos_return_recovery_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return production gate changed.');
+wcos_return_recovery_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate is not enabled.');
 wcos_return_recovery_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return production gate changed.');
 wcos_return_recovery_assert(class_exists('WCOS_Return_Compensator'), 'Return compensator is not loaded.');
 

--- a/tests/integration/return-review-confirm-authority-smoke.php
+++ b/tests/integration/return-review-confirm-authority-smoke.php
@@ -151,12 +151,10 @@ wp_set_current_user($operator_id);
 $controller = new WCOS_Return_Admin_Controller();
 $fixtures = array();
 
-wcos_return_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return production gate drifted on.');
-wcos_return_authority_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return production gate drifted on.');
-wcos_return_authority_assert(null === WCOS_Return_Admin_Controller::bootstrap(), 'Hard-off Return bootstrap returned a controller.');
-wcos_return_authority_assert(false === $controller->register_hooks(), 'Hard-off Return controller registered hooks.');
+wcos_return_authority_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate is not enabled.');
+wcos_return_authority_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return production gate drifted on.');
 foreach (array(WCOS_Return_Admin_Controller::REVIEW_ACTION, WCOS_Return_Admin_Controller::CONFIRM_ACTION, WCOS_Return_Admin_Controller::EXECUTE_ACTION) as $action) {
-	wcos_return_authority_assert(false === has_action('wp_ajax_' . $action), 'Hard-off Return AJAX hook was registered: ' . $action);
+	wcos_return_authority_assert(false !== has_action('wp_ajax_' . $action), 'Enabled Return AJAX hook is missing: ' . $action);
 }
 
 try {
@@ -165,8 +163,6 @@ try {
 		$fixtures[] = $fixture;
 		$index = count($fixtures) - 1;
 		$request = wcos_return_authority_request($fixture);
-		$child_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id']));
-		$original_before = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id']));
 		$review = $controller->review_request($request);
 		$fixtures[$index]['review_ids'][] = $review['review_id'];
 		wcos_return_authority_assert($strategy === $review['summary']['strategy'], 'Return Review lost exact Split strategy display authority.');
@@ -189,18 +185,17 @@ try {
 		wcos_return_authority_assert(is_array($confirm_record) && false === strpos(wp_json_encode($confirm_record), $confirm['confirmation_token']), 'Return Confirmation persisted its raw token.');
 		wcos_return_authority_assert(false === strpos(wp_json_encode($confirm_record), '@example.test'), 'Return Confirmation persisted customer PII.');
 
-		for ($attempt = 0; $attempt < 2; $attempt++) {
-			$disabled = false;
-			try {
-				$controller->execute_request(array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token'])));
-			} catch (WCOS_Return_Transport_Exception $exception) {
-				$disabled = 'workflow_disabled' === $exception->get_error_code();
-			}
-			wcos_return_authority_assert($disabled, 'Hard-off Return controller Execute did not return workflow_disabled.');
-		}
-		wcos_return_authority_assert(null === WCOS_Operation_Journal::get(wc_get_order($fixture['child_id']), $confirm['operation_id']), 'Hard-off Return controller Execute created a journal.');
-		wcos_return_authority_assert($child_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id'])), 'Hard-off Return controller Execute changed child commercial state.');
-		wcos_return_authority_assert($original_before === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id'])), 'Hard-off Return controller Execute changed original commercial state.');
+		$execute_request = array_merge($request, array('operation_id' => $confirm['operation_id'], 'confirmation_token' => $confirm['confirmation_token']));
+		$result = $controller->execute_request($execute_request);
+		wcos_return_authority_assert('completed' === $result['status'], 'Enabled Return controller Execute did not complete: ' . $strategy);
+		$child_after = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id']));
+		$original_after = WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id']));
+		$replay = $controller->execute_request($execute_request);
+		wcos_return_authority_assert($result === $replay, 'Enabled Return response-loss retry did not replay the exact terminal result.');
+		wcos_return_authority_assert($child_after === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['child_id'])), 'Enabled Return replay repeated child commercial writes.');
+		wcos_return_authority_assert($original_after === WCOS_Order_Contract_Snapshot::source_signature(wc_get_order($fixture['original_id'])), 'Enabled Return replay repeated original commercial writes.');
+		$journal = WCOS_Operation_Journal::get(wc_get_order($fixture['child_id']), $confirm['operation_id']);
+		wcos_return_authority_assert(is_array($journal) && 'completed' === $journal['status'], 'Enabled Return controller did not persist completed durable authority.');
 	}
 
 	$primary = wcos_return_authority_fixture('handoff', 'manual_quantity');
@@ -497,7 +492,7 @@ try {
 	wcos_return_authority_assert($legacy_rejected, 'Legacy yoos_* metadata minted Return Review authority.');
 	$legacy_child->delete(true); $legacy_original->delete(true); $legacy_product->delete(true);
 
-	echo "return-review-confirm-authority-ok strategies=3 gate_off_attempts=6 durable_handoff=1 immutable_handoff=1 legacy_addition_rejected=1 confirmed_states=4 corrupt_recovery=3 stripped_confirmed_quarantined=1 cas_single_consume=1\n";
+	echo "return-review-confirm-authority-ok strategies=3 enabled_execute=3 replay=3 durable_handoff=1 immutable_handoff=1 legacy_addition_rejected=1 confirmed_states=4 corrupt_recovery=3 stripped_confirmed_quarantined=1 cas_single_consume=1\n";
 } finally {
 	foreach (array_reverse($fixtures) as $fixture) {
 		try { wcos_return_authority_cleanup($fixture); } catch (Throwable $throwable) {}

--- a/tests/integration/return-service-adapter-smoke.php
+++ b/tests/integration/return-service-adapter-smoke.php
@@ -546,7 +546,7 @@ wp_set_current_user($admin_id);
 
 $evidence = array();
 try {
-	/* The adapter is directly callable while the production gateway gate remains hard-off. */
+	/* The adapter remains directly testable while production uses the enabled gateway/controller path. */
 	$fixture = wcos_return_service_fixture('success');
 	$return_operation = 'return-service-' . wp_generate_uuid4();
 	$child = wc_get_order($fixture['child_id']);
@@ -555,12 +555,7 @@ try {
 	try { (new WCOS_Return_WooCommerce_Adapter())->return_order(wc_get_order($fixture['original_id']), $unsupported_operation, 2); }
 	catch (WCOS_Return_Adapter_Exception $exception) { $unsupported = 0 === strpos($exception->get_error_code(), 'return_preflight_'); }
 	wcos_return_service_assert($unsupported && !is_array(WCOS_Operation_Journal::get(wc_get_order($fixture['original_id']), $unsupported_operation)), 'Return adapter did not reject unsupported lineage before journal persistence.');
-	$gateway_rejected = false;
-	$gate_operation = 'return-gate-' . wp_generate_uuid4();
-	try { (new WCOS_Mutation_Gateway())->return_order($child, $gate_operation, 2); }
-	catch (RuntimeException $exception) { $gateway_rejected = true; }
-	wcos_return_service_assert($gateway_rejected, 'Return production gateway did not fail before preflight while its gate is hard-off.');
-	wcos_return_service_assert(!is_array(WCOS_Operation_Journal::get($child, $gate_operation)), 'Return gate rejection created a journal.');
+	wcos_return_service_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gateway is not enabled.');
 
 	list($result, $retirement_counts) = wcos_return_service_observed_execute($child, $return_operation, 2);
 	$child = wc_get_order($fixture['child_id']); $original = wc_get_order($fixture['original_id']);

--- a/tests/integration/return-ui-readiness-smoke.php
+++ b/tests/integration/return-ui-readiness-smoke.php
@@ -15,12 +15,10 @@ $admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 
 wcos_return_ui_assert(!empty($admins), 'Return UI readiness requires an administrator fixture.');
 wp_set_current_user(absint($admins[0]));
 
-wcos_return_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate drifted on.');
-wcos_return_ui_assert(false === WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate drifted on.');
-wcos_return_ui_assert(null === WCOS_Return_Admin_Controller::bootstrap(), 'Hard-off Return bootstrap returned a controller.');
+wcos_return_ui_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Production Return gate is not enabled.');
+wcos_return_ui_assert(!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate drifted on.');
 
 $controller = new WCOS_Return_Admin_Controller();
-wcos_return_ui_assert(false === $controller->register_hooks(), 'Hard-off Return controller registered hooks.');
 $hook_contracts = array(
 	'wp_ajax_' . WCOS_Return_Admin_Controller::REVIEW_ACTION => 'ajax_review',
 	'wp_ajax_' . WCOS_Return_Admin_Controller::CONFIRM_ACTION => 'ajax_confirm',
@@ -30,10 +28,8 @@ $hook_contracts = array(
 	'admin_enqueue_scripts' => 'enqueue_assets',
 );
 foreach ($hook_contracts as $hook => $method) {
-	wcos_return_ui_assert(false === has_action($hook, array($controller, $method)), 'Hard-off Return hook was registered: ' . $hook);
+	wcos_return_ui_assert(false !== has_action($hook), 'Enabled Return hook is missing: ' . $hook);
 }
-wcos_return_ui_assert(!wp_script_is('wcos-return-admin', 'registered'), 'Return client was registered through an ungated path.');
-wcos_return_ui_assert(!wp_style_is('wcos-return-admin', 'registered'), 'Return stylesheet was registered through an ungated path.');
 
 $order = wc_create_order();
 $order->set_status('pending');
@@ -68,14 +64,24 @@ try {
 	ob_start();
 	$controller->render_launcher($order);
 	$launcher = (string) ob_get_clean();
-	wcos_return_ui_assert('' === $launcher, 'Hard-off Return launcher rendered.');
+	wcos_return_ui_assert('' === $launcher, 'Ineligible non-Split order exposed a Return launcher.');
 
 	$order_screen_id = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
 	set_current_screen($order_screen_id);
 	$_GET['id'] = (string) $order->get_id();
+	WCOS_Admin_Backbone_Modal_Assets::enqueue();
 	$controller->enqueue_assets();
-	wcos_return_ui_assert(!wp_script_is('wcos-return-admin', 'enqueued'), 'Hard-off Return script was enqueued on an order screen.');
-	wcos_return_ui_assert(!wp_style_is('wcos-return-admin', 'enqueued'), 'Hard-off Return stylesheet was enqueued on an order screen.');
+	WCOS_Admin_Backbone_Modal_Assets::bind_workflow_dependencies();
+	wcos_return_ui_assert(wp_script_is('wcos-return-admin', 'enqueued'), 'Enabled Return script was not enqueued on an order screen.');
+	wcos_return_ui_assert(wp_style_is('wcos-return-admin', 'enqueued'), 'Enabled Return stylesheet was not enqueued on an order screen.');
+	wcos_return_ui_assert(wp_script_is('wcos-admin-backbone-modal', 'enqueued'), 'Shared Backbone modal bridge was not enqueued with Return.');
+	$registered_scripts = wp_scripts();
+	$return_dependencies = isset($registered_scripts->registered['wcos-return-admin']) ? (array) $registered_scripts->registered['wcos-return-admin']->deps : array();
+	wcos_return_ui_assert(in_array('wcos-admin-backbone-modal', $return_dependencies, true), 'Return client is not bound to the shared Backbone modal dependency at runtime.');
+	$return_script_data = isset($registered_scripts->registered['wcos-return-admin']->extra['data']) ? (string) $registered_scripts->registered['wcos-return-admin']->extra['data'] : '';
+	foreach (array('@example.test', 'Private Return Street', '555-0060', 'Private Return Payment') as $private_value) {
+		wcos_return_ui_assert(false === strpos($return_script_data, $private_value), 'Return localized script data exposed customer/payment PII: ' . $private_value);
+	}
 
 	$client = file_get_contents($root . '/js/p2-return-admin.js');
 	wcos_return_ui_assert(is_string($client) && '' !== $client, 'Return admin client is missing.');
@@ -134,4 +140,4 @@ try {
 	$order->delete(true);
 }
 
-echo "return-ui-readiness-ok hard_off_hooks=0 shared_modal=1 pii_free=1 client_authority=bounded\n";
+echo "return-ui-readiness-ok production_enabled=1 ineligible_launcher=hidden assets=enabled shared_modal=1 pii_free=1 client_authority=bounded\n";

--- a/tests/js/p2-return-focus-lifecycle.js
+++ b/tests/js/p2-return-focus-lifecycle.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '../..');
+const client = fs.readFileSync(path.join(root, 'js/p2-return-admin.js'), 'utf8');
+
+function functionBody(name, nextName) {
+    const start = client.indexOf('function ' + name + '(');
+    const end = client.indexOf('function ' + nextName + '(', start);
+    assert.notEqual(start, -1, name + ' must exist');
+    assert.notEqual(end, -1, nextName + ' must follow ' + name);
+    return client.slice(start, end);
+}
+
+function assertOrdered(source, needles, message) {
+    let offset = -1;
+    needles.forEach((needle) => {
+        const next = source.indexOf(needle, offset + 1);
+        assert.notEqual(next, -1, message + ': missing ' + needle);
+        assert.ok(next > offset, message + ': wrong order for ' + needle);
+        offset = next;
+    });
+}
+
+const controls = functionBody('updateControls', 'setBusy');
+assert.match(controls, /confirmCheckbox\.disabled = busy \|\| 'reviewed' !== phase;/,
+    'Review acknowledgement must remain disabled while a request is in flight');
+assert.match(controls, /executeButton\.disabled = busy \|\| \('confirmed' !== phase && 'executing' !== phase\) \|\| !confirmationAuthority;/,
+    'Execute must remain disabled while a request is in flight');
+assert.match(controls, /cancelButton\.disabled = busy;/,
+    'Cancel must remain disabled while a request is in flight');
+assert.match(controls, /closeButton\.disabled = busy;/,
+    'Header close must remain disabled while a request is in flight');
+
+const review = functionBody('reviewReturn', 'confirmReturn');
+assertOrdered(review, [
+    'setBusy(true);',
+    'request(',
+    "setPhase('reviewed');",
+    '}).finally(function () {',
+    'setBusy(false);',
+    "if ('reviewed' === phase && reviewAuthority) {",
+    'confirmCheckbox.focus();'
+], 'Successful Review must clear busy before focusing the enabled acknowledgement');
+assert.equal((review.match(/confirmCheckbox\.focus\(\);/g) || []).length, 1,
+    'Review must have exactly one success-focus site');
+assertOrdered(review, [
+    '}).catch(function (error) {',
+    'resetForExplicitReview();',
+    'showError(error.message);',
+    '}).finally(function () {'
+], 'Review failure must reset authority and focus the error surface before cleanup');
+
+const confirm = functionBody('confirmReturn', 'executeSameOperation');
+assertOrdered(confirm, [
+    'setBusy(true);',
+    'request(',
+    'confirmationAuthority = { operationId: data.operation_id, token: data.confirmation_token };',
+    "setPhase('confirmed');",
+    '}).finally(function () {',
+    'setBusy(false);',
+    "if ('confirmed' === phase && confirmationAuthority) {",
+    'executeButton.focus();'
+], 'Successful Confirm must clear busy before focusing enabled Execute');
+assert.equal((confirm.match(/executeButton\.focus\(\);/g) || []).length, 1,
+    'Confirm must have exactly one success-focus site');
+assertOrdered(confirm, [
+    '}).catch(function (error) {',
+    'reviewAuthority = null;',
+    'confirmationAuthority = null;',
+    "setPhase('closed');",
+    'showError(error.message);',
+    '}).finally(function () {'
+], 'Confirm failure must close authority and focus the error surface before cleanup');
+
+assert.match(client, /function showError\(message\)[\s\S]*errorBox\.focus\(\);/,
+    'Failure paths must focus the modal-local error surface');
+assert.match(client, /if \('Escape' === event\.key && busy\) \{[\s\S]*event\.preventDefault\(\);[\s\S]*event\.stopImmediatePropagation\(\);/,
+    'Busy Escape protection must remain intact');
+
+console.log('p2-return-focus-lifecycle-ok');

--- a/tests/js/p2-return-focus-lifecycle.js
+++ b/tests/js/p2-return-focus-lifecycle.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const root = path.resolve(__dirname, '../..');
 const client = fs.readFileSync(path.join(root, 'js/p2-return-admin.js'), 'utf8');
@@ -80,5 +81,538 @@ assert.match(client, /function showError\(message\)[\s\S]*errorBox\.focus\(\);/,
     'Failure paths must focus the modal-local error surface');
 assert.match(client, /if \('Escape' === event\.key && busy\) \{[\s\S]*event\.preventDefault\(\);[\s\S]*event\.stopImmediatePropagation\(\);/,
     'Busy Escape protection must remain intact');
+assert.match(client, /root\.addEventListener\('keydown',[\s\S]*trapFocus\(event\);/,
+    'Return focus trap must be scoped to the current modal root');
+assert.doesNotMatch(client, /document\.addEventListener\('keydown'/,
+    'Return focus trap must not install a document-global listener');
+assert.equal((client.match(/window\.WCOSBackboneModal\.open/g) || []).length, 1,
+    'Return must continue to use exactly one shared modal entry point');
 
-console.log('p2-return-focus-lifecycle-ok');
+class ClassList {
+    constructor(element) {
+        this.element = element;
+    }
+
+    add(...tokens) {
+        tokens.forEach((token) => this.element.classes.add(token));
+    }
+
+    contains(token) {
+        return this.element.classes.has(token);
+    }
+
+    toString() {
+        return Array.from(this.element.classes).join(' ');
+    }
+}
+
+class Element {
+    constructor(tagName, ownerDocument) {
+        this.tagName = String(tagName).toUpperCase();
+        this.ownerDocument = ownerDocument;
+        this.parentNode = null;
+        this.children = [];
+        this.attributes = new Map();
+        this.classes = new Set();
+        this.classList = new ClassList(this);
+        this.listeners = new Map();
+        this.hidden = false;
+        this.disabled = false;
+        this.checked = false;
+        this._textContent = '';
+    }
+
+    get className() {
+        return this.classList.toString();
+    }
+
+    set className(value) {
+        this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+    }
+
+    get textContent() {
+        return this._textContent + this.children.map((child) => child.textContent).join('');
+    }
+
+    set textContent(value) {
+        this._textContent = String(value);
+        this.children.forEach((child) => { child.parentNode = null; });
+        this.children = [];
+    }
+
+    get isConnected() {
+        let current = this;
+        while (current) {
+            if (current === this.ownerDocument.body) {
+                return true;
+            }
+            current = current.parentNode;
+        }
+        return false;
+    }
+
+    appendChild(child) {
+        if (child.parentNode) {
+            child.parentNode.removeChild(child);
+        }
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    }
+
+    removeChild(child) {
+        const index = this.children.indexOf(child);
+        assert.notEqual(index, -1, 'removeChild target must belong to the parent');
+        this.children.splice(index, 1);
+        child.parentNode = null;
+        return child;
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(String(name), String(value));
+        if (name === 'class') {
+            this.className = value;
+        }
+    }
+
+    getAttribute(name) {
+        return this.attributes.has(name) ? this.attributes.get(name) : null;
+    }
+
+    removeAttribute(name) {
+        this.attributes.delete(name);
+    }
+
+    addEventListener(type, listener) {
+        if (!this.listeners.has(type)) {
+            this.listeners.set(type, []);
+        }
+        this.listeners.get(type).push(listener);
+    }
+
+    dispatchEvent(event) {
+        if (!event.target) {
+            event.target = this;
+        }
+        let current = this;
+        while (current) {
+            event.currentTarget = current;
+            const listeners = current.listeners.get(event.type) || [];
+            for (const listener of listeners) {
+                listener.call(current, event);
+                if (event.immediatePropagationStopped) {
+                    break;
+                }
+            }
+            if (event.propagationStopped) {
+                break;
+            }
+            current = current.parentNode;
+        }
+        return !event.defaultPrevented;
+    }
+
+    click() {
+        if (this.disabled) {
+            return;
+        }
+        this.focus();
+        this.dispatchEvent(keyEvent('click'));
+    }
+
+    focus() {
+        if (!this.disabled) {
+            this.ownerDocument.activeElement = this;
+        }
+    }
+
+    cloneNode(deep) {
+        const clone = new Element(this.tagName, this.ownerDocument);
+        this.attributes.forEach((value, name) => clone.setAttribute(name, value));
+        clone.className = this.className;
+        clone.hidden = this.hidden;
+        clone.disabled = this.disabled;
+        clone.checked = this.checked;
+        clone._textContent = this._textContent;
+        if (deep) {
+            this.children.forEach((child) => clone.appendChild(child.cloneNode(true)));
+        }
+        return clone;
+    }
+
+    contains(candidate) {
+        let current = candidate;
+        while (current) {
+            if (current === this) {
+                return true;
+            }
+            current = current.parentNode;
+        }
+        return false;
+    }
+
+    closest(selector) {
+        let current = this;
+        while (current) {
+            if (matchesSimple(current, selector)) {
+                return current;
+            }
+            current = current.parentNode;
+        }
+        return null;
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+
+    querySelectorAll(selector) {
+        const descendants = [];
+        const visit = (element) => {
+            element.children.forEach((child) => {
+                descendants.push(child);
+                visit(child);
+            });
+        };
+        visit(this);
+        const selectors = selector.split(',').map((value) => value.trim()).filter(Boolean);
+        return descendants.filter((element) => selectors.some((candidate) => matchesSelector(element, candidate, this)));
+    }
+}
+
+function matchesSimple(element, selector) {
+    if (selector.startsWith('.')) {
+        return element.classList.contains(selector.slice(1));
+    }
+    const attributeMatch = selector.match(/^([a-z]+)?\[([^=\]]+)(?:="([^"]*)")?\]$/i);
+    if (attributeMatch) {
+        const tagMatches = !attributeMatch[1] || element.tagName === attributeMatch[1].toUpperCase();
+        const attributeValue = element.getAttribute(attributeMatch[2]);
+        return tagMatches && attributeValue !== null && (attributeMatch[3] === undefined || attributeValue === attributeMatch[3]);
+    }
+    return element.tagName === selector.toUpperCase();
+}
+
+function matchesSelector(element, selector, boundary) {
+    const parts = selector.split(/\s+/).filter(Boolean);
+    if (!parts.length || !matchesSimple(element, parts[parts.length - 1])) {
+        return false;
+    }
+    let ancestor = element.parentNode;
+    for (let index = parts.length - 2; index >= 0; index -= 1) {
+        while (ancestor && ancestor !== boundary.parentNode && !matchesSimple(ancestor, parts[index])) {
+            ancestor = ancestor.parentNode;
+        }
+        if (!ancestor || ancestor === boundary.parentNode) {
+            return false;
+        }
+        ancestor = ancestor.parentNode;
+    }
+    return true;
+}
+
+class Document {
+    constructor() {
+        this.body = new Element('body', this);
+        this.activeElement = this.body;
+    }
+
+    createElement(tagName) {
+        return new Element(tagName, this);
+    }
+
+    getElementById(id) {
+        return this.body.querySelectorAll('[id]').find((element) => element.getAttribute('id') === id) || null;
+    }
+
+    querySelector(selector) {
+        return this.body.querySelector(selector);
+    }
+}
+
+function element(document, tagName, className, textContent = '') {
+    const node = document.createElement(tagName);
+    node.className = className || '';
+    node._textContent = textContent;
+    return node;
+}
+
+function keyEvent(type, values = {}) {
+    return Object.assign({
+        type,
+        key: '',
+        shiftKey: false,
+        defaultPrevented: false,
+        propagationStopped: false,
+        immediatePropagationStopped: false,
+        preventDefault() { this.defaultPrevented = true; },
+        stopPropagation() { this.propagationStopped = true; },
+        stopImmediatePropagation() {
+            this.immediatePropagationStopped = true;
+            this.propagationStopped = true;
+        }
+    }, values);
+}
+
+function pressTab(element, shiftKey = false) {
+    const event = keyEvent('keydown', { key: 'Tab', shiftKey });
+    element.dispatchEvent(event);
+    return event;
+}
+
+function buildSource(document) {
+    const launcher = element(document, 'button', 'wcos-return-launcher', 'Return to original order');
+    launcher.setAttribute('aria-controls', 'wcos-return-dialog-test');
+    launcher.setAttribute('aria-describedby', 'wcos-return-launcher-description');
+    const launcherDescription = element(document, 'span', '', 'Open Return');
+    launcherDescription.setAttribute('id', 'wcos-return-launcher-description');
+
+    const sourceDialog = element(document, 'div', 'wcos-return-dialog');
+    sourceDialog.setAttribute('id', 'wcos-return-dialog-test');
+    sourceDialog.setAttribute('data-child-order-id', '202');
+    sourceDialog.setAttribute('data-nonce', 'test-nonce');
+    sourceDialog.setAttribute('data-ajax-url', '/wp-admin/admin-ajax.php');
+    sourceDialog.setAttribute('data-review-action', 'wcos_return_review');
+    sourceDialog.setAttribute('data-confirm-action', 'wcos_return_confirm');
+    sourceDialog.setAttribute('data-execute-action', 'wcos_return_execute');
+
+    const panel = element(document, 'div', 'wcos-return-dialog__panel');
+    const header = element(document, 'div', 'wcos-return-dialog__header');
+    header.appendChild(element(document, 'h2', '', 'Return to original order'));
+    header.appendChild(element(document, 'p', '', 'Server-resolved original'));
+    panel.appendChild(header);
+    panel.appendChild(element(document, 'div', 'wcos-return-policy', 'Return safety policy'));
+
+    const review = element(document, 'div', 'wcos-return-review');
+    review.hidden = true;
+    review.appendChild(element(document, 'dl', 'wcos-return-review-summary'));
+    const label = element(document, 'label', 'wcos-return-confirm-label');
+    const checkbox = element(document, 'input', 'wcos-return-confirm-checkbox');
+    checkbox.setAttribute('type', 'checkbox');
+    label.appendChild(checkbox);
+    review.appendChild(label);
+    panel.appendChild(review);
+
+    const status = element(document, 'div', 'wcos-return-status');
+    status.setAttribute('tabindex', '-1');
+    panel.appendChild(status);
+    const error = element(document, 'div', 'wcos-return-error');
+    error.setAttribute('tabindex', '-1');
+    error.hidden = true;
+    panel.appendChild(error);
+    const result = element(document, 'div', 'wcos-return-result');
+    result.setAttribute('tabindex', '-1');
+    result.hidden = true;
+    panel.appendChild(result);
+
+    const actions = element(document, 'div', 'wcos-return-dialog__actions');
+    actions.appendChild(element(document, 'button', 'button wcos-return-cancel', 'Close'));
+    actions.appendChild(element(document, 'button', 'button wcos-return-review-button', 'Review return'));
+    const confirm = element(document, 'button', 'button wcos-return-confirm-button', 'Confirm return');
+    confirm.hidden = true;
+    confirm.disabled = true;
+    actions.appendChild(confirm);
+    const execute = element(document, 'button', 'button wcos-return-execute-button', 'Execute return');
+    execute.hidden = true;
+    execute.disabled = true;
+    actions.appendChild(execute);
+    panel.appendChild(actions);
+    sourceDialog.appendChild(panel);
+
+    document.body.appendChild(launcherDescription);
+    document.body.appendChild(launcher);
+    document.body.appendChild(sourceDialog);
+    return { launcher };
+}
+
+function createHarness() {
+    const document = new Document();
+    const source = buildSource(document);
+    const pending = [];
+    let modal = null;
+
+    const window = {
+        wcosReturnAdminStrings: {},
+        getComputedStyle() {
+            return { display: 'block', visibility: 'visible' };
+        },
+        fetch() {
+            return new Promise((resolve, reject) => pending.push({ resolve, reject }));
+        },
+        WCOSBackboneModal: {
+            open(options) {
+                const previousFocus = document.activeElement;
+                const rootElement = element(document, 'div', 'wc-backbone-modal wcos-admin-backbone-modal ' + options.modalClass);
+                const content = element(document, 'div', 'wc-backbone-modal-content');
+                content.setAttribute('tabindex', '-1');
+                const header = element(document, 'header', 'wc-backbone-modal-header');
+                header.appendChild(element(document, 'h1', 'wcos-admin-backbone-modal__title'));
+                const close = element(document, 'button', 'modal-close', 'Close modal panel');
+                header.appendChild(close);
+                const description = element(document, 'p', 'wcos-admin-backbone-modal__description');
+                const body = element(document, 'div', 'wcos-admin-backbone-modal__body');
+                const footer = element(document, 'div', 'wcos-admin-backbone-modal__footer');
+                content.appendChild(header);
+                content.appendChild(description);
+                content.appendChild(body);
+                content.appendChild(footer);
+                rootElement.appendChild(content);
+                document.body.appendChild(rootElement);
+
+                const handle = {
+                    focusContent() { content.focus(); }
+                };
+                options.build(body, footer, rootElement, handle);
+                rootElement.addEventListener('click', function (event) {
+                    if (!event.target.closest('.modal-close') || options.isBusy()) {
+                        return;
+                    }
+                    if (rootElement.parentNode) {
+                        rootElement.parentNode.removeChild(rootElement);
+                    }
+                    previousFocus.focus();
+                });
+                options.onReady(rootElement, handle);
+                modal = { root: rootElement, content, body, footer };
+                return handle;
+            }
+        }
+    };
+
+    vm.runInNewContext(client, {
+        window,
+        document,
+        URLSearchParams,
+        Object,
+        Array,
+        String,
+        Error,
+        parseInt
+    }, { filename: 'p2-return-admin.js' });
+
+    function controls() {
+        return {
+            close: modal.root.querySelector('.wc-backbone-modal-header .modal-close'),
+            cancel: modal.root.querySelector('.wcos-return-cancel'),
+            review: modal.root.querySelector('.wcos-return-review-button'),
+            confirm: modal.root.querySelector('.wcos-return-confirm-button'),
+            execute: modal.root.querySelector('.wcos-return-execute-button'),
+            checkbox: modal.root.querySelector('.wcos-return-confirm-checkbox'),
+            error: modal.root.querySelector('.wcos-return-error')
+        };
+    }
+
+    return {
+        document,
+        launcher: source.launcher,
+        open() {
+            source.launcher.focus();
+            source.launcher.click();
+            return { modal, controls: controls() };
+        },
+        resolveNext(payload) {
+            assert.ok(pending.length, 'A pending Return request must exist');
+            pending.shift().resolve({ json: () => Promise.resolve(payload) });
+        }
+    };
+}
+
+async function settle() {
+    for (let index = 0; index < 12; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+(async () => {
+    const harness = createHarness();
+    const opened = harness.open();
+    const modal = opened.modal;
+    const controls = opened.controls;
+
+    assert.equal(harness.document.activeElement, modal.content, 'Initial modal focus must remain inside the dialog');
+    controls.review.focus();
+    assert.equal(pressTab(controls.review).defaultPrevented, true, 'Initial forward Tab must wrap at the final control');
+    assert.equal(harness.document.activeElement, controls.close, 'Initial forward wrap must focus the first usable control');
+    assert.equal(pressTab(controls.close, true).defaultPrevented, true, 'Initial reverse Tab must wrap at the first control');
+    assert.equal(harness.document.activeElement, controls.review, 'Initial reverse wrap must focus the final usable control');
+
+    controls.review.click();
+    assert.equal(harness.document.activeElement, modal.content, 'Busy Review must focus the dialog fallback');
+    assert.equal(controls.close.disabled, true);
+    assert.equal(controls.cancel.disabled, true);
+    assert.equal(controls.review.disabled, true);
+    const busyReviewTab = pressTab(modal.content);
+    assert.equal(busyReviewTab.defaultPrevented, true, 'Busy Review Tab must be trapped');
+    assert.equal(harness.document.activeElement, modal.content, 'Busy Review Tab must not escape to BODY');
+    const busyEscape = keyEvent('keydown', { key: 'Escape' });
+    modal.content.dispatchEvent(busyEscape);
+    assert.equal(busyEscape.defaultPrevented, true, 'Busy Escape protection must remain active');
+
+    harness.resolveNext({
+        success: true,
+        data: {
+            review_id: 'review-id',
+            review_token: 'review-token',
+            summary: {
+                child: { id: 202, number: '202' },
+                original: { id: 101, number: '101' },
+                strategy: 'manual_quantity',
+                returned_line_count: 1,
+                quantity: '1.000000',
+                historical_subtotal: '9.92',
+                historical_total: '9.92',
+                historical_tax: '0.00',
+                currency: 'USD',
+                retirement: { policy: 'non_force_trash_archive', child_status_after: 'trash' }
+            }
+        }
+    });
+    await settle();
+    assert.equal(controls.checkbox.disabled, false, 'Review acknowledgement must be enabled after success');
+    assert.equal(harness.document.activeElement, controls.checkbox, 'Review success must focus the enabled acknowledgement');
+    controls.cancel.focus();
+    assert.equal(pressTab(controls.cancel).defaultPrevented, true, 'Reviewed forward Tab must wrap');
+    assert.equal(harness.document.activeElement, controls.close, 'Reviewed forward wrap must remain inside the dialog');
+    assert.equal(pressTab(controls.close, true).defaultPrevented, true, 'Reviewed reverse Tab must wrap');
+    assert.equal(harness.document.activeElement, controls.cancel, 'Reviewed reverse wrap must remain inside the dialog');
+
+    controls.checkbox.checked = true;
+    controls.checkbox.dispatchEvent(keyEvent('change'));
+    assert.equal(controls.confirm.disabled, false, 'Confirm must enable only after acknowledgement');
+    controls.confirm.click();
+    assert.equal(harness.document.activeElement, modal.content, 'Busy Confirm must focus the dialog fallback');
+    assert.equal(controls.execute.disabled, true, 'Execute must remain disabled while Confirm is in flight');
+    assert.equal(pressTab(modal.content).defaultPrevented, true, 'Busy Confirm Tab must be trapped');
+    assert.equal(harness.document.activeElement, modal.content, 'Busy Confirm Tab must not escape to BODY');
+
+    harness.resolveNext({
+        success: true,
+        data: { operation_id: 'operation-id', confirmation_token: 'confirmation-token' }
+    });
+    await settle();
+    assert.equal(controls.execute.disabled, false, 'Execute must enable after Confirm success');
+    assert.equal(harness.document.activeElement, controls.execute, 'Confirm success must focus enabled Execute');
+    assert.equal(pressTab(controls.execute).defaultPrevented, true, 'Confirmed forward Tab must wrap');
+    assert.equal(harness.document.activeElement, controls.close, 'Confirmed forward wrap must focus the first usable control');
+    assert.equal(pressTab(controls.close, true).defaultPrevented, true, 'Confirmed reverse Tab must wrap');
+    assert.equal(harness.document.activeElement, controls.execute, 'Confirmed reverse wrap must focus the final usable control');
+
+    controls.cancel.click();
+    assert.equal(harness.document.activeElement, harness.launcher, 'Closing Return must restore focus to its launcher');
+    assert.equal(modal.root.isConnected, false, 'Return-local trap must disappear with its modal instance');
+
+    const failureHarness = createHarness();
+    const failed = failureHarness.open();
+    failed.controls.review.click();
+    failureHarness.resolveNext({ success: false, data: { code: 'review_rejected', message: 'Review rejected', retryable: false } });
+    await settle();
+    assert.equal(failureHarness.document.activeElement, failed.controls.error, 'Review failure must focus the error surface');
+    assert.equal(failed.controls.confirm.disabled, true, 'Review failure must not manufacture Confirm authority');
+    failed.controls.cancel.click();
+    assert.equal(failureHarness.document.activeElement, failureHarness.launcher, 'Failure close must restore launcher focus');
+
+    console.log('p2-return-focus-lifecycle-ok');
+})().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #85

## Classification

- Task: `WOS-RETURN-007`
- Risk: `HIGH`
- Change class: `P2_WOOCOMMERCE_ADAPTER`
- Source main: `92f5341524203d2f7fa4b2f81fe927a9ef14b850`
- Exact PR head: `47f7475a5ac7f6bfc801aa39746851971cde392e`

## Scope

Enables the existing hardened single-order Return production workflow through `WCOS_Mutation_Gateway`. The only workflow gate transition is `RETURN_ORDER: false -> true`; `BULK_RETURN` remains hard-off. Split, Duplicate, and Merge remain enabled, and every accepted Split strategy gate remains enabled.

The branch also contains the two bounded accessibility corrections authorized in Issue comments 5421203785 and 5421337996:

- restore Review/Confirm success focus only after busy state clears;
- add a Return-local, modal-root keyboard focus trap with busy fallback, forward/reverse wrapping, and no global listener.

It does not modify the shared Backbone modal, introduce a second mutation engine, re-enable legacy handlers, or authorize release, packaging, publication, or deployment.

## Gate map

- Workflows: Split ON, Duplicate ON, Merge ON, Return ON, Bulk Return OFF
- Split strategies: Manual Quantity ON, Category ON, Stock Status ON

## Exact-head evidence

Local checks at `47f7475a5ac7f6bfc801aa39746851971cde392e`:

- full PHP syntax pass (PHP 8.4 Local; only pre-existing implicit-nullable deprecations);
- `php tests/unit/run.php`: 30 PASS;
- `bash tests/ci/workflow-contract.sh`: PASS;
- Return focus lifecycle JS regression: PASS;
- related strategy-modal and Split-method lifecycle JS regressions: PASS;
- focused WordPress/WooCommerce Local smokes: governance, Return lineage, recovery foundation, service adapter, Review/Confirm authority, UI readiness, enabled production, and Merge coexistence: PASS.

Hands-on WooCommerce 11.0.1 / HPOS-only validation covered:

- exactly one eligible launcher and no client-selectable participant authority;
- no fixture PII in launcher/modal/Return journal;
- initial, reviewed, confirmed, busy, and completed focus behavior;
- forward/reverse focus wrapping;
- busy controls disabled, Tab contained, and Escape blocked;
- exact server-resolved original, historical values, strategy, and retirement policy;
- Execute completed once with terminal result and original-order navigation;
- persisted database re-read: child `trash`, original `pending`, child history retained, child/original `_reduced_stock` totals `0.000000 / 2.000000`, stock flags `false / true`, physical stock unchanged at `50.000000`, reciprocal Return participation complete, active Split relation removed, and child-keyed Return journal `completed`;
- modal close restored focus to the launcher; the active original exposed no Return launcher;
- exact fixture orders/products/options/journal were permanently removed and absence was re-read from the database.

Canonical GitHub CI remains pending and is the merge authority. Keep this PR draft until exact-head checks and fresh Independent Codex Technical Review are complete.
