### PR TITLE
WOS-DIRECT-20260827-183142: align admin scheme controls

### DIFF
--- a/css/p2-bulk-return-admin.css
+++ b/css/p2-bulk-return-admin.css
@@ -42,8 +42,18 @@
 .wcos-bulk-return-ack {
 	display: flex;
 	align-items: flex-start;
-	gap: 8px;
+	gap: 10px;
 	font-weight: 600;
+	line-height: 1.45;
+}
+
+.wcos-bulk-return-ack input[type="checkbox"] {
+	flex: 0 0 auto;
+	margin: 2px 0 0;
+}
+
+.wcos-bulk-return-ack span {
+	min-width: 0;
 }
 
 .wcos-bulk-return-status,

--- a/css/p2-merge-admin.css
+++ b/css/p2-merge-admin.css
@@ -51,8 +51,19 @@
 
 .wcos-merge-backbone-modal .wcos-merge-confirm-label {
 	display: flex;
-	gap: 8px;
 	align-items: flex-start;
+	gap: 10px;
+	font-weight: 600;
+	line-height: 1.45;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-confirm-label input[type="checkbox"] {
+	flex: 0 0 auto;
+	margin: 2px 0 0;
+}
+
+.wcos-merge-backbone-modal .wcos-merge-confirm-label span {
+	min-width: 0;
 }
 
 .wcos-merge-backbone-modal .wcos-merge-status {

--- a/css/p2-return-admin.css
+++ b/css/p2-return-admin.css
@@ -55,12 +55,18 @@
 .wcos-return-backbone-modal .wcos-return-confirm-label {
 	display: flex;
 	align-items: flex-start;
-	gap: 8px;
+	gap: 10px;
 	font-weight: 600;
+	line-height: 1.45;
 }
 
-.wcos-return-backbone-modal .wcos-return-confirm-label input {
-	margin-top: 2px;
+.wcos-return-backbone-modal .wcos-return-confirm-label input[type="checkbox"] {
+	flex: 0 0 auto;
+	margin: 2px 0 0;
+}
+
+.wcos-return-backbone-modal .wcos-return-confirm-label span {
+	min-width: 0;
 }
 
 .wcos-return-backbone-modal .wcos-return-status {

--- a/css/p2-split-admin.css
+++ b/css/p2-split-admin.css
@@ -64,8 +64,8 @@
 
 .wcos-split-method-option:hover,
 .wcos-split-method-option:focus {
-    border-color: #2271b1;
-    box-shadow: 0 0 0 1px #2271b1;
+    border-color: var(--wp-admin-theme-color, #2271b1);
+    box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #2271b1);
     outline: none;
 }
 
@@ -262,8 +262,18 @@
 .wcos-split-confirm-label {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
+    gap: 10px;
     font-weight: 600;
+    line-height: 1.45;
+}
+
+.wcos-split-confirm-label input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin: 2px 0 0;
+}
+
+.wcos-split-confirm-label span {
+    min-width: 0;
 }
 
 .wcos-split-status,

--- a/css/p2-split-strategy-admin.css
+++ b/css/p2-split-strategy-admin.css
@@ -99,8 +99,8 @@
 }
 
 .wcos-strategy-bucket-option:focus-within {
-    border-color: #2271b1;
-    box-shadow: 0 0 0 1px #2271b1;
+    border-color: var(--wp-admin-theme-color, #2271b1);
+    box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #2271b1);
 }
 
 .wcos-strategy-bucket-option input[type="radio"] {
@@ -116,9 +116,19 @@
 .wcos-strategy-confirm-label {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
+    gap: 10px;
     margin: 12px 0 0;
     font-weight: 600;
+    line-height: 1.45;
+}
+
+.wcos-strategy-confirm-label input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin: 2px 0 0;
+}
+
+.wcos-strategy-confirm-label span {
+    min-width: 0;
 }
 
 .wcos-strategy-result ul {

--- a/css/style.css
+++ b/css/style.css
@@ -85,7 +85,7 @@
     justify-content: center;
     width: 32px;
     height: 32px;
-    color: #2271b1;
+    color: var(--wp-admin-theme-color, #2271b1);
     text-decoration: none;
 }
 
@@ -162,7 +162,7 @@
 }
 
 .wcos-dismiss-link:hover {
-    color: #2271b1;
+    color: var(--wp-admin-theme-color, #2271b1);
 }
 
 .wcos-premium-matrix {


### PR DESCRIPTION
## Summary

- route all six plugin-owned `#2271b1` declarations through `var(--wp-admin-theme-color, #2271b1)`
- standardize the remaining Bulk Return, Merge, Return, Split, and strategy Split confirmation checkbox/label rows against the accepted Duplicate presentation pattern
- preserve all markup, copy, accessible label relationships, focus/pointer behavior, checked/disabled semantics, and mutation authority

## Governance

- Task: `WOS-DIRECT-20260827-183142`
- Canonical Issue: #111
- Classification: `TRIVIAL / CODEX_DIRECT`
- Pre-edit authority: `DIRECT_HUMAN_AUTHORIZED` Issue comment `5438383016`
- Exact base: `1fa3d2e464187d3e476c9b72bf47c3fc7684fefc`
- Exact head: `c9f23ad4a4b3b12a25d65923be3608d9cffc7c4c`
- Exact head tree: `bc7ea6d41d2f869cacfe329c03d91ed1dfdd9ca5`
- Complete diff: six existing tracked regular ASCII mode-`100644` CSS files, all status M, 60 additions / 13 deletions
- Release hold: no package, tag, release, publication, deployment, or production-gate authority

## Static evidence

- exact literal inventory: all six `#2271b1` occurrences now appear only as fallbacks inside `var(--wp-admin-theme-color, #2271b1)`
- active Local WordPress core has eight admin color schemes (`blue`, `coffee`, `ectoplasm`, `light`, `midnight`, `modern`, `ocean`, `sunrise`), and every scheme CSS uses `--wp-admin-theme-color` for scheme-sensitive controls
- selector inventory confirms accepted Duplicate plus every remaining confirmation row has scoped label, checkbox, and text-span rules
- each remaining row uses `align-items: flex-start`, `gap: 10px`, `line-height: 1.45`, checkbox `flex: 0 0 auto; margin: 2px 0 0`, and text `min-width: 0`
- `git diff --check`
- `tests/ci/direct-css-fast-contract.sh`
- `tests/ci/required-ci-profile-contract.sh`
- `tests/ci/workflow-contract.sh`
- no Chrome/browser use, as explicitly requested

## Scope guard

No PHP, JavaScript, markup, strings/copy, interaction/state/security, mutation, gates, tests, workflows, governance, version, package, release, publication, deployment, or external resource changes.

Closes #111
