### PR TITLE
SUPERSEDED — WOS-UPSELL-001 contextual Advanced Order Actions upsell

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -20,5 +20,4 @@
 /inc/mutation-v2
 /js/bulk-return-action.js
 /js/merge-action.js
-/js/post-action-tip.js
 /js/split-table.js

--- a/.github/scripts/validate-distribution-contract.sh
+++ b/.github/scripts/validate-distribution-contract.sh
@@ -102,7 +102,6 @@ for forbidden_path in \
   'inc/backend/order-merge-option.php' \
   'js/bulk-return-action.js' \
   'js/merge-action.js' \
-  'js/post-action-tip.js' \
   'js/split-table.js' \
   'inc/mutation-v2'; do
   if test -e "$distribution_root/$forbidden_path"; then
@@ -113,6 +112,9 @@ done
 for required_path in \
   'wc-order-splitter.php' \
   'readme.txt' \
+  'inc/backend/class-wcos-premium-upsell.php' \
+  'css/premium-upsell.css' \
+  'js/post-action-tip.js' \
   'inc/backend/class-wcos-split-admin-controller.php' \
   'inc/backend/class-wcos-split-confirmation-store.php' \
   'inc/backend/class-wcos-split-request-parser.php' \

--- a/css/premium-upsell.css
+++ b/css/premium-upsell.css
@@ -1,0 +1,117 @@
+.wcos-settings-card {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin: 16px 0;
+    padding: 16px;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+}
+
+.wcos-settings-card h2 {
+    margin: 0 0 6px;
+    font-size: 15px;
+    line-height: 1.4;
+}
+
+.wcos-settings-card p {
+    margin: 0;
+    max-width: 820px;
+    color: #50575e;
+}
+
+.wcos-feature-list {
+    margin: 10px 0 0;
+    color: #3c434a;
+}
+
+.wcos-feature-list li {
+    margin: 4px 0 0 18px;
+    list-style: disc;
+}
+
+.wcos-card-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+    flex: 0 0 auto;
+}
+
+.wcos-dismiss-link {
+    color: #646970;
+    text-decoration: none;
+}
+
+.wcos-dismiss-link:hover {
+    color: var(--wp-admin-theme-color, #2271b1);
+}
+
+.wcos-premium-matrix {
+    max-width: 1180px;
+    margin-top: 12px;
+}
+
+.wcos-premium-matrix th:first-child,
+.wcos-premium-matrix td:first-child {
+    width: 24%;
+}
+
+.wcos-premium-matrix th:nth-child(2),
+.wcos-premium-matrix th:nth-child(3),
+.wcos-premium-matrix td:nth-child(2),
+.wcos-premium-matrix td:nth-child(3) {
+    width: 38%;
+    text-align: left;
+    vertical-align: top;
+}
+
+.wcos-upgrade-qualification {
+    max-width: 1180px;
+    margin-top: 10px;
+    color: #646970;
+}
+
+.wcos-split-upgrade-hint {
+    clear: both;
+    margin: 10px 0 0;
+    padding: 8px 10px;
+    border-left: 3px solid #c3c4c7;
+    background: #f6f7f7;
+    color: #50575e;
+    line-height: 1.5;
+}
+
+.wcos-split-upgrade-hint a {
+    white-space: nowrap;
+}
+
+.wcos-post-action-tip {
+    position: relative;
+    margin: 12px 0;
+    padding-right: 38px;
+}
+
+@media (max-width: 782px) {
+    .wcos-settings-card {
+        display: block;
+    }
+
+    .wcos-card-actions {
+        justify-content: flex-start;
+        margin-top: 12px;
+    }
+
+    .wcos-premium-matrix {
+        display: block;
+        overflow-x: auto;
+    }
+
+    .wcos-premium-matrix th,
+    .wcos-premium-matrix td {
+        min-width: 190px;
+    }
+}

--- a/inc/backend/class-wcos-premium-upsell.php
+++ b/inc/backend/class-wcos-premium-upsell.php
@@ -1,0 +1,159 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Presentation-only promotion boundary for the standalone Advanced Order Actions product.
+ *
+ * This class must not own or influence order mutation authority. It only renders
+ * commercial discovery surfaces and supplies local-only browser configuration.
+ */
+final class WCOS_Premium_Upsell {
+	const PRODUCT_URL = 'https://yoohw.com/product/woocommerce-advanced-order-actions/';
+
+	private static $instance = null;
+
+	public static function bootstrap() {
+		if (!self::$instance instanceof self) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public static function product_url() {
+		return self::PRODUCT_URL;
+	}
+
+	private function __construct() {
+		add_filter('plugin_action_links_' . plugin_basename(dirname(__DIR__, 2) . '/wc-order-splitter.php'), array($this, 'add_plugin_action_link'), 20);
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+	}
+
+	public function add_plugin_action_link($links) {
+		if (!current_user_can('manage_woocommerce')) {
+			return $links;
+		}
+
+		$link = sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			esc_url(self::product_url()),
+			esc_html__('Advanced Order Actions ↗', 'wc-order-splitter')
+		);
+
+		$insert_at = min(1, count($links));
+		array_splice($links, $insert_at, 0, array($link));
+
+		return $links;
+	}
+
+	public static function render_settings_card($title, $description, $features = array(), $cta_label = '') {
+		if (!current_user_can('manage_woocommerce')) {
+			return;
+		}
+
+		if ('' === $cta_label) {
+			$cta_label = esc_html__('Explore Advanced Order Actions', 'wc-order-splitter');
+		}
+		?>
+		<div class="wcos-settings-card wcos-upgrade-card">
+			<div>
+				<h2><?php echo esc_html($title); ?></h2>
+				<p><?php echo esc_html($description); ?></p>
+				<?php if (!empty($features)) : ?>
+					<ul class="wcos-feature-list">
+						<?php foreach ($features as $feature) : ?>
+							<li><?php echo esc_html($feature); ?></li>
+						<?php endforeach; ?>
+					</ul>
+				<?php endif; ?>
+			</div>
+			<div class="wcos-card-actions">
+				<a class="button button-primary" href="<?php echo esc_url(self::product_url()); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($cta_label); ?></a>
+			</div>
+		</div>
+		<?php
+	}
+
+	public function enqueue_assets() {
+		if (!current_user_can('manage_woocommerce')) {
+			return;
+		}
+
+		$is_settings = $this->is_orders_settings_screen();
+		$is_order_edit = $this->is_order_edit_screen();
+		if (!$is_settings && !$is_order_edit) {
+			return;
+		}
+
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_style(
+			'wcos-premium-upsell',
+			plugins_url('css/premium-upsell.css', $plugin_file),
+			array(),
+			WC_ORDER_SPLITTER_VERSION
+		);
+
+		if (!$is_order_edit) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'wcos-premium-upsell',
+			plugins_url('js/post-action-tip.js', $plugin_file),
+			array('jquery'),
+			WC_ORDER_SPLITTER_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wcos-premium-upsell',
+			'wcosPremiumUpsell',
+			array(
+				'productUrl' => self::product_url(),
+				'ctaLabel' => __('Explore Advanced Order Actions', 'wc-order-splitter'),
+				'dismissLabel' => __('Dismiss', 'wc-order-splitter'),
+				'splitHint' => __('Need more routing options? Advanced Order Actions adds product group, tag, attribute, vendor, bundle, and compatible-integration split modes.', 'wc-order-splitter'),
+				'splitHintCta' => __('See advanced split methods', 'wc-order-splitter'),
+				'thresholds' => array(
+					'split' => 3,
+					'duplicate' => 2,
+					'merge' => 2,
+				),
+				'executeActions' => array(
+					'wcos_split_execute' => 'split',
+					'wcos_split_strategy_execute' => 'split',
+					'wcos_duplicate_execute' => 'duplicate',
+					'wcos_merge_execute' => 'merge',
+				),
+				'actionTips' => array(
+					'split' => __('Doing this repeatedly? Advanced Order Actions can automate split or merge rules, queue scheduled work, and retry eligible failures.', 'wc-order-splitter'),
+					'duplicate' => __('Need more control over duplicates? Advanced Order Actions can choose contents, status and payment behavior, preview the result, and process recoverable Bulk Duplicate batches.', 'wc-order-splitter'),
+					'merge' => __('Merging orders regularly? Advanced Order Actions adds dry-run Merge previews and automatic same-customer merging within a configured time window.', 'wc-order-splitter'),
+				),
+			)
+		);
+	}
+
+	private function is_orders_settings_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen || 'woocommerce_page_wc-settings' !== $screen->id) {
+			return false;
+		}
+
+		$tab = isset($_GET['tab']) ? sanitize_key(wp_unslash($_GET['tab'])) : '';
+		return 'orders' === $tab;
+	}
+
+	private function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
+	}
+}

