### PR TITLE
WOS-COMPAT-001 — 1.5.x Compatibility Contract, Settings & Access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,9 @@ jobs:
       - name: Verify governance, authorization, and metadata policy
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/governance-smoke.php
 
+      - name: Verify 1.4.11 compatibility settings and access matrix
+        run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/compat-settings-access-smoke.php
+
       - name: Verify enabled Return domain and hardened Split lineage authority
         run: npx wp-env run cli wp eval-file wp-content/plugins/wc-order-splitter/tests/integration/return-domain-lineage-smoke.php
 

--- a/docs/1.4.11-to-1.5.x-functional-compatibility.md
+++ b/docs/1.4.11-to-1.5.x-functional-compatibility.md
@@ -1,0 +1,61 @@
+# 1.4.11 to 1.5.x functional compatibility
+
+## Authority and scope
+
+This document is the repository-owned functional compatibility contract for an in-place upgrade from the public Free `1.4.11` baseline to the 1.5.x hardened architecture.
+
+The reproducible repository baseline is commit `e1d8aeb` (`wc-order-splitter.php` declares `Version: 1.4.11`). The 1.5.x comparison source for `WOS-COMPAT-001` is commit `9ac096c7ce3a216f9dad91d9a0bec160261f13ee`, tree `aaf21a3183f640c5bc16a00d83bab668a10212a4`. The canonical task and product decisions are in GitHub Issue #116.
+
+Compatibility means preserving supported user outcomes through the current architecture. It does not authorize loading or restoring legacy mutation handlers.
+
+## Classification vocabulary
+
+- `PRESERVE_FUNCTIONAL_OUTCOME`: preserve the supported user-visible result through hardened 1.5.x code.
+- `INTENTIONAL_1_5_X_CHANGE`: retain a reviewed 1.5.x behavior that deliberately differs from 1.4.11.
+- `DEFERRED_COMPATIBILITY_WORK`: the mismatch is binding, but its runtime correction belongs to the named downstream task.
+- `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE`: do not restore the old mechanism even when a supported outcome must be preserved.
+
+## Binding compatibility matrix
+
+| Area | Classification | 1.5.x contract | Owner |
+| --- | --- | --- | --- |
+| Split child status | `DEFERRED_COMPATIBILITY_WORK` | Freeze the source order status accepted for the Split operation and apply it to each Split child. Split and Duplicate must not share one default-status policy. | `WOS-COMPAT-002` |
+| Duplicate target status | `INTENTIONAL_1_5_X_CHANGE` | Keep `pending` (Pending payment). Do not restore `checkout-draft` and do not inherit source status. | Current 1.5.x |
+| Review / Confirm / Execute | `INTENTIONAL_1_5_X_CHANGE` | Keep server-owned authority, confirmation binding, leases, journals, replay, recovery and compensation. | Current 1.5.x |
+| Category / Stock-status Split | `INTENTIONAL_1_5_X_CHANGE` | Keep reviewed buckets and the operator-selected source bucket. | Current 1.5.x |
+| Manual whole-line Split | `INTENTIONAL_1_5_X_CHANGE` | Keep accepted whole-line and order-level residual semantics. | Current 1.5.x |
+| Historical prices and taxes | `INTENTIONAL_1_5_X_CHANGE` | Preserve persisted commercial history; do not reprice from the current catalog or recalculate historical tax. | Current 1.5.x |
+| Return original selection | `INTENTIONAL_1_5_X_CHANGE` | Resolve the original on the server; browser input is not authority. | Current 1.5.x |
+| Return child history | `INTENTIONAL_1_5_X_CHANGE` | Preserve hardened commercial history and non-force retirement. | Current 1.5.x |
+| Legacy 1.4.11 Return children | `DEFERRED_COMPATIBILITY_WORK` | Provide a hardened compatibility path without restoring the legacy handler. | `WOS-COMPAT-003` |
+| Bulk Return pre-existing invalid rows | `DEFERRED_COMPATIBILITY_WORK` | Review them explicitly as `Skipped` so eligible work is not silently lost. | `WOS-COMPAT-004` |
+| Merge ordinary commercial envelope | `DEFERRED_COMPATIBILITY_WORK` | Expand the hardened Merge envelope without bypassing Review / Confirm / Execute. | `WOS-COMPAT-005` |
+| Paid/refund Merge | `DEFERRED_COMPATIBILITY_WORK` | Keep this as a separate financial tranche. | `WOS-COMPAT-006` |
+| Administrator / Shop Manager access | `PRESERVE_FUNCTIONAL_OUTCOME` | Both roles are supported by default, subject to every required WooCommerce per-order capability and hardened workflow eligibility check. | `WOS-COMPAT-001` |
+| Legacy Shop Manager option | `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE` | `order_splitter_shop_manager_permission` is retired. Stored `yes`, `no`, or an absent value have identical authorization behavior. A stale stored value may remain, but runtime and Settings do not read or write it as authority. | `WOS-COMPAT-001` |
+| Legacy direct mutation handlers | `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE` | Keep them unloaded. All production mutation transports enter through `WCOS_Mutation_Gateway`. | Current 1.5.x |
+| Global mutation email-recipient filters | `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE` | Do not restore the legacy global recipient filter. | Current 1.5.x |
+
+## Settings inventory
+
+| Option / surface | Public 1.4.11 behavior | Current 1.5.x state | Classification and action |
+| --- | --- | --- | --- |
+| `order_splitter_status_allowed` / Allowed status | Visible multiselect; used by Split and Duplicate presentation/requests and Return presentation. | Still visible and saved. Hardened Split, Duplicate and Merge transports consult it; workflow-specific preflight may independently reject unsupported commercial states. | `DEFERRED_COMPATIBILITY_WORK`: retain the setting. `WOS-COMPAT-002` removes the hidden Split-status contradiction while preserving independent integrity rejection. |
+| `order_splitter_exclude_shipping_fee` / Excluded fee | Visible checkbox controlling whether legacy Split children received shipping rows. | Still visible and saved, but the hardened Split service does not consume it. | `DEFERRED_COMPATIBILITY_WORK`: `WOS-COMPAT-002` must bind reviewed shipping policy to execution. |
+| `order_splitter_shop_manager_permission` / Permission | Visible checkbox and a site-wide Shop Manager denial layer for legacy surfaces. | Retired by `WOS-COMPAT-001`; absent from Settings/default creation and inert for authorization, including stored `no`. | `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE`. Do not replace it with another hidden or Premium permission gate. |
+| `order_splitter_order_label` / Order labels | Visible checkbox controlling relationship labels on order edit/list screens. | Visible, saved and read by `inc/backend/orders.php`. | `PRESERVE_FUNCTIONAL_OUTCOME`: active-compatible. |
+| `order_splitter_disable_split_order_email` | No active Free control was rendered in the 1.4.11 Notifications section, but activation created the hidden default `none`; a legacy globally registered recipient filter read non-default values. | No configurable Free rule is rendered. Hardened transports do not load the legacy global filter; a historical stored value is inert. | `UNSAFE_LEGACY_IMPLEMENTATION_NOT_TO_PRESERVE`: keep on-demand WooCommerce notification behavior and do not restore global recipient filtering. |
+| Automation section | Informational/upsell-only; no Free automation rule was saved. | Informational/upsell-only and no setting is saved. | `INTENTIONAL_1_5_X_CHANGE`: presentation-only, never mutation or permission authority. |
+| Premium section/cards | Presentation and outbound product comparison only. | Presentation-only and guarded by `manage_woocommerce`. | `INTENTIONAL_1_5_X_CHANGE`: it must not become Free workflow authorization authority. |
+
+## Access contract
+
+The complete plugin-level access equation is:
+
+`administrator or shop_manager role` + `required WooCommerce capability on every participating order` + `workflow gate and hardened eligibility/authority` = usable workflow.
+
+This applies to Split, Duplicate, Merge, Return and Bulk Return. Removing the legacy option does not relax nonces, Review/Confirm binding, per-order `edit_shop_order` / `delete_shop_order` checks, participant checks, status/settings checks, commercial preflight or code-owned workflow/strategy gates. A custom or lower-privilege role does not gain mutation authority merely by receiving WooCommerce order capabilities.
+
+## Downstream boundary
+
+`WOS-COMPAT-001` does not change Split status, shipping, coupon, fee, refund or nested-Split runtime behavior; Return/Bulk Return compatibility behavior; Merge commercial or financial support; Duplicate status; feature/strategy gates; versions; packaging; release or publication state. Those changes require their named downstream exact-head tasks and authority.

