### PR TITLE
WOS-QTY-001: Bind Manual Split quantities to per-line steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run Split method focus lifecycle regression
         run: node tests/js/p2-split-method-focus-lifecycle.js
 
+      - name: Run Split quantity-step integer-unit regression
+        run: node tests/js/p2-split-quantity-step-math.js
+
       - name: Verify Return admin client syntax
         run: node --check js/p2-return-admin.js
 

--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -148,6 +148,18 @@
     white-space: nowrap;
 }
 
+.wcos-split-step-hint,
+.wcos-split-non-splittable {
+    display: block;
+    margin-top: 3px;
+    color: #646970;
+    font-size: 12px;
+}
+
+.wcos-split-non-splittable {
+    color: #8a2424;
+}
+
 .wcos-split-remaining.is-invalid {
     color: #b32d2e;
 }

--- a/docs/p2-production-enablement.md
+++ b/docs/p2-production-enablement.md
@@ -94,9 +94,9 @@ The Split request itself must not change physical stock.
 
 The request-local guard proves stock safety only for integrations that participate in WooCommerce stock APIs/hooks or provide equivalent explicit evidence. An extension that mutates product stock directly in the database or raw metadata, bypassing WooCommerce stock hooks, is unsupported by the first production-enabled quantity Split unless a compatibility adapter provides an equivalent fail-closed contract.
 
-## Fractional quantities
+## Manual quantity steps
 
-WooCommerce uses integer stock amounts by default. Fractional transport quantities are rejected unless the active `woocommerce_stock_amount` integration actually preserves fractional values. Preflight exposes whether fractional quantity support is active and the server parser enforces the same policy.
+Manual quantity authority is derived per product line from WooCommerce's purchase step plus the admin edit-step filter. Every submitted quantity and the residual source quantity must be exact multiples of that frozen step. WooCommerce uses integer stock amounts by default, so a fractional step is rejected unless the active `woocommerce_stock_amount` integration also preserves fractional values. A fractional stock integration alone does not authorize the generic `0.000001` step.
 
 ## Review -> confirmation -> execute transport
 
@@ -144,9 +144,9 @@ The production parser is intentionally narrow:
 - maximum request size 64 KiB;
 - positive integer item IDs belonging to the source order;
 - quantities must be decimal strings, never JSON numeric values;
-- maximum six quantity decimals;
+- maximum six quantity decimals and an exact multiple of the reviewed per-line step;
 - no scientific notation;
-- fractional quantities require active fractional WooCommerce quantity support;
+- fractional steps require both WooCommerce line-step authority and active fractional quantity support;
 - aggregate child allocation for every source line must leave a positive residual on the source;
 - numeric overflow is a validation error, not a server error.
 

--- a/docs/p2-quantity-split-adapter.md
+++ b/docs/p2-quantity-split-adapter.md
@@ -61,8 +61,8 @@ The canonical WooCommerce integration matrix proves:
 - variation-owned stock preserves variation identity and does not move physical stock;
 - parent-managed variation stock resolves the real stock owner and remains unchanged;
 - backorder lines are identified and remain safe under the no-write Split policy;
-- native WooCommerce integer quantity behavior is respected;
-- fractional quantity behavior is proven only when an explicit integration replaces WooCommerce's default integer stock-amount filter.
+- native WooCommerce integer quantity behavior is respected through per-line step `1` authority;
+- fractional quantity behavior is proven only when an explicit integration both replaces WooCommerce's default integer stock-amount filter and exposes the applicable WooCommerce admin quantity step.
 
 ### Historical tax, charge, payment, and rounding contracts
 

--- a/docs/p2-split-production-enablement.md
+++ b/docs/p2-split-production-enablement.md
@@ -35,7 +35,7 @@ The first enabled manual quantity Split intentionally remains fail-closed for un
 - unclassified or inconsistently classified private line metadata;
 - direct database/raw-meta stock mutation integrations without an explicit compatibility adapter.
 
-Fractional quantities are accepted only when the active WooCommerce quantity integration preserves fractional stock amounts.
+Manual quantities must align exactly with each line's frozen WooCommerce admin quantity step. Fractional steps are accepted only when the active WooCommerce quantity integration also preserves fractional stock amounts.
 
 ## CI transition
 

