### PR TITLE
WOS-UPSELL-001 contextual Advanced Order Actions upsell

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -20,5 +20,4 @@
 /inc/mutation-v2
 /js/bulk-return-action.js
 /js/merge-action.js
-/js/post-action-tip.js
 /js/split-table.js

--- a/.github/scripts/validate-distribution-contract.sh
+++ b/.github/scripts/validate-distribution-contract.sh
@@ -102,7 +102,6 @@ for forbidden_path in \
   'inc/backend/order-merge-option.php' \
   'js/bulk-return-action.js' \
   'js/merge-action.js' \
-  'js/post-action-tip.js' \
   'js/split-table.js' \
   'inc/mutation-v2'; do
   if test -e "$distribution_root/$forbidden_path"; then
@@ -113,6 +112,9 @@ done
 for required_path in \
   'wc-order-splitter.php' \
   'readme.txt' \
+  'inc/backend/class-wcos-premium-upsell.php' \
+  'css/premium-upsell.css' \
+  'js/post-action-tip.js' \
   'inc/backend/class-wcos-split-admin-controller.php' \
   'inc/backend/class-wcos-split-confirmation-store.php' \
   'inc/backend/class-wcos-split-request-parser.php' \

--- a/css/premium-upsell.css
+++ b/css/premium-upsell.css
@@ -89,6 +89,17 @@
     white-space: nowrap;
 }
 
