### PR TITLE
WOS-GOV-006: Harden Main attestation recovery

### DIFF
--- a/.github/workflows/main-attestation.yml
+++ b/.github/workflows/main-attestation.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Exact current main commit SHA to attest
+        required: true
+        type: string
+      authority:
+        description: Governance reason or task reference authorizing recovery
+        required: true
+        type: string
 
 concurrency:
-  group: main-attestation-${{ github.ref }}
+  group: main-attestation-${{ github.event_name }}-${{ github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -17,6 +27,20 @@ jobs:
     name: Exact main tree attestation
     runs-on: ubuntu-latest
     steps:
+      - name: Validate manual recovery request
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          ATTESTATION_AUTHORITY: ${{ inputs.authority }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]
+          expected_sha="$(printf '%s' "$EXPECTED_SHA" | tr '[:upper:]' '[:lower:]')"
+          test "$GITHUB_SHA" = "$expected_sha"
+          test -n "${ATTESTATION_AUTHORITY//[[:space:]]/}"
+
       - name: Checkout exact main revision
         uses: actions/checkout@v7
         with:
@@ -24,12 +48,31 @@ jobs:
 
       - name: Record exact commit and tree identity
         shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          ATTESTATION_AUTHORITY: ${{ inputs.authority }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          checked_out_sha="$(git rev-parse HEAD)"
+          test "$checked_out_sha" = "$GITHUB_SHA"
+
+          if [[ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]]; then
+            test "$GITHUB_REF" = 'refs/heads/main'
+            [[ "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]
+            expected_sha="$(printf '%s' "$EXPECTED_SHA" | tr '[:upper:]' '[:lower:]')"
+            test "$GITHUB_SHA" = "$expected_sha"
+            test "$checked_out_sha" = "$expected_sha"
+            test -n "${ATTESTATION_AUTHORITY//[[:space:]]/}"
+          else
+            ATTESTATION_AUTHORITY='automatic push to main'
+          fi
+
           echo "main_commit_sha=$(git rev-parse HEAD)"
           echo "main_tree_sha=$(git rev-parse HEAD^{tree})"
           echo "main_parent_shas=$(git show -s --format=%P HEAD)"
+          echo "attestation_event_name=$GITHUB_EVENT_NAME"
+          echo "attestation_run_attempt=$GITHUB_RUN_ATTEMPT"
+          echo "attestation_authority=$ATTESTATION_AUTHORITY"
 
       - name: Setup representative PHP
         uses: shivammathur/setup-php@v2

--- a/tests/ci/workflow-contract.sh
+++ b/tests/ci/workflow-contract.sh
@@ -31,6 +31,18 @@ assert_absent() {
   fi
 }
 
+assert_occurrences() {
+  local file=$1
+  local text=$2
+  local expected=$3
+  local actual
+  actual=$(grep -Foc -- "$text" "$file" || true)
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "workflow-contract-error: expected '$text' exactly $expected times in $file, found $actual" >&2
+    exit 1
+  fi
+}
+
 ruby -e 'require "yaml"; ARGV.each { |file| Psych.parse_file(file) }' \
   "$ci_workflow" "$main_workflow" "$package_workflow"
 
@@ -57,8 +69,24 @@ assert_absent "$ci_workflow" 'actions/upload-artifact'
 assert_contains "$main_workflow" 'name: Main attestation'
 assert_contains "$main_workflow" '  push:'
 assert_contains "$main_workflow" '      - main'
+assert_contains "$main_workflow" '  workflow_dispatch:'
+assert_contains "$main_workflow" '      expected_sha:'
+assert_contains "$main_workflow" '      authority:'
+assert_occurrences "$main_workflow" '        required: true' 2
+assert_occurrences "$main_workflow" '        type: string' 2
+assert_contains "$main_workflow" 'group: main-attestation-${{ github.event_name }}-${{ github.sha }}'
+assert_contains "$main_workflow" "if: github.event_name == 'workflow_dispatch'"
+assert_occurrences "$main_workflow" "test \"\$GITHUB_REF\" = 'refs/heads/main'" 2
+assert_occurrences "$main_workflow" '[[ "$EXPECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]' 2
+assert_occurrences "$main_workflow" 'expected_sha="$(printf '\''%s'\'' "$EXPECTED_SHA" | tr '\''[:upper:]'\'' '\''[:lower:]'\'')"' 2
+assert_occurrences "$main_workflow" 'test "$GITHUB_SHA" = "$expected_sha"' 2
+assert_contains "$main_workflow" 'test "$checked_out_sha" = "$expected_sha"'
+assert_occurrences "$main_workflow" 'test -n "${ATTESTATION_AUTHORITY//[[:space:]]/}"' 2
 assert_contains "$main_workflow" 'git rev-parse HEAD^{tree}'
 assert_contains "$main_workflow" 'main_parent_shas=$(git show -s --format=%P HEAD)'
+assert_contains "$main_workflow" 'attestation_event_name=$GITHUB_EVENT_NAME'
+assert_contains "$main_workflow" 'attestation_run_attempt=$GITHUB_RUN_ATTEMPT'
+assert_contains "$main_workflow" 'attestation_authority=$ATTESTATION_AUTHORITY'
 assert_contains "$main_workflow" '.github/scripts/validate-distribution-contract.sh'
 assert_contains "$main_workflow" "grep -Fq 'self::BULK_RETURN => true' inc/domain/class-wcos-feature-gates.php"
 assert_absent "$main_workflow" "grep -Fq 'self::BULK_RETURN => false' inc/domain/class-wcos-feature-gates.php"


### PR DESCRIPTION
## Task

Closes #95 (`WOS-GOV-006`).

Classification: `P0_GOVERNANCE / CI_ATTESTATION_RESILIENCE`  
Risk: `MEDIUM`

## Scope

- preserve the automatic `push -> main` Main attestation path;
- add an authenticated `workflow_dispatch` recovery path requiring an exact SHA and governance authority;
- fail closed before checkout and after checkout for non-main refs, malformed or mismatched SHAs, and blank authority;
- isolate push and manual concurrency while deduplicating recovery for the same exact commit;
- keep the same full attestation body, read-only permissions, zero artifacts, and zero release/package/publication side effects;
- extend only the focused workflow topology contract.

## Local evidence

- `git diff --check`
- `bash -n tests/ci/workflow-contract.sh`
- `tests/ci/workflow-contract.sh`
- `.github/scripts/validate-distribution-contract.sh "$PWD" "/tmp/wos-gov-006-distribution"`
- full PHP lint via `find . -type f -name '*.php' -print0 | xargs -0 -n1 php -l`
- `php tests/unit/run.php`
- manual gate positive/negative probe: uppercase-equivalent exact SHA accepted; wrong ref, malformed SHA, mismatched SHA, and blank authority rejected

`actionlint` was not installed locally; canonical GitHub Actions CI remains authoritative.

## Boundaries

- no plugin/runtime file changes;
- no feature-gate or strategy-gate changes;
- no version, stable-tag, package, release, publication, deployment, or artifact changes.