--- a/inc/backend/class-wcos-bulk-return-admin-controller.php
+++ b/inc/backend/class-wcos-bulk-return-admin-controller.php
@@ -66,6 +66,10 @@ final class WCOS_Bulk_Return_Admin_Controller {
 	}
 
 	public function register_bulk_action(array $actions) {
+		if (!$this->is_supported_operator()) {
+			return $actions;
+		}
+
 		if (WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN)) {
 			$actions[self::BULK_ACTION] = __('Return to original order', 'wc-order-splitter');
 		}
@@ -146,7 +150,7 @@ final class WCOS_Bulk_Return_Admin_Controller {
 	public function ajax_resume() { $this->send_ajax('resume_request'); }
 
 	public function enqueue_assets() {
-		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN) || !$this->is_orders_list_screen()) { return; }
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN) || !$this->is_supported_operator() || !$this->is_orders_list_screen()) { return; }
 		$plugin_file = dirname(__DIR__, 2) . '/wc-order-splitter.php';
 		wp_enqueue_style('wcos-bulk-return-admin', plugins_url('css/p2-bulk-return-admin.css', $plugin_file), array('wcos-admin-backbone-modal'), WC_ORDER_SPLITTER_VERSION);
 		wp_enqueue_script('wcos-bulk-return-admin', plugins_url('js/p2-bulk-return-admin.js', $plugin_file), array('jquery', 'wcos-admin-backbone-modal'), WC_ORDER_SPLITTER_VERSION, true);
