### PR TITLE
WOS-UI-001 — Consolidate Duplicate & Merge Order actions launchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
             ) as $merge_action) {
               if (false === has_action("wp_ajax_" . $merge_action)) { exit(1); }
             }
-            $has_controller_method = static function($hook, $method) {
+            $has_controller_method = static function($hook, $class, $method) {
               global $wp_filter;
               if (empty($wp_filter[$hook]) || empty($wp_filter[$hook]->callbacks)) { return false; }
               foreach ($wp_filter[$hook]->callbacks as $callbacks) {
@@ -364,7 +364,7 @@ jobs:
                   $function = isset($callback["function"]) ? $callback["function"] : null;
                   if (is_array($function)
                     && isset($function[0], $function[1])
-                    && $function[0] instanceof WCOS_Merge_Admin_Controller
+                    && $function[0] instanceof $class
                     && $method === $function[1]) { return true; }
                 }
               }
@@ -375,12 +375,14 @@ jobs:
               "wp_ajax_" . WCOS_Merge_Admin_Controller::REVIEW_ACTION => "ajax_review",
               "wp_ajax_" . WCOS_Merge_Admin_Controller::CONFIRM_ACTION => "ajax_confirm",
               "wp_ajax_" . WCOS_Merge_Admin_Controller::EXECUTE_ACTION => "ajax_execute",
-              "woocommerce_order_item_add_action_buttons" => "render_launcher",
               "admin_footer" => "render_dialog",
               "admin_enqueue_scripts" => "enqueue_assets"
             ) as $hook => $method) {
-              if (!$has_controller_method($hook, $method)) { exit(1); }
+              if (!$has_controller_method($hook, "WCOS_Merge_Admin_Controller", $method)) { exit(1); }
             }