+.wcos-split-upgrade-hint-dismiss {
+    margin-left: 10px;
+    color: #646970;
+    white-space: nowrap;
+}
+
+.wcos-split-upgrade-hint-dismiss:hover,
+.wcos-split-upgrade-hint-dismiss:focus {
+    color: var(--wp-admin-theme-color, #2271b1);
+}
+
 .wcos-post-action-tip {
     position: relative;
     margin: 12px 0;

--- a/css/premium-upsell.css
+++ b/css/premium-upsell.css
@@ -1,0 +1,117 @@
+.wcos-settings-card {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin: 16px 0;
+    padding: 16px;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+}
+
+.wcos-settings-card h2 {
+    margin: 0 0 6px;
+    font-size: 15px;
+    line-height: 1.4;
+}
+
+.wcos-settings-card p {
+    margin: 0;
+    max-width: 820px;
+    color: #50575e;
+}
+
+.wcos-feature-list {
+    margin: 10px 0 0;
+    color: #3c434a;
+}
+
+.wcos-feature-list li {
+    margin: 4px 0 0 18px;
+    list-style: disc;
+}
+
+.wcos-card-actions {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.wcos-dismiss-link {
+    color: #646970;
+    text-decoration: none;
+}
+
+.wcos-dismiss-link:hover {
+    color: var(--wp-admin-theme-color, #2271b1);
+}
+
+.wcos-premium-matrix {
+    max-width: 1180px;
+    margin-top: 12px;
+}
+
+.wcos-premium-matrix th:first-child,
+.wcos-premium-matrix td:first-child {
+    width: 24%;
+}
+
+.wcos-premium-matrix th:nth-child(2),
+.wcos-premium-matrix th:nth-child(3),
+.wcos-premium-matrix td:nth-child(2),
+.wcos-premium-matrix td:nth-child(3) {
+    width: 38%;
+    text-align: left;
+    vertical-align: top;
+}
+
+.wcos-upgrade-qualification {
+    max-width: 1180px;
+    margin-top: 10px;
+    color: #646970;
+}
+
+.wcos-split-upgrade-hint {
+    clear: both;
+    margin: 10px 0 0;
+    padding: 8px 10px;
+    border-left: 3px solid #c3c4c7;
+    background: #f6f7f7;
+    color: #50575e;
+    line-height: 1.5;
+}
+
+.wcos-split-upgrade-hint a {
+    white-space: nowrap;
+}
+
+.wcos-post-action-tip {
+    position: relative;
+    margin: 12px 0;
+    padding-right: 38px;
+}
+
+@media (max-width: 782px) {
+    .wcos-settings-card {
+        display: block;
+    }
+
+    .wcos-card-actions {
+        justify-content: flex-start;
+        margin-top: 12px;
+    }
+
+    .wcos-premium-matrix {
+        display: block;
+        overflow-x: auto;
+    }
+
+    .wcos-premium-matrix th,
+    .wcos-premium-matrix td {
+        min-width: 190px;
+    }
+}

--- a/inc/backend/class-wcos-premium-upsell.php
+++ b/inc/backend/class-wcos-premium-upsell.php
@@ -1,0 +1,154 @@
+<?php
+
+defined('ABSPATH') || exit;
+
+/**
+ * Presentation-only discovery for the standalone Advanced Order Actions product.
+ *
+ * This boundary must not own or influence order-mutation authority. It renders
+ * commercial discovery surfaces and supplies browser-local promotion settings.
+ */
+final class WCOS_Premium_Upsell {
+	const PRODUCT_URL = 'https://yoohw.com/product/woocommerce-advanced-order-actions/';
+
+	private static $instance = null;
+
+	public static function bootstrap() {
+		if (!self::$instance instanceof self) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public static function product_url() {
+		return self::PRODUCT_URL;
+	}
+
+	private function __construct() {
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		add_filter('plugin_action_links_' . plugin_basename($plugin_file), array($this, 'add_plugin_action_link'), 20);
+		add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+	}
+
+	public function add_plugin_action_link($links) {
+		if (!current_user_can('manage_woocommerce')) {
+			return $links;
+		}
+
+		$product_link = sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			esc_url(self::product_url()),
+			esc_html__('Advanced Order Actions ↗', 'wc-order-splitter')
+		);
+
+		array_splice($links, min(1, count($links)), 0, array($product_link));
+		return $links;
+	}
+
+	public static function render_settings_card($title, $description, $features = array()) {
+		if (!current_user_can('manage_woocommerce')) {
+			return;
+		}
+		?>
+		<div class="wcos-settings-card wcos-upgrade-card">
+			<div>
+				<h2><?php echo esc_html($title); ?></h2>
+				<p><?php echo esc_html($description); ?></p>
+				<?php if (!empty($features)) : ?>
+					<ul class="wcos-feature-list">
+						<?php foreach ($features as $feature) : ?>
+							<li><?php echo esc_html($feature); ?></li>
+						<?php endforeach; ?>
+					</ul>
+				<?php endif; ?>
+			</div>
+			<div class="wcos-card-actions">
+				<a class="button button-primary" href="<?php echo esc_url(self::product_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Explore Advanced Order Actions', 'wc-order-splitter'); ?></a>
+			</div>
+		</div>
+		<?php
+	}
+
+	public function enqueue_assets() {
+		if (!current_user_can('manage_woocommerce')) {
+			return;
+		}
+
+		$is_settings_screen = $this->is_orders_settings_screen();
+		$is_order_edit_screen = $this->is_order_edit_screen();
+		if (!$is_settings_screen && !$is_order_edit_screen) {
+			return;
+		}
+
+		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
+		wp_enqueue_style(
+			'wcos-premium-upsell',
+			plugins_url('css/premium-upsell.css', $plugin_file),
+			array(),
+			WC_ORDER_SPLITTER_VERSION
+		);
+
+		if (!$is_order_edit_screen) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'wcos-premium-upsell',
+			plugins_url('js/post-action-tip.js', $plugin_file),
+			array('jquery'),
+			WC_ORDER_SPLITTER_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wcos-premium-upsell',
+			'wcosPremiumUpsell',
+			array(
+				'productUrl' => self::product_url(),
+				'ctaLabel' => __('Explore Advanced Order Actions', 'wc-order-splitter'),
+				'dismissLabel' => __('Dismiss', 'wc-order-splitter'),
+				'splitHint' => __('Need more routing options? Advanced Order Actions adds product group, tag, attribute, and conditional vendor or bundle routing.', 'wc-order-splitter'),
+				'splitHintCta' => __('See advanced split methods', 'wc-order-splitter'),
+				'thresholds' => array(
+					'split' => 3,
+					'duplicate' => 2,
+					'merge' => 2,
+				),
+				'executeActions' => array(
+					'wcos_split_execute' => 'split',
+					'wcos_split_strategy_execute' => 'split',
+					'wcos_duplicate_execute' => 'duplicate',
+					'wcos_merge_execute' => 'merge',
+				),
+				'actionTips' => array(
+					'split' => __('Splitting orders repeatedly? Advanced Order Actions can automate split or merge rules, show queued work and failure or skip reasons, and retry eligible failures.', 'wc-order-splitter'),
+					'duplicate' => __('Need more control over duplicates? Advanced Order Actions can choose full or itemless contents, status, payment and customer-note behavior, preview the result, and run recoverable Bulk Duplicate batches.', 'wc-order-splitter'),
+					'merge' => __('Merging orders regularly? Advanced Order Actions adds dry-run Merge previews and automatic same-customer merging within a configured time window.', 'wc-order-splitter'),
+				),
+			)
+		);
+	}
+
+	private function is_orders_settings_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen || 'woocommerce_page_wc-settings' !== $screen->id) {
+			return false;
+		}
+
+		$tab = isset($_GET['tab']) ? sanitize_key(wp_unslash($_GET['tab'])) : '';
+		return 'orders' === $tab;
+	}
+
+	private function is_order_edit_screen() {
+		$screen = function_exists('get_current_screen') ? get_current_screen() : null;
+		if (!$screen) {
+			return false;
+		}
+
+		$hpos_screen = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
+		$hpos_order_id = isset($_GET['id']) ? absint(wp_unslash($_GET['id'])) : 0;
+
+		return 'shop_order' === $screen->id || ($hpos_screen === $screen->id && $hpos_order_id > 0);
+	}
+}

--- a/inc/backend/class-wcos-premium-upsell.php
+++ b/inc/backend/class-wcos-premium-upsell.php
@@ -108,7 +108,7 @@ final class WCOS_Premium_Upsell {
 				'productUrl' => self::product_url(),
 				'ctaLabel' => __('Explore Advanced Order Actions', 'wc-order-splitter'),
 				'dismissLabel' => __('Dismiss', 'wc-order-splitter'),
-				'splitHint' => __('Need more routing options? Advanced Order Actions adds product group, tag, attribute, and conditional vendor or bundle routing.', 'wc-order-splitter'),
+				'splitHint' => __('Need more routing options? Advanced Order Actions adds product group, tag, attribute, and conditional routing. Vendor and bundle routing require compatible marketplace or bundle integrations.', 'wc-order-splitter'),
 				'splitHintCta' => __('See advanced split methods', 'wc-order-splitter'),
 				'thresholds' => array(
 					'split' => 3,

--- a/inc/backend/settings.php
+++ b/inc/backend/settings.php
@@ -70,7 +70,8 @@ class WooCommerce_Order_Splitter_Settings {
 			'automation_splitter' => esc_html__('Automation', 'wc-order-splitter'),
 		);
 
-		$sub_sub_tabs['premium'] = esc_html__('Premium', 'wc-order-splitter');
+		// Keep the historical section key for URL/backward compatibility.
+		$sub_sub_tabs['premium'] = esc_html__('Upgrade', 'wc-order-splitter');
 
 		// Free cancel/return plugin: add a single tab (optional)
 		if ( is_plugin_active('wc-order-cancellation-return/wc-order-cancellation-return.php') ) {
@@ -117,12 +118,12 @@ class WooCommerce_Order_Splitter_Settings {
 		woocommerce_admin_fields($this->get_split_order_settings());
 		woocommerce_admin_fields($this->get_advanced_settings());
 		$this->render_upgrade_card(
-			esc_html__('Need more order controls?', 'wc-order-splitter'),
-			esc_html__('Premium adds status controls after splitting, duplicate/merge restrictions, editable order status expansion, product groups, tags, attributes, bundles, vendors, and automated split rules.', 'wc-order-splitter'),
+			esc_html__('When manual order actions become repetitive', 'wc-order-splitter'),
+			esc_html__('Order Splitter keeps supported operations available on demand. Advanced Order Actions is the standalone path to previews, recoverable Bulk Duplicate, automation, and operational visibility when those tasks need to scale.', 'wc-order-splitter'),
 			array(
-				esc_html__('Set original and split order statuses after splitting.', 'wc-order-splitter'),
-				esc_html__('Control which orders can be duplicated or merged.', 'wc-order-splitter'),
-				esc_html__('Split by product group, tag, attribute, bundle, or vendor.', 'wc-order-splitter'),
+				esc_html__('Preview Split and Merge results before changing orders.', 'wc-order-splitter'),
+				esc_html__('Configure Duplicate contents and behavior, or run recoverable Bulk Duplicate batches.', 'wc-order-splitter'),
+				esc_html__('Inspect Action Logs, queue states, failure or skip reasons, retries, and guarded rollback.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -130,12 +131,12 @@ class WooCommerce_Order_Splitter_Settings {
 	public function output_automation_splitter_settings() {
 		woocommerce_admin_fields($this->get_automation_splitter_settings());
 		$this->render_upgrade_card(
-			esc_html__('Automate repeated split workflows', 'wc-order-splitter'),
-			esc_html__('Premium can schedule split actions after an order is created and apply rules based on quantity, product group, category, stock status, tag, attribute, bundle, or vendor.', 'wc-order-splitter'),
+			esc_html__('Automate repetitive order operations', 'wc-order-splitter'),
+			esc_html__('Advanced Order Actions can use prioritized rules to split, merge, or skip new orders, then track work through an Automation Queue.', 'wc-order-splitter'),
 			array(
-				esc_html__('Run split rules automatically after checkout.', 'wc-order-splitter'),
-				esc_html__('Add a delay timer for order processing workflows.', 'wc-order-splitter'),
-				esc_html__('Use WP-Cron based automation for repeatable operations.', 'wc-order-splitter'),
+				esc_html__('Build rules with priorities and ALL or ANY conditions.', 'wc-order-splitter'),
+				esc_html__('Choose Split, Merge, or Skip actions for matching orders.', 'wc-order-splitter'),
+				esc_html__('See pending, running, completed, failed, and skipped states with reasons and retry controls.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -143,12 +144,12 @@ class WooCommerce_Order_Splitter_Settings {
 	public function output_notifications_settings() {
 		woocommerce_admin_fields($this->get_notifications_settings());
 		$this->render_upgrade_card(
-			esc_html__('Need split-order email controls?', 'wc-order-splitter'),
-			esc_html__('Premium adds customer and administrator email controls so split orders can be communicated without duplicate or confusing order emails.', 'wc-order-splitter'),
+			esc_html__('Control split-order communication before customers see it', 'wc-order-splitter'),
+			esc_html__('Advanced Order Actions adds customer and administrator sending modes, per-method content controls, and live WooCommerce email previews.', 'wc-order-splitter'),
 			array(
-				esc_html__('Choose whether customers receive the original order email, split order emails, or both.', 'wc-order-splitter'),
-				esc_html__('Customize split-order email subject, heading, and message.', 'wc-order-splitter'),
-				esc_html__('Enable email rules per split method.', 'wc-order-splitter'),
+				esc_html__('Choose which original or split orders generate customer email.', 'wc-order-splitter'),
+				esc_html__('Customize subject, heading, and message per split method.', 'wc-order-splitter'),
+				esc_html__('Preview processing, on-hold, and completed customer emails.', 'wc-order-splitter'),
 			)
 		);
 	}
@@ -190,10 +191,19 @@ class WooCommerce_Order_Splitter_Settings {
 	}
 
 	private function get_premium_url() {
+		if (class_exists('WCOS_Premium_Upsell')) {
+			return WCOS_Premium_Upsell::product_url();
+		}
+
 		return 'https://yoohw.com/product/woocommerce-advanced-order-actions/';
 	}
 
 	private function render_upgrade_card($title, $description, $features = array()) {
+		if (class_exists('WCOS_Premium_Upsell')) {
+			WCOS_Premium_Upsell::render_settings_card($title, $description, $features);
+			return;
+		}
+
 		if (!current_user_can('manage_woocommerce')) {
 			return;
 		}
@@ -211,7 +221,7 @@ class WooCommerce_Order_Splitter_Settings {
 				<?php endif; ?>
 			</div>
 			<div class="wcos-card-actions">
-				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Compare Premium', 'wc-order-splitter'); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Explore Advanced Order Actions', 'wc-order-splitter'); ?></a>
 			</div>
 		</div>
 		<?php
@@ -260,46 +270,60 @@ class WooCommerce_Order_Splitter_Settings {
 	}
 
 	public function output_premium_settings() {
+		if (!current_user_can('manage_woocommerce')) {
+			return;
+		}
+
 		$features = array(
 			array(
-				'feature' => esc_html__('Manual split by product and quantity', 'wc-order-splitter'),
-				'free' => esc_html__('Included', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('On-demand order operations', 'wc-order-splitter'),
+				'free' => esc_html__('Split, Duplicate, Merge, Return, and Bulk Return for supported orders.', 'wc-order-splitter'),
+				'premium' => esc_html__('Expanded Split, Duplicate, and Merge controls for repeated operational workflows.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Split by category and stock status', 'wc-order-splitter'),
-				'free' => esc_html__('Included', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Split routing', 'wc-order-splitter'),
+				'free' => esc_html__('Manual quantity, category, and stock status.', 'wc-order-splitter'),
+				'premium' => esc_html__('Product group, tag, attribute, plus conditional vendor and bundle routing.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Split by product group, tag, attribute, bundle, or vendor', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Duplicate workflow', 'wc-order-splitter'),
+				'free' => esc_html__('Single reviewed Duplicate.', 'wc-order-splitter'),
+				'premium' => esc_html__('Full or itemless contents, status, payment and customer-note choices, preview, and recoverable Bulk Duplicate.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Automated split rules after order creation', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Merge workflow', 'wc-order-splitter'),
+				'free' => esc_html__('Single reviewed manual Merge.', 'wc-order-splitter'),
+				'premium' => esc_html__('Dry-run preview and automatic same-customer merge within a configured time window.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Order status controls after split, duplicate, and merge actions', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Automation', 'wc-order-splitter'),
+				'free' => esc_html__('On-demand operations.', 'wc-order-splitter'),
+				'premium' => esc_html__('Rule Builder with priorities, ALL/ANY conditions, Split/Merge/Skip actions, queue visibility, and retry.', 'wc-order-splitter'),
 			),
 			array(
-				'feature' => esc_html__('Customer and admin split-order email controls', 'wc-order-splitter'),
-				'free' => esc_html__('Locked', 'wc-order-splitter'),
-				'premium' => esc_html__('Included', 'wc-order-splitter'),
+				'feature' => esc_html__('Before-action visibility', 'wc-order-splitter'),
+				'free' => esc_html__('Server review and confirmation for hardened workflows.', 'wc-order-splitter'),
+				'premium' => esc_html__('Split and Merge dry-run previews before an operation changes orders.', 'wc-order-splitter'),
+			),
+			array(
+				'feature' => esc_html__('Operational history', 'wc-order-splitter'),
+				'free' => esc_html__('Durable operation safety, replay, and recovery foundations.', 'wc-order-splitter'),
+				'premium' => esc_html__('Action Logs, guarded rollback, Automation Queue state, failure or skip reasons, and retry controls.', 'wc-order-splitter'),
+			),
+			array(
+				'feature' => esc_html__('Split-order notifications', 'wc-order-splitter'),
+				'free' => esc_html__('Standard on-demand workflow behavior.', 'wc-order-splitter'),
+				'premium' => esc_html__('Customer/admin sending modes, per-method content, and live WooCommerce email previews.', 'wc-order-splitter'),
 			),
 		);
 		?>
 		<div class="wcos-settings-card wcos-premium-intro">
 			<div>
-				<h2><?php esc_html_e('Premium options for high-volume order operations', 'wc-order-splitter'); ?></h2>
-				<p><?php esc_html_e('The free plugin keeps manual splitting available. Premium is best for stores that repeatedly split by rules, need automated workflows, or need tighter email/status controls.', 'wc-order-splitter'); ?></p>
+				<h2><?php esc_html_e('Upgrade to WooCommerce Advanced Order Actions', 'wc-order-splitter'); ?></h2>
+				<p><?php esc_html_e('Advanced Order Actions is a standalone premium replacement for Order Splitter. It is designed for stores that have outgrown on-demand manual operations and need automation, bulk duplication, previews, and deeper operational control. When activated, it runs independently and Order Splitter is deactivated.', 'wc-order-splitter'); ?></p>
 			</div>
 			<div class="wcos-card-actions">
-				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Compare Premium', 'wc-order-splitter'); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url($this->get_premium_url()); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Explore Advanced Order Actions', 'wc-order-splitter'); ?></a>
 			</div>
 		</div>
 
@@ -307,8 +331,8 @@ class WooCommerce_Order_Splitter_Settings {
 			<thead>
 				<tr>
 					<th><?php esc_html_e('Workflow', 'wc-order-splitter'); ?></th>
-					<th><?php esc_html_e('Free', 'wc-order-splitter'); ?></th>
-					<th><?php esc_html_e('Premium', 'wc-order-splitter'); ?></th>
+					<th><?php esc_html_e('Order Splitter', 'wc-order-splitter'); ?></th>
+					<th><?php esc_html_e('Advanced Order Actions', 'wc-order-splitter'); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -321,6 +345,7 @@ class WooCommerce_Order_Splitter_Settings {
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+		<p class="description wcos-upgrade-qualification"><?php esc_html_e('Vendor and bundle routing require compatible marketplace or bundle plugins. Inventory readiness, location, and reconciliation capabilities require a compatible Stock Manager integration.', 'wc-order-splitter'); ?></p>
 		<?php
 	}
 
@@ -392,9 +417,9 @@ class WooCommerce_Order_Splitter_Settings {
 	public function get_automation_splitter_settings() {
 		$settings = array(
 			'section_title' => array(
-				'name'     => esc_html__('Automation splitter', 'wc-order-splitter'),
+				'name'     => esc_html__('Automation', 'wc-order-splitter'),
 				'type'     => 'title',
-				'desc'     => esc_html__('Automation is available in Premium for stores that need repeatable split rules after checkout.', 'wc-order-splitter'),
+				'desc'     => esc_html__('Order Splitter keeps supported order operations on demand; no automation rule is configured on this screen.', 'wc-order-splitter'),
 				'id'       => 'automation_splitter_section_title',
 			),
 			'section_end' => array(
@@ -411,7 +436,7 @@ class WooCommerce_Order_Splitter_Settings {
 			'section_title' => array(
 				'name'     => esc_html__('Split order email', 'wc-order-splitter'),
 				'type'     => 'title',
-				'desc'     => esc_html__('Split-order email controls are available in Premium for stores that need customer or administrator notification rules.', 'wc-order-splitter'),
+				'desc'     => esc_html__('Order Splitter keeps its on-demand notification behavior unchanged; this screen has no configurable split-order email rules.', 'wc-order-splitter'),
 				'id'       => 'notifications_order_splitter_section_title'
 			),
 			'section_end' => array(

--- a/inc/cores/script.php
+++ b/inc/cores/script.php
@@ -136,6 +136,8 @@ class WC_Order_Splitter_Script {
 		include_once $root . 'backend/class-wcos-bulk-return-admin-controller.php';
 		WCOS_Bulk_Return_Admin_Controller::bootstrap();
 
+		include_once $root . 'backend/class-wcos-premium-upsell.php';
+		WCOS_Premium_Upsell::bootstrap();
 		include_once $root . 'backend/settings.php';
 		include_once $root . 'backend/orders.php';
 		include_once $root . 'backend/yoohw-woo-settings-tabs-reorder.php';

--- a/js/post-action-tip.js
+++ b/js/post-action-tip.js
@@ -1,20 +1,24 @@
-jQuery(document).ready(function($) {
-    var storageKey = 'wcosPostActionTip';
-    var legacySplitKey = 'wcosPostSplitTip';
-    var dismissedKey = 'wcosPostActionTipDismissedAt';
-    var throttleMs = 7 * 24 * 60 * 60 * 1000;
+(function($) {
+    'use strict';
 
-    function escapeHtml(value) {
-        return String(value === undefined || value === null ? '' : value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
+    var config = window.wcosPremiumUpsell || {};
+    var storageKey = 'wcosPremiumUpsellStateV1';
+    var legacyKeys = [
+        'wcosPostActionTip',
+        'wcosPostSplitTip',
+        'wcosPostActionTipDismissedAt'
+    ];
+    var validActions = ['split', 'duplicate', 'merge'];
+    var seenLimit = 40;
 
-    function escapeHtmlAttr(value) {
-        return escapeHtml(value).replace(/`/g, '&#096;');
+    function emptyState() {
+        return {
+            usage: { split: 0, duplicate: 0, merge: 0 },
+            seenOperations: [],
+            pending: {},
+            shown: {},
+            dismissed: {}
+        };
     }
 
     function getStoredItem(key) {
@@ -37,92 +41,277 @@ jQuery(document).ready(function($) {
         } catch (error) {}
     }
 
-    function recentlyDismissed() {
-        var dismissedAt = parseInt(getStoredItem(dismissedKey), 10);
-
-        return dismissedAt && Date.now() - dismissedAt < throttleMs;
+    function isValidAction(action) {
+        return validActions.indexOf(action) !== -1;
     }
 
-    function getTipFromStorage() {
-        var storedTip = getStoredItem(storageKey);
-        var legacyTip = getStoredItem(legacySplitKey);
+    function normalizeCount(value) {
+        var count = parseInt(value, 10);
+        return isFinite(count) && count > 0 ? Math.min(count, seenLimit) : 0;
+    }
 
-        removeStoredItem(storageKey);
-        removeStoredItem(legacySplitKey);
+    function normalizeState(rawState) {
+        var normalized = emptyState();
+        var state = rawState && typeof rawState === 'object' ? rawState : {};
+        var i;
 
-        if (storedTip) {
+        for (i = 0; i < validActions.length; i++) {
+            var action = validActions[i];
+            normalized.usage[action] = normalizeCount(state.usage && state.usage[action]);
+            normalized.pending[action] = !!(state.pending && state.pending[action]);
+            normalized.shown[action] = !!(state.shown && state.shown[action]);
+            normalized.dismissed[action] = !!(state.dismissed && state.dismissed[action]);
+        }
+
+        if (Array.isArray(state.seenOperations)) {
+            normalized.seenOperations = state.seenOperations
+                .filter(function(operation) {
+                    return typeof operation === 'string' && operation.length > 0 && operation.length <= 120;
+                })
+                .slice(-seenLimit);
+        }
+
+        return normalized;
+    }
+
+    function readState() {
+        var stored = getStoredItem(storageKey);
+        if (!stored) {
+            return emptyState();
+        }
+
+        try {
+            return normalizeState(JSON.parse(stored));
+        } catch (error) {
+            return emptyState();
+        }
+    }
+
+    function saveState(state) {
+        setStoredItem(storageKey, JSON.stringify(normalizeState(state)));
+    }
+
+    function cleanupLegacyState() {
+        legacyKeys.forEach(function(key) {
+            removeStoredItem(key);
+        });
+    }
+
+    function actionFromBody(body) {
+        if (!body) {
+            return '';
+        }
+
+        if (typeof body === 'string') {
             try {
-                return JSON.parse(storedTip);
+                return new URLSearchParams(body).get('action') || '';
             } catch (error) {
-                return {
-                    action: 'custom',
-                    message: storedTip
-                };
+                var match = body.match(/(?:^|&)action=([^&]+)/);
+                return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : '';
             }
         }
 
-        if (legacyTip) {
-            return {
-                action: 'split',
-                message: legacyTip
-            };
+        if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+            return body.get('action') || '';
         }
 
-        return null;
+        if (typeof FormData !== 'undefined' && body instanceof FormData) {
+            return body.get('action') || '';
+        }
+
+        return '';
     }
 
-    function getTipFromUrl() {
-        var params = new URLSearchParams(window.location.search);
-        var action = params.get('wcos_action_tip');
-
-        if (!action || !window.wcosPostActionTip || !window.wcosPostActionTip.actionTips || !window.wcosPostActionTip.actionTips[action]) {
-            return null;
-        }
-
-        params.delete('wcos_action_tip');
-
-        var newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '') + window.location.hash;
-        window.history.replaceState({}, document.title, newUrl);
-
-        return {
-            action: action,
-            message: window.wcosPostActionTip.actionTips[action]
-        };
+    function thresholdFor(action) {
+        var thresholds = config.thresholds || {};
+        var threshold = parseInt(thresholds[action], 10);
+        return isFinite(threshold) && threshold > 0 ? threshold : 0;
     }
 
-    function getInsertionPoint() {
-        var $orderData = $('#woocommerce-order-data');
-        var $wpbody = $('#wpbody-content .wrap').first();
-
-        if ($orderData.length) {
-            return $orderData;
-        }
-
-        if ($wpbody.length) {
-            return $wpbody;
-        }
-
-        return $('#wpbody-content').first();
-    }
-
-    function renderTip(tip) {
-        if (!tip || !tip.message || $('.wcos-post-action-tip').length || recentlyDismissed()) {
+    function recordSuccessfulOperation(action, operationId) {
+        if (!isValidAction(action) || typeof operationId !== 'string' || !operationId || operationId.length > 100) {
             return;
         }
 
-        var html = '<div class="notice notice-success is-dismissible wcos-post-action-tip">' +
-            '<p>' +
-            escapeHtml(tip.message) + ' ' +
-            '<a href="' + escapeHtmlAttr(window.wcosPostActionTip.premiumUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(window.wcosPostActionTip.comparePremium) + '</a>' +
-            '</p>' +
-            '</div>';
+        var state = readState();
+        var operationKey = action + ':' + operationId;
+        if (state.seenOperations.indexOf(operationKey) !== -1) {
+            return;
+        }
 
-        getInsertionPoint().before(html);
+        state.seenOperations.push(operationKey);
+        state.seenOperations = state.seenOperations.slice(-seenLimit);
+        state.usage[action] = Math.min(normalizeCount(state.usage[action]) + 1, seenLimit);
+
+        var threshold = thresholdFor(action);
+        if (threshold > 0 && state.usage[action] >= threshold && !state.shown[action] && !state.dismissed[action]) {
+            state.pending[action] = true;
+        }
+
+        saveState(state);
     }
 
-    $(document).on('click', '.wcos-post-action-tip .notice-dismiss', function() {
-        setStoredItem(dismissedKey, String(Date.now()));
+    function nextPendingAction(state) {
+        var i;
+        for (i = 0; i < validActions.length; i++) {
+            var action = validActions[i];
+            if (state.pending[action] && !state.shown[action] && !state.dismissed[action]) {
+                return action;
+            }
+        }
+        return '';
+    }
+
+    function markCampaignShown(state, action) {
+        if (!isValidAction(action)) {
+            return state;
+        }
+
+        state.pending[action] = false;
+        state.shown[action] = true;
+        return state;
+    }
+
+    function dismissCampaign(action) {
+        if (!isValidAction(action)) {
+            return;
+        }
+
+        var state = readState();
+        state.dismissed[action] = true;
+        saveState(markCampaignShown(state, action));
+    }
+
+    function renderPendingTip() {
+        if (!config.productUrl || !config.actionTips || $('.wcos-post-action-tip').length) {
+            return;
+        }
+
+        var state = readState();
+        var action = nextPendingAction(state);
+        if (!action || !config.actionTips[action]) {
+            return;
+        }
+
+        var $insertionPoint = $('#woocommerce-order-data').first();
+        if (!$insertionPoint.length) {
+            return;
+        }
+
+        var $notice = $('<div>', {
+            'class': 'notice notice-info wcos-post-action-tip',
+            'data-wcos-upsell-action': action
+        });
+        var $paragraph = $('<p>');
+        $paragraph.append(document.createTextNode(config.actionTips[action] + ' '));
+        $('<a>', {
+            href: config.productUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            text: config.ctaLabel || 'Explore Advanced Order Actions'
+        }).appendTo($paragraph);
+        $notice.append($paragraph);
+
+        $('<button>', {
+            type: 'button',
+            'class': 'notice-dismiss',
+            'aria-label': config.dismissLabel || 'Dismiss'
+        }).append($('<span>', {
+            'class': 'screen-reader-text',
+            text: config.dismissLabel || 'Dismiss'
+        })).appendTo($notice);
+
+        $notice.on('click', '.notice-dismiss', function() {
+            dismissCampaign(action);
+            $notice.remove();
+        });
+
+        $insertionPoint.before($notice);
+        saveState(markCampaignShown(state, action));
+    }
+
+    function renderSplitHint() {
+        if (!config.productUrl || !config.splitHint || $('.wcos-split-upgrade-hint').length) {
+            return;
+        }
+
+        var $launcherArea = $('.wcos-split-launcher-description, .wcos-strategy-launcher-description').last();
+        if (!$launcherArea.length) {
+            $launcherArea = $('.wcos-split-launcher, .wcos-strategy-launcher').last();
+        }
+        if (!$launcherArea.length) {
+            return;
+        }
+
+        var $hint = $('<p>', { 'class': 'description wcos-split-upgrade-hint' });
+        $hint.append(document.createTextNode(config.splitHint + ' '));
+        $('<a>', {
+            href: config.productUrl,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            text: config.splitHintCta || 'See advanced split methods'
+        }).appendTo($hint);
+
+        $launcherArea.after($hint);
+    }
+
+    function observePayload(action, payload) {
+        if (!isValidAction(action) || !payload || payload.success !== true || !payload.data || typeof payload.data.operation_id !== 'string') {
+            return;
+        }
+
+        recordSuccessfulOperation(action, payload.data.operation_id);
+    }
+
+    function installFetchObserver() {
+        if (typeof window.fetch !== 'function' || window.fetch.__wcosPremiumUpsellObserved) {
+            return;
+        }
+
+        var originalFetch = window.fetch;
+        var observedFetch = function(input, init) {
+            var actionMap = config.executeActions || {};
+            var actionName = actionFromBody(init && init.body);
+            var action = actionMap[actionName];
+            var requestPromise = originalFetch.apply(this, arguments);
+
+            if (!isValidAction(action)) {
+                return requestPromise;
+            }
+
+            return requestPromise.then(function(response) {
+                if (response && typeof response.clone === 'function') {
+                    try {
+                        response.clone().json().then(function(payload) {
+                            observePayload(action, payload);
+                        }).catch(function() {});
+                    } catch (error) {}
+                }
+                return response;
+            });
+        };
+
+        observedFetch.__wcosPremiumUpsellObserved = true;
+        observedFetch.__wcosPremiumUpsellOriginal = originalFetch;
+        window.fetch = observedFetch;
+    }
+
+    cleanupLegacyState();
+
+    $(function() {
+        // Only state from an earlier page lifecycle can render here.
+        renderPendingTip();
+        renderSplitHint();
     });
 
-    renderTip(getTipFromUrl() || getTipFromStorage());
-});
+    if (window.wcosPremiumUpsellTestHooks && typeof window.wcosPremiumUpsellTestHooks === 'object') {
+        window.wcosPremiumUpsellTestHooks.readState = readState;
+        window.wcosPremiumUpsellTestHooks.recordSuccessfulOperation = recordSuccessfulOperation;
+        window.wcosPremiumUpsellTestHooks.nextPendingAction = nextPendingAction;
+        window.wcosPremiumUpsellTestHooks.markCampaignShown = markCampaignShown;
+        window.wcosPremiumUpsellTestHooks.dismissCampaign = dismissCampaign;
+        window.wcosPremiumUpsellTestHooks.observePayload = observePayload;
+    }
+
+    installFetchObserver();
+})(jQuery);

--- a/js/post-action-tip.js
+++ b/js/post-action-tip.js
@@ -17,7 +17,8 @@
             seenOperations: [],
             pending: {},
             shown: {},
-            dismissed: {}
+            dismissed: {},
+            hints: { splitRoutingDismissed: false }
         };
     }
 
@@ -70,6 +71,8 @@
                 })
                 .slice(-seenLimit);
         }
+
+        normalized.hints.splitRoutingDismissed = !!(state.hints && state.hints.splitRoutingDismissed);
 
         return normalized;
     }
@@ -182,6 +185,12 @@
         saveState(markCampaignShown(state, action));
     }
 
+    function dismissSplitHint() {
+        var state = readState();
+        state.hints.splitRoutingDismissed = true;
+        saveState(state);
+    }
+
     function renderPendingTip() {
         if (!config.productUrl || !config.actionTips || $('.wcos-post-action-tip').length) {
             return;
@@ -235,6 +244,10 @@
             return;
         }
 
+        if (readState().hints.splitRoutingDismissed) {
+            return;
+        }
+
         var $launcherArea = $('.wcos-split-launcher-description, .wcos-strategy-launcher-description').last();
         if (!$launcherArea.length) {
             $launcherArea = $('.wcos-split-launcher, .wcos-strategy-launcher').last();
@@ -250,6 +263,15 @@
             target: '_blank',
             rel: 'noopener noreferrer',
             text: config.splitHintCta || 'See advanced split methods'
+        }).appendTo($hint);
+
+        $('<button>', {
+            type: 'button',
+            'class': 'button-link wcos-split-upgrade-hint-dismiss',
+            text: config.dismissLabel || 'Dismiss'
+        }).on('click', function() {
+            dismissSplitHint();
+            $hint.remove();
         }).appendTo($hint);
 
         $launcherArea.after($hint);
@@ -310,6 +332,7 @@
         window.wcosPremiumUpsellTestHooks.nextPendingAction = nextPendingAction;
         window.wcosPremiumUpsellTestHooks.markCampaignShown = markCampaignShown;
         window.wcosPremiumUpsellTestHooks.dismissCampaign = dismissCampaign;
+        window.wcosPremiumUpsellTestHooks.dismissSplitHint = dismissSplitHint;
         window.wcosPremiumUpsellTestHooks.observePayload = observePayload;
     }
 

--- a/tests/ci/distribution-contract.sh
+++ b/tests/ci/distribution-contract.sh
@@ -46,6 +46,12 @@ expect_failure 'required hardened runtime path is missing: inc/domain/class-wcos
   "$missing_source/.github/scripts/validate-distribution-contract.sh" \
   "$missing_source" "$fixture_root/missing-required/distribution/wc-order-splitter"
 
+missing_upsell_source=$(make_source_fixture missing-upsell-runtime)
+rm "$missing_upsell_source/js/post-action-tip.js"
+expect_failure 'required hardened runtime path is missing: js/post-action-tip.js' \
+  "$missing_upsell_source/.github/scripts/validate-distribution-contract.sh" \
+  "$missing_upsell_source" "$fixture_root/missing-upsell-runtime/distribution/wc-order-splitter"
+
 symlink_source=$(make_source_fixture symlink)
 ln -s readme.txt "$symlink_source/unsafe-link"
 expect_failure 'symbolic links entered the distribution tree' \

--- a/tests/integration/premium-upsell-surface-smoke.php
+++ b/tests/integration/premium-upsell-surface-smoke.php
@@ -50,6 +50,7 @@ wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_execute' => 'split'"
 wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_strategy_execute' => 'split'"), 'Strategy Split execute mapping missing.');
 wcos_upsell_assert(false !== strpos($boundary, "'wcos_duplicate_execute' => 'duplicate'"), 'Duplicate execute mapping missing.');
 wcos_upsell_assert(false !== strpos($boundary, "'wcos_merge_execute' => 'merge'"), 'Merge execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, 'Vendor and bundle routing require compatible marketplace or bundle integrations.'), 'Contextual vendor and bundle claim must state its integration dependency.');
 
 wcos_upsell_assert(false !== strpos($settings, "\$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
 wcos_upsell_assert(false !== strpos($settings, 'standalone premium replacement for Order Splitter'), 'Standalone replacement positioning missing.');
@@ -64,6 +65,9 @@ wcos_upsell_assert(false !== strpos($bootstrap, 'WCOS_Premium_Upsell::bootstrap(
 wcos_upsell_assert(false !== strpos($client, 'payload.success !== true'), 'Success-only guard missing.');
 wcos_upsell_assert(false !== strpos($client, 'seenOperations'), 'Operation replay deduplication state missing.');
 wcos_upsell_assert(false !== strpos($client, 'renderPendingTip();'), 'Later-page pending promotion render missing.');
+wcos_upsell_assert(false !== strpos($client, 'hints: { splitRoutingDismissed: false }'), 'Split hint must have distinct browser-local dismissal state.');
+wcos_upsell_assert(false !== strpos($client, "'class': 'button-link wcos-split-upgrade-hint-dismiss'"), 'Split hint dismiss control missing.');
+wcos_upsell_assert(false !== strpos($client, 'dismissSplitHint();'), 'Split hint dismiss control must persist dismissal.');
 wcos_upsell_assert(false !== strpos($client, 'response.clone().json()'), 'Fetch observation must clone rather than consume the mutation response.');
 wcos_upsell_assert(false === strpos($client, 'navigator.sendBeacon'), 'Telemetry via sendBeacon is forbidden.');
 wcos_upsell_assert(false === strpos($client, 'XMLHttpRequest'), 'Upsell client must not create XHR telemetry.');

--- a/tests/integration/premium-upsell-surface-smoke.php
+++ b/tests/integration/premium-upsell-surface-smoke.php
@@ -1,0 +1,84 @@
+<?php
+
+$root = dirname(__DIR__, 2);
+
+function wcos_upsell_assert($condition, $message) {
+	if (!$condition) {
+		fwrite(STDERR, "premium-upsell-surface-smoke: FAIL: {$message}\n");
+		exit(1);
+	}
+}
+
+function wcos_upsell_read($path) {
+	$content = file_get_contents($path);
+	wcos_upsell_assert(false !== $content, 'Unable to read ' . $path);
+	return $content;
+}
+
+if (!defined('ABSPATH')) {
+	define('ABSPATH', $root . '/');
+}
+
+$wcos_upsell_can_manage = true;
+function current_user_can($capability) {
+	global $wcos_upsell_can_manage;
+	return 'manage_woocommerce' === $capability && $wcos_upsell_can_manage;
+}
+function plugin_basename($path) {
+	return basename($path);
+}
+function add_filter() {}
+function add_action() {}
+function esc_url($url) {
+	return $url;
+}
+function esc_html__($text) {
+	return $text;
+}
+
+$settings = wcos_upsell_read($root . '/inc/backend/settings.php');
+$boundary = wcos_upsell_read($root . '/inc/backend/class-wcos-premium-upsell.php');
+$bootstrap = wcos_upsell_read($root . '/inc/cores/script.php');
+$client = wcos_upsell_read($root . '/js/post-action-tip.js');
+
+wcos_upsell_assert(false !== strpos($boundary, "const PRODUCT_URL = 'https://yoohw.com/product/woocommerce-advanced-order-actions/';"), 'Canonical product URL missing.');
+wcos_upsell_assert(false !== strpos($boundary, "current_user_can('manage_woocommerce')"), 'Promotion capability gate missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'split' => 3"), 'Split threshold must be 3.');
+wcos_upsell_assert(false !== strpos($boundary, "'duplicate' => 2"), 'Duplicate threshold must be 2.');
+wcos_upsell_assert(false !== strpos($boundary, "'merge' => 2"), 'Merge threshold must be 2.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_execute' => 'split'"), 'Manual Split execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_strategy_execute' => 'split'"), 'Strategy Split execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_duplicate_execute' => 'duplicate'"), 'Duplicate execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'wcos_merge_execute' => 'merge'"), 'Merge execute mapping missing.');
+
+wcos_upsell_assert(false !== strpos($settings, "\$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
+wcos_upsell_assert(false !== strpos($settings, 'standalone premium replacement for Order Splitter'), 'Standalone replacement positioning missing.');
+wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Order Splitter'"), 'Order Splitter comparison column missing.');
+wcos_upsell_assert(false !== strpos($settings, "esc_html_e('Advanced Order Actions'"), 'Advanced Order Actions comparison column missing.');
+wcos_upsell_assert(false === strpos($settings, "esc_html__('Locked'"), 'Upgrade matrix must not use Locked.');
+wcos_upsell_assert(false !== strpos($settings, 'require a compatible Stock Manager integration'), 'Integration-dependent capability qualification missing.');
+
+wcos_upsell_assert(false !== strpos($bootstrap, "include_once \$root . 'backend/class-wcos-premium-upsell.php';"), 'Presentation boundary is not loaded.');
+wcos_upsell_assert(false !== strpos($bootstrap, 'WCOS_Premium_Upsell::bootstrap();'), 'Presentation boundary is not bootstrapped.');
+
+wcos_upsell_assert(false !== strpos($client, 'payload.success !== true'), 'Success-only guard missing.');
+wcos_upsell_assert(false !== strpos($client, 'seenOperations'), 'Operation replay deduplication state missing.');
+wcos_upsell_assert(false !== strpos($client, 'renderPendingTip();'), 'Later-page pending promotion render missing.');
+wcos_upsell_assert(false !== strpos($client, 'response.clone().json()'), 'Fetch observation must clone rather than consume the mutation response.');
+wcos_upsell_assert(false === strpos($client, 'navigator.sendBeacon'), 'Telemetry via sendBeacon is forbidden.');
+wcos_upsell_assert(false === strpos($client, 'XMLHttpRequest'), 'Upsell client must not create XHR telemetry.');
+wcos_upsell_assert(false === strpos($client, 'utm_'), 'Tracking parameters are forbidden.');
+wcos_upsell_assert(false === strpos($client, 'ref='), 'Referral parameters are forbidden.');
+
+require_once $root . '/inc/backend/class-wcos-premium-upsell.php';
+$upsell = WCOS_Premium_Upsell::bootstrap();
+$links = $upsell->add_plugin_action_link(array('<a href="settings">Settings</a>'));
+wcos_upsell_assert(2 === count($links), 'Plugin action link was not inserted.');
+wcos_upsell_assert(false !== strpos($links[1], WCOS_Premium_Upsell::product_url()), 'Plugin action link does not use the canonical product URL.');
+wcos_upsell_assert(false === strpos($links[1], '?'), 'Plugin action link must not include query or tracking parameters.');
+
+$wcos_upsell_can_manage = false;
+$links_without_capability = $upsell->add_plugin_action_link(array('Settings'));
+wcos_upsell_assert(array('Settings') === $links_without_capability, 'Plugin action link must be hidden without manage_woocommerce.');
+
+echo "premium-upsell-surface-smoke: ok\n";

--- a/tests/js/premium-upsell-state.js
+++ b/tests/js/premium-upsell-state.js
@@ -92,6 +92,11 @@ function assert(condition, message) {
 async function run() {
     assert(typeof hooks.observePayload === 'function', 'observePayload test hook missing');
     assert(typeof hooks.readState === 'function', 'readState test hook missing');
+    assert(typeof hooks.dismissSplitHint === 'function', 'dismissSplitHint test hook missing');
+
+    assert(hooks.readState().hints.splitRoutingDismissed === false, 'Split hint must be visible until it is dismissed');
+    hooks.dismissSplitHint();
+    assert(hooks.readState().hints.splitRoutingDismissed === true, 'Split hint dismissal must persist in local state');
 
     hooks.observePayload('split', { success: true, data: { operation_id: 'split-1' } });
     hooks.observePayload('split', { success: true, data: { operation_id: 'split-2' } });

--- a/tests/js/premium-upsell-state.js
+++ b/tests/js/premium-upsell-state.js
@@ -1,0 +1,168 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+const source = fs.readFileSync(path.join(__dirname, '../../js/post-action-tip.js'), 'utf8');
+const storage = new Map();
+const hooks = {};
+let fetchCalls = 0;
+let fetchResponse;
+
+const localStorage = {
+    getItem(key) {
+        return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+        storage.set(key, String(value));
+    },
+    removeItem(key) {
+        storage.delete(key);
+    }
+};
+
+function jqueryStub(arg) {
+    if (typeof arg === 'function') {
+        return undefined;
+    }
+
+    return {
+        length: 0,
+        first() { return this; },
+        last() { return this; },
+        after() { return this; },
+        before() { return this; },
+        append() { return this; },
+        appendTo() { return this; },
+        on() { return this; },
+        remove() { return this; }
+    };
+}
+
+const response = {
+    clone() {
+        return {
+            json() {
+                return Promise.resolve({ success: true, data: { operation_id: 'fetch-split-1' } });
+            }
+        };
+    }
+};
+fetchResponse = response;
+
+const context = {
+    window: {
+        localStorage,
+        wcosPremiumUpsellTestHooks: hooks,
+        wcosPremiumUpsell: {
+            productUrl: 'https://yoohw.com/product/woocommerce-advanced-order-actions/',
+            thresholds: { split: 3, duplicate: 2, merge: 2 },
+            executeActions: { wcos_split_execute: 'split' },
+            actionTips: {}
+        },
+        fetch() {
+            fetchCalls += 1;
+            return Promise.resolve(fetchResponse);
+        }
+    },
+    document: {},
+    jQuery: jqueryStub,
+    URLSearchParams,
+    FormData: typeof FormData === 'undefined' ? function FormData() {} : FormData,
+    isFinite,
+    Math,
+    JSON,
+    Array,
+    String,
+    Object,
+    parseInt,
+    decodeURIComponent,
+    console
+};
+context.window.window = context.window;
+
+vm.createContext(context);
+vm.runInContext(source, context, { filename: 'post-action-tip.js' });
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+async function run() {
+    assert(typeof hooks.observePayload === 'function', 'observePayload test hook missing');
+    assert(typeof hooks.readState === 'function', 'readState test hook missing');
+
+    hooks.observePayload('split', { success: true, data: { operation_id: 'split-1' } });
+    hooks.observePayload('split', { success: true, data: { operation_id: 'split-2' } });
+
+    let state = hooks.readState();
+    assert(state.usage.split === 2, 'Split should not qualify before the third unique success');
+    assert(!state.pending.split, 'Split promotion must not be pending before threshold');
+
+    hooks.observePayload('split', { success: false, data: { operation_id: 'split-failed' } });
+    state = hooks.readState();
+    assert(state.usage.split === 2, 'Failed Split must not increment usage');
+
+    hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
+    state = hooks.readState();
+    assert(state.usage.split === 3, 'Third unique successful Split must reach threshold');
+    assert(state.pending.split === true, 'Third unique successful Split must queue later-page promotion');
+    assert(state.shown.split === false, 'Promotion must not be marked shown during the completing operation');
+
+    hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
+    state = hooks.readState();
+    assert(state.usage.split === 3, 'Replay of an operation ID must not increment usage');
+
+    hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-1' } });
+    assert(!hooks.readState().pending.duplicate, 'Duplicate must not qualify on first success');
+    hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-2' } });
+    state = hooks.readState();
+    assert(state.usage.duplicate === 2 && state.pending.duplicate === true, 'Duplicate must qualify on second unique success');
+
+    hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-1' } });
+    assert(!hooks.readState().pending.merge, 'Merge must not qualify on first success');
+    hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-2' } });
+    state = hooks.readState();
+    assert(state.usage.merge === 2 && state.pending.merge === true, 'Merge must qualify on second unique success');
+    assert(hooks.nextPendingAction(state) === 'split', 'Pending action order must be deterministic');
+
+    hooks.markCampaignShown(state, 'split');
+    assert(state.shown.split === true && state.pending.split === false, 'Rendering must consume the pending Split campaign exactly once');
+    assert(hooks.nextPendingAction(state) === 'duplicate', 'A shown campaign must not become eligible again');
+
+    hooks.dismissCampaign('merge');
+    state = hooks.readState();
+    assert(state.dismissed.merge === true && state.pending.merge === false, 'Dismissal must persist in local campaign state');
+
+    const originalResponse = await context.window.fetch('/admin-ajax.php', {
+        method: 'POST',
+        body: new URLSearchParams({ action: 'wcos_split_execute' })
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert(fetchCalls === 1, 'Fetch observer must issue exactly the original request once');
+    assert(originalResponse === response, 'Fetch observer must return the original response');
+    assert(hooks.readState().usage.split === 4, 'Successful observed fetch must record one unique operation');
+
+    const cloneFailureResponse = {
+        clone() {
+            throw new Error('clone unavailable');
+        }
+    };
+    fetchResponse = cloneFailureResponse;
+    const cloneFailureResult = await context.window.fetch('/admin-ajax.php', {
+        method: 'POST',
+        body: new URLSearchParams({ action: 'wcos_split_execute' })
+    });
+    assert(cloneFailureResult === cloneFailureResponse, 'Clone failures must not reject or replace the mutation response');
+    assert(fetchCalls === 2, 'Clone failure path must still issue exactly one original request');
+
+    console.log('premium-upsell-state: ok');
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements `WOS-UPSELL-001` from canonical Issue #113 on a fresh Codex Executor branch created from exact accepted main `fbab16eb999d92348fbc48017c8bb014ffc9e0e0`.

This PR is the new canonical implementation produced after the Issue #113 `GOVERNANCE_AUTHORITY_RESET`. Superseded PR #114 was used only as non-authoritative discovery evidence and was not reopened, merged, or cherry-picked.

### Product surfaces

- adds one plugin-list `Advanced Order Actions ↗` action link using the canonical product URL with no query/tracking parameters;
- renames the visible historical `premium` section to `Upgrade` without changing its section key;
- repositions General around scaling repeated on-demand work;
- gives Automation one Rule Builder/queue/failure-reason/retry preview;
- gives Notifications one sending-mode/per-method/live-preview surface;
- rebuilds the comparison as `Order Splitter` vs standalone `Advanced Order Actions`, without `Locked` fake controls;
- qualifies vendor, bundle, Stock Manager, location, and reconciliation capabilities as integration-dependent;
- adds an unobtrusive, browser-locally dismissible advanced-routing hint beside Split launchers, outside every mutation modal, with vendor/bundle integration requirements qualified on that surface.

### Local-only usage-aware discovery

The presentation-only `js/post-action-tip.js` observes only the exact approved execute action bodies while leaving the original `window.fetch` request and response unchanged:

- Split qualifies after 3 unique successful operations;
- Duplicate qualifies after 2;
- Merge qualifies after 2;
- only `success === true` with a server `operation_id` counts;
- operation IDs are browser-local, bounded, and replay-deduplicated;
- qualifying campaigns remain pending until a later page load;
- each action campaign renders at most once and has local-only dismissal;
- failed operations never qualify;
- no telemetry, remote config/promotion call, beacon, impression/click report, UTM, or referral identifier exists.

### Scope and authority

Changed runtime code is presentation-only. The authenticated Issue #113 scope-review correction is applied only to distribution membership/validation so all three authoritative runtime assets ship:

- `inc/backend/class-wcos-premium-upsell.php`
- `css/premium-upsell.css`
- `js/post-action-tip.js`

Unchanged:

- all `inc/domain/**` mutation semantics;
- mutation gateway/service/adapter/recovery/journal/lease/stock/tax code;
- hardened `p2-*` Split/Duplicate/Merge clients and request envelopes;
- feature and strategy gates;
- Return/Bulk Return behavior;
- AJAX action names and authority fields;
- version/stable tag/readme/changelog;
- `.github/workflows/**`;
- release/package publication commands and Premium runtime.

### Local verification

- full PHP syntax sweep passed;
- `php tests/unit/run.php` passed;
- `php tests/integration/p2-admin-client-state-smoke.php` passed;
- `php tests/integration/premium-upsell-surface-smoke.php` passed;
- syntax checks for the upsell client and unchanged hardened Split/strategy/Duplicate/Merge clients passed;
- `node tests/js/premium-upsell-state.js` passed, including success-only thresholds, replay deduplication, later-page pending state, one-time/dismiss behavior, original-fetch single-call/response identity, and clone-failure isolation;
- `tests/ci/distribution-contract.sh` passed;
- Local browser smoke passed for Upgrade, General, Automation, Notifications, plugin-list action link, and order-edit contextual hint; no promotion surface was present inside mutation modal containers.

Exact head: `bd347eef4c9f7cecb258728bddcee114b96130a4`
Exact tree: `aaf21a3183f640c5bc16a00d83bab668a10212a4`
Task: #113

No merge, version bump, release ZIP, tag, WordPress.org publication, or deployment is authorized by this PR.