@@ -189,7 +193,7 @@ final class WCOS_Bulk_Return_Admin_Controller {
 	}
 
 	public function render_dialog() {
-		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN) || !$this->is_orders_list_screen()) { return; }
+		if (!WCOS_Feature_Gates::enabled(WCOS_Feature_Gates::BULK_RETURN) || !$this->is_supported_operator() || !$this->is_orders_list_screen()) { return; }
 		echo $this->dialog_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
@@ -286,5 +290,14 @@ final class WCOS_Bulk_Return_Admin_Controller {
 		if (!$screen) { return false; }
 		$hpos = function_exists('wc_get_page_screen_id') ? wc_get_page_screen_id('shop-order') : 'woocommerce_page_wc-orders';
 		return 'edit-shop_order' === $screen->id || ($hpos === $screen->id && empty($_GET['id']));
+	}
+
+	private function is_supported_operator() {
+		try {
+			WCOS_Order_Mutation_Authorizer::assert_operator();
+			return true;
+		} catch (Throwable $throwable) {
+			return false;
+		}
 	}
 }

--- a/inc/backend/settings.php
+++ b/inc/backend/settings.php
@@ -399,19 +399,22 @@ class WooCommerce_Order_Splitter_Settings {
 				'id'       => 'order_splitter_order_label',
 				'default'  => 'yes',
 			),
-			'allow_split_orders' => array(
-				'name'     => esc_html__('Permission', 'wc-order-splitter'),
-				'type'     => 'checkbox',
-				'desc'     => esc_html__('Enable the shop manager to split orders', 'wc-order-splitter'),
-				'id'       => 'order_splitter_shop_manager_permission',
-				'default'  => 'no',
-			),
 			'section_end' => array(
 				'type' => 'sectionend',
 				'id'   => 'advanced_order_splitter_section_end'
 			)
 		);