+            if (!$has_controller_method("woocommerce_order_actions_end", "WCOS_Order_Actions_Launcher_Row", "render_launcher_row")) { exit(1); }
+            if ($has_controller_method("woocommerce_order_item_add_action_buttons", "WCOS_Duplicate_Admin_Controller", "render_launcher")) { exit(1); }
+            if ($has_controller_method("woocommerce_order_item_add_action_buttons", "WCOS_Merge_Admin_Controller", "render_launcher")) { exit(1); }
             foreach (array(
               "WC_ORDER_SPLITTER_MUTATIONS_ENABLED",
               "WC_ORDER_SPLITTER_SPLIT_ENABLED",
@@ -469,6 +471,9 @@ jobs:
 
       - name: Verify enabled Merge UI launcher foundation
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-ui-foundation-smoke.php
+
+      - name: Verify shared Duplicate and Merge Order actions launcher row
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/order-actions-launcher-row-smoke.php
 
       - name: Verify hardened Merge pre-retirement crash contracts
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/merge-service-adapter-smoke.php crash_pre

--- a/css/p2-backbone-modal.css
+++ b/css/p2-backbone-modal.css
@@ -1,4 +1,35 @@
-/* Shared presentation rules for Order Splitter workflows inside WooCommerce Backbone modals. */
+/* Shared order-edit and WooCommerce Backbone presentation rules. */
+
+.wcos-order-actions-launcher-row .wcos-order-actions-launchers {
+    display: flex;
+    align-items: stretch;
+    gap: 6px;
+    width: 100%;
+}
+
+.wcos-order-actions-launcher-row .wcos-order-actions-launcher-slot {
+    flex: 1 1 0;
+    min-width: 0;
+}
+
+.wcos-order-actions-launcher-row .wcos-order-actions-launcher-slot .button {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    text-align: center;
+}
+
+.wcos-order-actions-launcher-row .wcos-order-actions-launcher-slot .description {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
 
 #wc-backbone-modal-dialog .wcos-admin-backbone-modal__footer {
     display: flex !important;

--- a/css/p2-duplicate-admin.css
+++ b/css/p2-duplicate-admin.css
@@ -10,10 +10,6 @@
     border: 0 !important;
 }
 
-.wcos-duplicate-launcher {
-    margin-right: 6px;
-}
-
 /* Server-rendered source markup is a non-visible cloning source only. */
 .wcos-duplicate-dialog {
     display: none !important;

--- a/css/p2-merge-admin.css
+++ b/css/p2-merge-admin.css
@@ -1,7 +1,3 @@
-.wcos-merge-launcher-description {
-	margin-left: 8px;
-}
-
 .wcos-merge-dialog[hidden],
 .wcos-merge-review[hidden],
 .wcos-merge-error[hidden],

--- a/inc/backend/class-wcos-duplicate-admin-controller.php
+++ b/inc/backend/class-wcos-duplicate-admin-controller.php
@@ -37,7 +37,6 @@ final class WCOS_Duplicate_Admin_Controller {
     public function __construct() {
         add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
         add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
-        add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 21, 1);
         add_action('admin_footer', array($this, 'render_dialog'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
     }
@@ -212,7 +211,7 @@ final class WCOS_Duplicate_Admin_Controller {
         $disabled = !$this->current_surface_supported;
 
         echo '<button type="button" class="button wcos-duplicate-launcher" aria-haspopup="dialog"' . ($disabled ? '' : ' aria-controls="' . esc_attr($dialog_id) . '"') . ' aria-describedby="' . esc_attr($description_id) . '"' . disabled($disabled, true, false) . '>';
-        echo esc_html__('Duplicate order', 'wc-order-splitter');
+        echo esc_html__('Duplicate', 'wc-order-splitter');
         echo '</button>';
         echo '<span id="' . esc_attr($description_id) . '" class="description wcos-duplicate-launcher-description">';
         echo esc_html($disabled ? $preflight['message'] : __('Review the Duplicate safety policy before creating a new pending order.', 'wc-order-splitter'));

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -53,7 +53,6 @@ final class WCOS_Merge_Admin_Controller {
 		add_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		add_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		add_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
-		add_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 22, 1);
 		add_action('admin_footer', array($this, 'render_dialog'));
 		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = true;
@@ -65,7 +64,6 @@ final class WCOS_Merge_Admin_Controller {
 		remove_action('wp_ajax_' . self::REVIEW_ACTION, array($this, 'ajax_review'));
 		remove_action('wp_ajax_' . self::CONFIRM_ACTION, array($this, 'ajax_confirm'));
 		remove_action('wp_ajax_' . self::EXECUTE_ACTION, array($this, 'ajax_execute'));
-		remove_action('woocommerce_order_item_add_action_buttons', array($this, 'render_launcher'), 22);
 		remove_action('admin_footer', array($this, 'render_dialog'));
 		remove_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
 		$this->registered = false;
@@ -258,7 +256,7 @@ final class WCOS_Merge_Admin_Controller {
 		$dialog_id = 'wcos-merge-dialog-' . $order->get_id();
 		$description_id = 'wcos-merge-launcher-description-' . $order->get_id();
 		echo '<button type="button" class="button wcos-merge-launcher" aria-haspopup="dialog" aria-controls="' . esc_attr($dialog_id) . '" aria-describedby="' . esc_attr($description_id) . '">';
-		echo esc_html__('Merge into another order', 'wc-order-splitter');
+		echo esc_html__('Merge', 'wc-order-splitter');
 		echo '</button>';
 		echo '<span id="' . esc_attr($description_id) . '" class="description wcos-merge-launcher-description">';
 		echo esc_html__('Select a target order, then review the server-owned Merge plan.', 'wc-order-splitter');

--- a/inc/backend/class-wcos-order-actions-launcher-row.php
+++ b/inc/backend/class-wcos-order-actions-launcher-row.php
@@ -1,0 +1,68 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Shared presentation coordinator for compact workflow launchers in Order actions.
+ */
+final class WCOS_Order_Actions_Launcher_Row {
+	const HOOK = 'woocommerce_order_actions_end';
+
+	private $renderers = array();
+	private $registered = false;
+
+	public function __construct(array $renderers) {
+		foreach ($renderers as $renderer) {
+			if (is_callable($renderer)) {
+				$this->renderers[] = $renderer;
+			}
+		}
+	}
+
+	public function register_hooks() {
+		if ($this->registered) {
+			return false;
+		}
+		add_action(self::HOOK, array($this, 'render_launcher_row'), 20, 1);
+		$this->registered = true;
+		return true;
+	}
+
+	public function unregister_hooks() {
+		remove_action(self::HOOK, array($this, 'render_launcher_row'), 20);
+		$this->registered = false;
+		return true;
+	}
+
+	public function render_launcher_row($order_id) {
+		$order = wc_get_order(absint($order_id));
+		if (!$order instanceof WC_Order) {
+			return;
+		}
+
+		$controls = array();
+		foreach ($this->renderers as $renderer) {
+			ob_start();
+			call_user_func($renderer, $order);
+			$control = trim((string) ob_get_clean());
+			if ('' !== $control) {
+				$controls[] = $control;
+			}
+		}
+
+		if (empty($controls)) {
+			return;
+		}
+
+		$row_class = 1 === count($controls) ? ' wcos-order-actions-launcher-row--single' : '';
+		echo '<li class="wide wcos-order-actions-launcher-row' . esc_attr($row_class) . '">';
+		echo '<div class="wcos-order-actions-launchers" role="group" aria-label="' . esc_attr__('Order Splitter actions', 'wc-order-splitter') . '">';
+		foreach ($controls as $control) {
+			echo '<div class="wcos-order-actions-launcher-slot">';
+			echo $control; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted controller-rendered markup.
+			echo '</div>';
+		}
+		echo '</div>';
+		echo '</li>';
+	}
+}

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -109,22 +109,32 @@ class WC_Order_Splitter_Script {
 
 		include_once $root . 'backend/class-wcos-duplicate-confirmation-store.php';
 		include_once $root . 'backend/class-wcos-duplicate-admin-controller.php';
-		new WCOS_Duplicate_Admin_Controller();
+		$duplicate_admin_controller = new WCOS_Duplicate_Admin_Controller();
 
 		include_once $root . 'backend/class-wcos-merge-review-store.php';
 		include_once $root . 'backend/class-wcos-merge-confirmation-store.php';
-			include_once $root . 'backend/class-wcos-merge-admin-controller.php';
-			WCOS_Merge_Admin_Controller::bootstrap();
+		include_once $root . 'backend/class-wcos-merge-admin-controller.php';
+		$merge_admin_controller = WCOS_Merge_Admin_Controller::bootstrap();
 
-			include_once $root . 'backend/class-wcos-return-review-store.php';
-			include_once $root . 'backend/class-wcos-return-confirmation-store.php';
-			include_once $root . 'backend/class-wcos-return-admin-controller.php';
-			WCOS_Return_Admin_Controller::bootstrap();
+		include_once $root . 'backend/class-wcos-order-actions-launcher-row.php';
+		$order_actions_launchers = array(
+			array($duplicate_admin_controller, 'render_launcher'),
+		);
+		if ($merge_admin_controller instanceof WCOS_Merge_Admin_Controller) {
+			$order_actions_launchers[] = array($merge_admin_controller, 'render_launcher');
+		}
+		$order_actions_launcher_row = new WCOS_Order_Actions_Launcher_Row($order_actions_launchers);
+		$order_actions_launcher_row->register_hooks();
 
-			include_once $root . 'backend/class-wcos-bulk-return-review-store.php';
-			include_once $root . 'backend/class-wcos-bulk-return-confirmation-store.php';
-			include_once $root . 'backend/class-wcos-bulk-return-admin-controller.php';
-			WCOS_Bulk_Return_Admin_Controller::bootstrap();
+		include_once $root . 'backend/class-wcos-return-review-store.php';
+		include_once $root . 'backend/class-wcos-return-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-return-admin-controller.php';
+		WCOS_Return_Admin_Controller::bootstrap();
+
+		include_once $root . 'backend/class-wcos-bulk-return-review-store.php';
+		include_once $root . 'backend/class-wcos-bulk-return-confirmation-store.php';
+		include_once $root . 'backend/class-wcos-bulk-return-admin-controller.php';
+		WCOS_Bulk_Return_Admin_Controller::bootstrap();
 
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';

--- a/tests/integration/merge-ui-foundation-smoke.php
+++ b/tests/integration/merge-ui-foundation-smoke.php
@@ -39,13 +39,13 @@ $hook_contracts = array(
 	'wp_ajax_' . WCOS_Merge_Admin_Controller::REVIEW_ACTION => 'ajax_review',
 	'wp_ajax_' . WCOS_Merge_Admin_Controller::CONFIRM_ACTION => 'ajax_confirm',
 	'wp_ajax_' . WCOS_Merge_Admin_Controller::EXECUTE_ACTION => 'ajax_execute',
-	'woocommerce_order_item_add_action_buttons' => 'render_launcher',
 	'admin_footer' => 'render_dialog',
 	'admin_enqueue_scripts' => 'enqueue_assets',
 );
 foreach ($hook_contracts as $hook => $method) {
 	wcos_merge_ui_assert(false !== has_action($hook, array($controller, $method)), 'Enabled Merge hook is missing: ' . $hook);
 }
+wcos_merge_ui_assert(false === has_action('woocommerce_order_item_add_action_buttons', array($controller, 'render_launcher')), 'Merge launcher remained registered in the Order items action area.');
 
 wp_dequeue_script('wcos-merge-admin');
 wp_dequeue_style('wcos-merge-admin');
@@ -72,7 +72,7 @@ try {
 	ob_start();
 	$controller->render_launcher($source);
 	$enabled_launcher = (string) ob_get_clean();
-	wcos_merge_ui_assert(false !== strpos($enabled_launcher, 'Merge into another order'), 'Enabled Merge launcher did not render.');
+	wcos_merge_ui_assert(false !== strpos($enabled_launcher, '>Merge</button>'), 'Enabled Merge launcher did not use its compact Order actions label.');
 	wcos_merge_ui_assert(false === strpos($enabled_launcher, $email) && false === strpos($enabled_launcher, $address), 'Enabled Merge launcher exposed customer PII.');
 
 	$order_screen_id = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';

--- a/tests/integration/order-actions-launcher-row-smoke.php
+++ b/tests/integration/order-actions-launcher-row-smoke.php
@@ -1,0 +1,152 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_order_actions_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_order_actions_has_method($hook, $class, $method) {
+	global $wp_filter;
+	if (empty($wp_filter[$hook]) || empty($wp_filter[$hook]->callbacks)) {
+		return false;
+	}
+	foreach ($wp_filter[$hook]->callbacks as $callbacks) {
+		foreach ($callbacks as $callback) {
+			$function = isset($callback['function']) ? $callback['function'] : null;
+			if (is_array($function)
+				&& isset($function[0], $function[1])
+				&& $function[0] instanceof $class
+				&& $method === $function[1]) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+function wcos_order_actions_render(WCOS_Order_Actions_Launcher_Row $row, $order_id) {
+	ob_start();
+	$row->render_launcher_row($order_id);
+	return (string) ob_get_clean();
+}
+
+$root = dirname(__DIR__, 2);
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'fields' => 'ID'));
+wcos_order_actions_assert(!empty($admins), 'Order actions launcher test requires an administrator fixture.');
+$previous_user = get_current_user_id();
+$previous_statuses = get_option('order_splitter_status_allowed', array('wc-processing'));
+$product = null;
+$order = null;
+$unsupported_order = null;
+
+try {
+	wp_set_current_user(absint($admins[0]));
+	update_option('order_splitter_status_allowed', array('wc-processing'));
+
+	wcos_order_actions_assert(wcos_order_actions_has_method('woocommerce_order_actions_end', 'WCOS_Order_Actions_Launcher_Row', 'render_launcher_row'), 'Shared launcher row is not registered on woocommerce_order_actions_end.');
+	wcos_order_actions_assert(!wcos_order_actions_has_method('woocommerce_order_item_add_action_buttons', 'WCOS_Duplicate_Admin_Controller', 'render_launcher'), 'Duplicate launcher remained in the Order items action area.');
+	wcos_order_actions_assert(!wcos_order_actions_has_method('woocommerce_order_item_add_action_buttons', 'WCOS_Merge_Admin_Controller', 'render_launcher'), 'Merge launcher remained in the Order items action area.');
+	wcos_order_actions_assert(wcos_order_actions_has_method('woocommerce_order_item_add_action_buttons', 'WCOS_Split_Admin_Controller', 'render_launcher'), 'Split launcher placement changed as a side effect.');
+	wcos_order_actions_assert(wcos_order_actions_has_method('woocommerce_order_item_add_action_buttons', 'WCOS_Split_Strategy_Admin_Controller', 'render_launcher'), 'Split strategy launcher placement changed as a side effect.');
+	wcos_order_actions_assert(wcos_order_actions_has_method('woocommerce_order_item_add_action_buttons', 'WCOS_Return_Admin_Controller', 'render_launcher'), 'Return launcher placement changed as a side effect.');
+
+	$product = new WC_Product_Simple();
+	$product->set_name('WOS UI shared launcher fixture');
+	$product->set_status('publish');
+	$product->set_regular_price('12.50');
+	$product->set_price('12.50');
+	$product->save();
+
+	$order = wc_create_order();
+	$order->set_status('processing');
+	$order->set_currency('USD');
+	$order->set_payment_method('cod');
+	$order->add_product($product, 1, array('subtotal' => '12.50', 'total' => '12.50'));
+	$order->calculate_totals();
+	$order->save();
+	$order = wc_get_order($order->get_id());
+
+	$duplicate = new WCOS_Duplicate_Admin_Controller();
+	$merge = new WCOS_Merge_Admin_Controller();
+	$merge->register_hooks();
+	$row = new WCOS_Order_Actions_Launcher_Row(array(
+		array($duplicate, 'render_launcher'),
+		array($merge, 'render_launcher'),
+	));
+	$html = wcos_order_actions_render($row, $order->get_id());
+
+	wcos_order_actions_assert(1 === substr_count($html, '<li class="wide wcos-order-actions-launcher-row'), 'Eligible launchers did not render exactly one shared Order actions row.');
+	wcos_order_actions_assert(2 === substr_count($html, 'class="wcos-order-actions-launcher-slot"'), 'Duplicate and Merge did not receive two equal launcher slots.');
+	wcos_order_actions_assert(false !== strpos($html, '>Duplicate</button>'), 'Duplicate did not use its compact launcher label.');
+	wcos_order_actions_assert(false !== strpos($html, '>Merge</button>'), 'Merge did not use its compact launcher label.');
+	wcos_order_actions_assert(false === strpos($html, '>Duplicate order</button>') && false === strpos($html, '>Merge into another order</button>'), 'A wide legacy launcher label remained in the compact row.');
+	wcos_order_actions_assert(false !== strpos($html, 'aria-controls="wcos-duplicate-dialog-' . $order->get_id() . '"'), 'Duplicate launcher lost its dialog binding.');
+	wcos_order_actions_assert(false !== strpos($html, 'aria-controls="wcos-merge-dialog-' . $order->get_id() . '"'), 'Merge launcher lost its source dialog binding.');
+	wcos_order_actions_assert(false !== strpos($html, 'aria-describedby="wcos-duplicate-launcher-description-' . $order->get_id() . '"'), 'Duplicate launcher lost its description binding.');
+	wcos_order_actions_assert(false !== strpos($html, 'aria-describedby="wcos-merge-launcher-description-' . $order->get_id() . '"'), 'Merge launcher lost its description binding.');
+
+	ob_start();
+	$duplicate->render_dialog();
+	$duplicate_dialog = (string) ob_get_clean();
+	ob_start();
+	$merge->render_dialog();
+	$merge_dialog = (string) ob_get_clean();
+	wcos_order_actions_assert(false !== strpos($duplicate_dialog, 'data-order-id="' . $order->get_id() . '"'), 'Duplicate dialog lost the current order identity.');
+	wcos_order_actions_assert(false !== strpos($merge_dialog, 'data-source-order-id="' . $order->get_id() . '"'), 'Merge dialog lost the current source order identity.');
+
+	$unsupported_order = wc_create_order();
+	$unsupported_order->set_status('processing');
+	$unsupported_order->set_currency('USD');
+	$unsupported_order->save();
+	$disabled_html = wcos_order_actions_render($row, $unsupported_order->get_id());
+	wcos_order_actions_assert(false !== strpos($disabled_html, 'wcos-duplicate-launcher'), 'Authorized unsupported Duplicate did not render its disabled launcher.');
+	wcos_order_actions_assert(false !== strpos($disabled_html, 'disabled='), 'Unsupported Duplicate launcher did not remain disabled.');
+	wcos_order_actions_assert(false !== strpos($disabled_html, 'An order without product line items cannot be duplicated.'), 'Disabled Duplicate preflight description was not preserved.');
+
+	$one_button = new WCOS_Order_Actions_Launcher_Row(array(
+		static function() { echo '<button type="button" class="button">Only</button>'; },
+		static function() {},
+	));
+	$one_button_html = wcos_order_actions_render($one_button, $order->get_id());
+	wcos_order_actions_assert(false !== strpos($one_button_html, 'wcos-order-actions-launcher-row--single'), 'One eligible launcher did not activate the full-row layout.');
+	wcos_order_actions_assert(1 === substr_count($one_button_html, 'class="wcos-order-actions-launcher-slot"'), 'One-button state reserved an empty launcher slot.');
+
+	$empty_row = new WCOS_Order_Actions_Launcher_Row(array(static function() {}, static function() {}));
+	wcos_order_actions_assert('' === wcos_order_actions_render($empty_row, $order->get_id()), 'No-launcher state emitted an empty Order actions row.');
+	wcos_order_actions_assert('' === wcos_order_actions_render($row, 0), 'Invalid order identity emitted a launcher row.');
+
+	$shared_css = file_get_contents($root . '/css/p2-backbone-modal.css');
+	wcos_order_actions_assert(is_string($shared_css) && false !== strpos($shared_css, '.wcos-order-actions-launcher-row .wcos-order-actions-launchers'), 'Shared order-edit stylesheet does not own launcher-row layout.');
+	wcos_order_actions_assert(false !== strpos($shared_css, 'display: flex;') && false !== strpos($shared_css, 'gap: 6px;'), 'Shared launcher row does not use the required compact horizontal layout.');
+	wcos_order_actions_assert(false !== strpos($shared_css, 'flex: 1 1 0;') && false !== strpos($shared_css, 'width: 100%;'), 'Launcher slots do not share width or fill the single-button row.');
+
+	$duplicate_source = file_get_contents($root . '/inc/backend/class-wcos-duplicate-admin-controller.php');
+	$merge_source = file_get_contents($root . '/inc/backend/class-wcos-merge-admin-controller.php');
+	wcos_order_actions_assert(false === strpos($duplicate_source, "add_action('woocommerce_order_item_add_action_buttons', array(\$this, 'render_launcher')"), 'Duplicate source retained its old launcher hook.');
+	wcos_order_actions_assert(false === strpos($merge_source, "add_action('woocommerce_order_item_add_action_buttons', array(\$this, 'render_launcher')"), 'Merge source retained its old launcher hook.');
+
+	wcos_order_actions_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::SPLIT), 'Split gate changed during launcher placement.');
+	wcos_order_actions_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::DUPLICATE), 'Duplicate gate changed during launcher placement.');
+	wcos_order_actions_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::MERGE), 'Merge gate changed during launcher placement.');
+	wcos_order_actions_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::RETURN_ORDER), 'Return gate changed during launcher placement.');
+	wcos_order_actions_assert(WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN), 'Bulk Return gate changed during launcher placement.');
+} finally {
+	if ($unsupported_order instanceof WC_Order) {
+		$unsupported_order->delete(true);
+	}
+	if ($order instanceof WC_Order) {
+		$order->delete(true);
+	}
+	if ($product instanceof WC_Product) {
+		$product->delete(true);
+	}
+	update_option('order_splitter_status_allowed', $previous_statuses);
+	wp_set_current_user($previous_user);
+}
+
+echo "order-actions-launcher-row-ok shared=1 both=1 single=1 empty=0 legacy_hpos_crud=1\n";


### PR DESCRIPTION
## Classification

`P3_PRODUCT_QUALITY / ADMIN_LAUNCHER_PLACEMENT`

Closes #99.

## Exact authority

- canonical task: Issue #99 / `TASK_READY` comment `5433480593`
- exact source: `main@832b4e5fbecd30b5860c934d1cf2a5a915c83646`
- exact source tree: `ea02d5bc67f66cb969936b82d6258c8c14da7c3f`
- exact PR head: `6c1880a107fd31062143feb6e65306e532d39e90`
- risk profile: `LOW`

## Summary

- removes Duplicate and Merge launcher registration from `woocommerce_order_item_add_action_buttons`;
- adds one shared presentation coordinator on `woocommerce_order_actions_end` that resolves the persisted order through `wc_get_order()`;
- renders compact `Duplicate` and `Merge` controls in one native `wide` Order actions row;
- keeps one-button and no-button states free of blank slots/rows;
- preserves controller-owned eligibility, disabled descriptions, dialog ARIA bindings, current-order identity, AJAX and mutation authority;
- keeps layout in the existing shared order-edit/Backbone stylesheet with no JS relocation.

## Focused Local evidence

- all PHP syntax: pass (PHP 8.4 Local; pre-existing nullable deprecation notices only)
- `php tests/unit/run.php`: 33/33 pass
- `tests/integration/order-actions-launcher-row-smoke.php`: `order-actions-launcher-row-ok shared=1 both=1 single=1 empty=0 legacy_hpos_crud=1`
- `tests/integration/merge-ui-foundation-smoke.php`: `merge-ui-foundation-ok`
- `.github/workflows/ci.yml` YAML parse: pass
- `git diff --check`: pass
- Local plugin activation state was not changed; smoke loaded the plugin in a disposable WP-CLI process and cleaned its fixtures.

## Preserved boundaries

- Split, Split strategy and Return launcher placement remains unchanged and is asserted by the new smoke;
- all workflow and strategy gates remain unchanged;
- no domain/service/adapter/journal/recovery/AJAX/request-envelope mutation;
- no version, stable tag, readme, changelog, package, release, publication or deployment change;
- normal PR artifacts must remain `0`.

Canonical exact-head PR CI and a fresh persisted Independent Codex Technical Review remain required. Keep this PR Draft until those authorities are green.