### PR TITLE
WOS-DIRECT-20260827-173334: align duplicate confirmation

### DIFF
--- a/css/p2-duplicate-admin.css
+++ b/css/p2-duplicate-admin.css
@@ -42,8 +42,18 @@
 .wcos-duplicate-confirm-label {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
+    gap: 10px;
     font-weight: 600;
+    line-height: 1.45;
+}
+
+.wcos-duplicate-confirm-label input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin: 2px 0 0;
+}
+
+.wcos-duplicate-confirm-label span {
+    min-width: 0;
 }
 
 .wcos-duplicate-status,


### PR DESCRIPTION
## Summary

- neutralize WooCommerce's negative checkbox margin in the Duplicate review acknowledgement row
- align the checkbox with the first text line and use one controlled horizontal gap
- stabilize multi-line label rhythm and shrinking without changing copy, markup, behavior, or state semantics

## Governance

- Task: `WOS-DIRECT-20260827-173334`
- Canonical Issue: #109
- Classification: `TRIVIAL / CODEX_DIRECT`
- Pre-edit authority: `DIRECT_HUMAN_AUTHORIZED` Issue comment `5437813819`
- Exact base: `42f1f41b0379a669e0e6b18dd24cc587ff3ca008`
- Exact head: `304970381756931ef7cf41ea341435e07a2f57c0`
- Exact head tree: `9c7258872a024488fa66be6c2a82f050b9ee0198`
- Complete diff: one existing tracked regular ASCII mode-`100644` file `css/p2-duplicate-admin.css`, status M, 11 additions / 1 deletion
- Release hold: no package, tag, release, publication, deployment, or production-gate authority

## Evidence

- `git diff --check`
- `tests/ci/direct-css-fast-contract.sh`
- `tests/ci/required-ci-profile-contract.sh`
- `tests/ci/workflow-contract.sh`
- Local WooCommerce order screen inspection: before-state computed checkbox margin was `-4px 4px 0 0`; final loaded CSS computes `margin: 2px 0 0`, `flex: 0 0 auto`, label `gap: 10px`, `line-height: 18.85px`, and text `min-width: 0`
- No order mutation or confirmation was submitted during Local inspection

## Scope guard

No PHP, JavaScript, markup, strings/copy, interaction/state/security, mutation, gates, tests, workflows, governance, version, package, release, publication, deployment, or external resource changes.

Closes #109