-		return apply_filters('advanced_settings', $settings);
+		$settings = apply_filters('advanced_settings', $settings);
+		// The retired option must not be reintroduced as a writable field.
+		foreach ($settings as $key => $setting) {
+			if (is_array($setting)
+				&& isset($setting['id'])
+				&& 'order_splitter_shop_manager_permission' === $setting['id']) {
+				unset($settings[$key]);
+			}
+		}
+
+		return $settings;
 	}
 
 	public function get_automation_splitter_settings() {
@@ -491,7 +494,6 @@ class WooCommerce_Order_Splitter_Settings {
 			'order_splitter_status_allowed' => array('wc-processing'),
 			'order_splitter_exclude_shipping_fee' => 'no',
 			'order_splitter_disable_split_order_email' => 'none',
-			'order_splitter_shop_manager_permission' => 'no',
 			'order_splitter_order_label' => 'yes',
 		);
 

--- a/inc/domain/class-wcos-order-mutation-authorizer.php
+++ b/inc/domain/class-wcos-order-mutation-authorizer.php
@@ -10,7 +10,7 @@ final class WCOS_Order_Mutation_Authorizer {
 	public static function assert_workflow($workflow, WC_Order $source, WC_Order $target = null) {
 		$workflow = sanitize_key((string) $workflow);
 		self::assert_shop_order($source);
-		self::assert_shop_manager_policy();
+		self::assert_operator();
 
 		switch ($workflow) {
 			case WCOS_Feature_Gates::SPLIT:
@@ -54,17 +54,17 @@ final class WCOS_Order_Mutation_Authorizer {
 	}
 
 	public static function assert_split(WC_Order $source) {
-		self::assert_shop_manager_policy();
+		self::assert_operator();
 		self::assert_can_edit($source);
 	}
 
 	public static function assert_duplicate(WC_Order $source) {
-		self::assert_shop_manager_policy();
+		self::assert_operator();
 		self::assert_can_edit($source);
 	}
 
 	public static function assert_return(WC_Order $child, WC_Order $parent) {
-		self::assert_shop_manager_policy();
+		self::assert_operator();
 		self::assert_can_edit($child);
 		self::assert_can_edit($parent);
 		self::assert_can_delete($child);
@@ -80,9 +80,26 @@ final class WCOS_Order_Mutation_Authorizer {
 
 	/** Authorize the current edited order before a Merge target is selected. */
 	public static function assert_merge_source(WC_Order $source) {
-		self::assert_shop_manager_policy();
+		self::assert_operator();
 		self::assert_can_edit($source);
 		self::assert_can_delete($source);
+	}
+
+	/**
+	 * Restrict plugin mutation workflows to the two supported operator roles.
+	 *
+	 * Per-order WooCommerce capability checks remain mandatory and are applied
+	 * separately by the workflow-specific methods above.
+	 */
+	public static function assert_operator() {
+		$user = wp_get_current_user();
+		if (!$user || !$user->exists()) {
+			throw new RuntimeException(__('You must be signed in to mutate orders.', 'wc-order-splitter'));
+		}
+
+		if (empty(array_intersect(array('administrator', 'shop_manager'), (array) $user->roles))) {
+			throw new RuntimeException(__('You are not allowed to use order mutation workflows.', 'wc-order-splitter'));
+		}
 	}
 
 	private static function assert_shop_order(WC_Order $order) {
@@ -91,15 +108,4 @@ final class WCOS_Order_Mutation_Authorizer {
 		}
 	}
 
-	private static function assert_shop_manager_policy() {
-		$user = wp_get_current_user();
-		if (!$user || !$user->exists()) {
-			throw new RuntimeException(__('You must be signed in to mutate orders.', 'wc-order-splitter'));
-		}
-
-		if (in_array('shop_manager', (array) $user->roles, true)
-			&& 'yes' !== get_option('order_splitter_shop_manager_permission', 'no')) {
-			throw new RuntimeException(__('Shop manager access to order mutation workflows is disabled.', 'wc-order-splitter'));
-		}
-	}
 }

--- a/tests/integration/compat-settings-access-smoke.php
+++ b/tests/integration/compat-settings-access-smoke.php
@@ -1,0 +1,192 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	exit(1);
+}
+
+function wcos_compat_assert($condition, $message) {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function wcos_compat_expect_runtime(callable $callback, $message) {
+	try {
+		$callback();
+	} catch (RuntimeException $exception) {
+		return;
+	}
+	throw new RuntimeException($message);
+}
+
+function wcos_compat_setting_ids(array $settings) {
+	$ids = array();
+	foreach ($settings as $setting) {
+		if (is_array($setting) && isset($setting['id'])) {
+			$ids[] = (string) $setting['id'];
+		}
+	}
+	return $ids;
+}
+
+$previous_user = get_current_user_id();
+$legacy_option_exists = false !== get_option('order_splitter_shop_manager_permission', false);
+$legacy_option_value = get_option('order_splitter_shop_manager_permission', null);
+$user_ids = array();
+$order_ids = array();
+$orders = array();
+$admin_id = 0;
+$manager_id = 0;
+$custom_role = 'wcos_compat_capable_operator';
+
+try {
+	$admin_id = wp_insert_user(array(
+		'user_login' => 'wcos_compat_admin_' . wp_generate_password(8, false),
+		'user_pass' => wp_generate_password(24, true),
+		'user_email' => 'wcos-compat-admin-' . wp_generate_uuid4() . '@example.test',
+		'role' => 'administrator',
+	));
+	$manager_id = wp_insert_user(array(
+		'user_login' => 'wcos_compat_manager_' . wp_generate_password(8, false),
+		'user_pass' => wp_generate_password(24, true),
+		'user_email' => 'wcos-compat-manager-' . wp_generate_uuid4() . '@example.test',
+		'role' => 'shop_manager',
+	));
+	wcos_compat_assert(!is_wp_error($admin_id) && !is_wp_error($manager_id), 'Unable to create supported operator fixtures.');
+	$user_ids[] = (int) $admin_id;
+	$user_ids[] = (int) $manager_id;
+
+	wp_set_current_user((int) $admin_id);
+	foreach (array('source', 'target', 'child', 'original') as $label) {
+		$order = wc_create_order(array('status' => 'pending'));
+		$order->set_customer_note('WOS-COMPAT-001 ' . $label);
+		$order->save();
+		$orders[$label] = $order;
+		$order_ids[] = $order->get_id();
+	}
+
+	foreach (array('absent', 'no', 'yes') as $legacy_state) {
+		if ('absent' === $legacy_state) {
+			delete_option('order_splitter_shop_manager_permission');
+		} else {
+			update_option('order_splitter_shop_manager_permission', $legacy_state);
+		}
+
+		foreach (array((int) $admin_id, (int) $manager_id) as $operator_id) {
+			wp_set_current_user($operator_id);
+			WCOS_Order_Mutation_Authorizer::assert_operator();
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $orders['source']);
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $orders['source']);
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $orders['source'], $orders['target']);
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $orders['child'], $orders['original']);
+			WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::BULK_RETURN, $orders['child'], $orders['original']);
+
+			$bulk_actions = (new WCOS_Bulk_Return_Admin_Controller())->register_bulk_action(array());
+			wcos_compat_assert(isset($bulk_actions[WCOS_Bulk_Return_Admin_Controller::BULK_ACTION]), 'A supported operator could not see the Bulk Return surface for legacy option state ' . $legacy_state . '.');
+		}
+	}
+
+	$shop_manager_role = get_role('shop_manager');
+	wcos_compat_assert($shop_manager_role instanceof WP_Role, 'Shop Manager role is unavailable.');
+	remove_role($custom_role);
+	add_role($custom_role, 'WOS compatibility capable operator', $shop_manager_role->capabilities);
+	$lower_id = wp_insert_user(array(
+		'user_login' => 'wcos_compat_lower_' . wp_generate_password(8, false),
+		'user_pass' => wp_generate_password(24, true),
+		'user_email' => 'wcos-compat-lower-' . wp_generate_uuid4() . '@example.test',
+		'role' => $custom_role,
+	));
+	wcos_compat_assert(!is_wp_error($lower_id), 'Unable to create capable lower-role fixture.');
+	$user_ids[] = (int) $lower_id;
+	wp_set_current_user((int) $lower_id);
+	wcos_compat_expect_runtime(static function() { WCOS_Order_Mutation_Authorizer::assert_operator(); }, 'A capable lower role was accepted as an Order Splitter operator.');
+	foreach (array(WCOS_Feature_Gates::SPLIT, WCOS_Feature_Gates::DUPLICATE) as $workflow) {
+		wcos_compat_expect_runtime(static function() use ($workflow, $orders) {
+			WCOS_Order_Mutation_Authorizer::assert_workflow($workflow, $orders['source']);
+		}, 'A capable lower role gained ' . $workflow . ' authority.');
+	}
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $orders['source'], $orders['target']);
+	}, 'A capable lower role gained Merge authority.');
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $orders['child'], $orders['original']);
+	}, 'A capable lower role gained Return authority.');
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::BULK_RETURN, $orders['child'], $orders['original']);
+	}, 'A capable lower role gained Bulk Return authority.');
+	wcos_compat_assert(!isset((new WCOS_Bulk_Return_Admin_Controller())->register_bulk_action(array())[WCOS_Bulk_Return_Admin_Controller::BULK_ACTION]), 'A capable lower role could see the Bulk Return surface.');
+
+	wp_set_current_user((int) $manager_id);
+	$denied_order_id = $orders['target']->get_id();
+	$deny_target_capability = static function($allcaps, $caps, $args) use (&$denied_order_id) {
+		$requested = isset($args[0]) ? (string) $args[0] : '';
+		$object_id = isset($args[2]) ? absint($args[2]) : 0;
+		if ($denied_order_id === $object_id && in_array($requested, array('edit_shop_order', 'delete_shop_order'), true)) {
+			foreach ((array) $caps as $capability) {
+				$allcaps[$capability] = false;
+			}
+		}
+		return $allcaps;
+	};
+	add_filter('user_has_cap', $deny_target_capability, 999, 3);
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::MERGE, $orders['source'], $orders['target']);
+	}, 'Merge did not check capability on its target participant.');
+	remove_filter('user_has_cap', $deny_target_capability, 999);
+
+	$denied_order_id = $orders['original']->get_id();
+	add_filter('user_has_cap', $deny_target_capability, 999, 3);
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::RETURN_ORDER, $orders['child'], $orders['original']);
+	}, 'Return did not check capability on its original participant.');
+	wcos_compat_expect_runtime(static function() use ($orders) {
+		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::BULK_RETURN, $orders['child'], $orders['original']);
+	}, 'Bulk Return did not check capability on its original participant.');
+	remove_filter('user_has_cap', $deny_target_capability, 999);
+
+	$settings = new WooCommerce_Order_Splitter_Settings();
+	wcos_compat_assert(!in_array('order_splitter_shop_manager_permission', wcos_compat_setting_ids($settings->get_advanced_settings()), true), 'Retired Shop Manager setting still renders.');
+	$reintroduce_retired_setting = static function($fields) {
+		$fields['legacy_permission'] = array('id' => 'order_splitter_shop_manager_permission', 'type' => 'checkbox');
+		return $fields;
+	};
+	add_filter('advanced_settings', $reintroduce_retired_setting, 999);
+	wcos_compat_assert(!in_array('order_splitter_shop_manager_permission', wcos_compat_setting_ids($settings->get_advanced_settings()), true), 'A filtered Settings definition reintroduced the retired permission control.');
+	remove_filter('advanced_settings', $reintroduce_retired_setting, 999);
+	delete_option('order_splitter_shop_manager_permission');
+	WooCommerce_Order_Splitter_Settings::set_default_settings();
+	wcos_compat_assert(false === get_option('order_splitter_shop_manager_permission', false), 'Activation defaults recreated the retired permission option.');
+
+	$root = dirname(__DIR__, 2);
+	$contract = file_get_contents($root . '/docs/1.4.11-to-1.5.x-functional-compatibility.md');
+	$duplicate_service = file_get_contents($root . '/inc/domain/class-wcos-duplicate-order-service.php');
+	wcos_compat_assert(false !== strpos($contract, 'Split child status') && false !== strpos($contract, 'Freeze the source order status'), 'Compatibility contract lost the Split source-status requirement.');
+	wcos_compat_assert(false !== strpos($contract, 'Duplicate target status') && false !== strpos($contract, 'Keep `pending`'), 'Compatibility contract lost the independent Duplicate pending policy.');
+	wcos_compat_assert(false !== strpos($duplicate_service, "'target_status' => 'pending'"), 'Duplicate runtime no longer reports its independent pending policy.');
+	wcos_compat_assert(false === strpos(file_get_contents($root . '/inc/domain/class-wcos-order-mutation-authorizer.php'), 'order_splitter_shop_manager_permission'), 'Central authorizer still reads the retired option.');
+
+	echo "compat-settings-access-ok roles=2 legacy_option_states=3 workflows=5 lower_role=denied cross_order=checked settings=retired status_policies=separate\n";
+} finally {
+	if ($admin_id) {
+		wp_set_current_user((int) $admin_id);
+	}
+	foreach ($order_ids as $order_id) {
+		$order = wc_get_order($order_id);
+		if ($order instanceof WC_Order) {
+			$order->delete(true);
+		}
+	}
+	if (!function_exists('wp_delete_user')) {
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+	}
+	foreach ($user_ids as $user_id) {
+		wp_delete_user($user_id);
+	}
+	remove_role($custom_role);
+	if ($legacy_option_exists) {
+		update_option('order_splitter_shop_manager_permission', $legacy_option_value);
+	} else {
+		delete_option('order_splitter_shop_manager_permission');
+	}
+	wp_set_current_user($previous_user);
+}

