### PR TITLE
WOS-UPSELL-002: completed action-modal conversion upsell

### DIFF
--- a/css/premium-upsell.css
+++ b/css/premium-upsell.css
@@ -75,35 +75,34 @@
     color: #646970;
 }
 
-.wcos-split-upgrade-hint {
+.wcos-modal-upsell {
     clear: both;
-    margin: 10px 0 0;
-    padding: 8px 10px;
+    margin: 16px 0 0;
+    padding: 12px 14px;
     border-left: 3px solid #c3c4c7;
     background: #f6f7f7;
     color: #50575e;
     line-height: 1.5;
 }
 
-.wcos-split-upgrade-hint a {
-    white-space: nowrap;
+.wcos-modal-upsell p {
+    margin: 0 0 8px;
 }
 
-.wcos-split-upgrade-hint-dismiss {
-    margin-left: 10px;
+.wcos-modal-upsell strong {
+    display: block;
+    margin-bottom: 6px;
+}
+
+.wcos-modal-upsell-dismiss {
+    margin-left: 14px;
     color: #646970;
     white-space: nowrap;
 }
 
-.wcos-split-upgrade-hint-dismiss:hover,
-.wcos-split-upgrade-hint-dismiss:focus {
+.wcos-modal-upsell-dismiss:hover,
+.wcos-modal-upsell-dismiss:focus {
     color: var(--wp-admin-theme-color, #2271b1);
-}
-
-.wcos-post-action-tip {
-    position: relative;
-    margin: 12px 0;
-    padding-right: 38px;
 }
 
 @media (max-width: 782px) {

--- a/css/premium-upsell.css
+++ b/css/premium-upsell.css
@@ -94,7 +94,7 @@
     margin-bottom: 6px;
 }
 
-.wcos-modal-upsell-dismiss {
+.wcos-modal-upsell .wcos-modal-upsell-dismiss {
     margin-left: 14px;
     color: #646970;
     white-space: nowrap;

--- a/inc/backend/class-wcos-premium-upsell.php
+++ b/inc/backend/class-wcos-premium-upsell.php
@@ -106,25 +106,21 @@ final class WCOS_Premium_Upsell {
 			'wcosPremiumUpsell',
 			array(
 				'productUrl' => self::product_url(),
-				'ctaLabel' => __('Explore Advanced Order Actions', 'wc-order-splitter'),
+				'ctaLabel' => __('Explore Advanced Order Actions →', 'wc-order-splitter'),
 				'dismissLabel' => __('Dismiss', 'wc-order-splitter'),
 				'splitHint' => __('Need more routing options? Advanced Order Actions adds product group, tag, attribute, and conditional routing. Vendor and bundle routing require compatible marketplace or bundle integrations.', 'wc-order-splitter'),
-				'splitHintCta' => __('See advanced split methods', 'wc-order-splitter'),
+				'splitHintTitle' => __('Need more advanced routing?', 'wc-order-splitter'),
 				'thresholds' => array(
 					'split' => 3,
 					'duplicate' => 2,
 					'merge' => 2,
-				),
-				'executeActions' => array(
-					'wcos_split_execute' => 'split',
-					'wcos_split_strategy_execute' => 'split',
-					'wcos_duplicate_execute' => 'duplicate',
-					'wcos_merge_execute' => 'merge',
+					'return' => 2,
 				),
 				'actionTips' => array(
 					'split' => __('Splitting orders repeatedly? Advanced Order Actions can automate split or merge rules, show queued work and failure or skip reasons, and retry eligible failures.', 'wc-order-splitter'),
 					'duplicate' => __('Need more control over duplicates? Advanced Order Actions can choose full or itemless contents, status, payment and customer-note behavior, preview the result, and run recoverable Bulk Duplicate batches.', 'wc-order-splitter'),
 					'merge' => __('Merging orders regularly? Advanced Order Actions adds dry-run Merge previews and automatic same-customer merging within a configured time window.', 'wc-order-splitter'),
+					'return' => __('Need more operational control? Advanced Order Actions adds Action Logs and guarded rollback for supported Split, Merge, Return and Duplicate workflows.', 'wc-order-splitter'),
 				),
 			)
 		);

--- a/js/p2-duplicate-admin.js
+++ b/js/p2-duplicate-admin.js
@@ -54,6 +54,7 @@
     function openDuplicateModal() {
         var busy = false;
         var completed = false;
+        var completedPresentation = null;
         var state = null;
         var dialog = null;
         var closeButton = null;
@@ -135,6 +136,14 @@
             executeButton.disabled = busy || completed || !state || !confirmCheckbox.checked;
             cancelButton.disabled = busy;
             closeButton.disabled = busy;
+            if (!busy && completedPresentation) {
+                var presentation = completedPresentation;
+                completedPresentation = null;
+                // Optional presentation must never change the completed operation.
+                try {
+                    resultBox.dispatchEvent(new CustomEvent('wcos:operation-completed', { bubbles: true, detail: presentation }));
+                } catch (error) {}
+            }
         }
 
         function reviewDuplicate() {
@@ -191,6 +200,7 @@
             }
             resultBox.hidden = false;
             resultBox.focus();
+            completedPresentation = { action: 'duplicate', operationId: data.operation_id, status: data.status };
         }
 
         function executeDuplicate() {

--- a/js/p2-merge-admin.js
+++ b/js/p2-merge-admin.js
@@ -54,6 +54,7 @@
 	function openMergeModal() {
 		var busy = false;
 		var completed = false;
+		var completedPresentation = null;
 		var selectedTarget = '';
 		var reviewAuthority = null;
 		var confirmationAuthority = null;
@@ -173,6 +174,14 @@
 			executeButton.disabled = busy || completed || (!retryReady && (!reviewAuthority || !confirmCheckbox.checked));
 			cancelButton.disabled = busy;
 			closeButton.disabled = busy;
+			if (!busy && completedPresentation) {
+				var presentation = completedPresentation;
+				completedPresentation = null;
+				// Optional presentation must never change the completed operation.
+				try {
+					resultBox.dispatchEvent(new CustomEvent('wcos:operation-completed', { bubbles: true, detail: presentation }));
+				} catch (error) {}
+			}
 		}
 
 		function reviewMerge() {
@@ -231,6 +240,7 @@
 			}
 			resultBox.hidden = false;
 			resultBox.focus();
+			completedPresentation = { action: 'merge', operationId: data.operation_id, status: data.status };
 		}
 
 		function handleExecuteFailure(error) {

--- a/js/p2-return-admin.js
+++ b/js/p2-return-admin.js
@@ -54,6 +54,7 @@
 	function openReturnModal() {
 		var phase = 'initial';
 		var busy = false;
+		var completedPresentation = null;
 		var reviewAuthority = null;
 		var confirmationAuthority = null;
 		var retryReady = false;
@@ -175,6 +176,14 @@
 		function setBusy(nextBusy) {
 			busy = !!nextBusy;
 			updateControls();
+			if (!busy && completedPresentation) {
+				var presentation = completedPresentation;
+				completedPresentation = null;
+				// Optional presentation must never change the completed operation.
+				try {
+					resultBox.dispatchEvent(new CustomEvent('wcos:operation-completed', { bubbles: true, detail: presentation }));
+				} catch (error) {}
+			}
 			if (busy && !focusableElements().length) {
 				focusDialogFallback();
 			}
@@ -348,6 +357,7 @@
 			}
 			resultBox.hidden = false;
 			resultBox.focus();
+			completedPresentation = { action: 'return', operationId: data.operation_id, status: data.status };
 		}
 
 		function executeReturn() {

--- a/js/p2-split-admin.js
+++ b/js/p2-split-admin.js
@@ -129,6 +129,7 @@
     function openQuantityDialog(trigger) {
         var busy = false;
         var completed = false;
+        var completedPresentation = null;
         var state = null;
         var activeChildren = 1;
         var maxChildren = 10;
@@ -547,6 +548,14 @@
                 editButton.disabled = busy || completed;
             }
             updateChildToolbar();
+            if (!busy && completedPresentation) {
+                var presentation = completedPresentation;
+                completedPresentation = null;
+                // Optional presentation must never change the completed operation.
+                try {
+                    resultBox.dispatchEvent(new CustomEvent('wcos:operation-completed', { bubbles: true, detail: presentation }));
+                } catch (error) {}
+            }
         }
 
         function reviewPlan() {
@@ -629,6 +638,7 @@
             resultBox.appendChild(reload);
             resultBox.hidden = false;
             resultBox.focus();
+            completedPresentation = { action: 'split', operationId: data.operation_id, status: data.status };
         }
 
         function executePlan() {
@@ -790,6 +800,11 @@
                 cancel.className = 'button button-large modal-close';
                 cancel.textContent = 'Cancel';
                 footer.appendChild(cancel);
+            },
+            onReady: function (root, handle) {
+                try {
+                    handle.body.dispatchEvent(new CustomEvent('wcos:split-method-chooser', { bubbles: true }));
+                } catch (error) {}
             }
         });
     }

--- a/js/p2-split-strategy-admin.js
+++ b/js/p2-split-strategy-admin.js
@@ -92,6 +92,7 @@
             var selectedBucket = '';
             var busy = false;
             var completed = false;
+            var completedPresentation = null;
             var dialog = null;
             var form = null;
             var closeButton = null;
@@ -201,6 +202,14 @@
                 executeButton.disabled = busy || completed || !confirmationState || !confirmCheckbox.checked;
                 closeButton.disabled = busy;
                 cancelButton.disabled = busy;
+                if (!busy && completedPresentation) {
+                    var presentation = completedPresentation;
+                    completedPresentation = null;
+                    // Optional presentation must never change the completed operation.
+                    try {
+                        resultBox.dispatchEvent(new CustomEvent('wcos:operation-completed', { bubbles: true, detail: presentation }));
+                    } catch (error) {}
+                }
             }
 
             function bucketQuantity(items) {
@@ -374,6 +383,7 @@
                 resultBox.appendChild(reload);
                 resultBox.hidden = false;
                 resultBox.focus();
+                completedPresentation = { action: 'split', operationId: data.operation_id, status: data.status };
             }
 
             function executeStrategy() {

--- a/js/post-action-tip.js
+++ b/js/post-action-tip.js
@@ -1,340 +1,194 @@
-(function($) {
+(function() {
     'use strict';
 
     var config = window.wcosPremiumUpsell || {};
+    // Keep V1 dismissals/shown campaigns; do not replay its later-page notices.
     var storageKey = 'wcosPremiumUpsellStateV1';
-    var legacyKeys = [
-        'wcosPostActionTip',
-        'wcosPostSplitTip',
-        'wcosPostActionTipDismissedAt'
-    ];
-    var validActions = ['split', 'duplicate', 'merge'];
+    var validActions = ['split', 'duplicate', 'merge', 'return'];
     var seenLimit = 40;
+    var memoryState = null;
+    var storageFailed = false;
+    var resultSelectors = {
+        split: '.wcos-split-result, .wcos-strategy-result',
+        duplicate: '.wcos-duplicate-result',
+        merge: '.wcos-merge-result',
+        return: '.wcos-return-result'
+    };
+
+    function thresholdFor(action) {
+        var threshold = parseInt((config.thresholds || {})[action], 10);
+        return isFinite(threshold) && threshold > 0 ? Math.min(threshold, 3) : 0;
+    }
 
     function emptyState() {
         return {
-            usage: { split: 0, duplicate: 0, merge: 0 },
+            usage: { split: 0, duplicate: 0, merge: 0, return: 0 },
             seenOperations: [],
-            pending: {},
             shown: {},
             dismissed: {},
             hints: { splitRoutingDismissed: false }
         };
     }
 
-    function getStoredItem(key) {
-        try {
-            return window.localStorage.getItem(key);
-        } catch (error) {
-            return null;
-        }
-    }
-
-    function setStoredItem(key, value) {
-        try {
-            window.localStorage.setItem(key, value);
-        } catch (error) {}
-    }
-
-    function removeStoredItem(key) {
-        try {
-            window.localStorage.removeItem(key);
-        } catch (error) {}
-    }
-
-    function isValidAction(action) {
-        return validActions.indexOf(action) !== -1;
-    }
-
-    function normalizeCount(value) {
-        var count = parseInt(value, 10);
-        return isFinite(count) && count > 0 ? Math.min(count, seenLimit) : 0;
-    }
-
     function normalizeState(rawState) {
         var normalized = emptyState();
         var state = rawState && typeof rawState === 'object' ? rawState : {};
-        var i;
-
-        for (i = 0; i < validActions.length; i++) {
-            var action = validActions[i];
-            normalized.usage[action] = normalizeCount(state.usage && state.usage[action]);
-            normalized.pending[action] = !!(state.pending && state.pending[action]);
+        validActions.forEach(function(action) {
+            var count = parseInt((state.usage || {})[action], 10);
+            normalized.usage[action] = isFinite(count) && count > 0 ? Math.min(count, thresholdFor(action)) : 0;
             normalized.shown[action] = !!(state.shown && state.shown[action]);
             normalized.dismissed[action] = !!(state.dismissed && state.dismissed[action]);
-        }
-
+        });
         if (Array.isArray(state.seenOperations)) {
-            normalized.seenOperations = state.seenOperations
-                .filter(function(operation) {
-                    return typeof operation === 'string' && operation.length > 0 && operation.length <= 120;
-                })
-                .slice(-seenLimit);
+            normalized.seenOperations = state.seenOperations.filter(function(operation, index, operations) {
+                return typeof operation === 'string' && /^(split|duplicate|merge|return):[a-z0-9_-]{1,100}$/.test(operation) && operations.indexOf(operation) === index;
+            }).slice(-seenLimit);
         }
-
         normalized.hints.splitRoutingDismissed = !!(state.hints && state.hints.splitRoutingDismissed);
-
         return normalized;
     }
 
     function readState() {
-        var stored = getStoredItem(storageKey);
-        if (!stored) {
-            return emptyState();
+        if (storageFailed) {
+            return normalizeState(memoryState);
         }
-
         try {
-            return normalizeState(JSON.parse(stored));
+            var stored = window.localStorage.getItem(storageKey);
+            return stored ? normalizeState(JSON.parse(stored)) : normalizeState(memoryState);
         } catch (error) {
-            return emptyState();
+            storageFailed = true;
+            return normalizeState(memoryState);
         }
     }
 
     function saveState(state) {
-        setStoredItem(storageKey, JSON.stringify(normalizeState(state)));
-    }
-
-    function cleanupLegacyState() {
-        legacyKeys.forEach(function(key) {
-            removeStoredItem(key);
-        });
-    }
-
-    function actionFromBody(body) {
-        if (!body) {
-            return '';
-        }
-
-        if (typeof body === 'string') {
-            try {
-                return new URLSearchParams(body).get('action') || '';
-            } catch (error) {
-                var match = body.match(/(?:^|&)action=([^&]+)/);
-                return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : '';
-            }
-        }
-
-        if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
-            return body.get('action') || '';
-        }
-
-        if (typeof FormData !== 'undefined' && body instanceof FormData) {
-            return body.get('action') || '';
-        }
-
-        return '';
-    }
-
-    function thresholdFor(action) {
-        var thresholds = config.thresholds || {};
-        var threshold = parseInt(thresholds[action], 10);
-        return isFinite(threshold) && threshold > 0 ? threshold : 0;
+        memoryState = normalizeState(state);
+        try {
+            window.localStorage.setItem(storageKey, JSON.stringify(memoryState));
+        } catch (error) { storageFailed = true; }
     }
 
     function recordSuccessfulOperation(action, operationId) {
-        if (!isValidAction(action) || typeof operationId !== 'string' || !operationId || operationId.length > 100) {
-            return;
-        }
-
         var state = readState();
         var operationKey = action + ':' + operationId;
         if (state.seenOperations.indexOf(operationKey) !== -1) {
+            return false;
+        }
+        // Saturating counts retain the IDs needed to reach each threshold.
+        // Later traffic cannot evict those IDs and inflate a campaign count.
+        if (state.usage[action] < thresholdFor(action)) {
+            state.seenOperations.push(operationKey);
+            state.usage[action] += 1;
+            saveState(state);
+        }
+        return true;
+    }
+
+    function eligible(action, state) {
+        return thresholdFor(action) > 0 && state.usage[action] >= thresholdFor(action) && !state.shown[action] && !state.dismissed[action];
+    }
+
+    function canPresent() {
+        return !storageFailed && config.productUrl === 'https://yoohw.com/product/woocommerce-advanced-order-actions/';
+    }
+
+    function visibleContent(target) {
+        return target && target.isConnected && target.closest('.wcos-admin-backbone-modal__body') &&
+            !target.closest('footer, [hidden], [aria-hidden="true"], [aria-busy="true"]');
+    }
+
+    function createCard(message, className, dismiss) {
+        var card = document.createElement('aside');
+        card.className = 'wcos-modal-upsell ' + className;
+        var paragraph = document.createElement('p');
+        paragraph.textContent = message;
+        card.appendChild(paragraph);
+        var link = document.createElement('a');
+        link.href = config.productUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = config.ctaLabel || 'Explore Advanced Order Actions →';
+        card.appendChild(link);
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'button-link wcos-modal-upsell-dismiss';
+        button.textContent = config.dismissLabel || 'Dismiss';
+        button.addEventListener('click', function() {
+            dismiss();
+            var result = card.parentNode;
+            card.remove();
+            // Do not strand keyboard focus when the focused dismiss button goes away.
+            var method = result.querySelector('.wcos-split-method-option');
+            (method || result).focus();
+        });
+        card.appendChild(button);
+        return card;
+    }
+
+    function completed(event) {
+        var detail = event.detail || {};
+        var action = detail.action;
+        var result = event.target;
+        if (validActions.indexOf(action) === -1 || detail.status !== 'completed' ||
+            typeof detail.operationId !== 'string' || !/^[a-z0-9_-]{1,100}$/.test(detail.operationId) ||
+            !visibleContent(result) || !result.matches(resultSelectors[action]) || !result.firstElementChild) {
             return;
         }
-
-        state.seenOperations.push(operationKey);
-        state.seenOperations = state.seenOperations.slice(-seenLimit);
-        state.usage[action] = Math.min(normalizeCount(state.usage[action]) + 1, seenLimit);
-
-        var threshold = thresholdFor(action);
-        if (threshold > 0 && state.usage[action] >= threshold && !state.shown[action] && !state.dismissed[action]) {
-            state.pending[action] = true;
+        var root = result.closest('#wc-backbone-modal-dialog');
+        if (!root || root.querySelector('[aria-busy="true"]')) {
+            return;
         }
-
-        saveState(state);
-    }
-
-    function nextPendingAction(state) {
-        var i;
-        for (i = 0; i < validActions.length; i++) {
-            var action = validActions[i];
-            if (state.pending[action] && !state.shown[action] && !state.dismissed[action]) {
-                return action;
-            }
+        // This event comes only after the action client has rendered its verified
+        // result and cleared busy. It carries no order/customer/payment data.
+        if (!recordSuccessfulOperation(action, detail.operationId)) {
+            return;
         }
-        return '';
-    }
-
-    function markCampaignShown(state, action) {
-        if (!isValidAction(action)) {
-            return state;
+        var state = readState();
+        if (!canPresent() || !eligible(action, state) || !(config.actionTips || {})[action] || root.querySelector('.wcos-modal-upsell')) {
+            return;
         }
-
-        state.pending[action] = false;
+        var card = createCard(config.actionTips[action], 'wcos-completed-upsell', function() {
+            var latest = readState();
+            latest.dismissed[action] = true;
+            saveState(latest);
+        });
+        card.setAttribute('data-wcos-upsell-action', action);
+        result.appendChild(card);
+        // No page-load advertising: completion consumes this campaign once.
         state.shown[action] = true;
-        return state;
-    }
-
-    function dismissCampaign(action) {
-        if (!isValidAction(action)) {
-            return;
-        }
-
-        var state = readState();
-        state.dismissed[action] = true;
-        saveState(markCampaignShown(state, action));
-    }
-
-    function dismissSplitHint() {
-        var state = readState();
-        state.hints.splitRoutingDismissed = true;
         saveState(state);
     }
 
-    function renderPendingTip() {
-        if (!config.productUrl || !config.actionTips || $('.wcos-post-action-tip').length) {
+    function splitChooser(event) {
+        var body = event.target;
+        if (!canPresent() || !config.splitHint || !visibleContent(body) ||
+            !body.matches('.wcos-admin-backbone-modal__body') || !body.closest('.wcos-split-method-backbone-modal') ||
+            !body.querySelector('.wcos-split-method-options') || body.querySelector('.wcos-modal-upsell') ||
+            readState().hints.splitRoutingDismissed) {
             return;
         }
-
-        var state = readState();
-        var action = nextPendingAction(state);
-        if (!action || !config.actionTips[action]) {
-            return;
-        }
-
-        var $insertionPoint = $('#woocommerce-order-data').first();
-        if (!$insertionPoint.length) {
-            return;
-        }
-
-        var $notice = $('<div>', {
-            'class': 'notice notice-info wcos-post-action-tip',
-            'data-wcos-upsell-action': action
+        var card = createCard(config.splitHint, 'wcos-split-upgrade-hint', function() {
+            var state = readState();
+            state.hints.splitRoutingDismissed = true;
+            saveState(state);
         });
-        var $paragraph = $('<p>');
-        $paragraph.append(document.createTextNode(config.actionTips[action] + ' '));
-        $('<a>', {
-            href: config.productUrl,
-            target: '_blank',
-            rel: 'noopener noreferrer',
-            text: config.ctaLabel || 'Explore Advanced Order Actions'
-        }).appendTo($paragraph);
-        $notice.append($paragraph);
-
-        $('<button>', {
-            type: 'button',
-            'class': 'notice-dismiss',
-            'aria-label': config.dismissLabel || 'Dismiss'
-        }).append($('<span>', {
-            'class': 'screen-reader-text',
-            text: config.dismissLabel || 'Dismiss'
-        })).appendTo($notice);
-
-        $notice.on('click', '.notice-dismiss', function() {
-            dismissCampaign(action);
-            $notice.remove();
-        });
-
-        $insertionPoint.before($notice);
-        saveState(markCampaignShown(state, action));
+        var heading = document.createElement('strong');
+        heading.textContent = config.splitHintTitle || 'Need more advanced routing?';
+        card.insertBefore(heading, card.firstChild);
+        body.appendChild(card);
     }
 
-    function renderSplitHint() {
-        if (!config.productUrl || !config.splitHint || $('.wcos-split-upgrade-hint').length) {
-            return;
-        }
-
-        if (readState().hints.splitRoutingDismissed) {
-            return;
-        }
-
-        var $launcherArea = $('.wcos-split-launcher-description, .wcos-strategy-launcher-description').last();
-        if (!$launcherArea.length) {
-            $launcherArea = $('.wcos-split-launcher, .wcos-strategy-launcher').last();
-        }
-        if (!$launcherArea.length) {
-            return;
-        }
-
-        var $hint = $('<p>', { 'class': 'description wcos-split-upgrade-hint' });
-        $hint.append(document.createTextNode(config.splitHint + ' '));
-        $('<a>', {
-            href: config.productUrl,
-            target: '_blank',
-            rel: 'noopener noreferrer',
-            text: config.splitHintCta || 'See advanced split methods'
-        }).appendTo($hint);
-
-        $('<button>', {
-            type: 'button',
-            'class': 'button-link wcos-split-upgrade-hint-dismiss',
-            text: config.dismissLabel || 'Dismiss'
-        }).on('click', function() {
-            dismissSplitHint();
-            $hint.remove();
-        }).appendTo($hint);
-
-        $launcherArea.after($hint);
-    }
-
-    function observePayload(action, payload) {
-        if (!isValidAction(action) || !payload || payload.success !== true || !payload.data || typeof payload.data.operation_id !== 'string') {
-            return;
-        }
-
-        recordSuccessfulOperation(action, payload.data.operation_id);
-    }
-
-    function installFetchObserver() {
-        if (typeof window.fetch !== 'function' || window.fetch.__wcosPremiumUpsellObserved) {
-            return;
-        }
-
-        var originalFetch = window.fetch;
-        var observedFetch = function(input, init) {
-            var actionMap = config.executeActions || {};
-            var actionName = actionFromBody(init && init.body);
-            var action = actionMap[actionName];
-            var requestPromise = originalFetch.apply(this, arguments);
-
-            if (!isValidAction(action)) {
-                return requestPromise;
-            }
-
-            return requestPromise.then(function(response) {
-                if (response && typeof response.clone === 'function') {
-                    try {
-                        response.clone().json().then(function(payload) {
-                            observePayload(action, payload);
-                        }).catch(function() {});
-                    } catch (error) {}
-                }
-                return response;
-            });
-        };
-
-        observedFetch.__wcosPremiumUpsellObserved = true;
-        observedFetch.__wcosPremiumUpsellOriginal = originalFetch;
-        window.fetch = observedFetch;
-    }
-
-    cleanupLegacyState();
-
-    $(function() {
-        // Only state from an earlier page lifecycle can render here.
-        renderPendingTip();
-        renderSplitHint();
+    ['wcosPostActionTip', 'wcosPostSplitTip', 'wcosPostActionTipDismissedAt'].forEach(function(key) {
+        try { window.localStorage.removeItem(key); } catch (error) {}
     });
+    // If durable local frequency limits are unavailable, omit advertising.
+    saveState(readState());
 
-    if (window.wcosPremiumUpsellTestHooks && typeof window.wcosPremiumUpsellTestHooks === 'object') {
-        window.wcosPremiumUpsellTestHooks.readState = readState;
-        window.wcosPremiumUpsellTestHooks.recordSuccessfulOperation = recordSuccessfulOperation;
-        window.wcosPremiumUpsellTestHooks.nextPendingAction = nextPendingAction;
-        window.wcosPremiumUpsellTestHooks.markCampaignShown = markCampaignShown;
-        window.wcosPremiumUpsellTestHooks.dismissCampaign = dismissCampaign;
-        window.wcosPremiumUpsellTestHooks.dismissSplitHint = dismissSplitHint;
-        window.wcosPremiumUpsellTestHooks.observePayload = observePayload;
-    }
-
-    installFetchObserver();
-})(jQuery);
+    // Listener failures are isolated from every operational client and control.
+    document.addEventListener('wcos:operation-completed', function(event) {
+        try { completed(event); } catch (error) {}
+    });
+    document.addEventListener('wcos:split-method-chooser', function(event) {
+        try { splitChooser(event); } catch (error) {}
+    });
+})();

--- a/tests/integration/premium-upsell-surface-smoke.php
+++ b/tests/integration/premium-upsell-surface-smoke.php
@@ -46,10 +46,9 @@ wcos_upsell_assert(false !== strpos($boundary, "current_user_can('manage_woocomm
 wcos_upsell_assert(false !== strpos($boundary, "'split' => 3"), 'Split threshold must be 3.');
 wcos_upsell_assert(false !== strpos($boundary, "'duplicate' => 2"), 'Duplicate threshold must be 2.');
 wcos_upsell_assert(false !== strpos($boundary, "'merge' => 2"), 'Merge threshold must be 2.');
-wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_execute' => 'split'"), 'Manual Split execute mapping missing.');
-wcos_upsell_assert(false !== strpos($boundary, "'wcos_split_strategy_execute' => 'split'"), 'Strategy Split execute mapping missing.');
-wcos_upsell_assert(false !== strpos($boundary, "'wcos_duplicate_execute' => 'duplicate'"), 'Duplicate execute mapping missing.');
-wcos_upsell_assert(false !== strpos($boundary, "'wcos_merge_execute' => 'merge'"), 'Merge execute mapping missing.');
+wcos_upsell_assert(false !== strpos($boundary, "'return' => 2"), 'Return threshold must be 2.');
+wcos_upsell_assert(false === strpos($boundary, 'executeActions'), 'Presentation must not observe transport actions.');
+wcos_upsell_assert(false !== strpos($boundary, 'Action Logs and guarded rollback for supported Split, Merge, Return and Duplicate workflows.'), 'Return positioning must remain qualified.');
 wcos_upsell_assert(false !== strpos($boundary, 'Vendor and bundle routing require compatible marketplace or bundle integrations.'), 'Contextual vendor and bundle claim must state its integration dependency.');
 
 wcos_upsell_assert(false !== strpos($settings, "\$sub_sub_tabs['premium'] = esc_html__('Upgrade'"), 'Historical premium section key must render Upgrade.');
@@ -62,17 +61,30 @@ wcos_upsell_assert(false !== strpos($settings, 'require a compatible Stock Manag
 wcos_upsell_assert(false !== strpos($bootstrap, "include_once \$root . 'backend/class-wcos-premium-upsell.php';"), 'Presentation boundary is not loaded.');
 wcos_upsell_assert(false !== strpos($bootstrap, 'WCOS_Premium_Upsell::bootstrap();'), 'Presentation boundary is not bootstrapped.');
 
-wcos_upsell_assert(false !== strpos($client, 'payload.success !== true'), 'Success-only guard missing.');
+wcos_upsell_assert(false !== strpos($client, "detail.status !== 'completed'"), 'Verified terminal-success guard missing.');
 wcos_upsell_assert(false !== strpos($client, 'seenOperations'), 'Operation replay deduplication state missing.');
-wcos_upsell_assert(false !== strpos($client, 'renderPendingTip();'), 'Later-page pending promotion render missing.');
+wcos_upsell_assert(false === strpos($client, 'renderPendingTip'), 'Later-page advertising must not duplicate completion campaigns.');
 wcos_upsell_assert(false !== strpos($client, 'hints: { splitRoutingDismissed: false }'), 'Split hint must have distinct browser-local dismissal state.');
-wcos_upsell_assert(false !== strpos($client, "'class': 'button-link wcos-split-upgrade-hint-dismiss'"), 'Split hint dismiss control missing.');
-wcos_upsell_assert(false !== strpos($client, 'dismissSplitHint();'), 'Split hint dismiss control must persist dismissal.');
-wcos_upsell_assert(false !== strpos($client, 'response.clone().json()'), 'Fetch observation must clone rather than consume the mutation response.');
+wcos_upsell_assert(false !== strpos($client, 'button-link wcos-modal-upsell-dismiss'), 'Modal hint dismiss control missing.');
+wcos_upsell_assert(false !== strpos($client, 'state.hints.splitRoutingDismissed = true;'), 'Split hint dismiss control must persist dismissal.');
+wcos_upsell_assert(false === strpos($client, 'window.fetch'), 'Promotion must not observe, wrap or issue fetch requests.');
+wcos_upsell_assert(false !== strpos($client, "document.addEventListener('wcos:operation-completed'"), 'Completion presentation listener missing.');
+wcos_upsell_assert(false !== strpos($client, "document.addEventListener('wcos:split-method-chooser'"), 'Method chooser presentation listener missing.');
+wcos_upsell_assert(false === strpos($client, '.wcos-split-launcher'), 'Obsolete external Split hint must not duplicate chooser card.');
 wcos_upsell_assert(false === strpos($client, 'navigator.sendBeacon'), 'Telemetry via sendBeacon is forbidden.');
 wcos_upsell_assert(false === strpos($client, 'XMLHttpRequest'), 'Upsell client must not create XHR telemetry.');
 wcos_upsell_assert(false === strpos($client, 'utm_'), 'Tracking parameters are forbidden.');
 wcos_upsell_assert(false === strpos($client, 'ref='), 'Referral parameters are forbidden.');
+
+foreach (array('split' => 'split', 'split-strategy' => 'split', 'duplicate' => 'duplicate', 'merge' => 'merge', 'return' => 'return') as $file_action => $campaign) {
+	$action_client = wcos_upsell_read($root . '/js/p2-' . $file_action . '-admin.js');
+	wcos_upsell_assert(1 === substr_count($action_client, "new CustomEvent('wcos:operation-completed'"), 'Exactly one bounded completion notification is required per client.');
+	wcos_upsell_assert(false !== strpos($action_client, "completedPresentation = { action: '" . $campaign . "', operationId: data.operation_id, status: data.status };"), 'Notification must contain only action, operation ID and server status.');
+	wcos_upsell_assert(false !== strpos($action_client, 'if (!busy && completedPresentation)'), 'Completion notification must wait for busy cleanup.');
+	wcos_upsell_assert(false === strpos($action_client, 'productUrl'), 'Commercial content must stay out of the action client.');
+}
+$bulk_client = wcos_upsell_read($root . '/js/p2-bulk-return-admin.js');
+wcos_upsell_assert(false === strpos($bulk_client, 'wcos:operation-completed'), 'Bulk Return must not join the Edit Order campaign.');
 
 require_once $root . '/inc/backend/class-wcos-premium-upsell.php';
 $upsell = WCOS_Premium_Upsell::bootstrap();

--- a/tests/js/helpers/upsell-dom.js
+++ b/tests/js/helpers/upsell-dom.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+class Element {
+    constructor(tag, ownerDocument) {
+        this.tagName = tag.toUpperCase();
+        this.ownerDocument = ownerDocument;
+        this.children = [];
+        this.parentNode = null;
+        this.attributes = {};
+        this.className = '';
+        this.listeners = {};
+        this.hidden = false;
+        this._text = '';
+        this.classList = {
+            contains: (name) => this.className.split(/\s+/).includes(name),
+            add: (...names) => { this.className += ' ' + names.join(' '); }
+        };
+    }
+    get isConnected() { return this === this.ownerDocument.body || !!(this.parentNode && this.parentNode.isConnected); }
+    get firstChild() { return this.children[0] || null; }
+    get firstElementChild() { return this.firstChild; }
+    get textContent() { return this._text + this.children.map((child) => child.textContent).join(''); }
+    set textContent(value) { this._text = value; this.children.forEach((child) => { child.parentNode = null; }); this.children = []; }
+    appendChild(child) { child.remove(); child.parentNode = this; this.children.push(child); return child; }
+    insertBefore(child, before) { child.remove(); child.parentNode = this; this.children.splice(this.children.indexOf(before), 0, child); }
+    remove() {
+        if (this.parentNode) {
+            this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+            this.parentNode = null;
+        }
+    }
+    setAttribute(name, value) { this.attributes[name] = String(value); }
+    getAttribute(name) { return this.attributes[name] === undefined ? null : this.attributes[name]; }
+    matches(selector) {
+        return selector.split(',').some((part) => {
+            part = part.trim();
+            if (part.startsWith('.')) return this.classList.contains(part.slice(1));
+            if (part.startsWith('#')) return this.getAttribute('id') === part.slice(1);
+            if (part.startsWith('[')) {
+                const match = part.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+                if (!match) throw new Error('Unsupported selector: ' + part);
+                if (match[1] === 'hidden') return this.hidden;
+                return match[2] === undefined ? this.getAttribute(match[1]) !== null : this.getAttribute(match[1]) === match[2];
+            }
+            return this.tagName === part.toUpperCase();
+        });
+    }
+    closest(selector) { return this.matches(selector) ? this : this.parentNode && this.parentNode.closest(selector); }
+    querySelectorAll(selector) {
+        return this.children.flatMap((child) => [...(child.matches(selector) ? [child] : []), ...child.querySelectorAll(selector)]);
+    }
+    querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
+    addEventListener(name, listener) { (this.listeners[name] ||= []).push(listener); }
+    dispatchEvent(event) {
+        event.target ||= this;
+        (this.listeners[event.type] || []).forEach((listener) => listener(event));
+        if (event.bubbles) {
+            if (this.parentNode) this.parentNode.dispatchEvent(event);
+            else if (this === this.ownerDocument.body) this.ownerDocument.dispatchEvent(event);
+        }
+        return true;
+    }
+    focus() { this.ownerDocument.activeElement = this; }
+    click() { this.dispatchEvent({ type: 'click', bubbles: true }); }
+}
+
+function harness(options = {}) {
+    const storage = options.storage || new Map();
+    const document = {
+        listeners: {},
+        createElement(tag) { return new Element(tag, this); },
+        addEventListener(name, listener) { (this.listeners[name] ||= []).push(listener); },
+        dispatchEvent(event) { (this.listeners[event.type] || []).forEach((listener) => listener(event)); }
+    };
+    document.body = document.createElement('body');
+    const config = {
+        productUrl: 'https://yoohw.com/product/woocommerce-advanced-order-actions/',
+        thresholds: { split: 3, duplicate: 2, merge: 2, return: 2 },
+        actionTips: { split: 'Split automation', duplicate: 'Duplicate control', merge: 'Merge previews', return: 'Action Logs and guarded rollback' },
+        splitHint: 'Product group, tag, attribute and conditional routing. Vendor and bundle routing require compatible integrations.',
+        ...options.config
+    };
+    const window = {
+        wcosPremiumUpsell: config,
+        localStorage: {
+            getItem(key) { if (options.denyRead) throw new Error('Storage blocked'); return storage.get(key) || null; },
+            setItem(key, value) { if (options.denyWrite) throw new Error('Quota exceeded'); storage.set(key, value); },
+            removeItem(key) { storage.delete(key); }
+        },
+        fetch() { throw new Error('Promotion must not make network calls'); }
+    };
+    const originalFetch = window.fetch;
+    const context = vm.createContext({ window, document, console });
+    vm.runInContext(fs.readFileSync(path.join(__dirname, '../../../js/post-action-tip.js'), 'utf8'), context);
+    function modal(action, chooser = false) {
+        document.body.textContent = '';
+        const root = document.body.appendChild(document.createElement('div'));
+        root.setAttribute('id', 'wc-backbone-modal-dialog');
+        const shell = root.appendChild(document.createElement('div'));
+        shell.className = chooser ? 'wcos-split-method-backbone-modal' : 'wcos-' + action + '-backbone-modal';
+        const body = shell.appendChild(document.createElement('div'));
+        body.className = 'wcos-admin-backbone-modal__body';
+        const footer = shell.appendChild(document.createElement('footer'));
+        const close = footer.appendChild(document.createElement('button'));
+        close.textContent = 'Close';
+        const result = body.appendChild(document.createElement('div'));
+        result.className = 'wcos-' + action + '-result';
+        const outcome = result.appendChild(document.createElement('p'));
+        outcome.textContent = 'Operation completed. Operation evidence remains visible.';
+        const continuation = result.appendChild(document.createElement('a'));
+        continuation.href = '/order';
+        continuation.textContent = 'View order';
+        return { root, shell, body, footer, close, result, outcome, continuation };
+    }
+    function emit(action, operationId, status = 'completed', target) {
+        target ||= modal(action).result;
+        target.dispatchEvent({ type: 'wcos:operation-completed', bubbles: true, detail: { action, operationId, status } });
+        return target;
+    }
+    return { document, window, originalFetch, storage, config, modal, emit, context,
+        read: () => JSON.parse(storage.get('wcosPremiumUpsellStateV1') || '{}') };
+}
+
+module.exports = { harness, Element };

--- a/tests/js/premium-upsell-modal-lifecycle.js
+++ b/tests/js/premium-upsell-modal-lifecycle.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const { harness } = require('./helpers/upsell-dom');
+
+// Execute the actual production lifecycle functions, not a second client model.
+function extract(source, name) {
+    const match = new RegExp('^([ \\t]*)function ' + name + '\\(', 'm').exec(source);
+    assert.ok(match, name + ' exists');
+    const start = match.index;
+    let position = source.indexOf('{', start), depth = 0, quote = '', comment = '';
+    for (; position < source.length; position++) {
+        const char = source[position], next = source[position + 1];
+        if (comment === '//') { if (char === '\n') comment = ''; continue; }
+        if (comment === '/*') { if (char === '*' && next === '/') { comment = ''; position++; } continue; }
+        if (quote) { if (char === '\\') position++; else if (char === quote) quote = ''; continue; }
+        if (char === '"' || char === "'") { quote = char; continue; }
+        if (char === '/' && (next === '/' || next === '*')) { comment = char + next; position++; continue; }
+        if (char === '{') depth++;
+        if (char === '}' && --depth === 0) return source.slice(start, position + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+const cases = [
+    ['split', 'split', 'executePlan'],
+    ['split-strategy', 'split', 'executeStrategy'],
+    ['duplicate', 'duplicate', 'executeDuplicate'],
+    ['merge', 'merge', 'confirmAndMerge'],
+    ['return', 'return', 'executeReturn']
+];
+
+async function runCase(fileAction, action, execute, outcome, presentationMode = 'normal') {
+    const source = fs.readFileSync(path.join(__dirname, '../../js/p2-' + fileAction + '-admin.js'), 'utf8');
+    const h = harness();
+    for (let i = 1; i < h.config.thresholds[action]; i++) h.emit(action, 'previous-' + i);
+    const m = h.modal(fileAction === 'split-strategy' ? 'strategy' : action);
+    m.result.hidden = true;
+    m.result.textContent = '';
+    const control = () => m.footer.appendChild(h.document.createElement('button'));
+    const events = [], requests = [], failures = [];
+    h.document.addEventListener('wcos:operation-completed', (event) => {
+        assert.equal(h.context.busy, false);
+        if (action === 'return') assert.equal(h.context.phase, 'completed');
+        else assert.equal(h.context.completed, true);
+        assert.ok(m.result.firstElementChild, 'Success result precedes notification');
+        assert.equal(m.result.hidden, false);
+        assert.deepEqual(Object.keys(event.detail).sort(), ['action', 'operationId', 'status']);
+        events.push(event.detail);
+    });
+    if (presentationMode === 'absent') h.document.listeners['wcos:operation-completed'] = [];
+    if (presentationMode === 'throws') m.result.dispatchEvent = () => { throw new Error('Presentation failed'); };
+    const authority = { operationId: 'current-operation', token: 'unchanged-token' };
+    const attributes = {
+        'data-order-id': '10', 'data-source-order-id': '10', 'data-child-order-id': '10',
+        'data-nonce': 'unchanged-nonce', 'data-execute-action': 'wcos_' + action + '_execute',
+        'data-confirm-action': 'wcos_' + action + '_confirm', 'data-strategy': 'category'
+    };
+    const context = h.context;
+    Object.assign(context, {
+        busy: false, completed: false, completedPresentation: null,
+        phase: 'confirmed', state: authority, confirmationState: authority,
+        confirmationAuthority: authority, reviewState: {}, reviewAuthority: { reviewId: 'review-id', token: 'review-token' },
+        selectedBucket: 'bucket', selectedTarget: '20', retryReady: false,
+        dialog: m.root, form: m.body, resultBox: m.result,
+        sourceDialog: { getAttribute: (key) => attributes[key] || '' },
+        reviewButton: control(), confirmButton: control(), executeButton: control(),
+        cancelButton: control(), closeButton: control(), editButton: control(), targetSelect: control(),
+        confirmCheckbox: control(), reviewBox: control(),
+        text: (key, fallback) => fallback,
+        canBuildPlan: () => true, updateChildToolbar() {}, updateReviewAvailability() {},
+        clearError() {}, clearResult() { m.result.textContent = ''; m.result.hidden = true; },
+        showError(message) { failures.push(message); }, setStatus() {}, hideWorkflowActions() {},
+        invalidateReview() {}, showExecuteAction() {}, focusableElements: () => [m.close], focusDialogFallback() {},
+        $: () => ({ prop() {} }),
+        CustomEvent: class { constructor(type, options) { this.type = type; Object.assign(this, options); } },
+        request(...args) {
+            requests.push({ action: args.at(-2), data: args.at(-1) });
+            if (outcome === 'failure' || outcome === 'retry') {
+                const error = new Error(outcome);
+                error.retryable = outcome === 'retry';
+                return Promise.reject(error);
+            }
+            return Promise.resolve({
+                operation_id: 'current-operation', status: outcome,
+                target: { id: 20, edit_url: '/target' }, original: { id: 30, edit_url: '/original' },
+                children: [{ id: 40, edit_url: '/child' }]
+            });
+        }
+    });
+    context.confirmCheckbox.checked = true;
+    const names = ['setBusy', 'renderSuccess', execute];
+    if (action === 'merge') names.push('executeSameOperation', 'finishExecute', 'handleExecuteFailure');
+    if (action === 'return') names.push('executeSameOperation', 'setPhase', 'updateControls');
+    vm.runInContext(names.map((name) => extract(source, name)).join('\n'), context);
+    vm.runInContext(execute + '()', context);
+    assert.equal(m.result.querySelector('.wcos-modal-upsell'), null, 'No ad while executing');
+    assert.equal(context.busy, true);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(context.busy, false);
+    assert.equal(requests.length, 1, 'Exactly the existing Execute request is issued');
+    assert.equal(requests[0].data.operation_id, authority.operationId);
+    assert.equal(requests[0].data.confirmation_token, authority.token);
+    assert.equal(requests[0].data.nonce, 'unchanged-nonce');
+    assert.equal(m.footer.querySelector('.wcos-modal-upsell'), null);
+    assert.equal(context.cancelButton.disabled, false);
+    assert.equal(context.closeButton.disabled, false);
+    const card = m.result.querySelector('.wcos-completed-upsell');
+    if (outcome === 'completed') {
+        assert.equal(failures.length, 0, 'Optional presentation must not convert success into failure');
+        assert.equal(m.result.hidden, false);
+        assert.ok(m.result.textContent.includes('successfully') || m.result.textContent.includes('Return completed'));
+        assert.ok(m.result.querySelector('a'), 'Operational order link remains available');
+        if (presentationMode === 'normal') {
+            assert.equal(events.length, 1);
+            assert.ok(card, fileAction + ' integrates the completed campaign');
+            assert.equal(h.read().usage[action], h.config.thresholds[action]);
+        } else assert.equal(card, null);
+    } else {
+        assert.equal(card, null, 'Failure/nonterminal state must not advertise');
+        assert.equal(h.read().usage[action], h.config.thresholds[action] - 1);
+        if (outcome === 'failure' || outcome === 'retry') assert.equal(events.length, 0);
+    }
+}
+
+(async () => {
+    for (const [fileAction, action, execute] of cases) {
+        for (const outcome of ['completed', 'failure', 'retry', 'recovery_pending', 'compensated', 'manual_reconciliation']) {
+            await runCase(fileAction, action, execute, outcome);
+        }
+        await runCase(fileAction, action, execute, 'completed', 'absent');
+        await runCase(fileAction, action, execute, 'completed', 'throws');
+    }
+    console.log('premium-upsell-modal-lifecycle: ok (five real clients; completion, failure, recovery, absent/throwing presentation)');
+})().catch((error) => { console.error(error); process.exit(1); });

--- a/tests/js/premium-upsell-state.js
+++ b/tests/js/premium-upsell-state.js
@@ -1,173 +1,139 @@
-const fs = require('fs');
-const vm = require('vm');
-const path = require('path');
+'use strict';
 
-const source = fs.readFileSync(path.join(__dirname, '../../js/post-action-tip.js'), 'utf8');
-const storage = new Map();
-const hooks = {};
-let fetchCalls = 0;
-let fetchResponse;
+const assert = require('node:assert/strict');
+const { harness } = require('./helpers/upsell-dom');
 
-const localStorage = {
-    getItem(key) {
-        return storage.has(key) ? storage.get(key) : null;
-    },
-    setItem(key, value) {
-        storage.set(key, String(value));
-    },
-    removeItem(key) {
-        storage.delete(key);
+for (const [action, threshold] of Object.entries({ split: 3, duplicate: 2, merge: 2, return: 2 })) {
+    const h = harness();
+    for (let i = 1; i < threshold; i++) {
+        const result = h.emit(action, 'operation-' + i);
+        assert.equal(h.read().usage[action], i);
+        assert.equal(result.querySelector('.wcos-modal-upsell'), null, action + ' must not advertise early');
+        h.emit(action, 'operation-' + i);
+        assert.equal(h.read().usage[action], i, 'Replay must not increment');
     }
-};
-
-function jqueryStub(arg) {
-    if (typeof arg === 'function') {
-        return undefined;
-    }
-
-    return {
-        length: 0,
-        first() { return this; },
-        last() { return this; },
-        after() { return this; },
-        before() { return this; },
-        append() { return this; },
-        appendTo() { return this; },
-        on() { return this; },
-        remove() { return this; }
-    };
+    const m = h.modal(action);
+    h.emit(action, 'threshold', 'completed', m.result);
+    const card = m.result.querySelector('.wcos-completed-upsell');
+    assert.ok(card, action + ' must render at its threshold');
+    assert.equal(m.result.children.at(-1), card, 'Banner follows all operation evidence and continuation');
+    assert.equal(m.result.children[0], m.outcome);
+    assert.equal(m.result.children[1], m.continuation);
+    assert.equal(m.footer.querySelector('.wcos-modal-upsell'), null, 'No footer CTA');
+    assert.equal(m.close.disabled, undefined, 'Close remains independently usable');
+    assert.equal(card.querySelector('a').href, h.config.productUrl);
+    assert.equal(card.querySelector('a').rel, 'noopener noreferrer');
+    assert.equal(card.querySelector('p').textContent, h.config.actionTips[action]);
+    assert.equal(h.read().shown[action], true);
+    h.emit(action, 'threshold', 'completed', m.result);
+    assert.equal(m.result.querySelectorAll('.wcos-modal-upsell').length, 1);
+    card.querySelector('button').click();
+    assert.equal(h.read().dismissed[action], true);
+    assert.equal(m.result.querySelector('.wcos-modal-upsell'), null);
+    assert.equal(h.document.activeElement, m.result);
+    for (let i = 0; i < 100; i++) h.emit(action, 'later-' + i);
+    assert.equal(h.read().usage[action], threshold, 'Usage saturates without replay-ID eviction');
+    assert.equal(h.read().seenOperations.length, threshold, 'Retained IDs stay bounded');
+    assert.equal(h.emit(action, 'operation-1').querySelector('.wcos-modal-upsell'), null);
+    const nextPage = harness({ storage: h.storage });
+    assert.equal(nextPage.document.body.children.length, 0, 'No later-page duplicate advertising');
+    assert.equal(nextPage.emit(action, 'new-page-success').querySelector('.wcos-modal-upsell'), null);
+    assert.equal(h.window.fetch, h.originalFetch, 'Mutation transport must not be wrapped/replaced');
 }
 
-const response = {
-    clone() {
-        return {
-            json() {
-                return Promise.resolve({ success: true, data: { operation_id: 'fetch-split-1' } });
-            }
-        };
+for (const action of ['split', 'duplicate', 'merge', 'return']) {
+    for (const status of [undefined, null, '', 'reviewed', 'confirmed', 'executing', 'busy', 'failed', 'retry_required', 'replayed', 'recovery_required', 'recovery_pending', 'compensating', 'compensated', 'manual_reconciliation']) {
+        const h = harness();
+        // Explicit detail allows a missing status (emit has a completed default).
+        const m = h.modal(action);
+        m.result.dispatchEvent({ type: 'wcos:operation-completed', bubbles: true, detail: { action, operationId: 'rejected', status } });
+        assert.equal(h.read().usage[action], 0, action + '/' + status + ' cannot count');
+        assert.equal(m.result.querySelector('.wcos-modal-upsell'), null);
     }
-};
-fetchResponse = response;
-
-const context = {
-    window: {
-        localStorage,
-        wcosPremiumUpsellTestHooks: hooks,
-        wcosPremiumUpsell: {
-            productUrl: 'https://yoohw.com/product/woocommerce-advanced-order-actions/',
-            thresholds: { split: 3, duplicate: 2, merge: 2 },
-            executeActions: { wcos_split_execute: 'split' },
-            actionTips: {}
-        },
-        fetch() {
-            fetchCalls += 1;
-            return Promise.resolve(fetchResponse);
-        }
-    },
-    document: {},
-    jQuery: jqueryStub,
-    URLSearchParams,
-    FormData: typeof FormData === 'undefined' ? function FormData() {} : FormData,
-    isFinite,
-    Math,
-    JSON,
-    Array,
-    String,
-    Object,
-    parseInt,
-    decodeURIComponent,
-    console
-};
-context.window.window = context.window;
-
-vm.createContext(context);
-vm.runInContext(source, context, { filename: 'post-action-tip.js' });
-
-function assert(condition, message) {
-    if (!condition) {
-        throw new Error(message);
+    for (const unsafe of ['hidden', 'detached', 'busy', 'footer', 'wrong-result', 'empty-result', 'outside-modal']) {
+        const h = harness();
+        const m = h.modal(action);
+        if (unsafe === 'hidden') m.result.hidden = true;
+        if (unsafe === 'detached') m.root.remove();
+        if (unsafe === 'busy') m.root.setAttribute('aria-busy', 'true');
+        if (unsafe === 'footer') m.footer.appendChild(m.result);
+        if (unsafe === 'wrong-result') m.result.className = 'wcos-review';
+        if (unsafe === 'empty-result') m.result.textContent = '';
+        if (unsafe === 'outside-modal') h.document.body.appendChild(m.result);
+        h.emit(action, 'unsafe', 'completed', m.result);
+        assert.equal(h.read().usage[action], 0, unsafe + ' cannot count');
+        assert.equal(m.result.querySelector('.wcos-modal-upsell'), null);
     }
 }
+const scoped = harness();
+scoped.emit('split', 'shared-id');
+scoped.emit('duplicate', 'shared-id');
+assert.equal(scoped.read().usage.split, 1);
+assert.equal(scoped.read().usage.duplicate, 1, 'Deduplication is action scoped');
+scoped.emit('bulk_return', 'excluded');
+assert.equal(scoped.read().usage.bulk_return, undefined);
+for (const id of ['', 'contains@email.example', 'private data', 'x'.repeat(101), 123, null]) {
+    scoped.emit('return', id);
+}
+assert.equal(scoped.read().usage.return, 0, 'Malformed IDs / PII are not retained');
 
-async function run() {
-    assert(typeof hooks.observePayload === 'function', 'observePayload test hook missing');
-    assert(typeof hooks.readState === 'function', 'readState test hook missing');
-    assert(typeof hooks.dismissSplitHint === 'function', 'dismissSplitHint test hook missing');
-
-    assert(hooks.readState().hints.splitRoutingDismissed === false, 'Split hint must be visible until it is dismissed');
-    hooks.dismissSplitHint();
-    assert(hooks.readState().hints.splitRoutingDismissed === true, 'Split hint dismissal must persist in local state');
-
-    hooks.observePayload('split', { success: true, data: { operation_id: 'split-1' } });
-    hooks.observePayload('split', { success: true, data: { operation_id: 'split-2' } });
-
-    let state = hooks.readState();
-    assert(state.usage.split === 2, 'Split should not qualify before the third unique success');
-    assert(!state.pending.split, 'Split promotion must not be pending before threshold');
-
-    hooks.observePayload('split', { success: false, data: { operation_id: 'split-failed' } });
-    state = hooks.readState();
-    assert(state.usage.split === 2, 'Failed Split must not increment usage');
-
-    hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
-    state = hooks.readState();
-    assert(state.usage.split === 3, 'Third unique successful Split must reach threshold');
-    assert(state.pending.split === true, 'Third unique successful Split must queue later-page promotion');
-    assert(state.shown.split === false, 'Promotion must not be marked shown during the completing operation');
-
-    hooks.observePayload('split', { success: true, data: { operation_id: 'split-3' } });
-    state = hooks.readState();
-    assert(state.usage.split === 3, 'Replay of an operation ID must not increment usage');
-
-    hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-1' } });
-    assert(!hooks.readState().pending.duplicate, 'Duplicate must not qualify on first success');
-    hooks.observePayload('duplicate', { success: true, data: { operation_id: 'dup-2' } });
-    state = hooks.readState();
-    assert(state.usage.duplicate === 2 && state.pending.duplicate === true, 'Duplicate must qualify on second unique success');
-
-    hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-1' } });
-    assert(!hooks.readState().pending.merge, 'Merge must not qualify on first success');
-    hooks.observePayload('merge', { success: true, data: { operation_id: 'merge-2' } });
-    state = hooks.readState();
-    assert(state.usage.merge === 2 && state.pending.merge === true, 'Merge must qualify on second unique success');
-    assert(hooks.nextPendingAction(state) === 'split', 'Pending action order must be deterministic');
-
-    hooks.markCampaignShown(state, 'split');
-    assert(state.shown.split === true && state.pending.split === false, 'Rendering must consume the pending Split campaign exactly once');
-    assert(hooks.nextPendingAction(state) === 'duplicate', 'A shown campaign must not become eligible again');
-
-    hooks.dismissCampaign('merge');
-    state = hooks.readState();
-    assert(state.dismissed.merge === true && state.pending.merge === false, 'Dismissal must persist in local campaign state');
-
-    const originalResponse = await context.window.fetch('/admin-ajax.php', {
-        method: 'POST',
-        body: new URLSearchParams({ action: 'wcos_split_execute' })
+function chooser(h) {
+    const m = h.modal('split', true);
+    m.result.remove();
+    const options = m.body.appendChild(h.document.createElement('div'));
+    options.className = 'wcos-split-method-options';
+    const methods = ['By quantity', 'By category', 'By stock status'].map((label) => {
+        const button = options.appendChild(h.document.createElement('button'));
+        button.className = 'wcos-split-method-option';
+        button.textContent = label;
+        return button;
     });
-    await Promise.resolve();
-    await Promise.resolve();
-
-    assert(fetchCalls === 1, 'Fetch observer must issue exactly the original request once');
-    assert(originalResponse === response, 'Fetch observer must return the original response');
-    assert(hooks.readState().usage.split === 4, 'Successful observed fetch must record one unique operation');
-
-    const cloneFailureResponse = {
-        clone() {
-            throw new Error('clone unavailable');
-        }
-    };
-    fetchResponse = cloneFailureResponse;
-    const cloneFailureResult = await context.window.fetch('/admin-ajax.php', {
-        method: 'POST',
-        body: new URLSearchParams({ action: 'wcos_split_execute' })
-    });
-    assert(cloneFailureResult === cloneFailureResponse, 'Clone failures must not reject or replace the mutation response');
-    assert(fetchCalls === 2, 'Clone failure path must still issue exactly one original request');
-
-    console.log('premium-upsell-state: ok');
+    m.body.dispatchEvent({ type: 'wcos:split-method-chooser', bubbles: true });
+    return { ...m, methods };
 }
+const h = harness();
+const choice = chooser(h);
+choice.body.dispatchEvent({ type: 'wcos:split-method-chooser', bubbles: true });
+assert.equal(choice.body.querySelectorAll('.wcos-modal-upsell').length, 1);
+assert.equal(choice.footer.querySelector('.wcos-modal-upsell'), null);
+assert.equal(choice.body.children[0].className, 'wcos-split-method-options');
+choice.methods.forEach((button) => assert.equal(button.disabled, undefined));
+choice.body.querySelector('.wcos-modal-upsell-dismiss').click();
+assert.equal(h.read().hints.splitRoutingDismissed, true);
+assert.equal(h.document.activeElement, choice.methods[0]);
+assert.equal(chooser(h).body.querySelector('.wcos-modal-upsell'), null);
+assert.equal(chooser(harness({ storage: h.storage })).body.querySelector('.wcos-modal-upsell'), null);
 
-run().catch((error) => {
-    console.error(error);
-    process.exit(1);
-});
+const migrated = new Map([['wcosPremiumUpsellStateV1', JSON.stringify({
+    usage: { split: 999, duplicate: 2 }, shown: { duplicate: true }, pending: { split: true },
+    seenOperations: ['split:legacy-1', 'private@example.com'], hints: { splitRoutingDismissed: true }, customer: 'must be discarded'
+})]]);
+const migration = harness({ storage: migrated });
+assert.equal(migration.read().usage.split, 3);
+assert.equal(migration.read().shown.duplicate, true);
+assert.deepEqual(migration.read().seenOperations, ['split:legacy-1']);
+assert.equal(migration.read().pending, undefined, 'Obsolete later-page queue is removed');
+assert.equal(migration.read().customer, undefined);
+assert.equal(migration.document.body.children.length, 0);
+assert.equal(chooser(migration).body.querySelector('.wcos-modal-upsell'), null);
+
+for (const options of [{ denyRead: true }, { denyWrite: true }, { config: { productUrl: 'https://yoohw.com/product/woocommerce-advanced-order-actions/?utm_source=bad' } }]) {
+    const limited = harness(options);
+    assert.equal(chooser(limited).body.querySelector('.wcos-modal-upsell'), null);
+    limited.emit('duplicate', 'one');
+    assert.equal(limited.emit('duplicate', 'two').querySelector('.wcos-modal-upsell'), null, 'Fail closed without local limits/canonical URL');
+}
+const malformed = harness({ storage: new Map([['wcosPremiumUpsellStateV1', '{bad json']]) });
+assert.equal(malformed.read().usage.split, 0);
+const brokenDom = harness();
+brokenDom.emit('return', 'one');
+const m = brokenDom.modal('return');
+const append = m.result.appendChild;
+m.result.appendChild = () => { throw new Error('Presentation render failure'); };
+assert.doesNotThrow(() => brokenDom.emit('return', 'two', 'completed', m.result));
+assert.equal(m.result.children[0], m.outcome);
+assert.equal(m.result.children[1], m.continuation);
+assert.equal(m.footer.children[0], m.close);
+m.result.appendChild = append;
+
+console.log('premium-upsell-state: ok (four campaigns, unsafe states, replay, migration, bounded storage, isolated presentation)');


### PR DESCRIPTION
## WOS-UPSELL-002

Closes #138.

Classification: `P3_PRODUCT_QUALITY`. Native path profile: `CRITICAL` (bounded presentation notifications in existing mutation clients).

Base: `55cca511f42a915c57aa16163f9f889d1f55ee12`.

Current reviewed/tested head: `2d0e13cb530c35bc759b93616136867f2ca103e6`.

## Scope

- Consolidate the old external Split hint into one dismissible Split Method Chooser card, after all Free methods.
- Show action-specific secondary content only inside visible completed results: Split after 3 unique successes; Duplicate/Merge/Return after 2.
- Existing clients emit only action, operation ID and the existing server status after result rendering and busy cleanup. Presentation errors are isolated.
- Remove fetch interception and later-page advertising, preventing duplicate campaigns. Retain V1 shown/dismissed state, saturate usage counters, bound replay IDs, and omit advertising if local persistence is unavailable.
- Canonical query-free product CTA; no promotion network requests, licensing, telemetry, checkout, installation or Premium runtime dependency.
- Bulk Return remains outside this tranche. No new runtime asset or distribution rules change.

## Exact gate invariants

Workflow: `split=true`, `duplicate=true`, `merge=true`, `return=true`, `bulk_return=true`.
Strategy: `manual_quantity=true`, `category=true`, `stock_status=true`.

Gate files, server controllers/request envelopes, authorization, domain/services/gateway, money/tax/stock, journal/lease/recovery and completion semantics are unchanged. No version/readme/changelog/stable tag/package/release changes.

## Evidence

- `bash .github/scripts/run-fast.sh`: PASS, including unchanged distribution requirements.
- PHP 8.3 `bash .github/scripts/run-static.sh`: PASS, including domain units, static product contracts and existing JS regressions.
- `php tests/integration/premium-upsell-surface-smoke.php`: PASS.
- `tests/js/premium-upsell-state.js`: thresholds, replay/action isolation, forbidden states/locations, V1 migration, one-time/dismissal, saturated bounds, canonical CTA, blocked storage, render failure and no fetch wrapping.
- `tests/js/premium-upsell-modal-lifecycle.js`: runs actual functions from all five clients (manual/strategy Split, Duplicate, Merge, Return); verifies post-busy notification, existing request fields, failures/recovery and absent/throwing presentation.
- [Native CI run 33723564413](https://github.com/yoohwz/wc-order-splitter/actions/runs/33723564413): SUCCESS on the current head, including **Required CI**, PHP 7.4/8.1/8.3 and product integration in legacy/HPOS/HPOS-sync.
- [Fresh Independent Codex Technical Review](https://github.com/yoohwz/wc-order-splitter/pull/139#issuecomment-5521488141) and [current-head correction reassessment](https://github.com/yoohwz/wc-order-splitter/pull/139#issuecomment-5521567915): no actionable P0/P1/P2 blockers. Source read-only; not Executor self-review, GitHub Approval, or Acceptance.

## Hands-on Local UI evidence

Executed against the exact active plugin worktree/head loaded by WordPress Local, WooCommerce 11.0.1, HPOS enabled. No file copying or detached implementation worktree. Browser actions used disposable synthetic pending orders with one non-taxable managed-stock product; no existing customer orders or store settings were changed.

- Three real manual Split operations, two real Return operations, two full source/target Review-to-confirm-and-execute Merge operations, and two real Duplicate operations completed through the existing admin controls.
- Review/confirmation screens remained free of upsell content. Result messages and generated order links stayed intact. Return, Merge and Duplicate each showed their action-specific banner after the second success, not the first; the CTA stayed inside completed result content, outside the action footer. Dismiss removed only the banner and preserved result links/focus.
- The existing Local browser profile suppressed Split promotion. Its storage was neither read nor reset. A separate fresh loopback-origin presentation fixture loaded the actual current WordPress/WooCommerce modal dependencies and plugin assets: the actual chooser showed all three enabled Free methods followed by one dismissible card; dismiss focused the first Free method. Isolated completed-result samples showed no Split banner at counts 1/2, one at 3, and none after dismissal at 4. These samples prove fresh-state presentation only, not real order mutation; the real Split client-to-completion boundary is additionally covered by the three Local operations and the actual-client lifecycle regression suite.
- Screenshot inspection found the WordPress button-link margin reset overriding Dismiss spacing. The sole correction after the first review was a scoped CSS specificity increase; desktop screenshots then confirmed CTA/Dismiss spacing in the chooser and completed banners. The independent reviewer reassessed that exact correction.
- Separate WooCommerce CRUD/database re-read after all nine operations: nine completed journals; unique persisted item ownership; managed product stock remained 100; no `_reduced_stock` copied; tax remained zero. Source plus its still-active Split child conserved 8 units / USD 80 after two Returns. The active Merge target held 6 units / USD 60; retired sources retained history in trash. Both duplicates were pending with 7 units / USD 70 and no transaction ID.
- Cleanup revalidated exact fixture identities, then permanently removed only the nine disposable orders, their operation journals/confirmation records, the synthetic product and fixture manifest. Post-cleanup re-read confirmed orders/product/manifest absent. The temporary preview server was stopped. No package was created.

Failure/retry/recovery/replay, blocked persistence, absent/throwing promotion code, action isolation and bounds are automated regression evidence; they were not fault-injected into the hands-on Local session. The full storage/PHP matrix is native CI evidence, not a claim that the Local browser session covered all storage modes.

Capability copy follows the approved Issue and [canonical shipped product page](https://yoohw.com/product/woocommerce-advanced-order-actions/), with local Premium source confirmation for Action Logs/guarded rollback. Integration-dependent routing is qualified in the chooser.

`READY_TO_FINALIZE: WOS-UPSELL-002`. Keep draft for ChatGPT Finalize. No merge, version, package, release, tag, publication or deployment authority was exercised.

NEXT_ACTION_HINT
Who: Human
Where: ChatGPT
Command: Finalize WOS-UPSELL-002
Expected: Verify and accept the exact tested/reviewed head before any owner-authorized merge; release remains separate.