--- a/inc/backend/settings.php
+++ b/inc/backend/settings.php
@@ -5,10 +5,10 @@ defined('ABSPATH') || exit;
 class WooCommerce_Order_Splitter_Settings {
 
 	public function __construct() {
-			add_filter('woocommerce_settings_tabs_array', array($this, 'add_orders_settings_tab'), 30);
-			add_action('woocommerce_settings_tabs_orders', array($this, 'order_splitter_settings_tab'), 9);
-			add_action('woocommerce_update_options_orders', array($this, 'update_order_splitter_settings'));
-			add_action('admin_init', array($this, 'handle_settings_actions'));
+		add_filter('woocommerce_settings_tabs_array', array($this, 'add_orders_settings_tab'), 30);
+		add_action('woocommerce_settings_tabs_orders', array($this, 'order_splitter_settings_tab'), 9);
+		add_action('woocommerce_update_options_orders', array($this, 'update_order_splitter_settings'));
+		add_action('admin_init', array($this, 'handle_settings_actions'));
 
 		if (class_exists('WC_Order_Cancellation_Return_Premium_Settings')) {
 			$wc_order_cancel_return_settings = new WC_Order_Cancellation_Return_Premium_Settings();
@@ -70,10 +70,11 @@ class WooCommerce_Order_Splitter_Settings {
 			'automation_splitter' => esc_html__('Automation', 'wc-order-splitter'),
 		);
 
-		$sub_sub_tabs['premium'] = esc_html__('Premium', 'wc-order-splitter');
+		// Keep the historical section key for URL/backward compatibility.
+		$sub_sub_tabs['premium'] = esc_html__('Upgrade', 'wc-order-splitter');
 
 		// Free cancel/return plugin: add a single tab (optional)
-		if ( is_plugin_active('wc-order-cancellation-return/wc-order-cancellation-return.php') ) {
+		if (is_plugin_active('wc-order-cancellation-return/wc-order-cancellation-return.php')) {
 			$sub_sub_tabs['cancel_return'] = esc_html__('Cancel & Return', 'wc-order-splitter');
 		}
 
@@ -117,12 +118,12 @@ class WooCommerce_Order_Splitter_Settings {
 		woocommerce_admin_fields($this->get_split_order_settings());
 		woocommerce_admin_fields($this->get_advanced_settings());
 		$this->render_upgrade_card(
-			esc_html__('Need more order controls?', 'wc-order-splitter'),
-			esc_html__('Premium adds status controls after splitting, duplicate/merge restrictions, editable order status expansion, product groups, tags, attributes, bundles, vendors, and automated split rules.', 'wc-order-splitter'),
+			esc_html__('When manual order actions become repetitive', 'wc-order-splitter'),
+			esc_html__('Order Splitter keeps supported order operations on demand. Advanced Order Actions adds previews, configurable and bulk operations, automation, and operational visibility for stores handling these tasks repeatedly.', 'wc-order-splitter'),
 			array(
-				esc_html__('Set original and split order statuses after splitting.', 'wc-order-splitter'),
-				esc_html__('Control which orders can be duplicated or merged.', 'wc-order-splitter'),
-				esc_html__('Split by product group, tag, attribute, bundle, or vendor.', 'wc-order-splitter'),
+				esc_html__('Preview Split and Merge results before changing orders.', 'wc-order-splitter'),
+				esc_html__('Configure Duplicate behavior and process recoverable Bulk Duplicate batches.', 'wc-order-splitter'),
+				esc_html__('Track operations with Action Logs, automation queues, retry visibility, and guarded rollback.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -130,12 +131,12 @@ class WooCommerce_Order_Splitter_Settings {
 	public function output_automation_splitter_settings() {
 		woocommerce_admin_fields($this->get_automation_splitter_settings());
 		$this->render_upgrade_card(
-			esc_html__('Automate repeated split workflows', 'wc-order-splitter'),
-			esc_html__('Premium can schedule split actions after an order is created and apply rules based on quantity, product group, category, stock status, tag, attribute, bundle, or vendor.', 'wc-order-splitter'),
+			esc_html__('Automate repetitive order operations', 'wc-order-splitter'),
+			esc_html__('Advanced Order Actions can use prioritized rules to split, merge, or skip new orders, then track scheduled work through an automation queue.', 'wc-order-splitter'),
 			array(
-				esc_html__('Run split rules automatically after checkout.', 'wc-order-splitter'),
-				esc_html__('Add a delay timer for order processing workflows.', 'wc-order-splitter'),
-				esc_html__('Use WP-Cron based automation for repeatable operations.', 'wc-order-splitter'),
+				esc_html__('Build rules with ALL or ANY conditions.', 'wc-order-splitter'),
+				esc_html__('Match customer role, shipping zone, payment method, vendor, product meta, and compatible-integration signals.', 'wc-order-splitter'),
+				esc_html__('Inspect pending, failed, and skipped jobs, see reasons, and retry eligible failures.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -143,12 +144,12 @@ class WooCommerce_Order_Splitter_Settings {
 	public function output_notifications_settings() {
 		woocommerce_admin_fields($this->get_notifications_settings());
 		$this->render_upgrade_card(
-			esc_html__('Need split-order email controls?', 'wc-order-splitter'),
-			esc_html__('Premium adds customer and administrator email controls so split orders can be communicated without duplicate or confusing order emails.', 'wc-order-splitter'),
+			esc_html__('Control split-order communication before customers see it', 'wc-order-splitter'),
+			esc_html__('Advanced Order Actions adds customer and administrator split-order controls with configurable sending modes and live WooCommerce email previews.', 'wc-order-splitter'),
 			array(
-				esc_html__('Choose whether customers receive the original order email, split order emails, or both.', 'wc-order-splitter'),
-				esc_html__('Customize split-order email subject, heading, and message.', 'wc-order-splitter'),
-				esc_html__('Enable email rules per split method.', 'wc-order-splitter'),
+				esc_html__('Choose which original or split orders generate customer email.', 'wc-order-splitter'),
+				esc_html__('Customize subject, heading, and message per split method.', 'wc-order-splitter'),
+				esc_html__('Preview processing, on-hold, and completed customer emails before using the configuration.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -190,10 +191,19 @@ class WooCommerce_Order_Splitter_Settings {
 	}
 
 	private function get_premium_url() {
+		if (class_exists('WCOS_Premium_Upsell')) {
+			return WCOS_Premium_Upsell::product_url();
+		}
+
 		return 'https://yoohw.com/product/woocommerce-advanced-order-actions/';
 	}
 
 	private function render_upgrade_card($title, $description, $features = array()) {
+		if (class_exists('WCOS_Premium_Upsell')) {
+			WCOS_Premium_Upsell::render_settings_card($title, $description, $features);
+			return;
+		}
+
 		if (!current_user_can('manage_woocommerce')) {
 			return;
 		}
@@ -211,7 +221,7 @@ class WooCommerce_Order_Splitter_Settings {
 				<?php endif; ?>
 			</div>
 			<div class="wcos-card-actions">
-				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Compare Premium', 'wc-order-splitter'); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Explore Advanced Order Actions', 'wc-order-splitter'); ?></a>
 			</div>
 		</div>
 		<?php
@@ -262,44 +272,54 @@ class WooCommerce_Order_Splitter_Settings {
 	public function output_premium_settings() {
 		$features = array(
 			array(
-				'feature' => esc_html__('Manual split by product and quantity', 'wc-order-splitter'),
-				'free' => esc_html__('Included', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('On-demand order operations', 'wc-order-splitter'),
+				'free' => esc_html__('Split, Duplicate, Merge, Return, and Bulk Return for supported orders.', 'wc-order-splitter'),
+				'premium' => esc_html__('Expanded Split, Duplicate, Merge, and Return controls for operational workflows.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Split by category and stock status', 'wc-order-splitter'),
-				'free' => esc_html__('Included', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Split routing', 'wc-order-splitter'),
+				'free' => esc_html__('Manual quantity, category, and stock status.', 'wc-order-splitter'),
+				'premium' => esc_html__('Product group, tag, attribute, vendor, bundle, plus compatible-integration routing.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Split by product group, tag, attribute, bundle, or vendor', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Duplicate workflow', 'wc-order-splitter'),
+				'free' => esc_html__('Single reviewed Duplicate.', 'wc-order-splitter'),
+				'premium' => esc_html__('Configurable contents, status and payment behavior, preview, and recoverable Bulk Duplicate.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Automated split rules after order creation', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Merge workflow', 'wc-order-splitter'),
+				'free' => esc_html__('Single reviewed manual Merge.', 'wc-order-splitter'),
+				'premium' => esc_html__('Dry-run preview plus automatic same-customer merge within a configured time window.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Order status controls after split, duplicate, and merge actions', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Automation', 'wc-order-splitter'),
+				'free' => esc_html__('On-demand operations.', 'wc-order-splitter'),
+				'premium' => esc_html__('Rule Builder with priorities, ALL/ANY conditions, Split/Merge/Skip actions, queue visibility, and retry.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Customer and admin split-order email controls', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Before-action visibility', 'wc-order-splitter'),
+				'free' => esc_html__('Server review and confirmation for hardened workflows.', 'wc-order-splitter'),
+				'premium' => esc_html__('Rich dry-run previews for items, statuses, shipping, and email behavior; compatible integrations can add inventory/allocation context.', 'wc-order-splitter'),
+			),
+			array(
+				'feature' => esc_html__('Operational history', 'wc-order-splitter'),
+				'free' => esc_html__('Durable operation safety, replay, and recovery foundations.', 'wc-order-splitter'),
+				'premium' => esc_html__('User-facing Action Logs, guarded rollback, Automation Queue status, failure/skip reasons, and retry controls.', 'wc-order-splitter'),
+			),
+			array(
+				'feature' => esc_html__('Split-order notifications', 'wc-order-splitter'),
+				'free' => esc_html__('Standard on-demand workflow behavior.', 'wc-order-splitter'),
+				'premium' => esc_html__('Customer/admin sending modes, per-method subject/heading/message, and live WooCommerce email previews.', 'wc-order-splitter'),
 			),
 		);
 		?>
 		<div class="wcos-settings-card wcos-premium-intro">
 			<div>
-				<h2><?php esc_html_e('Premium options for high-volume order operations', 'wc-order-splitter'); ?></h2>
-				<p><?php esc_html_e('The free plugin keeps manual splitting available. Premium is best for stores that repeatedly split by rules, need automated workflows, or need tighter email/status controls.', 'wc-order-splitter'); ?></p>
+				<h2><?php esc_html_e('Upgrade to WooCommerce Advanced Order Actions', 'wc-order-splitter'); ?></h2>
+				<p><?php esc_html_e('Advanced Order Actions is a standalone premium replacement for Order Splitter. It is designed for stores that have outgrown on-demand manual operations and need automation, bulk workflows, previews, and deeper operational controls. When activated, it runs independently and Order Splitter is deactivated.', 'wc-order-splitter'); ?></p>
 			</div>
 			<div class="wcos-card-actions">
-				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Compare Premium', 'wc-order-splitter'); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Explore Advanced Order Actions', 'wc-order-splitter'); ?></a>
 			</div>
 		</div>
 
@@ -307,8 +327,8 @@ class WooCommerce_Order_Splitter_Settings {
 			<thead>
 				<tr>
 					<th><?php esc_html_e('Workflow', 'wc-order-splitter'); ?></th>
-					<th><?php esc_html_e('Free', 'wc-order-splitter'); ?></th>
-					<th><?php esc_html_e('Premium', 'wc-order-splitter'); ?></th>
+					<th><?php esc_html_e('Order Splitter', 'wc-order-splitter'); ?></th>
+					<th><?php esc_html_e('Advanced Order Actions', 'wc-order-splitter'); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -321,6 +341,7 @@ class WooCommerce_Order_Splitter_Settings {
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+		<p class="description wcos-upgrade-qualification"><?php esc_html_e('Vendor and bundle routing require compatible marketplace or bundle plugins. Inventory readiness/location and reconciliation capabilities require a compatible Stock Manager integration.', 'wc-order-splitter'); ?></p>
 		<?php
 	}
 
@@ -392,9 +413,9 @@ class WooCommerce_Order_Splitter_Settings {
 	public function get_automation_splitter_settings() {
 		$settings = array(
 			'section_title' => array(
-				'name'     => esc_html__('Automation splitter', 'wc-order-splitter'),
+				'name'     => esc_html__('Automation', 'wc-order-splitter'),
 				'type'     => 'title',
-				'desc'     => esc_html__('Automation is available in Premium for stores that need repeatable split rules after checkout.', 'wc-order-splitter'),
+				'desc'     => esc_html__('Order Splitter keeps supported order operations on demand; no automation rule is configured on this screen.', 'wc-order-splitter'),
 				'id'       => 'automation_splitter_section_title',
 			),
 			'section_end' => array(
@@ -411,7 +432,7 @@ class WooCommerce_Order_Splitter_Settings {
 			'section_title' => array(
 				'name'     => esc_html__('Split order email', 'wc-order-splitter'),
 				'type'     => 'title',
-				'desc'     => esc_html__('Split-order email controls are available in Premium for stores that need customer or administrator notification rules.', 'wc-order-splitter'),
+				'desc'     => esc_html__('Order Splitter keeps its on-demand workflow notification behavior unchanged; this screen has no configurable split-order email rules.', 'wc-order-splitter'),
 				'id'       => 'notifications_order_splitter_section_title'
 			),
 			'section_end' => array(

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -136,6 +136,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'backend/class-wcos-bulk-return-admin-controller.php';
 		WCOS_Bulk_Return_Admin_Controller::bootstrap();
 
+		include_once $root . 'backend/class-wcos-premium-upsell.php';
+		WCOS_Premium_Upsell::bootstrap();
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';
 		include_once $root . 'backend/yoohw-woo-settings-tabs-reorder.php';

--- a/js/post-action-tip.js
+++ b/js/post-action-tip.js
@@ -1,20 +1,28 @@
-jQuery(document).ready(function($) {
-    var storageKey = 'wcosPostActionTip';
-    var legacySplitKey = 'wcosPostSplitTip';
-    var dismissedKey = 'wcosPostActionTipDismissedAt';
-    var throttleMs = 7 * 24 * 60 * 60 * 1000;
+(function($) {
+    'use strict';
 
-    function escapeHtml(value) {
-        return String(value === undefined || value === null ? '' : value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
+    var config = window.wcosPremiumUpsell || {};
+    var storageKey = 'wcosPremiumUpsellStateV1';
+    var legacyKeys = [
+        'wcosPostActionTip',
+        'wcosPostSplitTip',
+        'wcosPostActionTipDismissedAt'
+    ];
+    var validActions = ['split', 'duplicate', 'merge'];
+    var seenLimit = 40;
 
-    function escapeHtmlAttr(value) {
-        return escapeHtml(value).replace(/`/g, '&#096;');
+    function emptyState() {
+        return {
+            usage: {
+                split: 0,
+                duplicate: 0,
+                merge: 0
+            },
+            seenOperations: [],
+            pending: {},
+            shown: {},
+            dismissed: {}
+        };
     }
 
     function getStoredItem(key) {
@@ -28,7 +36,10 @@ jQuery(document).ready(function($) {
     function setStoredItem(key, value) {
         try {
             window.localStorage.setItem(key, value);
-        } catch (error) {}
+            return true;
+        } catch (error) {
+            return false;
+        }
     }
 
     function removeStoredItem(key) {
@@ -37,92 +48,291 @@ jQuery(document).ready(function($) {
         } catch (error) {}
     }
 
-    function recentlyDismissed() {
-        var dismissedAt = parseInt(getStoredItem(dismissedKey), 10);
-
-        return dismissedAt && Date.now() - dismissedAt < throttleMs;
+    function isValidAction(action) {
+        return validActions.indexOf(action) !== -1;
     }
 
-    function getTipFromStorage() {
-        var storedTip = getStoredItem(storageKey);
-        var legacyTip = getStoredItem(legacySplitKey);
+    function normalizeCount(value) {
+        var count = parseInt(value, 10);
+        return isFinite(count) && count > 0 ? count : 0;
+    }
 
-        removeStoredItem(storageKey);
-        removeStoredItem(legacySplitKey);
+    function normalizeState(rawState) {
+        var normalized = emptyState();
+        var state = rawState && typeof rawState === 'object' ? rawState : {};
+        var i;
 
-        if (storedTip) {
+        for (i = 0; i < validActions.length; i++) {
+            var action = validActions[i];
+            normalized.usage[action] = normalizeCount(state.usage && state.usage[action]);
+            normalized.pending[action] = !!(state.pending && state.pending[action]);
+            normalized.shown[action] = !!(state.shown && state.shown[action]);
+            normalized.dismissed[action] = !!(state.dismissed && state.dismissed[action]);
+        }
+
+        if (Array.isArray(state.seenOperations)) {
+            normalized.seenOperations = state.seenOperations
+                .filter(function(operation) {
+                    return typeof operation === 'string' && operation.length > 0 && operation.length <= 100;
+                })
+                .slice(-seenLimit);
+        }
+
+        return normalized;
+    }
+
+    function readState() {
+        var stored = getStoredItem(storageKey);
+        if (!stored) {
+            return emptyState();
+        }
+
+        try {
+            return normalizeState(JSON.parse(stored));
+        } catch (error) {
+            return emptyState();
+        }
+    }
+
+    function saveState(state) {
+        setStoredItem(storageKey, JSON.stringify(normalizeState(state)));
+    }
+
+    function cleanupLegacyState() {
+        legacyKeys.forEach(function(key) {
+            removeStoredItem(key);
+        });
+    }
+
+    function actionFromBody(body) {
+        if (!body) {
+            return '';
+        }
+
+        if (typeof body === 'string') {
             try {
-                return JSON.parse(storedTip);
+                return new URLSearchParams(body).get('action') || '';
             } catch (error) {
-                return {
-                    action: 'custom',
-                    message: storedTip
-                };
+                var match = body.match(/(?:^|&)action=([^&]+)/);
+                return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : '';
             }
         }
 
-        if (legacyTip) {
-            return {
-                action: 'split',
-                message: legacyTip
-            };
+        if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+            return body.get('action') || '';
+        }
+
+        if (typeof FormData !== 'undefined' && body instanceof FormData) {
+            return body.get('action') || '';
+        }
+
+        return '';
+    }
+
+    function requestAction(settings) {
+        var data = settings && settings.data;
+
+        if (data && typeof data === 'object' && typeof data.action === 'string') {
+            return data.action;
+        }
+
+        return actionFromBody(data);
+    }
+
+    function responsePayload(xhr, data) {
+        if (data && typeof data === 'object') {
+            return data;
+        }
+
+        if (xhr && xhr.responseJSON && typeof xhr.responseJSON === 'object') {
+            return xhr.responseJSON;
+        }
+
+        if (xhr && typeof xhr.responseText === 'string') {
+            try {
+                return JSON.parse(xhr.responseText);
+            } catch (error) {}
         }
 
         return null;
     }
 
-    function getTipFromUrl() {
-        var params = new URLSearchParams(window.location.search);
-        var action = params.get('wcos_action_tip');
-
-        if (!action || !window.wcosPostActionTip || !window.wcosPostActionTip.actionTips || !window.wcosPostActionTip.actionTips[action]) {
-            return null;
-        }
-
-        params.delete('wcos_action_tip');
-
-        var newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '') + window.location.hash;
-        window.history.replaceState({}, document.title, newUrl);
-
-        return {
-            action: action,
-            message: window.wcosPostActionTip.actionTips[action]
-        };
+    function thresholdFor(action) {
+        var thresholds = config.thresholds || {};
+        var threshold = parseInt(thresholds[action], 10);
+        return isFinite(threshold) && threshold > 0 ? threshold : 0;
     }
 
-    function getInsertionPoint() {
-        var $orderData = $('#woocommerce-order-data');
-        var $wpbody = $('#wpbody-content .wrap').first();
-
-        if ($orderData.length) {
-            return $orderData;
-        }
-
-        if ($wpbody.length) {
-            return $wpbody;
-        }
-
-        return $('#wpbody-content').first();
+    function operationAlreadySeen(state, operationKey) {
+        return state.seenOperations.indexOf(operationKey) !== -1;
     }
 
-    function renderTip(tip) {
-        if (!tip || !tip.message || $('.wcos-post-action-tip').length || recentlyDismissed()) {
+    function recordSuccessfulOperation(action, operationId) {
+        if (!isValidAction(action) || typeof operationId !== 'string' || !operationId) {
             return;
         }
 
-        var html = '<div class="notice notice-success is-dismissible wcos-post-action-tip">' +
-            '<p>' +
-            escapeHtml(tip.message) + ' ' +
-            '<a href="' + escapeHtmlAttr(window.wcosPostActionTip.premiumUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(window.wcosPostActionTip.comparePremium) + '</a>' +
-            '</p>' +
-            '</div>';
+        var state = readState();
+        var operationKey = action + ':' + operationId;
+        if (operationAlreadySeen(state, operationKey)) {
+            return;
+        }
 
-        getInsertionPoint().before(html);
+        state.seenOperations.push(operationKey);
+        state.seenOperations = state.seenOperations.slice(-seenLimit);
+        state.usage[action] = normalizeCount(state.usage[action]) + 1;
+
+        var threshold = thresholdFor(action);
+        if (threshold > 0 && state.usage[action] >= threshold && !state.shown[action] && !state.dismissed[action]) {
+            state.pending[action] = true;
+        }
+
+        saveState(state);
     }
 
-    $(document).on('click', '.wcos-post-action-tip .notice-dismiss', function() {
-        setStoredItem(dismissedKey, String(Date.now()));
+    function nextPendingAction(state) {
+        var i;
+        for (i = 0; i < validActions.length; i++) {
+            var action = validActions[i];
+            if (state.pending[action] && !state.shown[action] && !state.dismissed[action]) {
+                return action;
+            }
+        }
+        return '';
+    }
+
+    function renderPendingTip() {
+        if (!config.productUrl || !config.actionTips || $('.wcos-post-action-tip').length) {
+            return;
+        }
+
+        var state = readState();
+        var action = nextPendingAction(state);
+        if (!action || !config.actionTips[action]) {
+            return;
+        }
+
+        var $insertionPoint = $('#woocommerce-order-data').first();
+        if (!$insertionPoint.length) {
+            return;
+        }
+
+        state.pending[action] = false;
+        state.shown[action] = true;
+        saveState(state);
+
+        var $notice = $('<div>', {
+            'class': 'notice notice-info wcos-post-action-tip',
+            'data-wcos-upsell-action': action
+        });
+        var $paragraph = $('<p>');
+        $paragraph.append(document.createTextNode(config.actionTips[action] + ' '));
+        $('<a>', {
+            href: config.productUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            text: config.ctaLabel || 'Explore Advanced Order Actions'
+        }).appendTo($paragraph);
+        $notice.append($paragraph);
+
+        $('<button>', {
+            type: 'button',
+            'class': 'notice-dismiss',
+            'aria-label': config.dismissLabel || 'Dismiss'
+        }).append($('<span>', {
+            'class': 'screen-reader-text',
+            text: config.dismissLabel || 'Dismiss'
+        })).appendTo($notice);
+
+        $notice.on('click', '.notice-dismiss', function() {
+            var current = readState();
+            current.dismissed[action] = true;
+            current.pending[action] = false;
+            current.shown[action] = true;
+            saveState(current);
+            $notice.remove();
+        });
+
+        $insertionPoint.before($notice);
+    }
+
+    function renderSplitHint() {
+        if (!config.productUrl || !config.splitHint || $('.wcos-split-upgrade-hint').length) {
+            return;
+        }
+
+        var $anchor = $('.wcos-split-launcher').last();
+        if (!$anchor.length) {
+            return;
+        }
+
+        var $hint = $('<p>', {
+            'class': 'description wcos-split-upgrade-hint'
+        });
+        $hint.append(document.createTextNode(config.splitHint + ' '));
+        $('<a>', {
+            href: config.productUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            text: config.splitHintCta || 'See advanced split methods'
+        }).appendTo($hint);
+
+        $anchor.after($hint);
+    }
+
+    cleanupLegacyState();
+
+    $(function() {
+        // Promotions are rendered from state that existed before this page's AJAX work.
+        // A success recorded later in this page lifecycle can only surface on a later load.
+        renderPendingTip();
+        renderSplitHint();
     });
 
-    renderTip(getTipFromUrl() || getTipFromStorage());
-});
+    function observePayload(action, payload) {
+        if (!isValidAction(action) || !payload || payload.success !== true || !payload.data || typeof payload.data.operation_id !== 'string') {
+            return;
+        }
+
+        recordSuccessfulOperation(action, payload.data.operation_id);
+    }
+
+    function installFetchObserver() {
+        if (typeof window.fetch !== 'function' || window.fetch.__wcosPremiumUpsellObserved) {
+            return;
+        }
+
+        var originalFetch = window.fetch;
+        var observedFetch = function(input, init) {
+            var actionMap = config.executeActions || {};
+            var actionName = actionFromBody(init && init.body);
+            var action = actionMap[actionName];
+
+            var requestPromise = originalFetch.apply(this, arguments);
+            if (!isValidAction(action)) {
+                return requestPromise;
+            }
+
+            return requestPromise.then(function(response) {
+                if (response && typeof response.clone === 'function') {
+                    response.clone().json().then(function(payload) {
+                        observePayload(action, payload);
+                    }).catch(function() {});
+                }
+                return response;
+            });
+        };
+
+        observedFetch.__wcosPremiumUpsellObserved = true;
+        observedFetch.__wcosPremiumUpsellOriginal = originalFetch;
+        window.fetch = observedFetch;
+    }
+
+    installFetchObserver();
+
+    $(document).ajaxSuccess(function(event, xhr, settings, data) {
+        var actionMap = config.executeActions || {};
+        var action = actionMap[requestAction(settings)];
+        observePayload(action, responsePayload(xhr, data));
+    });
+})(jQuery);

--- a/js/post-action-tip.js
+++ b/js/post-action-tip.js
@@ -297,6 +297,13 @@
         recordSuccessfulOperation(action, payload.data.operation_id);
     }
 
+    if (window.wcosPremiumUpsellTestHooks && typeof window.wcosPremiumUpsellTestHooks === 'object') {
+        window.wcosPremiumUpsellTestHooks.readState = readState;
+        window.wcosPremiumUpsellTestHooks.recordSuccessfulOperation = recordSuccessfulOperation;
+        window.wcosPremiumUpsellTestHooks.nextPendingAction = nextPendingAction;
+        window.wcosPremiumUpsellTestHooks.observePayload = observePayload;
+    }
+
     function installFetchObserver() {
         if (typeof window.fetch !== 'function' || window.fetch.__wcosPremiumUpsellObserved) {
             return;

--- a/tests/ci/distribution-contract.sh
+++ b/tests/ci/distribution-contract.sh
@@ -46,6 +46,12 @@ expect_failure 'required hardened runtime path is missing: inc/domain/class-wcos
   "$missing_source/.github/scripts/validate-distribution-contract.sh" \
   "$missing_source" "$fixture_root/missing-required/distribution/wc-order-splitter"
 
+missing_upsell_source=$(make_source_fixture missing-upsell-runtime)
+rm "$missing_upsell_source/js/post-action-tip.js"
+expect_failure 'required hardened runtime path is missing: js/post-action-tip.js' \
+  "$missing_upsell_source/.github/scripts/validate-distribution-contract.sh" \
+  "$missing_upsell_source" "$fixture_root/missing-upsell-runtime/distribution/wc-order-splitter"
+
 symlink_source=$(make_source_fixture symlink)
 ln -s readme.txt "$symlink_source/unsafe-link"
 expect_failure 'symbolic links entered the distribution tree' \

--- a/tests/integration/premium-upsell-surface-smoke.php
+++ b/tests/integration/premium-upsell-surface-smoke.php
@@ -1,0 +1,51 @@
+<?php
+
+$root = dirname(__DIR__, 2);
+
+function wcos_upsell_assert($condition, $message) {
+	if (!$condition) {
+		fwrite(STDERR, "premium-upsell-surface-smoke: FAIL: {$message}\n");
+		exit(1);
+	}
+}
+
+function wcos_upsell_read($path) {
+	$content = file_get_contents($path);
+	wcos_upsell_assert(false !== $content, 'Unable to read ' . $path);
+	return $content;
+}
+
+$settings = wcos_upsell_read($root . '/inc/backend/settings.php');
+$boundary = wcos_upsell_read($root . '/inc/backend/class-wcos-premium-upsell.php');
+$script = wcos_upsell_read($root . '/inc/cores/script.php');
+$client = wcos_upsell_read($root . '/js/post-action-tip.js');
+
+wcos_upsell_assert(false !== strpos($boundary, "const PRODUCT_URL = 'https://yoohw.com/product/woocommerce-advanced-order-actions/';"), 'Canonical product URL missing.');
+wcos_upsell_assert(false !== strpos($boundary, "current_user_can('manage_woocommerce')"), 'Promotion capability gate missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'split' => 3"), 'Split threshold must be 3.');
+wcos_upsell_assert(false !== strpos($boundary, "'duplicate' => 2"), 'Duplicate threshold must be 2.');
+wcos_upsell_assert(false !== strpos($boundary, "'merge' => 2"), 'Merge threshold must be 2.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_execute' => 'split'"), 'Manual Split execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_strategy_execute' => 'split'"), 'Strategy Split execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_duplicate_execute' => 'duplicate'"), 'Duplicate execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_merge_execute' => 'merge'"), 'Merge execute mapping missing.');
+
+wcos_upsell_assert(false !== strpos($settings, "$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
+wcos_upsell_assert(false !== strpos($settings, 'standalone premium replacement for Order Splitter'), 'Standalone replacement positioning missing.');
+wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Order Splitter'"), 'Order Splitter comparison column missing.');
+wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Advanced Order Actions'"), 'Advanced Order Actions comparison column missing.');
+wcos_upsell_assert(false === strpos($settings, "esc_html__('Locked'"), 'Upgrade matrix must not use Locked.');
+
+wcos_upsell_assert(false !== strpos($script, "include_once $root . 'backend/class-wcos-premium-upsell.php';"), 'Presentation boundary is not loaded.');
+wcos_upsell_assert(false !== strpos($script, 'WCOS_Premium_Upsell::bootstrap();'), 'Presentation boundary is not bootstrapped.');
+
+wcos_upsell_assert(false !== strpos($client, 'payload.success !== true'), 'Success-only guard missing.');
+wcos_upsell_assert(false !== strpos($client, 'seenOperations'), 'Operation replay deduplication state missing.');
+wcos_upsell_assert(false !== strpos($client, 'renderPendingTip();'), 'Later-page pending promotion render missing.');
+wcos_upsell_assert(false !== strpos($client, 'response.clone().json()'), 'Fetch observation must clone rather than consume the mutation response.');
+wcos_upsell_assert(false === strpos($client, 'navigator.sendBeacon'), 'Telemetry via sendBeacon is forbidden.');
+wcos_upsell_assert(false === strpos($client, 'XMLHttpRequest'), 'Upsell client must not create XHR telemetry.');
+wcos_upsell_assert(false === strpos($client, 'utm_'), 'Tracking parameters are forbidden.');
+wcos_upsell_assert(false === strpos($client, 'ref='), 'Referral parameters are forbidden.');
+
+echo "premium-upsell-surface-smoke: ok\n";

--- a/tests/integration/premium-upsell-surface-smoke.php
+++ b/tests/integration/premium-upsell-surface-smoke.php
@@ -30,13 +30,13 @@ wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_strategy_execute' =>
 wcos_upsell_assert(false !== strpos($boundary, "'wcos_duplicate_execute' => 'duplicate'"), 'Duplicate execute mapping missing.');
 wcos_upsell_assert(false !== strpos($boundary, "'wcos_merge_execute' => 'merge'"), 'Merge execute mapping missing.');
 
-wcos_upsell_assert(false !== strpos($settings, "$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
+wcos_upsell_assert(false !== strpos($settings, "\$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
 wcos_upsell_assert(false !== strpos($settings, 'standalone premium replacement for Order Splitter'), 'Standalone replacement positioning missing.');
 wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Order Splitter'"), 'Order Splitter comparison column missing.');
 wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Advanced Order Actions'"), 'Advanced Order Actions comparison column missing.');
 wcos_upsell_assert(false === strpos($settings, "esc_html__('Locked'"), 'Upgrade matrix must not use Locked.');
 
-wcos_upsell_assert(false !== strpos($script, "include_once $root . 'backend/class-wcos-premium-upsell.php';"), 'Presentation boundary is not loaded.');
+wcos_upsell_assert(false !== strpos($script, "include_once \$root . 'backend/class-wcos-premium-upsell.php';"), 'Presentation boundary is not loaded.');
 wcos_upsell_assert(false !== strpos($script, 'WCOS_Premium_Upsell::bootstrap();'), 'Presentation boundary is not bootstrapped.');
 
 wcos_upsell_assert(false !== strpos($client, 'payload.success !== true'), 'Success-only guard missing.');

--- a/tests/js/premium-upsell-state.js
+++ b/tests/js/premium-upsell-state.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const source = fs.readFileSync(path.join(__dirname, '../../js/post-action-tip.js'), 'utf8');
+const storage = new Map();
+const hooks = {};
+
+const localStorage = {
+    getItem(key) {
+        return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+        storage.set(key, String(value));
+    },
+    removeItem(key) {
+        storage.delete(key);
+    }
+};
+
+function jqueryStub(arg) {
+    if (typeof arg === 'function') {
+        return undefined;
+    }
+
+    return {
+        length: 0,
+        ajaxSuccess() { return this; },
+        first() { return this; },
+        last() { return this; },
+        after() { return this; },
+        before() { return this; },
+        append() { return this; },
+        appendTo() { return this; },
+        on() { return this; },
+        remove() { return this; }
+    };
+}
+
+const context = {
+    window: {
+        localStorage,
+        wcosPremiumUpsellTestHooks: hooks,
+        wcosPremiumUpsell: {
+            productUrl: 'https://yoohw.com/product/woocommerce-advanced-order-actions/',
+            thresholds: { split: 3, duplicate: 2, merge: 2 },
+            executeActions: {},
+            actionTips: {}
+        },
+        fetch() {
+            return Promise.reject(new Error('fetch should not be called by this state test'));
+        }
+    },
+    document: {},
+    jQuery: jqueryStub,
+    URLSearchParams,
+    FormData: typeof FormData === 'undefined' ? function FormData() {} : FormData,
+    isFinite,
+    JSON,
+    Array,
+    String,
+    Object,
+    parseInt,
+    decodeURIComponent,
+    console
+};
+context.window.window = context.window;
+
+vm.createContext(context);
+vm.runInContext(source, context, { filename: 'post-action-tip.js' });
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+assert(typeof hooks.observePayload === 'function', 'observePayload test hook missing');
+assert(typeof hooks.readState === 'function', 'readState test hook missing');
+
+hooks.observePayload('split', { success: true, data: { operation_id: 'split-1' } });
+hooks.observePayload('split', { success: true, data: { operation_id: 'split-2' } });
+
+let state = hooks.readState();
+assert(state.usage.split === 2, 'Split should not qualify before the third unique success');
+assert(!state.pending.split, 'Split promotion must not be pending before threshold');
+
+hooks.observePayload('split', { success: false, data: { operation_id: 'split-failed' } });
+state = hooks.readState();
+assert(state.usage.split === 2, 'Failed Split must not increment usage');
+
+hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
+state = hooks.readState();
+assert(state.usage.split === 3, 'Third unique successful Split must reach threshold');
+assert(state.pending.split === true, 'Third unique successful Split must queue later-page promotion');
+assert(state.shown.split === false, 'Promotion must not be marked shown during the completing operation');
+
+hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
+state = hooks.readState();
+assert(state.usage.split === 3, 'Replay of an operation ID must not increment usage');
+
+hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-1' } });
+state = hooks.readState();
+assert(!state.pending.duplicate, 'Duplicate must not qualify on first success');
+hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-2' } });
+state = hooks.readState();
+assert(state.usage.duplicate === 2 && state.pending.duplicate === true, 'Duplicate must qualify on second unique success');
+
+hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-1' } });
+state = hooks.readState();
+assert(!state.pending.merge, 'Merge must not qualify on first success');
+hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-2' } });
+state = hooks.readState();
+assert(state.usage.merge === 2 && state.pending.merge === true, 'Merge must qualify on second unique success');
+
+assert(hooks.nextPendingAction(state) === 'split', 'Pending action order must be deterministic');
+
+console.log('premium-upsell-state: ok');


### PR DESCRIPTION
## Summary

Implements `WOS-UPSELL-001` (Issue #113) as a contextual upsell tranche for the standalone WooCommerce Advanced Order Actions product.

### P0
- adds a high-intent `Advanced Order Actions ↗` plugin action link;
- repositions General upsell around scaling repeated manual operations;
- replaces redundant Automation/Notifications messaging with capability-focused upgrade cards;
- keeps the historical `section=premium` URL key but labels the tab `Upgrade`;
- rebuilds the comparison around Order Splitter vs standalone Advanced Order Actions and removes `Locked` wording.

### P1
- adds one unobtrusive advanced-routing hint beside the Split launcher, outside mutation modal authority;
- converts the dormant post-action tip primitive into local-only usage-aware promotion:
  - Split after 3 unique successful operations;
  - Duplicate after 2;
  - Merge after 2;
  - replay-deduplicated by bounded local `operation_id` state;
  - only eligible after `success === true`;
  - promotion renders only on a later order-page load and at most once per action.

## Lower-blast-radius implementation adjustment

The hardened `p2-*` mutation clients remain unchanged. The presentation script observes only the exact approved execute action bodies, calls the existing `window.fetch` unchanged, clones successful responses for local bookkeeping, and returns the original response untouched. No request fields, AJAX action names, Review/Confirm/Execute authority, domain logic, feature gates, release metadata, or Premium runtime are changed.

## Independent-review correction

The first exact-head Codex review found that `js/post-action-tip.js` was still excluded by the historical distribution contract. The correction was scope-reviewed on Issue #113 and is intentionally limited to distribution membership/validation:

- removed `js/post-action-tip.js` from `.distignore`;
- removed it from the validator's forbidden paths;
- made `inc/backend/class-wcos-premium-upsell.php`, `css/premium-upsell.css`, and `js/post-action-tip.js` required runtime distribution paths;
- added a negative distribution regression proving the package contract fails if `js/post-action-tip.js` is absent.

No `.github/workflows/**`, version/stable tag, changelog/readme, release publication command, mutation/domain/gate code, or Premium runtime was changed.

## Privacy / promotion constraints

- no remote promotion/config request;
- no telemetry, impression/click reporting, referral ID, or UTM parameters;
- local state contains only bounded usage flags and operation IDs used for replay deduplication;
- only `manage_woocommerce` users receive promotion assets/surfaces;
- no site-wide admin nag;
- no promotion is inserted inside Review/Confirm/Execute modal bodies;
- failed operations do not qualify a promotion.

## Verification

Focused verification before the distribution correction:
- `php -l inc/backend/class-wcos-premium-upsell.php`
- `php -l inc/backend/settings.php`
- `php -l inc/cores/script.php`
- `php -l tests/integration/premium-upsell-surface-smoke.php`
- `node --check js/post-action-tip.js`
- `node tests/js/premium-upsell-state.js`
- `php tests/integration/premium-upsell-surface-smoke.php`

Behavior test proves first-use does not qualify, Split qualifies only on its third unique success, Duplicate/Merge only on their second unique successes, failures do not increment usage, replayed operation IDs are deduplicated, and the qualifying campaign remains pending rather than shown during the completing operation.

The corrected exact-head GitHub CI additionally runs the canonical distributable-tree validation and negative distribution regressions; package safety is green on the corrected head.

## Scope

Changed runtime files remain presentation-only. The only non-presentation correction is the scope-reviewed distribution membership/validation needed to ship those runtime assets. `inc/domain/**`, mutation gateways/services/adapters, hardened `p2-*` clients, feature/strategy gates, version/stable tag, readme/changelog, `.github/workflows/**`, release publication state, and Premium runtime remain unchanged.

Task: #113

No merge or release is authorized by this PR alone.