### PR TITLE
WOS-DIRECT-20260827-133426: Align Split quantity table text

### DIFF
--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -121,40 +121,62 @@
 
 .wcos-split-table th,
 .wcos-split-table td {
-    padding: 14px 16px;
-    vertical-align: middle;
+    padding: 14px 18px !important;
+    vertical-align: middle !important;
 }
 
 .wcos-split-table thead th {
+    padding-top: 12px !important;
+    padding-bottom: 12px !important;
     background: #f6f7f7;
+    color: #2c3338;
     font-weight: 600;
     line-height: 1.3;
     white-space: nowrap;
+}
+
+.wcos-split-table tbody th,
+.wcos-split-table tbody td {
+    padding-top: 18px !important;
+    padding-bottom: 18px !important;
+    vertical-align: top !important;
 }
 
 .wcos-split-table th:first-child,
 .wcos-split-table td:first-child {
     width: 30%;
     min-width: 220px;
-    text-align: left;
+    text-align: left !important;
 }
 
 .wcos-split-table th:nth-child(2),
 .wcos-split-table td:nth-child(2) {
     width: 210px;
     min-width: 210px;
-    text-align: left;
+    text-align: left !important;
 }
 
 .wcos-split-table th:nth-child(n + 3),
 .wcos-split-table td:nth-child(n + 3) {
     width: 150px;
     min-width: 150px;
-    text-align: center;
+    text-align: center !important;
+}
+
+.wcos-split-table tbody td:nth-child(n + 3) {
+    padding-top: 12px !important;
 }
 
 .wcos-split-table tbody th {
-    font-weight: 500;
+    color: #3c434a;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.wcos-split-table tbody td:nth-child(2) {
+    color: #3c434a;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
     line-height: 1.4;
 }
 
@@ -169,9 +191,11 @@
 
 .wcos-split-remaining-hint {
     display: block;
-    margin-top: 3px;
+    margin-top: 6px;
     color: #646970;
     font-size: 12px;
+    font-weight: 600;
+    line-height: 1.4;
     white-space: nowrap;
 }
 
@@ -182,10 +206,12 @@
     margin-top: 4px;
     color: #646970;
     font-size: 12px;
+    font-weight: 400;
     line-height: 1.45;
 }
 
 .wcos-split-non-splittable {
+    margin-top: 6px;
     color: #8a2424;
 }
 
@@ -288,7 +314,17 @@
 
     .wcos-split-table th,
     .wcos-split-table td {
-        padding: 12px;
+        padding: 12px !important;
+    }
+
+    .wcos-split-table tbody th,
+    .wcos-split-table tbody td {
+        padding-top: 14px !important;
+        padding-bottom: 14px !important;
+    }
+
+    .wcos-split-table tbody td:nth-child(n + 3) {
+        padding-top: 8px !important;
     }
 
     .wcos-split-table th:first-child,


### PR DESCRIPTION
## Summary

- align Product, Current quantity, and Child input content to a consistent top rhythm;
- restore consistent header/body insets against WooCommerce Backbone table overrides;
- center Child headings over their inputs;
- strengthen the quantity/step/warning/remaining typographic hierarchy;
- keep responsive spacing bounded to the existing mobile breakpoint.

## Governance

- Task: `WOS-DIRECT-20260827-133426`
- Canonical Issue: #105
- Classification: `TRIVIAL / CODEX_DIRECT`
- Pre-edit authority: `DIRECT_HUMAN_AUTHORIZED` Issue comment `5435299493`
- Exact source: `f1d69351825de2d555af24b699afa6a46085aa08`
- Exact head: `d8f9243784f2ae147238722468350f1da94d413c`
- Complete diff: existing tracked regular-text mode-`100644` `css/p2-split-admin.css` only
- No PHP, JavaScript, markup, copy, runtime, state, gate, version, package, release, publication, or deployment change.

## Evidence

- `git diff --check`
- exact path/status/mode/text scope checks
- denylist scan of added CSS lines
- `tests/ci/direct-css-fast-contract.sh`
- `tests/ci/required-ci-profile-contract.sh`
- `tests/ci/workflow-contract.sh`
- hands-on Local order #21328 modal validation: header insets, centered Child heading, top-aligned Product/quantity cells, input baseline compensation, warning/remaining hierarchy
- runtime computed-style checks confirmed the intended padding, text alignment, font weight, and vertical alignment on the visible Backbone modal clone

The repository classifier intentionally selects `FULL / css_comment_delimiter_present` because the existing resulting stylesheet contains comments and responsive at-rules outside the lexical FAST safe-subset. This is a conservative CI-cost fallback only; the actual diff remains CSS-only and presentation-only.

Closes #105

No release or publication is authorized.