--- a/tests/integration/governance-smoke.php
+++ b/tests/integration/governance-smoke.php
@@ -19,6 +19,9 @@ function wcos_governance_expect_runtime(callable $callback, $message) {
 	throw new RuntimeException($message);
 }
 
+$legacy_permission_exists = false !== get_option('order_splitter_shop_manager_permission', false);
+$legacy_permission_value = get_option('order_splitter_shop_manager_permission', null);
+
 /* External configuration must never alter the internally approved gate set. */
 foreach (array(
 	'WC_ORDER_SPLITTER_MUTATIONS_ENABLED',
@@ -64,21 +67,20 @@ $subscriber_id = wp_insert_user(array(
 ));
 wcos_governance_assert(!is_wp_error($admin_id) && !is_wp_error($manager_id) && !is_wp_error($subscriber_id), 'Unable to create governance test users.');
 
-update_option('order_splitter_shop_manager_permission', 'no');
 wp_set_current_user($admin_id);
 WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
 WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $order);
 
 wp_set_current_user($manager_id);
-wcos_governance_expect_runtime(
-	static function() use ($order) {
-		WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
-	},
-	'Shop manager policy did not fail closed.'
-);
-update_option('order_splitter_shop_manager_permission', 'yes');
-WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
-WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $order);
+foreach (array('no', 'yes', null) as $legacy_permission) {
+	if (null === $legacy_permission) {
+		delete_option('order_splitter_shop_manager_permission');
+	} else {
+		update_option('order_splitter_shop_manager_permission', $legacy_permission);
+	}
+	WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::SPLIT, $order);
+	WCOS_Order_Mutation_Authorizer::assert_workflow(WCOS_Feature_Gates::DUPLICATE, $order);
+}
 
 wp_set_current_user($subscriber_id);
 wcos_governance_expect_runtime(
@@ -169,6 +171,11 @@ if (!function_exists('wp_delete_user')) {
 wp_delete_user($admin_id);
 wp_delete_user($manager_id);
 wp_delete_user($subscriber_id);
+if ($legacy_permission_exists) {
+	update_option('order_splitter_shop_manager_permission', $legacy_permission_value);
+} else {
+	delete_option('order_splitter_shop_manager_permission');
+}
 wp_set_current_user(0);
 
 echo "mutation-governance-and-metadata-policy-ok\n";

--- a/tests/integration/merge-production-enabled-smoke.php
+++ b/tests/integration/merge-production-enabled-smoke.php
@@ -184,11 +184,13 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 		wp_set_current_user((int) $manager);
 		update_option('order_splitter_shop_manager_permission', 'no');
 		$manager_request = self::request($source, $target);
-		self::expect_transport(function() use ($controller, $manager_request) { $controller->review_request($manager_request); }, 'authorization_failed');
+		$manager_review = $controller->review_request($manager_request);
+		self::assert(!empty($manager_review['review_id']), 'Stored legacy no value still blocked Shop Manager Review.');
+		WCOS_Merge_Review_Store::delete($manager_review['review_id']);
 		update_option('order_splitter_shop_manager_permission', 'yes');
 		$manager_request['nonce'] = wp_create_nonce('wcos_merge_order_' . $source->get_id());
 		$manager_review = $controller->review_request($manager_request);
-		self::assert(!empty($manager_review['review_id']), 'Enabled shop-manager semantics did not allow Review.');
+		self::assert(!empty($manager_review['review_id']), 'Stored legacy yes value did not allow Shop Manager Review.');
 		WCOS_Merge_Review_Store::delete($manager_review['review_id']);
 		wp_set_current_user(self::$admin_id);
 		update_option('order_splitter_shop_manager_permission', self::$old_shop_permission);
@@ -202,7 +204,7 @@ final class WCOS_Merge_Production_Enabled_Matrix {
 			'source_excluded' => true,
 			'invalid_input_rejected' => true,
 			'unauthorized_rejected' => true,
-			'shop_manager_option_enforced' => true,
+			'shop_manager_option_inert' => true,
 		);
 	}
 


### PR DESCRIPTION
## Task

Closes #116 (`WOS-COMPAT-001`).

- Classification: `P1_DOMAIN_CONTRACT` / compatibility foundation and settings access
- Risk profile: `HIGH`
- Exact source main: `9ac096c7ce3a216f9dad91d9a0bec160261f13ee`
- Exact source tree: `aaf21a3183f640c5bc16a00d83bab668a10212a4`
- Release/package/publication authority: none

## Summary

- adds the repository-owned public `1.4.11 -> 1.5.x` functional compatibility contract and settings inventory;
- retires the visible `order_splitter_shop_manager_permission` setting and prevents filters/default initialization from reintroducing it;
- replaces the option-controlled Shop Manager denial with a centralized `administrator` / `shop_manager` operator-role boundary plus existing WooCommerce per-order capabilities;
- applies the role boundary to the Bulk Return Orders-list surface;
- preserves independent Split and Duplicate status policy decisions without changing either runtime mutation policy in this task.

## Invariants

- production workflow gates remain `SPLIT=true`, `DUPLICATE=true`, `MERGE=true`, `RETURN_ORDER=true`, `BULK_RETURN=true`;
- Split strategy gates remain `MANUAL_QUANTITY=true`, `CATEGORY=true`, `STOCK_STATUS=true`;
- all mutation transports continue through `WCOS_Mutation_Gateway`;
- no money, tax, stock, `_reduced_stock`, journal, recovery, compensation, status, shipping or commercial mutation semantics changed;
- no version, Stable tag, package, release, publication or deployment change;
- a stale legacy permission value may remain stored but is inert.

## Focused Local evidence

- full PHP syntax pass over every `*.php` file;
- `php tests/unit/run.php` — all unit contracts pass;
- `tests/ci/workflow-contract.sh` — `workflow-contract-ok`;
- `tests/ci/required-ci-profile-contract.sh` — `required-ci-profile-contract-ok`;
- Local WordPress `compat-settings-access-smoke.php` — roles=2, legacy option states=3, workflows=5, capable lower role denied, cross-order capabilities checked, retired setting protected, Split/Duplicate policies separate;
- Local WordPress `governance-smoke.php` — pass;
- Local WordPress `merge-production-enabled-smoke.php` — pass, including legacy option inertness.

## Canonical evidence pending

Draft until full exact-head PR CI passes across PHP 7.4/8.1/8.3 and WooCommerce legacy/HPOS/HPOS-sync storage, followed by a fresh persisted Independent Codex Technical Review.