--- a/inc/backend/class-wcos-split-admin-controller.php
+++ b/inc/backend/class-wcos-split-admin-controller.php
@@ -50,14 +50,7 @@ final class WCOS_Split_Admin_Controller {
         $order = $this->authorized_order($request, $order_id);
         $raw_plan = isset($request['plan']) ? (string) $request['plan'] : '';
 
-        try {
-            $plan = WCOS_Split_Request_Parser::parse_json($raw_plan, $order);
-            $summary = $this->plan_summary($plan);
-        } catch (InvalidArgumentException $exception) {
-            throw new WCOS_Split_Transport_Exception('invalid_plan', $exception->getMessage(), 422, false);
-        }
-
-        $preflight = (new WCOS_Mutation_Gateway())->split_preflight($order);
+        $preflight = (new WCOS_Mutation_Gateway())->manual_split_preflight($order);
         if (empty($preflight['supported'])) {
             throw new WCOS_Split_Transport_Exception(
                 'preflight_' . (isset($preflight['reason']) ? $preflight['reason'] : 'unsupported'),
@@ -67,8 +60,28 @@ final class WCOS_Split_Admin_Controller {
                 array('preflight' => $preflight)
             );
         }
+		if (empty($preflight['manual_quantity_authority']) || !is_array($preflight['manual_quantity_authority'])) {
+			throw new WCOS_Split_Transport_Exception('preflight_quantity_authority_missing', __('The server could not establish Manual Split quantity-step authority.', 'wc-order-splitter'), 409, false);
+		}
 
-        $confirmation = WCOS_Split_Confirmation_Store::create($order, $plan, $preflight, get_current_user_id());
+		try {
+			$plan = WCOS_Split_Request_Parser::parse_json($raw_plan, $order, $preflight['manual_quantity_authority']);
+			$summary = $this->plan_summary($plan);
+		} catch (InvalidArgumentException $exception) {
+			throw new WCOS_Split_Transport_Exception('invalid_plan', $exception->getMessage(), 422, false);
+		}
+
+		try {
+			$confirmation = WCOS_Split_Confirmation_Store::create($order, $plan, $preflight, get_current_user_id());
+		} catch (WCOS_Split_Confirmation_Exception $exception) {
+			$reason = $exception->get_reason();
+			throw new WCOS_Split_Transport_Exception(
+				'confirmation_' . $reason,
+				$exception->getMessage(),
+				in_array($reason, array('source_changed', 'quantity_authority_changed', 'quantity_authority_incomplete'), true) ? 409 : 422,
+				false
+			);
+		}
         return array(
             'operation_id' => $confirmation['operation_id'],
             'confirmation_token' => $confirmation['confirmation_token'],
@@ -105,6 +118,8 @@ final class WCOS_Split_Admin_Controller {
                 'manual_reconciliation' => 409,
                 'operation_closed' => 409,
                 'journal_incomplete' => 409,
+				'quantity_authority_changed' => 409,
+				'quantity_authority_incomplete' => 409,
             );
             $reason = $exception->get_reason();
             throw new WCOS_Split_Transport_Exception(
@@ -125,11 +140,12 @@ final class WCOS_Split_Admin_Controller {
         }
 
         try {
-            $children = (new WCOS_Mutation_Gateway())->split(
+            $children = (new WCOS_Mutation_Gateway())->split_manual_confirmed(
                 $order,
                 $confirmation['plan'],
                 $operation_id,
-                $confirmation['price_precision']
+				$confirmation['price_precision'],
+				$confirmation
             );
         } catch (WCOS_Split_Preflight_Exception $exception) {
             throw new WCOS_Split_Transport_Exception(
@@ -139,6 +155,14 @@ final class WCOS_Split_Admin_Controller {
                 false,
                 array('preflight' => $exception->get_report())
             );
+		} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+			throw new WCOS_Split_Transport_Exception(
+				'confirmation_quantity_authority_changed',
+				$exception->getMessage(),
+				409,
+				false,
+				array('quantity_authority' => $exception->get_report())
+			);
         } catch (WCOS_Unexpected_Stock_Mutation_Exception $exception) {
             throw new WCOS_Split_Transport_Exception(
                 'manual_reconciliation_required',
@@ -206,7 +230,7 @@ final class WCOS_Split_Admin_Controller {
         try {
             WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
             $this->assert_status_enabled($order);
-            $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($order);
+            $preflight = (new WCOS_Split_WooCommerce_Adapter())->manual_preflight($order);
         } catch (Throwable $throwable) {
             return;
         }
@@ -260,15 +284,20 @@ final class WCOS_Split_Admin_Controller {
     }
 
     public function dialog_html(WC_Order $order, array $preflight = array()) {
-        if (empty($preflight)) {
-            $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($order);
+        if (empty($preflight['manual_quantity_authority'])) {
+            $preflight = (new WCOS_Split_WooCommerce_Adapter())->manual_preflight($order);
         }
         $dialog_id = 'wcos-split-dialog-' . $order->get_id();
         $title_id = $dialog_id . '-title';
         $description_id = $dialog_id . '-description';
         $nonce = wp_create_nonce('wcos_split_order_' . $order->get_id());
-        $fractional_supported = !empty($preflight['fractional_quantity_supported']);
-        $step = $fractional_supported ? '0.000001' : '1';
+		$quantity_authority = WCOS_Manual_Split_Quantity_Authority::assert_valid($preflight['manual_quantity_authority']);
+		$step_labels = array();
+		foreach ($quantity_authority['lines'] as $line_authority) {
+			$step_labels[] = WCOS_Manual_Split_Quantity_Authority::display_decimal($line_authority['quantity_step']);
+		}
+		$step_labels = array_values(array_unique($step_labels));
+		sort($step_labels, SORT_NATURAL);
 
         ob_start();
         ?>
@@ -297,18 +326,30 @@ final class WCOS_Split_Admin_Controller {
                             </thead>
                             <tbody>
                                 <?php foreach ($order->get_items('line_item') as $item_id => $item) :
-                                    $quantity = WCOS_Decimal::normalize($item->get_quantity(), 6);
+									$line_authority = isset($quantity_authority['lines'][$item_id]) ? $quantity_authority['lines'][$item_id] : array();
+									$quantity = isset($line_authority['source_quantity']) ? (string) $line_authority['source_quantity'] : WCOS_Decimal::normalize($item->get_quantity(), 6);
+									$display_quantity = WCOS_Manual_Split_Quantity_Authority::display_decimal($quantity);
+									$step = WCOS_Manual_Split_Quantity_Authority::display_decimal($line_authority['quantity_step']);
+									$maximum = WCOS_Manual_Split_Quantity_Authority::display_decimal($line_authority['maximum_quantity']);
+									$inputmode = 0 === ((int) $line_authority['step_units'] % WCOS_Decimal::factor(6)) ? 'numeric' : 'decimal';
+									$can_partially_split = !empty($line_authority['can_partially_split']);
                                     ?>
-                                    <tr data-item-id="<?php echo esc_attr($item_id); ?>" data-source-quantity="<?php echo esc_attr($quantity); ?>">
+									<tr data-item-id="<?php echo esc_attr($item_id); ?>" data-source-quantity="<?php echo esc_attr($quantity); ?>" data-source-units="<?php echo esc_attr($line_authority['source_quantity_units']); ?>" data-step-units="<?php echo esc_attr($line_authority['step_units']); ?>" data-maximum-units="<?php echo esc_attr($line_authority['maximum_quantity_units']); ?>" data-splittable="<?php echo $can_partially_split ? '1' : '0'; ?>">
                                         <th scope="row"><?php echo esc_html($item->get_name()); ?></th>
-                                        <td><?php echo esc_html($quantity); ?></td>
+										<td>
+											<?php echo esc_html($display_quantity); ?>
+											<small class="wcos-split-step-hint"><?php echo esc_html(sprintf(__('Step: %s', 'wc-order-splitter'), $step)); ?></small>
+											<?php if (!$can_partially_split) : ?>
+												<small class="wcos-split-non-splittable"><?php esc_html_e('No partial quantity can move while retaining one step.', 'wc-order-splitter'); ?></small>
+											<?php endif; ?>
+										</td>
                                         <?php for ($child_index = 1; $child_index <= 10; $child_index++) :
                                             $child_key = 'child-' . $child_index;
                                             $quantity_id = 'wcos-split-quantity-' . $order->get_id() . '-' . $item_id . '-' . $child_index;
                                             ?>
                                             <td>
                                                 <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php echo esc_html(sprintf(__('Quantity of %1$s to move to Child %2$d', 'wc-order-splitter'), $item->get_name(), $child_index)); ?></label>
-                                                <input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" data-child-key="<?php echo esc_attr($child_key); ?>" type="number" min="0" max="<?php echo esc_attr($quantity); ?>" step="<?php echo esc_attr($step); ?>" inputmode="decimal" value="0" />
+												<input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" data-child-key="<?php echo esc_attr($child_key); ?>" type="number" min="0" max="<?php echo esc_attr($maximum); ?>" step="<?php echo esc_attr($step); ?>" inputmode="<?php echo esc_attr($inputmode); ?>" value="0"<?php echo disabled(!$can_partially_split, true, false); ?> />
                                             </td>
                                         <?php endfor; ?>
                                     </tr>
@@ -326,7 +367,7 @@ final class WCOS_Split_Admin_Controller {
                             <li><?php esc_html_e('The Split request must not write physical product stock.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('Coupons, refunds, negative fees, nested splits, and unclassified private line metadata are rejected before mutation.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('Extensions that change stock directly in the database instead of WooCommerce stock APIs are unsupported unless they provide an explicit compatibility adapter.', 'wc-order-splitter'); ?></li>
-                            <li><?php echo esc_html($fractional_supported ? __('Fractional quantities are enabled by the active WooCommerce quantity integration.', 'wc-order-splitter') : __('The active WooCommerce quantity integration only supports integer Split quantities.', 'wc-order-splitter')); ?></li>
+							<li><?php echo esc_html(sprintf(__('Manual allocation steps are enforced per line: %s.', 'wc-order-splitter'), implode(', ', $step_labels))); ?></li>
                         </ul>
                     </div>
 

--- a/inc/backend/class-wcos-split-confirmation-store.php
+++ b/inc/backend/class-wcos-split-confirmation-store.php
@@ -23,7 +23,7 @@ final class WCOS_Split_Confirmation_Exception extends RuntimeException {
  * interrupted operation can be resumed after the confirmation TTL expires.
  */
 final class WCOS_Split_Confirmation_Store {
-    const SCHEMA_VERSION = 1;
+    const SCHEMA_VERSION = 2;
     const TTL = 1800;
 
     private static $verified_source_signatures = array();
@@ -40,6 +40,16 @@ final class WCOS_Split_Confirmation_Store {
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
         try {
             $reviewed_signature = isset($preflight['source_signature']) ? (string) $preflight['source_signature'] : '';
+			try {
+				$manual_authority = WCOS_Manual_Split_Quantity_Authority::assert_valid(
+					isset($preflight['manual_quantity_authority']) && is_array($preflight['manual_quantity_authority'])
+						? $preflight['manual_quantity_authority']
+						: array()
+				);
+				$plan = WCOS_Manual_Split_Quantity_Authority::assert_plan($plan, $manual_authority);
+			} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+				throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', $exception->getMessage());
+			}
 
             /*
              * The passed source is the exact object the strict request parser
@@ -47,7 +57,9 @@ final class WCOS_Split_Confirmation_Store {
              * closing parser -> preflight races inside one Review request.
              */
             $parsed_signature = WCOS_Order_Contract_Snapshot::source_signature($source);
-            if ('' === $reviewed_signature || !hash_equals($reviewed_signature, $parsed_signature)) {
+            if ('' === $reviewed_signature
+				|| !hash_equals($reviewed_signature, $parsed_signature)
+				|| !hash_equals($reviewed_signature, (string) $manual_authority['source_signature'])) {
                 throw new WCOS_Split_Confirmation_Exception(
                     'source_changed',
                     __('The order changed while the Split plan was being reviewed. Review the current order state again before creating a confirmation.', 'wc-order-splitter')
@@ -70,6 +82,11 @@ final class WCOS_Split_Confirmation_Store {
                     __('The order changed while the Split confirmation was being created. Review the current order state again.', 'wc-order-splitter')
                 );
             }
+			try {
+				WCOS_Manual_Split_Quantity_Authority::assert_current($scoped_source, $manual_authority);
+			} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+				throw new WCOS_Split_Confirmation_Exception('quantity_authority_changed', $exception->getMessage());
+			}
 
             $now = time();
             $record = array(
@@ -82,6 +99,8 @@ final class WCOS_Split_Confirmation_Store {
                 'plan' => WCOS_Split_Plan::canonicalize_request($plan),
                 'price_precision' => $precision,
                 'policy_version' => isset($preflight['policy']['policy_version']) ? absint($preflight['policy']['policy_version']) : 0,
+				'manual_quantity_authority' => $manual_authority,
+				'manual_quantity_authority_fingerprint' => $manual_authority['authority_fingerprint'],
                 'created_at' => $now,
                 'expires_at' => $now + self::TTL,
             );
@@ -127,6 +146,22 @@ final class WCOS_Split_Confirmation_Store {
         if (!isset($record['policy_version']) || (int) $record['policy_version'] !== (int) WCOS_Split_Preflight::POLICY_VERSION) {
             throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
         }
+		if (!isset($record['schema_version']) || self::SCHEMA_VERSION !== (int) $record['schema_version']) {
+			throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', __('The Split confirmation predates the required Manual quantity-step authority. Review the plan again.', 'wc-order-splitter'));
+		}
+		try {
+			$manual_authority = WCOS_Manual_Split_Quantity_Authority::assert_valid(
+				isset($record['manual_quantity_authority']) && is_array($record['manual_quantity_authority'])
+					? $record['manual_quantity_authority']
+					: array()
+			);
+		} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+			throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', $exception->getMessage());
+		}
+		if (empty($record['manual_quantity_authority_fingerprint'])
+			|| !hash_equals((string) $record['manual_quantity_authority_fingerprint'], (string) $manual_authority['authority_fingerprint'])) {
+			throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', __('The Split confirmation quantity-step fingerprint is incomplete.', 'wc-order-splitter'));
+		}
 
         $precision = WCOS_Price_Precision_Scope::validate(isset($record['price_precision']) ? $record['price_precision'] : null);
         $precision_token = WCOS_Price_Precision_Scope::begin($precision);
@@ -144,6 +179,19 @@ final class WCOS_Split_Confirmation_Store {
                     throw new WCOS_Split_Confirmation_Exception('source_changed', __('The order changed after the Split plan was reviewed. Review the plan again before executing it.', 'wc-order-splitter'));
                 }
                 self::$verified_source_signatures[$operation_id] = $expected;
+				try {
+					WCOS_Manual_Split_Quantity_Authority::assert_current($scoped_source, $manual_authority);
+				} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+					throw new WCOS_Split_Confirmation_Exception('quantity_authority_changed', $exception->getMessage());
+				}
+				try {
+					WCOS_Manual_Split_Quantity_Authority::assert_plan(
+						isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array(),
+						$manual_authority
+					);
+				} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+					throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', $exception->getMessage());
+				}
             } else {
                 $journal_context = isset($journal['context']) && is_array($journal['context']) ? $journal['context'] : array();
                 if (!array_key_exists('price_precision', $journal_context)
@@ -154,11 +202,24 @@ final class WCOS_Split_Confirmation_Store {
                     || (int) $journal_context['policy_version'] !== (int) $record['policy_version']) {
                     throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The durable Split operation no longer matches the safety policy that was reviewed.', 'wc-order-splitter'));
                 }
+				if (empty($journal_context['manual_quantity_authority'])
+					|| !is_array($journal_context['manual_quantity_authority'])) {
+					throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', __('The durable Split operation is missing Manual quantity-step replay authority.', 'wc-order-splitter'));
+				}
+				try {
+					$journal_authority = WCOS_Manual_Split_Quantity_Authority::assert_valid($journal_context['manual_quantity_authority']);
+				} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+					throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', $exception->getMessage());
+				}
+				if (!hash_equals($manual_authority['authority_fingerprint'], $journal_authority['authority_fingerprint'])) {
+					throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', __('The durable Split quantity-step authority does not match its confirmation.', 'wc-order-splitter'));
+				}
             }
 
             $record['operation_id'] = $operation_id;
             $record['plan'] = WCOS_Split_Plan::canonicalize_request(isset($record['plan']) && is_array($record['plan']) ? $record['plan'] : array());
             $record['price_precision'] = $precision;
+			$record['manual_quantity_authority'] = $manual_authority;
             $record['replay_authority'] = is_array($journal) ? 'journal' : 'confirmation';
             return $record;
         } finally {
@@ -212,7 +273,7 @@ final class WCOS_Split_Confirmation_Store {
             throw new WCOS_Split_Confirmation_Exception('policy_changed', __('The Split safety policy changed after this durable operation started. Review the operation manually before continuing it.', 'wc-order-splitter'));
         }
 
-        return array(
+        $result = array(
             'schema_version' => self::SCHEMA_VERSION,
             'operation_id' => $operation_id,
             'source_order_id' => $source->get_id(),
@@ -221,6 +282,19 @@ final class WCOS_Split_Confirmation_Store {
             'policy_version' => (int) $context['policy_version'],
             'replay_authority' => 'journal',
         );
+		if (!isset($context['manual_quantity_authority']) || !is_array($context['manual_quantity_authority'])) {
+			throw new WCOS_Split_Confirmation_Exception(
+				'quantity_authority_incomplete',
+				__('The durable Manual Split operation predates required quantity-step authority and cannot be resumed automatically.', 'wc-order-splitter')
+			);
+		}
+		try {
+			$result['manual_quantity_authority'] = WCOS_Manual_Split_Quantity_Authority::assert_valid($context['manual_quantity_authority']);
+			$result['plan'] = WCOS_Manual_Split_Quantity_Authority::assert_plan($result['plan'], $result['manual_quantity_authority']);
+		} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+			throw new WCOS_Split_Confirmation_Exception('quantity_authority_incomplete', $exception->getMessage());
+		}
+		return $result;
     }
 
     private static function token_hash($token) {

--- a/inc/backend/class-wcos-split-request-parser.php
+++ b/inc/backend/class-wcos-split-request-parser.php
@@ -13,7 +13,7 @@ final class WCOS_Split_Request_Parser {
     const MAX_CHILDREN = 10;
     const MAX_LINE_ASSIGNMENTS = 500;
 
-    public static function parse_json($raw_plan, WC_Order $source) {
+    public static function parse_json($raw_plan, WC_Order $source, array $quantity_authority) {
         if (!is_string($raw_plan)) {
             throw new InvalidArgumentException(__('The Split plan must be a JSON string.', 'wc-order-splitter'));
         }
@@ -26,17 +26,29 @@ final class WCOS_Split_Request_Parser {
         if (JSON_ERROR_NONE !== json_last_error() || !is_array($decoded)) {
             throw new InvalidArgumentException(__('The Split plan contains invalid JSON.', 'wc-order-splitter'));
         }
-        return self::parse_array($decoded, $source);
+        return self::parse_array($decoded, $source, $quantity_authority);
     }
 
-    public static function parse_array(array $plan, WC_Order $source) {
+    public static function parse_array(array $plan, WC_Order $source, array $quantity_authority) {
         if (empty($plan) || count($plan) > self::MAX_CHILDREN) {
             throw new InvalidArgumentException(__('A Split plan must contain between one and ten child orders.', 'wc-order-splitter'));
         }
 
+        try {
+            $quantity_authority = WCOS_Manual_Split_Quantity_Authority::assert_valid($quantity_authority);
+        } catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+            throw new InvalidArgumentException($exception->getMessage(), 0, $exception);
+        }
+        if ($source->get_id() !== (int) $quantity_authority['source_order_id']
+            || !hash_equals(
+                (string) $quantity_authority['source_signature'],
+                WCOS_Order_Contract_Snapshot::source_signature($source)
+            )) {
+            throw new InvalidArgumentException(__('The source order no longer matches the reviewed Manual Split quantity authority.', 'wc-order-splitter'));
+        }
+
         $strict = array();
         $assignments = 0;
-        $fractional_supported = WCOS_Split_Preflight::fractional_quantities_supported();
         foreach ($plan as $raw_child_key => $items) {
             $child_key = (string) $raw_child_key;
             if (!preg_match('/^child-(?:[1-9]|10)$/D', $child_key)) {
@@ -65,10 +77,7 @@ final class WCOS_Split_Request_Parser {
                 if (!$item_id || $quantity_units <= 0) {
                     throw new InvalidArgumentException(__('Split item IDs and quantities must be positive.', 'wc-order-splitter'));
                 }
-                if (0 !== ($quantity_units % 1000000) && !$fractional_supported) {
-                    throw new InvalidArgumentException(__('Fractional Split quantities require an integration that enables fractional WooCommerce stock amounts.', 'wc-order-splitter'));
-                }
-                if (!$source->get_item($item_id) instanceof WC_Order_Item_Product) {
+                if (!isset($quantity_authority['lines'][$item_id])) {
                     throw new InvalidArgumentException(__('The Split plan references an item outside the source order.', 'wc-order-splitter'));
                 }
                 if (isset($strict[$child_key][$item_id])) {
@@ -84,7 +93,9 @@ final class WCOS_Split_Request_Parser {
         }
 
         try {
-            return WCOS_Split_Plan::normalize($source, $strict);
+            return WCOS_Manual_Split_Quantity_Authority::assert_plan($strict, $quantity_authority);
+        } catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+            throw new InvalidArgumentException($exception->getMessage(), 0, $exception);
         } catch (OverflowException $exception) {
             throw new InvalidArgumentException(__('The Split plan exceeds the supported numeric range.', 'wc-order-splitter'), 0, $exception);
         }

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -43,6 +43,7 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'domain/class-wcos-order-totals-rebuilder.php';
 		include_once $root . 'domain/class-wcos-tax-item-synchronizer.php';
 		include_once $root . 'domain/class-wcos-order-contract-snapshot.php';
+		include_once $root . 'domain/class-wcos-manual-split-quantity-authority.php';
 		include_once $root . 'domain/class-wcos-order-copy-context.php';
 		include_once $root . 'domain/class-wcos-order-mutation-snapshot.php';
 		include_once $root . 'domain/class-wcos-merge-retirement-policy.php';

--- a/inc/domain/class-wcos-manual-split-quantity-authority.php
+++ b/inc/domain/class-wcos-manual-split-quantity-authority.php
@@ -1,0 +1,309 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+final class WCOS_Manual_Split_Quantity_Authority_Exception extends RuntimeException {
+	private $reason;
+	private $report;
+
+	public function __construct($reason, $message, array $report = array()) {
+		$this->reason = sanitize_key((string) $reason);
+		$this->report = $report;
+		parent::__construct((string) $message);
+	}
+
+	public function get_reason() {
+		return $this->reason;
+	}
+
+	public function get_report() {
+		return $this->report;
+	}
+}
+
+/**
+ * Frozen per-line quantity-step authority for Manual Quantity Split.
+ *
+ * This primitive is intentionally separate from the general Split preflight:
+ * server-built whole-line strategies must not depend on editable-quantity
+ * semantics. All quantity comparisons use six-decimal integer units.
+ */
+final class WCOS_Manual_Split_Quantity_Authority {
+	const SCHEMA_VERSION = 1;
+	const POLICY_VERSION = 1;
+	const PRECISION = 6;
+
+	public static function create(WC_Order $source) {
+		$source_id = absint($source->get_id());
+		if (!$source_id) {
+			self::reject('source_unpersisted', __('A persisted source order is required to derive Manual Split quantity authority.', 'wc-order-splitter'));
+		}
+
+		$lines = array();
+		foreach ($source->get_items('line_item') as $item_id => $item) {
+			if (!$item instanceof WC_Order_Item_Product) {
+				self::reject('line_type_invalid', __('Manual Split quantity authority only supports WooCommerce product lines.', 'wc-order-splitter'));
+			}
+			$item_id = absint($item_id);
+			try {
+				$source_units = WCOS_Decimal::to_units($item->get_quantity(), self::PRECISION);
+			} catch (Throwable $throwable) {
+				self::reject('source_quantity_invalid', __('A source line has an invalid quantity for Manual Split.', 'wc-order-splitter'));
+			}
+			if (!$item_id || $source_units <= 0) {
+				self::reject('source_quantity_invalid', __('Every Manual Split source line must have a positive quantity.', 'wc-order-splitter'));
+			}
+
+			$product = $item->get_product();
+			if (!$product instanceof WC_Product) {
+				if (0 !== ($source_units % WCOS_Decimal::factor(self::PRECISION))) {
+					self::reject(
+						'deleted_product_fractional_step_unprovable',
+						__('A deleted or unavailable product has a fractional historical quantity whose Manual Split step cannot be proven.', 'wc-order-splitter'),
+						array('source_order_id' => $source_id, 'source_item_id' => $item_id)
+					);
+				}
+				$step_units = WCOS_Decimal::factor(self::PRECISION);
+			} else {
+				$raw_step = method_exists($product, 'get_purchase_quantity_step')
+					? $product->get_purchase_quantity_step()
+					: 1;
+				$raw_step = apply_filters('woocommerce_quantity_input_step_admin', $raw_step, $product, 'edit');
+				$step_units = self::exact_step_units($raw_step);
+				if (0 !== ($step_units % WCOS_Decimal::factor(self::PRECISION))
+					&& !WCOS_Split_Preflight::fractional_quantities_supported()) {
+					self::reject(
+						'fractional_step_unsupported',
+						__('A product exposes a fractional Manual Split step, but the active WooCommerce stock-amount integration does not preserve fractional quantities.', 'wc-order-splitter'),
+						array('source_order_id' => $source_id, 'source_item_id' => $item_id)
+					);
+				}
+			}
+
+			if (0 !== ($source_units % $step_units)) {
+				self::reject(
+					'source_quantity_step_mismatch',
+					__('A source line quantity is not aligned to its current WooCommerce Manual Split step.', 'wc-order-splitter'),
+					array('source_order_id' => $source_id, 'source_item_id' => $item_id)
+				);
+			}
+
+			$maximum_units = $source_units > $step_units ? $source_units - $step_units : 0;
+			$lines[$item_id] = array(
+				'source_order_id' => $source_id,
+				'source_item_id' => $item_id,
+				'product_id' => absint($item->get_product_id()),
+				'variation_id' => absint($item->get_variation_id()),
+				'source_quantity' => WCOS_Decimal::from_units($source_units, self::PRECISION),
+				'source_quantity_units' => $source_units,
+				'quantity_step' => WCOS_Decimal::from_units($step_units, self::PRECISION),
+				'step_units' => $step_units,
+				'maximum_quantity' => WCOS_Decimal::from_units($maximum_units, self::PRECISION),
+				'maximum_quantity_units' => $maximum_units,
+				'can_partially_split' => $maximum_units >= $step_units,
+			);
+		}
+		ksort($lines, SORT_NUMERIC);
+
+		$authority = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'policy_version' => self::POLICY_VERSION,
+			'precision' => self::PRECISION,
+			'source_order_id' => $source_id,
+			'source_signature' => WCOS_Order_Contract_Snapshot::source_signature($source),
+			'lines' => $lines,
+		);
+		$authority['authority_fingerprint'] = self::fingerprint($authority);
+		return self::assert_valid($authority);
+	}
+
+	public static function assert_valid(array $authority) {
+		$required = array('schema_version', 'policy_version', 'precision', 'source_order_id', 'source_signature', 'lines', 'authority_fingerprint');
+		foreach ($required as $field) {
+			if (!array_key_exists($field, $authority)) {
+				self::reject('authority_incomplete', __('Manual Split quantity authority is incomplete.', 'wc-order-splitter'));
+			}
+		}
+		if (self::SCHEMA_VERSION !== (int) $authority['schema_version']
+			|| self::POLICY_VERSION !== (int) $authority['policy_version']
+			|| self::PRECISION !== (int) $authority['precision']
+			|| absint($authority['source_order_id']) <= 0
+			|| !self::is_fingerprint($authority['source_signature'])
+			|| !self::is_fingerprint($authority['authority_fingerprint'])
+			|| !is_array($authority['lines'])
+			|| empty($authority['lines'])) {
+			self::reject('authority_malformed', __('Manual Split quantity authority is malformed.', 'wc-order-splitter'));
+		}
+
+		$canonical_lines = array();
+		foreach ($authority['lines'] as $raw_item_id => $line) {
+			$item_id = absint($raw_item_id);
+			if (!$item_id || !is_array($line) || isset($canonical_lines[$item_id])) {
+				self::reject('line_authority_malformed', __('A Manual Split line authority is malformed.', 'wc-order-splitter'));
+			}
+			$line_required = array(
+				'source_order_id', 'source_item_id', 'product_id', 'variation_id', 'source_quantity',
+				'source_quantity_units', 'quantity_step', 'step_units', 'maximum_quantity',
+				'maximum_quantity_units', 'can_partially_split',
+			);
+			foreach ($line_required as $field) {
+				if (!array_key_exists($field, $line)) {
+					self::reject('line_authority_incomplete', __('A Manual Split line authority is incomplete.', 'wc-order-splitter'));
+				}
+			}
+			$source_units = self::positive_integer($line['source_quantity_units']);
+			$step_units = self::positive_integer($line['step_units']);
+			$maximum_units = self::nonnegative_integer($line['maximum_quantity_units']);
+			$expected_maximum = $source_units > $step_units ? $source_units - $step_units : 0;
+			if (absint($line['source_order_id']) !== absint($authority['source_order_id'])
+				|| absint($line['source_item_id']) !== $item_id
+				|| (string) $line['source_quantity'] !== WCOS_Decimal::from_units($source_units, self::PRECISION)
+				|| (string) $line['quantity_step'] !== WCOS_Decimal::from_units($step_units, self::PRECISION)
+				|| (string) $line['maximum_quantity'] !== WCOS_Decimal::from_units($maximum_units, self::PRECISION)
+				|| 0 !== ($source_units % $step_units)
+				|| $maximum_units !== $expected_maximum
+				|| (bool) $line['can_partially_split'] !== ($maximum_units >= $step_units)) {
+				self::reject('line_authority_inconsistent', __('A Manual Split line authority is internally inconsistent.', 'wc-order-splitter'));
+			}
+			$canonical_lines[$item_id] = array(
+				'source_order_id' => absint($line['source_order_id']),
+				'source_item_id' => $item_id,
+				'product_id' => absint($line['product_id']),
+				'variation_id' => absint($line['variation_id']),
+				'source_quantity' => (string) $line['source_quantity'],
+				'source_quantity_units' => $source_units,
+				'quantity_step' => (string) $line['quantity_step'],
+				'step_units' => $step_units,
+				'maximum_quantity' => (string) $line['maximum_quantity'],
+				'maximum_quantity_units' => $maximum_units,
+				'can_partially_split' => (bool) $line['can_partially_split'],
+			);
+		}
+		ksort($canonical_lines, SORT_NUMERIC);
+
+		$canonical = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'policy_version' => self::POLICY_VERSION,
+			'precision' => self::PRECISION,
+			'source_order_id' => absint($authority['source_order_id']),
+			'source_signature' => strtolower((string) $authority['source_signature']),
+			'lines' => $canonical_lines,
+			'authority_fingerprint' => strtolower((string) $authority['authority_fingerprint']),
+		);
+		if (!hash_equals($canonical['authority_fingerprint'], self::fingerprint($canonical))) {
+			self::reject('authority_fingerprint_mismatch', __('Manual Split quantity authority failed its integrity fingerprint.', 'wc-order-splitter'));
+		}
+		return $canonical;
+	}
+
+	public static function assert_current(WC_Order $source, array $frozen) {
+		$frozen = self::assert_valid($frozen);
+		$current = self::create($source);
+		if (!hash_equals($frozen['authority_fingerprint'], $current['authority_fingerprint'])) {
+			self::reject('authority_changed', __('The WooCommerce quantity-step authority changed after Review. Review the Manual Split plan again.', 'wc-order-splitter'));
+		}
+		return $frozen;
+	}
+
+	public static function assert_plan(array $plan, array $authority) {
+		$authority = self::assert_valid($authority);
+		$canonical = WCOS_Split_Plan::canonicalize_request($plan);
+		$totals = array();
+		foreach ($canonical as $items) {
+			foreach ($items as $item_id => $quantity) {
+				if (!isset($authority['lines'][$item_id])) {
+					self::reject('plan_item_outside_authority', __('The Manual Split plan references an item outside the reviewed quantity authority.', 'wc-order-splitter'));
+				}
+				$quantity_units = WCOS_Decimal::to_units($quantity, self::PRECISION);
+				$step_units = (int) $authority['lines'][$item_id]['step_units'];
+				if ($quantity_units <= 0 || 0 !== ($quantity_units % $step_units)) {
+					self::reject('plan_quantity_step_mismatch', __('A Manual Split quantity is not an exact multiple of the reviewed line step.', 'wc-order-splitter'));
+				}
+				$current = isset($totals[$item_id]) ? $totals[$item_id] : 0;
+				if ($quantity_units > PHP_INT_MAX - $current) {
+					self::reject('plan_quantity_overflow', __('The Manual Split quantity total exceeds the supported numeric range.', 'wc-order-splitter'));
+				}
+				$totals[$item_id] = $current + $quantity_units;
+			}
+		}
+
+		foreach ($totals as $item_id => $moved_units) {
+			$line = $authority['lines'][$item_id];
+			$residual_units = (int) $line['source_quantity_units'] - $moved_units;
+			if ($moved_units > (int) $line['maximum_quantity_units']
+				|| $residual_units <= 0
+				|| 0 !== ($residual_units % (int) $line['step_units'])) {
+				self::reject('plan_residual_invalid', __('The Manual Split plan must retain a positive, step-aligned source quantity.', 'wc-order-splitter'));
+			}
+		}
+		return $canonical;
+	}
+
+	public static function display_decimal($value) {
+		$value = WCOS_Decimal::normalize($value, self::PRECISION);
+		$value = rtrim(rtrim($value, '0'), '.');
+		return '' === $value ? '0' : $value;
+	}
+
+	private static function exact_step_units($value) {
+		if (is_int($value)) {
+			$raw = (string) $value;
+		} elseif (is_float($value)) {
+			if (is_nan($value) || is_infinite($value)) {
+				self::reject('quantity_step_invalid', __('The WooCommerce quantity step must be finite and positive.', 'wc-order-splitter'));
+			}
+			$raw = rtrim(rtrim(sprintf('%.14F', $value), '0'), '.');
+		} elseif (is_string($value) || is_numeric($value)) {
+			$raw = trim((string) $value);
+		} else {
+			self::reject('quantity_step_invalid', __('The WooCommerce quantity step must be numeric.', 'wc-order-splitter'));
+		}
+		if (!preg_match('/^\+?(?:0|[1-9][0-9]*)(?:\.([0-9]*))?$/D', $raw, $matches)) {
+			self::reject('quantity_step_invalid', __('The WooCommerce quantity step is not a representable positive decimal.', 'wc-order-splitter'));
+		}
+		$fraction = isset($matches[1]) ? $matches[1] : '';
+		if (strlen($fraction) > self::PRECISION && '' !== trim(substr($fraction, self::PRECISION), '0')) {
+			self::reject('quantity_step_precision_invalid', __('The WooCommerce quantity step exceeds the supported six-decimal precision.', 'wc-order-splitter'));
+		}
+		try {
+			$units = WCOS_Decimal::to_units($raw, self::PRECISION);
+		} catch (Throwable $throwable) {
+			self::reject('quantity_step_invalid', __('The WooCommerce quantity step exceeds the supported numeric range.', 'wc-order-splitter'));
+		}
+		if ($units <= 0) {
+			self::reject('quantity_step_invalid', __('The WooCommerce quantity step must be positive.', 'wc-order-splitter'));
+		}
+		return $units;
+	}
+
+	private static function fingerprint(array $authority) {
+		unset($authority['authority_fingerprint']);
+		return WCOS_Mutation_Fingerprint::create(
+			'manual_split_quantity_authority_v1',
+			absint(isset($authority['source_order_id']) ? $authority['source_order_id'] : 0),
+			$authority
+		);
+	}
+
+	private static function positive_integer($value) {
+		if (!is_int($value) || $value <= 0) {
+			self::reject('authority_units_invalid', __('Manual Split quantity authority contains invalid positive units.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function nonnegative_integer($value) {
+		if (!is_int($value) || $value < 0) {
+			self::reject('authority_units_invalid', __('Manual Split quantity authority contains invalid non-negative units.', 'wc-order-splitter'));
+		}
+		return $value;
+	}
+
+	private static function is_fingerprint($value) {
+		return is_string($value) && 1 === preg_match('/^[a-f0-9]{64}$/D', strtolower($value));
+	}
+
+	private static function reject($reason, $message, array $report = array()) {
+		throw new WCOS_Manual_Split_Quantity_Authority_Exception($reason, $message, $report);
+	}
+}

--- a/inc/domain/class-wcos-mutation-gateway.php
+++ b/inc/domain/class-wcos-mutation-gateway.php
@@ -17,9 +17,53 @@ final class WCOS_Mutation_Gateway {
 		return (new WCOS_Split_WooCommerce_Adapter())->split($source, $plan, $operation_id, $confirmed_precision);
 	}
 
+	public function split_manual_confirmed(WC_Order $source, array $plan, $operation_id, $confirmed_precision, array $confirmation) {
+		WCOS_Feature_Gates::assert_enabled(WCOS_Feature_Gates::SPLIT);
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
+		$operation_id = sanitize_key((string) $operation_id);
+		$replay_authority = isset($confirmation['replay_authority']) ? sanitize_key((string) $confirmation['replay_authority']) : '';
+		$confirmation_operation_id = isset($confirmation['operation_id']) ? sanitize_key((string) $confirmation['operation_id']) : '';
+		$confirmation_source_id = isset($confirmation['source_order_id']) ? absint($confirmation['source_order_id']) : 0;
+		$confirmation_plan = isset($confirmation['plan']) && is_array($confirmation['plan'])
+			? WCOS_Split_Plan::canonicalize_request($confirmation['plan'])
+			: array();
+		$canonical_plan = WCOS_Split_Plan::canonicalize_request($plan);
+		$precision = WCOS_Price_Precision_Scope::validate($confirmed_precision);
+		$confirmation_precision = WCOS_Price_Precision_Scope::validate(
+			isset($confirmation['price_precision']) ? $confirmation['price_precision'] : null
+		);
+		if (!in_array($replay_authority, array('confirmation', 'journal'), true)
+			|| '' === $operation_id
+			|| $operation_id !== $confirmation_operation_id
+			|| $source->get_id() !== $confirmation_source_id
+			|| $canonical_plan !== $confirmation_plan
+			|| $precision !== $confirmation_precision) {
+			throw new RuntimeException(__('The verified Manual Split confirmation does not match this mutation request.', 'wc-order-splitter'));
+		}
+		$operation_context = array();
+		if (isset($confirmation['manual_quantity_authority']) && is_array($confirmation['manual_quantity_authority'])) {
+			$operation_context['manual_quantity_authority'] = WCOS_Manual_Split_Quantity_Authority::assert_valid($confirmation['manual_quantity_authority']);
+		} else {
+			throw new RuntimeException(__('A verified server Manual Split quantity authority is required.', 'wc-order-splitter'));
+		}
+		return (new WCOS_Split_WooCommerce_Adapter())->split(
+			$source,
+			$canonical_plan,
+			$operation_id,
+			$precision,
+			WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY,
+			$operation_context
+		);
+	}
+
 	public function split_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
 		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
 		return (new WCOS_Split_WooCommerce_Adapter())->preflight($source, $operation_id, $confirmed_precision);
+	}
+
+	public function manual_split_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $source);
+		return (new WCOS_Split_WooCommerce_Adapter())->manual_preflight($source, $operation_id, $confirmed_precision);
 	}
 
 	public function split_strategy(WC_Order $source, $strategy, array $plan, $operation_id, $confirmed_precision = null, array $confirmation = array()) {

--- a/inc/domain/class-wcos-operation-journal.php
+++ b/inc/domain/class-wcos-operation-journal.php
@@ -518,7 +518,7 @@ final class WCOS_Operation_Journal {
 		}
 
         foreach (array(
-            'execution_policy', 'fully_moved_item_ids', 'strategy_authority', 'merge_pair',
+            'execution_policy', 'fully_moved_item_ids', 'strategy_authority', 'manual_quantity_authority', 'merge_pair',
             'merge_recovery_snapshot', 'merge_recovery_snapshot_fingerprint', 'return_pair',
 			'return_plan',
             'return_recovery_snapshot', 'return_recovery_snapshot_fingerprint',

--- a/inc/domain/class-wcos-return-lineage-authority.php
+++ b/inc/domain/class-wcos-return-lineage-authority.php
@@ -83,7 +83,7 @@ final class WCOS_Return_Lineage_Authority {
 			self::reject('execution_policy_mismatch', __('A partial-line Split journal contains whole-line provenance.', 'wc-order-splitter'));
 		}
 
-		$strategy = self::assert_strategy_authority($context, $execution_policy, $snapshot);
+		$strategy = self::assert_strategy_authority($context, $execution_policy, $snapshot, $plan);
 		self::assert_split_fingerprint($record, $plan, $execution_policy, $context);
 		$initial_target_ids = self::canonical_id_list(isset($context['target_order_ids']) ? $context['target_order_ids'] : array(), 'target_order_ids');
 		$current_relation_ids = self::canonical_id_list($source->get_meta(WCOS_Split_Order_Service::RELATION_CHILDREN_META, true), 'source_child_relations');
@@ -275,11 +275,23 @@ final class WCOS_Return_Lineage_Authority {
 		}
 	}
 
-	private static function assert_strategy_authority(array $context, $execution_policy, array $snapshot) {
+	private static function assert_strategy_authority(array $context, $execution_policy, array $snapshot, array $plan) {
 		$has_strategy = isset($context['strategy_authority']) && is_array($context['strategy_authority']);
 		if (WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY === $execution_policy) {
 			if ($has_strategy) {
 				self::reject('strategy_policy_mismatch', __('A manual partial Split unexpectedly carries strategy authority.', 'wc-order-splitter'));
+			}
+			if (isset($context['manual_quantity_authority'])) {
+				try {
+					$manual = WCOS_Manual_Split_Quantity_Authority::assert_valid($context['manual_quantity_authority']);
+					WCOS_Manual_Split_Quantity_Authority::assert_plan($plan, $manual);
+				} catch (Throwable $throwable) {
+					self::reject('manual_quantity_authority_invalid', __('The durable Manual Split quantity-step authority is invalid.', 'wc-order-splitter'));
+				}
+				if ((int) $manual['source_order_id'] !== (int) $snapshot['order_id']
+					|| !hash_equals((string) $manual['source_signature'], (string) $snapshot['source_signature'])) {
+					self::reject('manual_quantity_authority_mismatch', __('The durable Manual Split quantity-step authority does not match its source snapshot.', 'wc-order-splitter'));
+				}
 			}
 			return 'manual_quantity';
 		}
@@ -314,6 +326,9 @@ final class WCOS_Return_Lineage_Authority {
 		);
 		if (isset($context['strategy_authority'])) {
 			$fingerprint_context['strategy_authority'] = $context['strategy_authority'];
+		}
+		if (isset($context['manual_quantity_authority'])) {
+			$fingerprint_context['manual_quantity_authority'] = $context['manual_quantity_authority'];
 		}
 		$expected = WCOS_Mutation_Fingerprint::create('split', absint($record['source_order_id']), $fingerprint_context);
 		$stored = self::fingerprint_value(isset($record['fingerprint']) ? $record['fingerprint'] : '', 'split_operation_fingerprint');

--- a/inc/domain/class-wcos-split-order-service.php
+++ b/inc/domain/class-wcos-split-order-service.php
@@ -39,6 +39,12 @@ final class WCOS_Split_Order_Service {
 		}
 
 		$canonical_plan = WCOS_Split_Plan::canonicalize_request($plan);
+		if (isset($operation_context['manual_quantity_authority'])) {
+			$canonical_plan = WCOS_Manual_Split_Quantity_Authority::assert_plan(
+				$canonical_plan,
+				$operation_context['manual_quantity_authority']
+			);
+		}
 		$existing = WCOS_Operation_Journal::get($source, $operation_id);
 		$legacy_journal = is_array($existing)
 			&& (!isset($existing['context']) || !is_array($existing['context']) || !array_key_exists('execution_policy', $existing['context']));
@@ -58,6 +64,9 @@ final class WCOS_Split_Order_Service {
 		}
 		if (isset($operation_context['strategy_authority'])) {
 			$fingerprint_context['strategy_authority'] = $operation_context['strategy_authority'];
+		}
+		if (isset($operation_context['manual_quantity_authority'])) {
+			$fingerprint_context['manual_quantity_authority'] = $operation_context['manual_quantity_authority'];
 		}
 		$fingerprint = WCOS_Mutation_Fingerprint::create(self::TYPE, $source->get_id(), $fingerprint_context);
 
@@ -146,6 +155,9 @@ final class WCOS_Split_Order_Service {
 				);
 				if (isset($operation_context['strategy_authority'])) {
 					$context['strategy_authority'] = $operation_context['strategy_authority'];
+				}
+				if (isset($operation_context['manual_quantity_authority'])) {
+					$context['manual_quantity_authority'] = $operation_context['manual_quantity_authority'];
 				}
 				if (!WCOS_Operation_Journal::start($source, $operation_id, self::TYPE, $context, $fingerprint)) {
 					throw new RuntimeException(__('Unable to start the split operation journal.', 'wc-order-splitter'));
@@ -268,19 +280,33 @@ final class WCOS_Split_Order_Service {
 
 	private function normalize_operation_context(array $operation_context, $execution_policy) {
 		foreach (array_keys($operation_context) as $key) {
-			if ('strategy_authority' !== $key) {
+			if (!in_array($key, array('strategy_authority', 'manual_quantity_authority'), true)) {
 				throw new InvalidArgumentException(__('Unknown Split operation authority context.', 'wc-order-splitter'));
 			}
 		}
-		if (!array_key_exists('strategy_authority', $operation_context)) {
+		$has_strategy = array_key_exists('strategy_authority', $operation_context);
+		$has_manual = array_key_exists('manual_quantity_authority', $operation_context);
+		if ($has_strategy && $has_manual) {
+			throw new InvalidArgumentException(__('A Split operation cannot carry both strategy and Manual quantity authority.', 'wc-order-splitter'));
+		}
+		if (!$has_strategy && !$has_manual) {
 			return array();
 		}
-		if (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $execution_policy
+		if ($has_strategy && (WCOS_Split_Execution_Policy::ALLOW_WHOLE_LINE_TRANSFER !== $execution_policy
 			|| !is_array($operation_context['strategy_authority'])
-			|| empty($operation_context['strategy_authority'])) {
+			|| empty($operation_context['strategy_authority']))) {
 			throw new InvalidArgumentException(__('Semantic Split strategy authority requires the whole-line execution policy.', 'wc-order-splitter'));
 		}
-		return array('strategy_authority' => $operation_context['strategy_authority']);
+		if ($has_strategy) {
+			return array('strategy_authority' => $operation_context['strategy_authority']);
+		}
+		if (WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY !== $execution_policy
+			|| !is_array($operation_context['manual_quantity_authority'])) {
+			throw new InvalidArgumentException(__('Manual quantity authority requires the partial-lines-only Split policy.', 'wc-order-splitter'));
+		}
+		return array(
+			'manual_quantity_authority' => WCOS_Manual_Split_Quantity_Authority::assert_valid($operation_context['manual_quantity_authority']),
+		);
 	}
 
 	private function assert_supported_source(WC_Order $source) {

--- a/inc/domain/class-wcos-split-woocommerce-adapter.php
+++ b/inc/domain/class-wcos-split-woocommerce-adapter.php
@@ -39,6 +39,14 @@ final class WCOS_Split_WooCommerce_Adapter {
 
             $this->assert_verified_confirmation_source($source, $operation_id);
             $this->assert_supported($source, $precision);
+			$existing_journal = WCOS_Operation_Journal::get($source, $operation_id);
+			if (!is_array($existing_journal) && isset($operation_context['manual_quantity_authority'])) {
+				$manual_authority = WCOS_Manual_Split_Quantity_Authority::assert_current(
+					$source,
+					$operation_context['manual_quantity_authority']
+				);
+				WCOS_Manual_Split_Quantity_Authority::assert_plan($plan, $manual_authority);
+			}
             $stock_token = WCOS_Stock_Side_Effect_Guard::begin($operation_id);
 
             /*
@@ -115,6 +123,34 @@ final class WCOS_Split_WooCommerce_Adapter {
             WCOS_Price_Precision_Scope::end($precision_token);
         }
     }
+
+	public function manual_preflight(WC_Order $source, $operation_id = '', $confirmed_precision = null) {
+		$source_id = $source->get_id();
+		$precision = WCOS_Price_Precision_Scope::for_operation($source, $operation_id, $confirmed_precision);
+		$precision_token = WCOS_Price_Precision_Scope::begin($precision);
+		try {
+			$source = $source_id ? wc_get_order($source_id) : $source;
+			if (!$source instanceof WC_Order) {
+				throw new RuntimeException(__('The source order is no longer available.', 'wc-order-splitter'));
+			}
+			$report = $this->apply_reconciliation_blocker($source, WCOS_Split_Preflight::report($source, $precision));
+			$report['source_signature'] = WCOS_Order_Contract_Snapshot::source_signature($source);
+			if (empty($report['supported'])) {
+				return $report;
+			}
+			try {
+				$report['manual_quantity_authority'] = WCOS_Manual_Split_Quantity_Authority::create($source);
+			} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+				$report['supported'] = false;
+				$report['reason'] = 'manual_quantity_' . $exception->get_reason();
+				$report['message'] = $exception->getMessage();
+				$report['manual_quantity_authority_error'] = $exception->get_report();
+			}
+			return $report;
+		} finally {
+			WCOS_Price_Precision_Scope::end($precision_token);
+		}
+	}
 
     private function assert_verified_confirmation_source(WC_Order $source, $operation_id) {
         $expected = '';

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -2,6 +2,52 @@
     'use strict';
 
     var strings = window.wcosSplitAdminStrings || {};
+
+	function decimalToUnits(value) {
+		var normalized = String(value == null ? '' : value).trim();
+		var match = /^(?:0|[1-9][0-9]*)(?:\.([0-9]{1,6}))?$/.exec(normalized);
+		if (!match) {
+			throw new Error('invalid_decimal');
+		}
+		var parts = normalized.split('.');
+		var fraction = (parts[1] || '').padEnd(6, '0');
+		return BigInt(parts[0] + fraction);
+	}
+
+	function unitsToDecimal(units) {
+		if (typeof units !== 'bigint' || units < BigInt(0)) {
+			throw new Error('invalid_units');
+		}
+		var digits = units.toString().padStart(7, '0');
+		var whole = digits.slice(0, -6);
+		var fraction = digits.slice(-6).replace(/0+$/, '');
+		return fraction ? whole + '.' + fraction : whole;
+	}
+
+	function rowQuantityAuthority(row) {
+		var sourceRaw = row.getAttribute('data-source-units') || '';
+		var stepRaw = row.getAttribute('data-step-units') || '';
+		var maximumRaw = row.getAttribute('data-maximum-units') || '';
+		if (!/^\d+$/.test(sourceRaw) || !/^\d+$/.test(stepRaw) || !/^\d+$/.test(maximumRaw)) {
+			throw new Error('invalid_row_authority');
+		}
+		var source = BigInt(sourceRaw);
+		var step = BigInt(stepRaw);
+		var maximum = BigInt(maximumRaw);
+		var expectedMaximum = source > step ? source - step : BigInt(0);
+		var splittable = row.getAttribute('data-splittable') === '1';
+		if (source <= BigInt(0) || step <= BigInt(0) || source % step !== BigInt(0) || maximum !== expectedMaximum || splittable !== (maximum >= step)) {
+			throw new Error('invalid_row_authority');
+		}
+		return { source: source, step: step, maximum: maximum, splittable: splittable };
+	}
+
+	if (window.wcosSplitAdminTestHooks && typeof window.wcosSplitAdminTestHooks === 'object') {
+		window.wcosSplitAdminTestHooks.decimalToUnits = decimalToUnits;
+		window.wcosSplitAdminTestHooks.unitsToDecimal = unitsToDecimal;
+		window.wcosSplitAdminTestHooks.rowQuantityAuthority = rowQuantityAuthority;
+	}
+
     var launcher = document.querySelector('.wcos-split-launcher');
     if (!launcher || !window.WCOSBackboneModal) {
         return;
@@ -154,7 +200,6 @@
                 if (!currentCell) {
                     return;
                 }
-                currentCell.textContent = humanDecimal(sourceQuantity);
                 var remaining = document.createElement('span');
                 remaining.className = 'wcos-split-remaining-hint';
                 var label = document.createElement('span');
@@ -276,15 +321,6 @@
             });
         }
 
-        function decimalIsPositiveAndLessThan(value, sourceValue) {
-            if (!/^(?:0|[1-9][0-9]*)(?:\.[0-9]{1,6})?$/.test(value)) {
-                return false;
-            }
-            var valueNumber = Number(value);
-            var sourceNumber = Number(sourceValue);
-            return Number.isFinite(valueNumber) && Number.isFinite(sourceNumber) && valueNumber > 0 && valueNumber < sourceNumber;
-        }
-
         function buildPlan() {
             var plan = {};
             var hasQuantity = false;
@@ -292,8 +328,14 @@
 
             Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
                 var itemId = row.getAttribute('data-item-id');
-                var sourceQuantity = row.getAttribute('data-source-quantity') || '0';
-                var movedForLine = 0;
+				var authority;
+				try {
+					authority = rowQuantityAuthority(row);
+				} catch (error) {
+					invalid = true;
+					return;
+				}
+				var movedForLine = BigInt(0);
 
                 Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (quantityInput) {
                     var cell = quantityInput.closest('td');
@@ -301,10 +343,20 @@
                         return;
                     }
                     var quantity = quantityInput.value.trim();
-                    if (quantity === '' || Number(quantity) === 0) {
+					var quantityUnits;
+					if (quantity === '') {
                         return;
                     }
-                    if (!decimalIsPositiveAndLessThan(quantity, sourceQuantity)) {
+					try {
+						quantityUnits = decimalToUnits(quantity);
+					} catch (error) {
+						invalid = true;
+						return;
+					}
+					if (quantityUnits === BigInt(0)) {
+						return;
+					}
+					if (!authority.splittable || quantityUnits % authority.step !== BigInt(0) || quantityUnits > authority.maximum) {
                         invalid = true;
                         return;
                     }
@@ -316,12 +368,12 @@
                     if (!plan[childKey]) {
                         plan[childKey] = {};
                     }
-                    plan[childKey][itemId] = quantity;
-                    movedForLine += Number(quantity);
+					plan[childKey][itemId] = unitsToDecimal(quantityUnits);
+					movedForLine += quantityUnits;
                     hasQuantity = true;
                 });
 
-                if (movedForLine >= Number(sourceQuantity)) {
+				if (movedForLine > authority.maximum) {
                     invalid = true;
                 }
             });
@@ -340,23 +392,38 @@
 
         function updateRemaining() {
             Array.prototype.forEach.call(dialog.querySelectorAll('tbody tr[data-item-id]'), function (row) {
-                var source = Number(row.getAttribute('data-source-quantity') || 0);
-                var moved = 0;
+				var authority;
+				var moved = BigInt(0);
+				var valid = true;
+				try {
+					authority = rowQuantityAuthority(row);
+				} catch (error) {
+					valid = false;
+					authority = { source: BigInt(0), step: BigInt(1) };
+				}
                 Array.prototype.forEach.call(row.querySelectorAll('.wcos-split-quantity[data-child-key]'), function (field) {
                     var cell = field.closest('td');
                     if (cell && cell.hidden) {
                         return;
                     }
-                    var value = Number(field.value || 0);
-                    if (Number.isFinite(value) && value > 0) {
-                        moved += value;
-                    }
+					if (!field.value.trim()) {
+						return;
+					}
+					try {
+						var units = decimalToUnits(field.value);
+						if (units > BigInt(0)) {
+							moved += units;
+							valid = valid && units % authority.step === BigInt(0);
+						}
+					} catch (error) {
+						valid = false;
+					}
                 });
-                var remaining = source - moved;
+				var remaining = authority.source > moved ? authority.source - moved : BigInt(0);
                 var output = row.querySelector('.wcos-split-remaining');
                 if (output) {
-                    output.textContent = humanDecimal(String(Math.max(0, remaining).toFixed(6)));
-                    output.classList.toggle('is-invalid', remaining <= 0);
+					output.textContent = unitsToDecimal(remaining);
+					output.classList.toggle('is-invalid', !valid || remaining <= BigInt(0) || remaining % authority.step !== BigInt(0));
                 }
             });
         }
@@ -414,7 +481,9 @@
             busy = !!nextBusy;
             form.setAttribute('aria-busy', busy ? 'true' : 'false');
             Array.prototype.forEach.call(dialog.querySelectorAll('.wcos-split-quantity'), function (field) {
-                field.disabled = busy || completed || !!state;
+				var row = field.closest('tr[data-item-id]');
+				var permanentlyDisabled = !row || row.getAttribute('data-splittable') !== '1';
+				field.disabled = permanentlyDisabled || busy || completed || !!state;
             });
             reviewButton.disabled = busy || completed || !!state || !canBuildPlan();
             confirmCheckbox.disabled = busy || completed || !state;

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ Manual Quantity Split lets an authorized administrator review and allocate suppo
 
 Category and Stock-status Split move whole product lines according to server-built buckets. One reviewed bucket stays on the source and every other bucket becomes a child order. Category classification rejects catalog state it cannot prove, including deleted products or unrelated leaf-category ambiguity. Stock-status classification uses the reviewed server state. Confirmed plans use frozen server authority for execution.
 
-Historical line taxes are allocated without recalculating current rates. Fractional quantities are accepted only when the active WooCommerce quantity integration actually preserves fractional stock amounts.
+Historical line taxes are allocated without recalculating current rates. Manual allocations must be exact multiples of each line's current WooCommerce admin quantity step. Fractional steps are accepted only when the active WooCommerce quantity integration also preserves fractional stock amounts.
 
 == Duplicate safety policy ==
 

--- a/tests/integration/operation-control-smoke.php
+++ b/tests/integration/operation-control-smoke.php
@@ -135,6 +135,7 @@ wcos_control_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 
 wcos_control_assert(WC_Order_Splitter_Safety_Guard::mutations_enabled(), 'Safety guard did not restore the production-enabled state.');
 
 require __DIR__ . '/p2-production-split-enabled-smoke.php';
+require __DIR__ . '/p2-manual-quantity-step-authority-smoke.php';
 require __DIR__ . '/p2-production-duplicate-enabled-smoke.php';
 require __DIR__ . '/p2-whole-line-plan-smoke.php';
 require __DIR__ . '/p2-duplicate-side-effects-smoke.php';

--- a/tests/integration/p2-admin-client-state-smoke.php
+++ b/tests/integration/p2-admin-client-state-smoke.php
@@ -12,7 +12,11 @@ wcos_p2_adapter_assert(is_string($js) && '' !== $js, 'Unable to read the Split a
 foreach (array(
     'var completed = false;',
     "dialog.querySelectorAll('.wcos-split-quantity')",
-    'field.disabled = busy || completed || !!state;',
+	"row.getAttribute('data-splittable') !== '1'",
+	'field.disabled = permanentlyDisabled || busy || completed || !!state;',
+	'quantityUnits % authority.step !== BigInt(0)',
+	'movedForLine > authority.maximum',
+	'unitsToDecimal(quantityUnits)',
     'reviewButton.disabled = busy || completed || !!state || !canBuildPlan();',
     'confirmCheckbox.disabled = busy || completed || !state;',
     'executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;',
@@ -47,6 +51,9 @@ wcos_p2_adapter_assert(
 );
 wcos_p2_adapter_assert(false === strpos($js, 'window.alert'), 'Split admin client reintroduced blocking alert UI.');
 wcos_p2_adapter_assert(false === strpos($js, '.innerHTML'), 'Split admin client reintroduced innerHTML rendering.');
+wcos_p2_adapter_assert(false === strpos($js, 'toFixed(6)'), 'Split admin client uses binary floating-point formatting for quantity conservation.');
+wcos_p2_adapter_assert(false === strpos($js, 'movedForLine += Number('), 'Split admin client uses Number() for quantity accumulation.');
+wcos_p2_adapter_assert(false === strpos($js, 'currentCell.textContent = humanDecimal(sourceQuantity);'), 'Split admin client removes server-rendered per-line step guidance.');
 
 $bridge = file_get_contents($root . '/js/p2-backbone-modal.js');
 wcos_p2_adapter_assert(is_string($bridge) && '' !== $bridge, 'WooCommerce Backbone modal bridge is missing.');

--- a/tests/integration/p2-admin-transport-smoke.php
+++ b/tests/integration/p2-admin-transport-smoke.php
@@ -65,25 +65,25 @@ try {
     /* Strict parser rejects ambiguous or unsafe request shapes. */
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('new-order' => array($transport_item_id => '1.000000'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('new-order' => array($transport_item_id => '1.000000'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser accepted a non-canonical child key.'
     );
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => 1))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => 1))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser accepted a JSON numeric quantity instead of a decimal string.'
     );
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array('99999999' => '1.000000'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array('99999999' => '1.000000'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser accepted an order item outside the source.'
     );
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '4.000000'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '4.000000'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser allowed a Split plan to consume the entire source line.'
     );
@@ -92,19 +92,31 @@ try {
             WCOS_Split_Request_Parser::parse_json(wp_json_encode(array(
                 'child-1' => array($transport_item_id => '2.000000'),
                 'child-2' => array($transport_item_id => '2.000000'),
-            )), $transport_source);
+            )), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser allowed aggregate multi-child allocation to consume the entire source line.'
     );
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '1e0'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '1e0'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser accepted scientific-notation quantity input.'
     );
+	foreach (array('0', '-1', '0,5', '0.0000001') as $invalid_decimal) {
+		wcos_p2_transport_expect_invalid_plan(
+			static function() use ($transport_source, $transport_item_id, $invalid_decimal) {
+				WCOS_Split_Request_Parser::parse_json(
+					wp_json_encode(array('child-1' => array($transport_item_id => $invalid_decimal))),
+					$transport_source,
+					WCOS_Manual_Split_Quantity_Authority::create($transport_source)
+				);
+			},
+			'Parser accepted invalid canonical decimal input: ' . $invalid_decimal
+		);
+	}
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '999999999999999999999999999999999999'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '999999999999999999999999999999999999'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser allowed numeric overflow to escape validation.'
     );
@@ -113,7 +125,7 @@ try {
     wcos_p2_adapter_assert(!WCOS_Split_Preflight::fractional_quantities_supported(), 'Default WooCommerce fixture unexpectedly supports fractional stock amounts.');
     wcos_p2_transport_expect_invalid_plan(
         static function() use ($transport_source, $transport_item_id) {
-            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))), $transport_source);
+            WCOS_Split_Request_Parser::parse_json(wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))), $transport_source, WCOS_Manual_Split_Quantity_Authority::create($transport_source));
         },
         'Parser accepted fractional transport input under integer-only WooCommerce stock amounts.'
     );
@@ -122,12 +134,31 @@ try {
     add_filter('woocommerce_stock_amount', 'floatval');
     try {
         wcos_p2_adapter_assert(WCOS_Split_Preflight::fractional_quantities_supported(), 'Explicit fractional integration was not detected.');
+		wcos_p2_transport_expect_invalid_plan(
+			static function() use ($transport_source, $transport_item_id) {
+				WCOS_Split_Request_Parser::parse_json(
+					wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))),
+					$transport_source,
+					WCOS_Manual_Split_Quantity_Authority::create($transport_source)
+				);
+			},
+			'Fractional stock support incorrectly authorized a quantity below the default product step.'
+		);
+		$quarter_step = static function($step, $product, $context) use ($transport_product) {
+			return $product instanceof WC_Product && $product->get_id() === $transport_product->get_id() && 'edit' === $context ? '0.25' : $step;
+		};
+		add_filter('woocommerce_quantity_input_step_admin', $quarter_step, 10, 3);
         $fractional_plan = WCOS_Split_Request_Parser::parse_json(
             wp_json_encode(array('child-1' => array($transport_item_id => '0.500000'))),
-            $transport_source
+			$transport_source,
+			WCOS_Manual_Split_Quantity_Authority::create($transport_source)
         );
         wcos_p2_adapter_assert('0.500000' === $fractional_plan['child-1'][$transport_item_id], 'Fractional transport input was not preserved exactly.');
+		remove_filter('woocommerce_quantity_input_step_admin', $quarter_step, 10);
     } finally {
+		if (isset($quarter_step)) {
+			remove_filter('woocommerce_quantity_input_step_admin', $quarter_step, 10);
+		}
         remove_filter('woocommerce_stock_amount', 'floatval');
         add_filter('woocommerce_stock_amount', 'intval');
     }
@@ -267,7 +298,13 @@ try {
         '>Child 10<',
         'scope="row"',
         'change stock directly in the database',
-        'only supports integer Split quantities',
+		'data-step-units="1000000"',
+		'data-maximum-units="3000000"',
+		'max="3"',
+		'step="1"',
+		'inputmode="numeric"',
+		'Step: 1',
+		'Manual allocation steps are enforced per line: 1.',
     ) as $needle) {
         wcos_p2_adapter_assert(false !== strpos($html, $needle), 'Accessible Split dialog is missing required markup: ' . $needle);
     }

--- a/tests/integration/p2-confirmation-mutation-boundary-smoke.php
+++ b/tests/integration/p2-confirmation-mutation-boundary-smoke.php
@@ -31,7 +31,7 @@ try {
     /* Split: verify succeeds, source changes, adapter must still fail before journal/child persistence. */
     $split_source = wc_get_order($split_source_id);
     $split_plan = array('child-1' => array($split_item_id => '1.000000'));
-    $split_preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($split_source);
+    $split_preflight = (new WCOS_Split_WooCommerce_Adapter())->manual_preflight($split_source);
     $split_confirmation = WCOS_Split_Confirmation_Store::create(
         $split_source,
         $split_plan,
@@ -51,17 +51,34 @@ try {
         'Split verify did not publish request-local source authority.'
     );
 
+	$confirmation_mismatch_rejected = false;
+	try {
+		$forged_confirmation = $split_verified;
+		$forged_confirmation['operation_id'] = wp_generate_uuid4();
+		(new WCOS_Mutation_Gateway())->split_manual_confirmed(
+			wc_get_order($split_source_id),
+			$split_verified['plan'],
+			$split_operation,
+			$split_verified['price_precision'],
+			$forged_confirmation
+		);
+	} catch (RuntimeException $exception) {
+		$confirmation_mismatch_rejected = false !== strpos($exception->getMessage(), 'does not match');
+	}
+	wcos_p2_adapter_assert($confirmation_mismatch_rejected, 'Split mutation Gateway accepted mismatched verified confirmation authority.');
+
     $changed_split = wc_get_order($split_source_id);
     $changed_split->set_customer_note('changed-after-split-verify');
     $changed_split->save();
 
     $split_rejected = false;
     try {
-        (new WCOS_Mutation_Gateway())->split(
+        (new WCOS_Mutation_Gateway())->split_manual_confirmed(
             wc_get_order($split_source_id),
             $split_verified['plan'],
             $split_operation,
-            $split_verified['price_precision']
+			$split_verified['price_precision'],
+			$split_verified
         );
     } catch (WCOS_Split_Preflight_Exception $exception) {
         $split_rejected = 'source_changed_after_confirmation' === $exception->get_reason();

--- a/tests/integration/p2-confirmation-precision-smoke.php
+++ b/tests/integration/p2-confirmation-precision-smoke.php
@@ -18,7 +18,7 @@ try {
         '1.001'
     );
     $confirmation_precision_source_id = $confirmation_precision_source->get_id();
-    $preflight = (new WCOS_Split_WooCommerce_Adapter())->preflight($confirmation_precision_source);
+    $preflight = (new WCOS_Split_WooCommerce_Adapter())->manual_preflight($confirmation_precision_source);
     wcos_p2_adapter_assert(3 === (int) $preflight['price_precision'], 'Confirmation precision fixture was not reviewed at three decimals.');
 
     $confirmation = WCOS_Split_Confirmation_Store::create(

--- a/tests/integration/p2-durable-replay-smoke.php
+++ b/tests/integration/p2-durable-replay-smoke.php
@@ -58,7 +58,9 @@ try {
             wc_get_order($replay_source_id),
             $replay_plan,
             $replay_operation,
-            $review['preflight']['price_precision']
+			$review['preflight']['price_precision'],
+			WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY,
+			array('manual_quantity_authority' => $review['preflight']['manual_quantity_authority'])
         );
     } catch (RuntimeException $exception) {
         $crashed = false !== strpos($exception->getMessage(), 'Injected durable replay crash.');
@@ -106,7 +108,9 @@ try {
         wc_get_order($replay_source_id),
         $durable['plan'],
         $replay_operation,
-        $durable['price_precision']
+		$durable['price_precision'],
+		WCOS_Split_Execution_Policy::PARTIAL_LINES_ONLY,
+		array('manual_quantity_authority' => $durable['manual_quantity_authority'])
     );
     wcos_p2_adapter_assert(1 === count($replayed_children), 'Durable replay did not complete with one child.');
     wcos_p2_adapter_assert($persisted_children[0]->get_id() === $replayed_children[0]->get_id(), 'Durable replay created a duplicate child.');

--- a/tests/integration/p2-manual-quantity-step-authority-smoke.php
+++ b/tests/integration/p2-manual-quantity-step-authority-smoke.php
@@ -1,0 +1,297 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_quantity_step_expect_authority_reason($reason, callable $callback, $message) {
+	try {
+		$callback();
+	} catch (WCOS_Manual_Split_Quantity_Authority_Exception $exception) {
+		wcos_p2_adapter_assert($reason === $exception->get_reason(), $message . ' Wrong reason: ' . $exception->get_reason());
+		return;
+	}
+	throw new RuntimeException($message);
+}
+
+$quantity_step_previous_user = get_current_user_id();
+$quantity_step_allowed_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$quantity_step_user_id = 0;
+$quantity_step_product_ids = array();
+$quantity_step_order_ids = array();
+$quantity_step_operation_ids = array();
+$quantity_step_map = array();
+$quantity_step_filter = static function($step, $product, $context) use (&$quantity_step_map) {
+	$product_id = $product instanceof WC_Product ? $product->get_id() : 0;
+	return 'edit' === $context && isset($quantity_step_map[$product_id]) ? $quantity_step_map[$product_id] : $step;
+};
+
+remove_filter('woocommerce_stock_amount', 'intval');
+add_filter('woocommerce_stock_amount', 'floatval');
+add_filter('woocommerce_quantity_input_step_admin', $quantity_step_filter, 10, 3);
+
+try {
+	$quantity_step_user_id = wp_insert_user(array(
+		'user_login' => 'wcos_quantity_step_' . wp_generate_password(8, false),
+		'user_pass' => wp_generate_password(24, true),
+		'user_email' => 'wcos-quantity-step-' . wp_generate_uuid4() . '@example.test',
+		'role' => 'administrator',
+	));
+	wcos_p2_adapter_assert(!is_wp_error($quantity_step_user_id), 'Unable to create quantity-step test user.');
+	wp_set_current_user($quantity_step_user_id);
+	update_option('order_splitter_status_allowed', array('wc-pending'));
+
+	$integer_product = wcos_p2_adapter_product('WCOS quantity step integer', '10.00', 20);
+	$fractional_product = wcos_p2_adapter_product('WCOS quantity step quarter', '8.00', 20);
+	$quantity_step_product_ids[] = $integer_product->get_id();
+	$quantity_step_product_ids[] = $fractional_product->get_id();
+	$quantity_step_map[$fractional_product->get_id()] = '0.25';
+
+	$mixed = wc_create_order();
+	$mixed->set_status('pending');
+	$mixed->add_product($integer_product, 4);
+	$mixed->add_product($fractional_product, 3.5);
+	$mixed->calculate_totals(false);
+	$mixed->save();
+	$mixed = wc_get_order($mixed->get_id());
+	$quantity_step_order_ids[] = $mixed->get_id();
+	$mixed_items = array_values($mixed->get_items('line_item'));
+	$integer_item_id = $mixed_items[0]->get_product_id() === $integer_product->get_id() ? $mixed_items[0]->get_id() : $mixed_items[1]->get_id();
+	$fractional_item_id = $mixed_items[0]->get_product_id() === $fractional_product->get_id() ? $mixed_items[0]->get_id() : $mixed_items[1]->get_id();
+
+	$authority = WCOS_Manual_Split_Quantity_Authority::create($mixed);
+	wcos_p2_adapter_assert(1000000 === $authority['lines'][$integer_item_id]['step_units'], 'Integer line did not retain step 1.');
+	wcos_p2_adapter_assert(250000 === $authority['lines'][$fractional_item_id]['step_units'], 'Admin edit step 0.25 was not bound.');
+	wcos_p2_adapter_assert(3000000 === $authority['lines'][$integer_item_id]['maximum_quantity_units'], 'Integer line maximum did not retain one source step.');
+	wcos_p2_adapter_assert(3250000 === $authority['lines'][$fractional_item_id]['maximum_quantity_units'], 'Fractional line maximum did not retain one source step.');
+
+	$accepted = WCOS_Split_Request_Parser::parse_json(
+		wp_json_encode(array('child-1' => array($integer_item_id => '1.000000', $fractional_item_id => '0.50'))),
+		$mixed,
+		$authority
+	);
+	wcos_p2_adapter_assert('0.500000' === $accepted['child-1'][$fractional_item_id], 'Quarter-step parser did not preserve the canonical decimal.');
+	foreach (array('1', '2', '3') as $integer_quantity) {
+		$integer_plan = WCOS_Split_Request_Parser::parse_json(
+			wp_json_encode(array('child-1' => array($integer_item_id => $integer_quantity))),
+			$mixed,
+			$authority
+		);
+		wcos_p2_adapter_assert(
+			WCOS_Decimal::normalize($integer_quantity, 6) === $integer_plan['child-1'][$integer_item_id],
+			'Default integer line rejected an exact step allocation: ' . $integer_quantity
+		);
+	}
+	foreach (array(
+		array($integer_item_id, '0.5'),
+		array($integer_item_id, '0.000001'),
+		array($fractional_item_id, '0.1'),
+		array($fractional_item_id, '0.000001'),
+		array($fractional_item_id, '0.30'),
+	) as $invalid) {
+		$rejected = false;
+		try {
+			WCOS_Split_Request_Parser::parse_json(
+				wp_json_encode(array('child-1' => array($invalid[0] => $invalid[1]))),
+				$mixed,
+				$authority
+			);
+		} catch (InvalidArgumentException $exception) {
+			$rejected = true;
+		}
+		wcos_p2_adapter_assert($rejected, 'Parser accepted a quantity outside per-line step authority: ' . $invalid[1]);
+	}
+
+	$aggregate_rejected = false;
+	try {
+		WCOS_Split_Request_Parser::parse_json(
+			wp_json_encode(array(
+				'child-1' => array($fractional_item_id => '1.750000'),
+				'child-2' => array($fractional_item_id => '1.750000'),
+			)),
+			$mixed,
+			$authority
+		);
+	} catch (InvalidArgumentException $exception) {
+		$aggregate_rejected = true;
+	}
+	wcos_p2_adapter_assert($aggregate_rejected, 'Parser allowed aggregate child allocation to consume the fractional source line.');
+
+	$quantity_step_map[$fractional_product->get_id()] = '0.1';
+	$tenth_authority = WCOS_Manual_Split_Quantity_Authority::create($mixed);
+	$tenth_plan = WCOS_Split_Request_Parser::parse_json(
+		wp_json_encode(array(
+			'child-1' => array($fractional_item_id => '0.1'),
+			'child-2' => array($fractional_item_id => '0.2'),
+		)),
+		$mixed,
+		$tenth_authority
+	);
+	wcos_p2_adapter_assert(
+		300000 === WCOS_Decimal::to_units($tenth_plan['child-1'][$fractional_item_id], 6)
+			+ WCOS_Decimal::to_units($tenth_plan['child-2'][$fractional_item_id], 6),
+		'Tenth-step multi-child allocation lost exact decimal-unit arithmetic.'
+	);
+	$tenth_mismatch_rejected = false;
+	try {
+		WCOS_Split_Request_Parser::parse_json(
+			wp_json_encode(array('child-1' => array($fractional_item_id => '0.25'))),
+			$mixed,
+			$tenth_authority
+		);
+	} catch (InvalidArgumentException $exception) {
+		$tenth_mismatch_rejected = true;
+	}
+	wcos_p2_adapter_assert($tenth_mismatch_rejected, 'Tenth-step authority accepted a non-multiple quantity.');
+	$quantity_step_map[$fractional_product->get_id()] = '0.25';
+
+	$controller = new WCOS_Split_Admin_Controller();
+	$preflight = (new WCOS_Mutation_Gateway())->manual_split_preflight($mixed);
+	wcos_p2_adapter_assert(!empty($preflight['supported']), 'Mixed-line Manual Split preflight failed.');
+	$html = $controller->dialog_html($mixed, $preflight);
+	foreach (array(
+		'data-step-units="1000000"', 'data-step-units="250000"',
+		'data-maximum-units="3000000"', 'data-maximum-units="3250000"',
+		'step="1"', 'step="0.25"', 'max="3"', 'max="3.25"',
+		'inputmode="numeric"', 'inputmode="decimal"',
+	) as $needle) {
+		wcos_p2_adapter_assert(false !== strpos($html, $needle), 'Mixed-line dialog omitted per-line quantity metadata: ' . $needle);
+	}
+	wcos_p2_adapter_assert(false === strpos($html, 'step="0.000001"'), 'Dialog reintroduced the global generic fractional step.');
+
+	list($single_source, $single_item_id) = wcos_p2_adapter_order($integer_product, 1, 'pending');
+	$quantity_step_order_ids[] = $single_source->get_id();
+	$single_preflight = (new WCOS_Mutation_Gateway())->manual_split_preflight($single_source);
+	$single_html = $controller->dialog_html($single_source, $single_preflight);
+	wcos_p2_adapter_assert(false !== strpos($single_html, 'data-splittable="0"'), 'A one-step source line was not marked non-splittable.');
+	wcos_p2_adapter_assert(false !== strpos($single_html, 'disabled='), 'A one-step source line retained editable allocation inputs.');
+
+	$drift_preflight = (new WCOS_Mutation_Gateway())->manual_split_preflight($mixed);
+	$drift_confirmation = WCOS_Split_Confirmation_Store::create(
+		$mixed,
+		array('child-1' => array($fractional_item_id => '0.500000')),
+		$drift_preflight,
+		$quantity_step_user_id
+	);
+	$quantity_step_operation_ids[] = $drift_confirmation['operation_id'];
+	$quantity_step_map[$fractional_product->get_id()] = '0.5';
+	$drift_rejected = false;
+	try {
+		WCOS_Split_Confirmation_Store::verify(
+			$mixed,
+			$drift_confirmation['operation_id'],
+			$drift_confirmation['confirmation_token'],
+			$quantity_step_user_id
+		);
+	} catch (WCOS_Split_Confirmation_Exception $exception) {
+		$drift_rejected = 'quantity_authority_changed' === $exception->get_reason();
+	}
+	wcos_p2_adapter_assert($drift_rejected, 'Step drift after Review did not invalidate confirmation authority.');
+	wcos_p2_adapter_assert(null === WCOS_Operation_Journal::get($mixed, $drift_confirmation['operation_id']), 'Step-drift rejection created a mutation journal.');
+	$quantity_step_map[$fractional_product->get_id()] = '0.25';
+
+	foreach (array('0', '-0.25', 'not-a-number', '0.0000001', '999999999999999999999999') as $invalid_step) {
+		$quantity_step_map[$fractional_product->get_id()] = $invalid_step;
+		wcos_quantity_step_expect_authority_reason(
+			'0.0000001' === $invalid_step ? 'quantity_step_precision_invalid' : 'quantity_step_invalid',
+			static function() use ($mixed) { WCOS_Manual_Split_Quantity_Authority::create($mixed); },
+			'Invalid WooCommerce admin quantity step was accepted: ' . $invalid_step
+		);
+	}
+	$quantity_step_map[$fractional_product->get_id()] = '0.3';
+	wcos_quantity_step_expect_authority_reason(
+		'source_quantity_step_mismatch',
+		static function() use ($mixed) { WCOS_Manual_Split_Quantity_Authority::create($mixed); },
+		'A source quantity outside the current product quantum was accepted.'
+	);
+	$quantity_step_map[$fractional_product->get_id()] = '0.25';
+
+	$deleted_integer_product = wcos_p2_adapter_product('WCOS deleted integer step', '5.00');
+	$deleted_fractional_product = wcos_p2_adapter_product('WCOS deleted fractional step', '5.00');
+	$quantity_step_product_ids[] = $deleted_integer_product->get_id();
+	$quantity_step_product_ids[] = $deleted_fractional_product->get_id();
+	list($deleted_integer_source) = wcos_p2_adapter_order($deleted_integer_product, 2, 'pending');
+	list($deleted_fractional_source) = wcos_p2_adapter_order($deleted_fractional_product, 1.5, 'pending');
+	$quantity_step_order_ids[] = $deleted_integer_source->get_id();
+	$quantity_step_order_ids[] = $deleted_fractional_source->get_id();
+	wp_delete_post($deleted_integer_product->get_id(), true);
+	wp_delete_post($deleted_fractional_product->get_id(), true);
+	$deleted_integer_authority = WCOS_Manual_Split_Quantity_Authority::create(wc_get_order($deleted_integer_source->get_id()));
+	$deleted_integer_lines = array_values($deleted_integer_authority['lines']);
+	wcos_p2_adapter_assert(1000000 === $deleted_integer_lines[0]['step_units'], 'Deleted integer product did not fail closed to step 1.');
+	wcos_quantity_step_expect_authority_reason(
+		'deleted_product_fractional_step_unprovable',
+		static function() use ($deleted_fractional_source) { WCOS_Manual_Split_Quantity_Authority::create(wc_get_order($deleted_fractional_source->get_id())); },
+		'Deleted fractional product retained unprovable Manual Split authority.'
+	);
+
+	list($execute_source, $execute_item_id) = wcos_p2_adapter_order($fractional_product, 3.5, 'pending');
+	$execute_source_id = $execute_source->get_id();
+	$quantity_step_order_ids[] = $execute_source_id;
+	$execute_nonce = wp_create_nonce('wcos_split_order_' . $execute_source_id);
+	$stock_before = wc_get_product($fractional_product->get_id())->get_stock_quantity();
+	$review = $controller->review_request(array(
+		'order_id' => $execute_source_id,
+		'nonce' => $execute_nonce,
+		'plan' => wp_json_encode(array('child-1' => array($execute_item_id => '0.500000'))),
+	));
+	$quantity_step_operation_ids[] = $review['operation_id'];
+	$result = $controller->execute_request(array(
+		'order_id' => $execute_source_id,
+		'nonce' => $execute_nonce,
+		'operation_id' => $review['operation_id'],
+		'confirmation_token' => $review['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $result['status'] && 1 === count($result['children']), 'Fractional-step Manual Split did not complete exactly once.');
+	$record = WCOS_Operation_Journal::get(wc_get_order($execute_source_id), $review['operation_id']);
+	wcos_p2_adapter_assert(is_array($record) && 'completed' === $record['status'], 'Fractional-step Split journal did not complete.');
+	wcos_p2_adapter_assert(250000 === $record['context']['manual_quantity_authority']['lines'][$execute_item_id]['step_units'], 'Split journal lost frozen quarter-step authority.');
+	$children = wcos_p2_adapter_children($execute_source_id, $review['operation_id']);
+	wcos_p2_adapter_assert(1 === count($children), 'Fractional-step Split produced the wrong child set.');
+	$lineage = WCOS_Return_Lineage_Authority::resolve(reset($children));
+	wcos_p2_adapter_assert('manual_quantity' === $lineage['strategy'], 'Return lineage rejected the new Manual quantity authority context.');
+	wcos_p2_adapter_assert($stock_before == wc_get_product($fractional_product->get_id())->get_stock_quantity(), 'Fractional-step Split changed physical product stock.');
+
+	$quantity_step_map[$fractional_product->get_id()] = '0.5';
+	$retry = $controller->execute_request(array(
+		'order_id' => $execute_source_id,
+		'nonce' => $execute_nonce,
+		'operation_id' => $review['operation_id'],
+		'confirmation_token' => $review['confirmation_token'],
+	));
+	wcos_p2_adapter_assert('completed' === $retry['status'] && 1 === count($retry['children']), 'Durable journal replay reinterpreted current quantity-step drift.');
+	wcos_p2_adapter_assert(1 === count(wcos_p2_adapter_children($execute_source_id, $review['operation_id'])), 'Durable replay duplicated the child set.');
+} finally {
+	remove_filter('woocommerce_quantity_input_step_admin', $quantity_step_filter, 10);
+	remove_filter('woocommerce_stock_amount', 'floatval');
+	add_filter('woocommerce_stock_amount', 'intval');
+	foreach ($quantity_step_operation_ids as $operation_id) {
+		WCOS_Split_Confirmation_Store::delete($operation_id);
+	}
+	foreach (array_reverse(array_unique(array_map('absint', $quantity_step_order_ids))) as $order_id) {
+		$order = wc_get_order($order_id);
+		if ($order instanceof WC_Order) {
+			foreach (WCOS_Order_Relation_Repository::find(array(array('key' => WCOS_Split_Order_Service::RELATION_PARENT_META, 'value' => $order_id, 'type' => 'NUMERIC')), -1) as $child) {
+				if ($child instanceof WC_Order) {
+					$child->delete(true);
+				}
+			}
+			$order->delete(true);
+		}
+	}
+	foreach (array_unique(array_map('absint', $quantity_step_product_ids)) as $product_id) {
+		if ($product_id) {
+			wp_delete_post($product_id, true);
+		}
+	}
+	update_option('order_splitter_status_allowed', $quantity_step_allowed_statuses);
+	wp_set_current_user($quantity_step_previous_user);
+	if ($quantity_step_user_id && !is_wp_error($quantity_step_user_id)) {
+		if (!function_exists('wp_delete_user')) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+		wp_delete_user($quantity_step_user_id);
+	}
+}
+
+echo "p2-manual-quantity-step-authority-ok\n";

--- a/tests/integration/p2-policy-replay-smoke.php
+++ b/tests/integration/p2-policy-replay-smoke.php
@@ -17,6 +17,7 @@ list($policy_source, $policy_item_id) = wcos_p2_adapter_order($policy_product, 3
 $policy_source_id = $policy_source->get_id();
 $policy_operation = wp_generate_uuid4();
 $policy_plan = array('child-1' => array($policy_item_id => '1.000000'));
+$policy_quantity_authority = WCOS_Manual_Split_Quantity_Authority::create($policy_source);
 $policy_fingerprint = WCOS_Mutation_Fingerprint::create(
     'split',
     $policy_source_id,
@@ -28,7 +29,7 @@ wcos_p2_adapter_assert(
         $policy_source,
         $policy_operation,
         'split',
-        array('plan' => $policy_plan),
+		array('plan' => $policy_plan, 'manual_quantity_authority' => $policy_quantity_authority),
         $policy_fingerprint
     ),
     'Unable to start durable-policy journal fixture.'
@@ -93,6 +94,26 @@ try {
     $policy_changed = 'policy_changed' === $exception->get_reason();
 }
 wcos_p2_adapter_assert($policy_changed, 'Durable replay crossed a changed Split safety policy.');
+
+update_option($journal_key, $policy_record, false);
+wp_cache_delete($journal_key, 'options');
+
+$legacy_record = $policy_record;
+unset($legacy_record['context']['manual_quantity_authority']);
+update_option($journal_key, $legacy_record, false);
+wp_cache_delete($journal_key, 'options');
+$legacy_authority_rejected = false;
+try {
+	WCOS_Split_Confirmation_Store::verify(
+		wc_get_order($policy_source_id),
+		$policy_operation,
+		'',
+		$policy_user_id
+	);
+} catch (WCOS_Split_Confirmation_Exception $exception) {
+	$legacy_authority_rejected = 'quantity_authority_incomplete' === $exception->get_reason();
+}
+wcos_p2_adapter_assert($legacy_authority_rejected, 'Durable Manual Split replay accepted a journal without quantity-step authority.');
 
 update_option($journal_key, $policy_record, false);
 wp_cache_delete($journal_key, 'options');

--- a/tests/integration/p2-review-confirmation-toctou-smoke.php
+++ b/tests/integration/p2-review-confirmation-toctou-smoke.php
@@ -16,7 +16,7 @@ $review_product = wcos_p2_adapter_product('WCOS P2 review confirmation race', '1
 list($review_source, $review_item_id) = wcos_p2_adapter_order($review_product, 5);
 $review_source_id = $review_source->get_id();
 $review_adapter = new WCOS_Split_WooCommerce_Adapter();
-$review_preflight = $review_adapter->preflight($review_source);
+$review_preflight = $review_adapter->manual_preflight($review_source);
 wcos_p2_adapter_assert(!empty($review_preflight['supported']), 'Review-race fixture failed initial preflight.');
 wcos_p2_adapter_assert(
     !empty($review_preflight['source_signature']),
@@ -56,7 +56,7 @@ wcos_p2_adapter_assert(
  * confirmation must still be rejected because the parser source does not equal
  * the source that preflight reviewed.
  */
-$fresh_preflight = $review_adapter->preflight(wc_get_order($review_source_id));
+$fresh_preflight = $review_adapter->manual_preflight(wc_get_order($review_source_id));
 wcos_p2_adapter_assert(!empty($fresh_preflight['supported']), 'Fresh concurrent source was not preflight-compatible for parser-race test.');
 wcos_p2_adapter_assert(
     !hash_equals($review_preflight['source_signature'], $fresh_preflight['source_signature']),

--- a/tests/js/p2-split-quantity-step-math.js
+++ b/tests/js/p2-split-quantity-step-math.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '../..');
+const client = fs.readFileSync(path.join(root, 'js/p2-split-admin.js'), 'utf8');
+const hooks = {};
+
+vm.runInNewContext(client, {
+    window: {
+        wcosSplitAdminStrings: {},
+        wcosSplitAdminTestHooks: hooks
+    },
+    document: {
+        querySelector() { return null; }
+    },
+    String,
+    BigInt,
+    Error
+});
+
+assert.equal(hooks.decimalToUnits('0.1') + hooks.decimalToUnits('0.2'), 300000n, '0.1 + 0.2 must use exact integer units');
+assert.equal(hooks.unitsToDecimal(300000n), '0.3', 'exact units must format as a canonical decimal string');
+assert.equal(hooks.decimalToUnits('0.250000'), 250000n);
+assert.equal(hooks.decimalToUnits('999999999999.999999'), 999999999999999999n, 'large valid quantities must not lose precision');
+
+for (const invalid of ['1e0', '0,25', '-0.25', '0.0000001', '01.00', '', 'NaN']) {
+    assert.throws(() => hooks.decimalToUnits(invalid), undefined, `invalid decimal syntax must fail: ${invalid}`);
+}
+
+function row(attributes) {
+    return {
+        getAttribute(name) {
+            return Object.prototype.hasOwnProperty.call(attributes, name) ? attributes[name] : null;
+        }
+    };
+}
+
+const quarter = hooks.rowQuantityAuthority(row({
+    'data-source-units': '3500000',
+    'data-step-units': '250000',
+    'data-maximum-units': '3250000',
+    'data-splittable': '1'
+}));
+assert.equal(quarter.source, 3500000n);
+assert.equal(quarter.step, 250000n);
+assert.equal(hooks.decimalToUnits('1.75') % quarter.step, 0n);
+assert.notEqual(hooks.decimalToUnits('0.1') % quarter.step, 0n);
+assert.notEqual(hooks.decimalToUnits('0.000001') % quarter.step, 0n);
+
+const integer = hooks.rowQuantityAuthority(row({
+    'data-source-units': '4000000',
+    'data-step-units': '1000000',
+    'data-maximum-units': '3000000',
+    'data-splittable': '1'
+}));
+assert.notEqual(hooks.decimalToUnits('1.000001') % integer.step, 0n);
+assert.equal(integer.maximum, 3000000n);
+
+assert.throws(() => hooks.rowQuantityAuthority(row({
+    'data-source-units': '1000000',
+    'data-step-units': '250000',
+    'data-maximum-units': '1000000',
+    'data-splittable': '1'
+})), undefined, 'a browser-authored maximum must not pass client integrity checks');
+
+console.log('Split quantity-step integer-unit math regression passed.');

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -29,6 +29,7 @@ require_once $root . 'class-wcos-mutation-fingerprint.php';
 require_once $root . 'class-wcos-price-precision-scope.php';
 require_once $root . 'class-wcos-mutation-contract.php';
 require_once $root . 'class-wcos-split-plan.php';
+require_once $root . 'class-wcos-manual-split-quantity-authority.php';
 require_once $root . 'class-wcos-merge-retirement-policy.php';
 require_once $root . 'class-wcos-merge-plan.php';
 require_once $root . 'class-wcos-merge-recovery-state-graph.php';
@@ -38,6 +39,50 @@ require_once $root . 'class-wcos-return-retirement-policy.php';
 require_once $root . 'class-wcos-return-recovery-state-graph.php';
 
 $tests = array();
+
+function manual_quantity_authority_fixture() {
+	$authority = array(
+		'schema_version' => WCOS_Manual_Split_Quantity_Authority::SCHEMA_VERSION,
+		'policy_version' => WCOS_Manual_Split_Quantity_Authority::POLICY_VERSION,
+		'precision' => 6,
+		'source_order_id' => 42,
+		'source_signature' => str_repeat('a', 64),
+		'lines' => array(
+			11 => array(
+				'source_order_id' => 42,
+				'source_item_id' => 11,
+				'product_id' => 101,
+				'variation_id' => 0,
+				'source_quantity' => '4.000000',
+				'source_quantity_units' => 4000000,
+				'quantity_step' => '1.000000',
+				'step_units' => 1000000,
+				'maximum_quantity' => '3.000000',
+				'maximum_quantity_units' => 3000000,
+				'can_partially_split' => true,
+			),
+			22 => array(
+				'source_order_id' => 42,
+				'source_item_id' => 22,
+				'product_id' => 202,
+				'variation_id' => 203,
+				'source_quantity' => '3.500000',
+				'source_quantity_units' => 3500000,
+				'quantity_step' => '0.250000',
+				'step_units' => 250000,
+				'maximum_quantity' => '3.250000',
+				'maximum_quantity_units' => 3250000,
+				'can_partially_split' => true,
+			),
+		),
+	);
+	$authority['authority_fingerprint'] = WCOS_Mutation_Fingerprint::create(
+		'manual_split_quantity_authority_v1',
+		42,
+		$authority
+	);
+	return $authority;
+}
 
 $tests['decimal rounds half up without binary floats'] = static function() {
 	assert_same(1001, WCOS_Decimal::to_units('10.005', 2));
@@ -131,6 +176,40 @@ $tests['split request rejects normalized source item ID collisions'] = static fu
 			'child-a' => array('01' => '0.25', 1 => '0.50'),
 		));
 	}, InvalidArgumentException::class);
+};
+
+$tests['manual split authority accepts exact mixed-line step multiples'] = static function() {
+	$authority = manual_quantity_authority_fixture();
+	$plan = WCOS_Manual_Split_Quantity_Authority::assert_plan(array(
+		'child-2' => array(22 => '1.75'),
+		'child-1' => array(11 => '1', 22 => '0.50'),
+	), $authority);
+	assert_same('1.000000', $plan['child-1'][11]);
+	assert_same('0.500000', $plan['child-1'][22]);
+	assert_same('1.750000', $plan['child-2'][22]);
+};
+
+$tests['manual split authority rejects sub-step and aggregate residual violations'] = static function() {
+	$authority = manual_quantity_authority_fixture();
+	foreach (array('0.000001', '0.1', '0.30') as $quantity) {
+		assert_throws(static function() use ($authority, $quantity) {
+			WCOS_Manual_Split_Quantity_Authority::assert_plan(array('child-1' => array(22 => $quantity)), $authority);
+		}, WCOS_Manual_Split_Quantity_Authority_Exception::class);
+	}
+	assert_throws(static function() use ($authority) {
+		WCOS_Manual_Split_Quantity_Authority::assert_plan(array(
+			'child-1' => array(22 => '1.750000'),
+			'child-2' => array(22 => '1.750000'),
+		), $authority);
+	}, WCOS_Manual_Split_Quantity_Authority_Exception::class);
+};
+
+$tests['manual split authority fingerprint rejects browser or journal tampering'] = static function() {
+	$authority = manual_quantity_authority_fixture();
+	$authority['lines'][22]['step_units'] = 100000;
+	assert_throws(static function() use ($authority) {
+		WCOS_Manual_Split_Quantity_Authority::assert_valid($authority);
+	}, WCOS_Manual_Split_Quantity_Authority_Exception::class);
 };
 
 $tests['mutation contract accepts conserved snapshot'] = static function() {


### PR DESCRIPTION
## Summary

- derive a deterministic, PII-free per-line Manual Quantity Split authority from WooCommerce purchase/admin quantity steps
- bind exact step authority through Review, confirmation, gateway, mutation fingerprint, durable journal replay, and Return lineage validation
- replace client binary floating-point quantity decisions with six-decimal `BigInt` units and render exact per-line `step`/`max`/input mode
- fail closed for invalid, unprovable, drifted, or legacy incomplete authority without changing workflow/strategy gates or release metadata

## Classification

`P1_RUNTIME_CORRECTION / MANUAL_SPLIT_QUANTITY_STEP_AUTHORITY` (HIGH risk)

## Local evidence

- complete PHP syntax check: pass
- `php tests/unit/run.php`: pass
- Split quantity-step JS exact-unit regression: pass
- Split focus/client lifecycle regressions: pass
- `tests/ci/workflow-contract.sh`: pass
- `tests/ci/distribution-contract.sh`: pass
- isolated Local WooCommerce operation-control suite: pass, including integer/0.25/0.1/mixed steps, drift, durable replay, money/tax/stock/recovery, strategy and Duplicate non-regression
- disposable Local fixture cleanup: `task_products=0 task_users=0`

## Governance

- Closes #93
- Draft pending exact-head canonical CI and fresh Independent Codex Technical Review
- no feature/strategy gate changes
- no version/tag/release/package/publication/deployment authority
