### PR TITLE
WOS-REL-002: bootstrap human-gated WordPress.org publisher

### DIFF
--- a/.github/actions/publisher-context/action.yml
+++ b/.github/actions/publisher-context/action.yml
@@ -1,0 +1,35 @@
+name: Authenticated WOS publication context
+description: Trusted main guard and candidate/artifact authentication without an SVN credential
+runs:
+  using: composite
+  steps:
+    - name: Guard trusted main and data inputs
+      shell: bash
+      run: |
+        set -euo pipefail
+        test "$GITHUB_REPOSITORY" = yoohwz/wc-order-splitter
+        test "$GITHUB_REF" = refs/heads/main
+        test "$GITHUB_REF_PROTECTED" = true
+        test "$GITHUB_WORKFLOW_REF" = yoohwz/wc-order-splitter/.github/workflows/publish-wordpress-org.yml@refs/heads/main
+        test "$GITHUB_WORKFLOW_SHA" = "$GITHUB_SHA"
+        test "$GITHUB_RUN_ATTEMPT" = 1
+        test -z "${WPORG_SVN_PASSWORD:-}"
+        [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+        [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]
+        [[ "$PREPARATION_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+    - name: Checkout candidate as non-executable data
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        ref: ${{ env.CANDIDATE_SHA }}
+        path: candidate-data
+        persist-credentials: false
+    - name: Ensure SVN and canonical staging tools
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install --yes subversion rsync
+    - name: Authenticate prepared product and independent candidate tree
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: python3 control/.github/scripts/release_cli.py context

--- a/.github/release/wporg-policy.json
+++ b/.github/release/wporg-policy.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "slug": "wc-order-splitter",
+  "svn_url": "https://plugins.svn.wordpress.org/wc-order-splitter",
+  "assets_mode": "unchanged",
+  "release_confirmation": {
+    "mode": "unknown",
+    "observed_at": null,
+    "source": "Not yet verified for Order Splitter; fail safe until a WordPress.org committer records Release Management state."
+  }
+}

--- a/.github/scripts/release-plugin-check.sh
+++ b/.github/scripts/release-plugin-check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Only invoked by secret-free Prepare. Never mount the control plane in Docker.
+set -euo pipefail
+test -z "${WPORG_SVN_PASSWORD:-}"
+test -z "${GH_TOKEN:-}"
+control_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+release_work="$RUNNER_TEMP/wcos-release"
+check_root="$release_work/plugin-check-runtime"
+mkdir "$check_root"
+python3 - "$check_root" "$release_work/stage-a" <<'PY'
+import json
+from pathlib import Path
+import sys
+root, payload = map(Path, sys.argv[1:])
+config = {
+    'core': None, 'phpVersion': '8.3', 'testsEnvironment': False,
+    'plugins': ['https://downloads.wordpress.org/plugin/woocommerce.11.0.1.zip',
+                'https://downloads.wordpress.org/plugin/plugin-check.2.1.0.zip'],
+    'mappings': {'wp-content/plugins/wc-order-splitter': str(payload)},
+    'config': {'WP_DEBUG': False},
+}
+(root / '.wp-env.json').write_text(json.dumps(config) + '\n')
+PY
+cd "$check_root"
+wp_env="$control_root/node_modules/.bin/wp-env"
+trap '"$wp_env" stop >/dev/null 2>&1 || true' EXIT
+"$wp_env" start
+"$wp_env" run cli wp plugin activate woocommerce plugin-check wc-order-splitter
+"$wp_env" run cli wp plugin check wc-order-splitter --format=strict-json --mode=update \
+  --slug=wc-order-splitter --fields=file,line,column,type,code,message,docs \
+  --require=./wp-content/plugins/plugin-check/cli.php > "$release_work/plugin-check-raw.txt"
+# The trusted Python entry point parses the report and fails on every ERROR.
+# No ignore list/baseline is introduced by this bootstrap.

--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Narrow workflow entry points; all executable control comes from protected main."""
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import release_package as pkg
+import release_github as gh
+import wporg_release as wp
+
+
+def settings():
+    candidate, version = os.environ['CANDIDATE_SHA'], os.environ['VERSION']
+    pkg.inputs(candidate, version)
+    work = Path(os.environ['RUNNER_TEMP']) / 'wcos-release'
+    work.mkdir(exist_ok=True)
+    return candidate, version, work
+
+
+def say(state, **evidence):
+    value = {'state': state, **evidence}
+    print(pkg.encoded(value).decode(), end='')
+    if os.environ.get('GITHUB_STEP_SUMMARY'):
+        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as handle:
+            handle.write('## ' + state + '\n\n```json\n' + pkg.encoded(value).decode() + '```\n')
+    if os.environ.get('GITHUB_OUTPUT'):
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as handle:
+            handle.write('state=' + state + '\n')
+
+
+def candidate_tree(candidate, work, expected, *, validate=False, suffix='candidate-stage'):
+    source = Path(os.environ['CANDIDATE_DIR']).resolve()
+    pkg.require(source != pkg.ROOT and pkg.ROOT not in source.parents, 'candidate must be separate non-executable data')
+    actual = subprocess.check_output(['git', '-C', str(source), 'rev-parse', 'HEAD']).decode().strip()
+    pkg.require(actual == candidate, 'candidate checkout SHA mismatch')
+    digest = pkg.stage(source, work / suffix, validate=validate)
+    pkg.require(digest == expected, 'candidate does not match certified product identity')
+
+
+def prepare():
+    candidate, version, work = settings()
+    api = gh.API()
+    gh.control_context(api, gh.PREPARE)
+    digest, cert_run = os.environ['PRODUCT_TREE_SHA'], os.environ['RELEASE_CERT_RUN_ID']
+    pkg.inputs(candidate, version, digest, cert_run)
+    gh.accepted_source(api, candidate)
+    gh.certificate(api, cert_run, digest)
+    for suffix in ('a', 'b'):
+        candidate_tree(candidate, work, digest, validate=True, suffix='stage-' + suffix)
+        pkg.build(work / ('stage-' + suffix), work / ('rc-' + suffix), candidate, version,
+                  digest, cert_run, os.environ['GITHUB_RUN_ID'])
+    for name in (f'{pkg.SLUG}-{version}.zip', 'release-manifest.json'):
+        pkg.require((work / 'rc-a' / name).read_bytes() == (work / 'rc-b' / name).read_bytes(), 'nondeterministic package build')
+    say('DETERMINISTIC_PACKAGE_VERIFIED', candidate_sha=candidate, product_tree_sha=digest, EXTERNAL_MUTATION='NONE')
+
+
+def plugin_check_report(raw):
+    lines = re.sub(r'\x1b\[[0-9;]*m', '', raw).splitlines()
+    matches = [json.loads(line) for line in lines if line.startswith('[')]
+    clean = lines.count('Success: Checks complete. No errors found.')
+    pkg.require(len(matches) == 1 and clean == 0 or not matches and clean == 1, 'Plugin Check report missing or ambiguous')
+    report = matches[0] if matches else []
+    pkg.require(isinstance(report, list) and all(isinstance(item, dict) and 'type' in item and 'code' in item
+                and 'file' in item for item in report), 'invalid Plugin Check report')
+    pkg.require(all(item['type'].upper() in {'WARNING', 'ERROR'} for item in report), 'unexpected Plugin Check result type')
+    pkg.require(not any(item['type'].upper() == 'ERROR' for item in report), 'Plugin Check Errors block preparation; no ignore baseline')
+    return report
+
+
+def finish_prepare():
+    candidate, version, work = settings()
+    api = gh.API()
+    control = gh.control_context(api, gh.PREPARE)
+    manifest = pkg.read_json(work / 'rc-a/release-manifest.json')
+    pkg.require(manifest['candidate_sha'] == candidate and manifest['version'] == version and
+                manifest['product_tree_sha'] == os.environ['PRODUCT_TREE_SHA'], 'prepared identity changed')
+    pkg.verify_tree(work / 'stage-a', manifest)
+    pkg.validate_payload((work / 'rc-a' / manifest['package_name']).read_bytes(), manifest, work / 'validated-package')
+    report = plugin_check_report((work / 'plugin-check-raw.txt').read_text())
+    pkg.write_json(work / 'rc-a/plugin-check.json', report)
+    name = f'{pkg.SLUG}-{version}-{candidate}'
+    record = {'schema_version': 1, 'repository': pkg.REPOSITORY, 'workflow_path': gh.PREPARE,
+              'control_sha': control, 'run_id': int(os.environ['GITHUB_RUN_ID']), 'run_attempt': 1,
+              'manifest_sha256': pkg.sha(pkg.encoded(manifest)), 'artifact_name': name,
+              'status': 'RC_PREPARED', 'external_mutation': 'NONE', **pkg.manifest_identity(manifest)}
+    pkg.write_json(work / 'rc-a/preparation-record.json', record)
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as handle:
+        handle.write('artifact_name=' + name + '\n')
+    say('RC_PREPARED', **pkg.manifest_identity(manifest), file_count=manifest['file_count'], EXTERNAL_MUTATION='NONE')
+
+
+def publication_context():
+    candidate, version, work = settings()
+    pkg.require(os.environ.get('OPERATION') in {'publish', 'verify-only'} and os.environ.get('DRY_RUN') in {'true', 'false'}, 'invalid publication operation')
+    if os.environ['OPERATION'] == 'verify-only':
+        pkg.inputs(candidate, version, run_id=os.environ['ORIGINAL_PUBLISH_RUN_ID'])
+    api = gh.API()
+    control = gh.control_context(api, gh.PUBLISH)
+    manifest, provenance = gh.prepared(api, os.environ['PREPARATION_RUN_ID'], candidate, version, work / 'prepared')
+    candidate_tree(candidate, work, manifest['product_tree_sha'])
+    pkg.write_json(work / 'context.json', {'control_sha': control, 'artifact': provenance})
+    return manifest, work
+
+
+def current():
+    candidate, version, work = settings()
+    manifest = pkg.read_json(work / 'prepared/release-manifest.json')
+    pkg.require(manifest['candidate_sha'] == candidate and manifest['version'] == version and
+                manifest['preparation_run_id'] == int(os.environ['PREPARATION_RUN_ID']), 'current manifest/input mismatch')
+    pkg.verify_tree(work / 'prepared/payload', manifest)
+    return manifest, work
+
+
+def record_base(manifest):
+    return {'schema_version': 1, 'repository': pkg.REPOSITORY, 'workflow_path': gh.PUBLISH,
+            'control_sha': os.environ['GITHUB_SHA'], 'run_id': int(os.environ['GITHUB_RUN_ID']),
+            'identity': pkg.manifest_identity(manifest)}
+
+
+def preflight():
+    manifest, work = current()
+    pkg.require(os.environ['OPERATION'] == 'publish', 'preflight is publish-only')
+    release_policy = wp.policy()
+    repo = wp.SVN(work / 'svn-preflight').checkout()
+    before = repo.stage(work / 'prepared/payload', manifest, release_policy)
+    record = {**record_base(manifest), 'state': 'READ_ONLY_PUBLICATION_PREFLIGHT',
+              'dry_run': os.environ['DRY_RUN'] == 'true', 'snapshot': before,
+              'preparation_artifact': pkg.read_json(work / 'context.json')['artifact']}
+    pkg.write_json(work / 'preflight-record.json', record)
+    say(record['state'], record=record, EXTERNAL_MUTATION='NONE')
+
+
+def original_preflight(api, run_id, manifest, work, active=False):
+    run = api.get(f'actions/runs/{run_id}')
+    gh.workflow_run(run, gh.PUBLISH, success=False)
+    if not active:
+        pkg.require(run['status'] == 'completed', 'original publisher is still running')
+    pkg.require(gh.ancestor(api, run['head_sha'], gh.protected_main(api)), 'original publisher control not accepted')
+    jobs = api.pages(f'actions/runs/{run_id}/attempts/1/jobs', 'jobs')
+    found = [job for job in jobs if job['name'] == 'Read-only publication preflight']
+    pkg.require(len(found) == 1 and found[0]['conclusion'] == 'success', 'original preflight job did not pass')
+    gh.artifact(api, run, f'wporg-preflight-{run_id}', work / 'approved', {'preflight-record.json'})
+    approved = pkg.read_json(work / 'approved/preflight-record.json')
+    expected = {'schema_version': 1, 'repository': pkg.REPOSITORY, 'workflow_path': gh.PUBLISH,
+                'control_sha': run['head_sha'], 'run_id': int(run_id), 'identity': pkg.manifest_identity(manifest),
+                'state': 'READ_ONLY_PUBLICATION_PREFLIGHT',
+                'preparation_artifact': pkg.read_json(work / 'context.json')['artifact']}
+    pkg.require(all(approved.get(key) == value for key, value in expected.items()), 'original preflight provenance mismatch')
+    pkg.require(approved['snapshot']['target_tag_exists'] is False, 'preflight did not prove tag absence')
+    if not active:
+        pkg.require(approved['dry_run'] is False, 'dry-run evidence cannot authorize publication recovery')
+    return approved, run
+
+
+def recheck():
+    manifest, work = current()
+    api = gh.API()
+    approved, _ = original_preflight(api, os.environ['GITHUB_RUN_ID'], manifest, work, active=True)
+    pkg.require(approved['dry_run'] == (os.environ['DRY_RUN'] == 'true'), 'preflight dry-run intent changed')
+    repo = wp.SVN(work / 'svn-final').checkout()
+    repo.stage(work / 'prepared/payload', manifest, wp.policy(), approved['snapshot'])
+    pkg.write_json(work / 'final-record.json', {**record_base(manifest), 'state': 'FINAL_PRE_MUTATION_REMOTE_RECHECK',
+                   'preflight_sha256': pkg.sha(pkg.encoded(approved))})
+    say('FINAL_PRE_MUTATION_REMOTE_RECHECK', identity=pkg.manifest_identity(manifest), EXTERNAL_MUTATION='NONE')
+
+
+def mutation_guard(manifest, work):
+    pkg.require(os.environ.get('OPERATION') == 'publish' and os.environ.get('DRY_RUN') == 'false'
+                and os.environ.get('PUBLISH_ENVIRONMENT') == 'wordpress-org-production', 'production Environment boundary required')
+    final = pkg.read_json(work / 'final-record.json')
+    pkg.require(final == {**record_base(manifest), 'state': 'FINAL_PRE_MUTATION_REMOTE_RECHECK',
+                'preflight_sha256': pkg.sha((work / 'approved/preflight-record.json').read_bytes())}, 'final recheck record mismatch')
+
+
+def seal():
+    manifest, work = current()
+    mutation_guard(manifest, work)
+    tag = gh.git_tag(gh.API(), manifest, create=True)
+    pkg.write_json(work / 'tag-record.json', {'identity': pkg.manifest_identity(manifest), 'tag_object': tag})
+    say('TAG_SEALED', identity=pkg.manifest_identity(manifest), tag_object=tag)
+
+
+def commit():
+    manifest, work = current()
+    mutation_guard(manifest, work)
+    pkg.require(pkg.read_json(work / 'tag-record.json')['identity'] == pkg.manifest_identity(manifest), 'Git tag seal missing')
+    approved = pkg.read_json(work / 'approved/preflight-record.json')
+    # Recheck again after tag creation, before the only SVN write attempt.
+    wp.SVN(work / 'svn-before-commit').checkout().compare(approved['snapshot'], manifest['version'], wp.policy())
+    wp.SVN(work / 'svn-final').atomic_commit(manifest, os.environ['GITHUB_RUN_ID'], work / 'commit-attempt.json')
+    say('SVN_COMMIT_REQUIRES_VERIFICATION', identity=pkg.manifest_identity(manifest))
+
+
+def verification(manifest, work, approved, original_run, *, verify_only):
+    api = gh.API()
+    gh.git_tag(api, manifest)
+    result = wp.SVN(work / 'svn-verification').checkout().verify(manifest, approved, original_run)
+    durable = {**record_base(manifest), **result}
+    pkg.write_json(work / 'publication-record.json', durable)
+    state = wp.public_state(manifest, work / 'public-payload',
+                            confirmation=approved['snapshot']['release_confirmation']['mode'], verify_only=verify_only)
+    durable['state'] = state
+    pkg.write_json(work / 'publication-record.json', durable)
+    say(state, identity=pkg.manifest_identity(manifest), svn_revision=result['svn_revision'],
+        next_step='verify-only; never recommit SVN' if state != 'WPORG_PUBLIC_RELEASE_VERIFIED' else 'GitHub Release may follow')
+    return durable
+
+
+def verify():
+    manifest, work = current()
+    pkg.require((work / 'commit-attempt.json').exists(), 'no SVN commit attempt to verify')
+    verification(manifest, work, pkg.read_json(work / 'approved/preflight-record.json'), os.environ['GITHUB_RUN_ID'], verify_only=False)
+
+
+def recover():
+    manifest, work = current()
+    pkg.require(os.environ['OPERATION'] == 'verify-only' and not os.environ.get('WPORG_SVN_PASSWORD'), 'verify-only must have no SVN password')
+    api, run_id = gh.API(), os.environ['ORIGINAL_PUBLISH_RUN_ID']
+    approved, run = original_preflight(api, run_id, manifest, work)
+    result = verification(manifest, work, approved, run_id, verify_only=True)
+    artifacts = api.pages(f'actions/runs/{run_id}/artifacts', 'artifacts')
+    if any(item['name'] == f'wporg-publication-{run_id}' for item in artifacts):
+        gh.artifact(api, run, f'wporg-publication-{run_id}', work / 'original-publication', {'publication-record.json'})
+        original = pkg.read_json(work / 'original-publication/publication-record.json')
+        for key in ('identity', 'svn_revision', 'svn_url', 'publish_run_id', 'assets'):
+            pkg.require(original[key] == result[key], 'durable publication record mismatch: ' + key)
+    # Absence alone is recoverable from the authenticated immutable preflight +
+    # tag + exact SVN author/message/revision/atomic path set, never by recommit.
+
+
+def release():
+    manifest, work = current()
+    pkg.require(os.environ['DRY_RUN'] == 'false' and os.environ.get('PUBLISH_ENVIRONMENT') == 'wordpress-org-production'
+                and not os.environ.get('WPORG_SVN_PASSWORD'), 'GitHub Release boundary violated')
+    api = gh.API()
+    run_id = os.environ['GITHUB_RUN_ID']
+    run = api.get(f'actions/runs/{run_id}')
+    gh.workflow_run(run, gh.PUBLISH, success=False)
+    gh.artifact(api, run, f'wporg-publication-{run_id}', work / 'verified', {'publication-record.json'})
+    record = pkg.read_json(work / 'verified/publication-record.json')
+    pkg.require(all(record.get(key) == value for key, value in record_base(manifest).items())
+                and record['state'] == 'WPORG_PUBLIC_RELEASE_VERIFIED', 'authenticated public verification required')
+    original_run = str(record['publish_run_id'])
+    approved, _ = original_preflight(api, original_run, manifest, work, active=original_run == run_id)
+    # Revalidate public/SVN identity after any Environment wait, not just an output token.
+    refreshed = verification(manifest, work, approved, original_run, verify_only=True)
+    pkg.require(refreshed['svn_revision'] == record['svn_revision'], 'SVN publication revision drifted')
+    say(gh.github_release(api, manifest, work / 'prepared', refreshed), identity=pkg.manifest_identity(manifest))
+
+
+COMMANDS = {'prepare': prepare, 'finish-prepare': finish_prepare, 'context': publication_context,
+            'preflight': preflight, 'recheck': recheck, 'seal': seal, 'commit': commit,
+            'verify': verify, 'recover': recover, 'release': release}
+
+if __name__ == '__main__':
+    try:
+        pkg.require(len(sys.argv) == 2 and sys.argv[1] in COMMANDS, 'unknown release command')
+        COMMANDS[sys.argv[1]]()
+    except (ValueError, KeyError, OSError, subprocess.SubprocessError) as error:
+        sys.exit('release-control-error: ' + str(error))

--- a/.github/scripts/release_github.py
+++ b/.github/scripts/release_github.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""GitHub-native provenance checks; no Issue parsing or alternative merge policy."""
+import json
+import os
+from pathlib import Path
+import re
+import urllib.error
+import urllib.request
+
+import release_package as pkg
+
+PREPARE = '.github/workflows/release-prepare.yml'
+PUBLISH = '.github/workflows/publish-wordpress-org.yml'
+CERT = '.github/workflows/release-cert.yml'
+
+
+class SafeRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, message, headers, newurl):
+        pkg.require(newurl.startswith('https://'), 'non-HTTPS API redirect')
+        redirected = super().redirect_request(request, fp, code, message, headers, newurl)
+        if redirected is not None:
+            redirected.remove_header('Authorization')
+        return redirected
+
+
+class API:
+    def __init__(self):
+        self.token = os.environ.get('GH_TOKEN', '')
+        pkg.require(self.token, 'GitHub token is missing')
+        self.opener = urllib.request.build_opener(SafeRedirect())
+
+    def request(self, path, method='GET', value=None, binary=False, missing=False, upload=None):
+        pkg.require(path.startswith(f'repos/{pkg.REPOSITORY}/') and '..' not in path, 'unsafe GitHub API path')
+        host = 'https://uploads.github.com/' if upload is not None else 'https://api.github.com/'
+        headers = {'Authorization': f'Bearer {self.token}', 'User-Agent': 'WOS-release-control',
+                   'Accept': 'application/octet-stream' if binary and '/releases/assets/' in path else 'application/vnd.github+json',
+                   'X-GitHub-Api-Version': '2022-11-28'}
+        data = pkg.encoded(value) if value is not None else upload
+        if data is not None:
+            headers['Content-Type'] = 'application/octet-stream' if upload is not None else 'application/json'
+        request = urllib.request.Request(host + path, data=data, headers=headers, method=method)
+        try:
+            with self.opener.open(request, timeout=60) as response:
+                raw = response.read(pkg.LIMIT + 1)
+                pkg.require(len(raw) <= pkg.LIMIT, 'GitHub response too large')
+                return raw if binary else json.loads(raw)
+        except urllib.error.HTTPError as error:
+            if missing and error.code == 404:
+                return None
+            # Never print response bodies, credentials or redirect query strings.
+            raise ValueError(f'GitHub API {method} failed: HTTP {error.code}') from None
+
+    def get(self, endpoint, **kwargs):
+        return self.request(f'repos/{pkg.REPOSITORY}/{endpoint}', **kwargs)
+
+    def pages(self, endpoint, key=None):
+        result = []
+        for page in range(1, 101):
+            separator = '&' if '?' in endpoint else '?'
+            value = self.get(f'{endpoint}{separator}per_page=100&page={page}')
+            batch = value[key] if key else value
+            result.extend(batch)
+            if len(batch) < 100:
+                return result
+        raise ValueError('GitHub pagination limit exceeded')
+
+
+def workflow_run(run, path, success=True, main=True):
+    pkg.require(run['repository']['full_name'] == pkg.REPOSITORY and
+                run['head_repository']['full_name'] == pkg.REPOSITORY, 'run repository mismatch')
+    pkg.require(run['path'] == path and run['event'] == 'workflow_dispatch', 'run workflow/event mismatch')
+    if main:
+        pkg.require(run['head_branch'] == 'main' and run['run_attempt'] == 1, 'untrusted control-plane run')
+    if success:
+        pkg.require(run['status'] == 'completed' and run['conclusion'] == 'success', 'run is not successful')
+
+
+def ancestor(api, older, newer):
+    pkg.inputs(older, '1.5.0')
+    pkg.inputs(newer, '1.5.0')
+    return api.get(f'compare/{older}...{newer}')['status'] in {'ahead', 'identical'}
+
+
+def protected_main(api):
+    branch = api.get('branches/main')
+    pkg.require(branch['protected'] is True, 'main is not protected')
+    return branch['commit']['sha']
+
+
+def control_context(api, path):
+    expected = {'GITHUB_REPOSITORY': pkg.REPOSITORY, 'GITHUB_REF': 'refs/heads/main',
+                'GITHUB_REF_PROTECTED': 'true', 'GITHUB_EVENT_NAME': 'workflow_dispatch',
+                'GITHUB_RUN_ATTEMPT': '1', 'GITHUB_WORKFLOW_REF': f'{pkg.REPOSITORY}/{path}@refs/heads/main'}
+    pkg.require(all(os.environ.get(key) == value for key, value in expected.items()), 'untrusted workflow context')
+    control = os.environ['GITHUB_SHA']
+    pkg.inputs(control, '1.5.0')
+    pkg.require(os.environ.get('GITHUB_WORKFLOW_SHA') == control, 'workflow/control SHA mismatch')
+    pkg.require(ancestor(api, control, protected_main(api)), 'control SHA is not on protected main')
+    return control
+
+
+def ci_check(api, head):
+    checks = [check for check in api.pages(f'commits/{head}/check-runs', 'check_runs')
+              if check['name'] == 'Required CI' and check.get('app', {}).get('slug') == 'github-actions']
+    pkg.require(checks, 'native Required CI missing')
+    check = max(checks, key=lambda item: item['id'])
+    pkg.require(check['status'] == 'completed' and check['conclusion'] == 'success', 'latest Required CI did not pass')
+    match = re.fullmatch(r'https://github.com/yoohwz/wc-order-splitter/actions/runs/([0-9]+)/job/[0-9]+', check['details_url'])
+    pkg.require(match, 'Required CI has an unexpected run URL')
+    run = api.get(f'actions/runs/{match[1]}')
+    pkg.require(run['repository']['full_name'] == pkg.REPOSITORY and run['head_repository']['full_name'] == pkg.REPOSITORY
+                and run['path'] == '.github/workflows/ci.yml' and run['event'] == 'pull_request'
+                and run['head_sha'] == head and run['status'] == 'completed' and run['conclusion'] == 'success',
+                'Required CI provenance mismatch')
+    return int(match[1])
+
+
+def accepted_source(api, candidate, allow_merged_head=False):
+    """Squash merges inherit their PR's native CI, not a fictitious new head check."""
+    main = protected_main(api)
+    is_main = ancestor(api, candidate, main)
+    pulls = api.pages(f'commits/{candidate}/pulls')
+    for pull in pulls:
+        if not pull.get('merged_at') or pull['base']['ref'] != 'main' or pull['base']['repo']['full_name'] != pkg.REPOSITORY:
+            continue
+        merge, head = pull['merge_commit_sha'], pull['head']['sha']
+        if candidate != merge and not (allow_merged_head and candidate == head):
+            continue
+        if not ancestor(api, merge, main):
+            continue
+        # Require tree-preserving accepted provenance; ambiguous rebases fail closed.
+        merge_tree = api.get(f'git/commits/{merge}')['tree']['sha']
+        head_tree = api.get(f'git/commits/{head}')['tree']['sha']
+        if merge_tree == head_tree and (is_main or allow_merged_head):
+            return {'accepted_sha': merge, 'reviewed_head': head, 'required_ci_run_id': ci_check(api, head)}
+    pkg.require(is_main, 'candidate is not an accepted ancestor of protected main')
+    return {'accepted_sha': candidate, 'reviewed_head': candidate, 'required_ci_run_id': ci_check(api, candidate)}
+
+
+def certificate(api, run_id, digest):
+    pkg.inputs('0' * 40, '1.5.0', digest, run_id)
+    run = api.get(f'actions/runs/{run_id}')
+    workflow_run(run, CERT, main=False)
+    accepted_source(api, run['head_sha'], allow_merged_head=True)
+    jobs = api.pages(f'actions/runs/{run_id}/attempts/{run["run_attempt"]}/jobs', 'jobs')
+    finals = [job for job in jobs if job['name'] == 'RELEASE_CERT']
+    pkg.require(len(finals) == 1 and finals[0]['status'] == 'completed' and finals[0]['conclusion'] == 'success',
+                'expected exactly one successful RELEASE_CERT job')
+    job = finals[0]
+    expected_prefix = f'https://api.github.com/repos/{pkg.REPOSITORY}/check-runs/'
+    check_url = job['check_run_url']
+    pkg.require(check_url.startswith(expected_prefix) and check_url[len(expected_prefix):].isdigit(), 'invalid certificate check URL')
+    check = api.get('check-runs/' + check_url[len(expected_prefix):])
+    pkg.require(check['name'] == 'RELEASE_CERT' and check['status'] == 'completed' and check['conclusion'] == 'success'
+                and check['app']['slug'] == 'github-actions' and check['head_sha'] == run['head_sha'], 'untrusted certificate check')
+    pkg.require(not api.pages(f'actions/runs/{run_id}/artifacts', 'artifacts'), 'RELEASE_CERT artifacts must be zero')
+    raw = api.get(f'actions/jobs/{job["id"]}/logs', binary=True).decode('utf-8-sig')
+    lines = [re.sub(r'^\d{4}-\d\d-\d\dT[0-9:.]+Z ', '', line) for line in raw.splitlines()]
+    for marker in (f'PRODUCT_TREE_SHA={digest}', f'REPO_HEAD_SHA={run["head_sha"]}',
+                   f'PUBLIC_BASELINE={pkg.BASELINE}; GENUINE_UPGRADE=passed',
+                   'ARTIFACTS=0; no ZIP, tag, release, publication or deployment'):
+        pkg.require(lines.count(marker) == 1, 'certificate evidence identity mismatch')
+    return {'run_id': int(run_id), 'run_attempt': run['run_attempt'], 'head_sha': run['head_sha'],
+            'product_tree_sha': digest, 'public_baseline': pkg.BASELINE, 'artifacts': 0}
+
+
+def artifact(api, run, name, destination, allowed):
+    matches = [item for item in api.pages(f'actions/runs/{run["id"]}/artifacts', 'artifacts') if item['name'] == name]
+    pkg.require(len(matches) == 1 and not matches[0]['expired'], 'immutable artifact missing/ambiguous/expired')
+    item = matches[0]
+    pkg.require(item['workflow_run']['id'] == run['id'] and item['workflow_run']['head_sha'] == run['head_sha'],
+                'artifact run identity mismatch')
+    pkg.require(re.fullmatch('sha256:[0-9a-f]{64}', item.get('digest', '')), 'artifact API digest missing')
+    raw = api.get(f'actions/artifacts/{item["id"]}/zip', binary=True)
+    pkg.require('sha256:' + pkg.sha(raw) == item['digest'], 'downloaded artifact API digest mismatch')
+    contents = pkg.zip_data(raw)
+    pkg.require(set(contents) == set(allowed), 'unexpected artifact file set')
+    destination = Path(destination)
+    pkg.require(not destination.exists(), 'artifact destination already exists')
+    destination.mkdir(parents=True)
+    for filename, data in contents.items():
+        (destination / filename).write_bytes(data)
+    return {'id': item['id'], 'digest': item['digest'], 'name': name, 'run_id': run['id']}
+
+
+def prepared(api, run_id, candidate, version, destination):
+    pkg.inputs(candidate, version, run_id=run_id)
+    run = api.get(f'actions/runs/{run_id}')
+    workflow_run(run, PREPARE)
+    pkg.require(ancestor(api, run['head_sha'], protected_main(api)), 'preparation control not on protected main')
+    accepted_source(api, candidate)
+    name = f'{pkg.SLUG}-{version}-{candidate}'
+    expected = {f'{pkg.SLUG}-{version}.zip', 'release-manifest.json', 'preparation-record.json', 'plugin-check.json'}
+    provenance = artifact(api, run, name, destination, expected)
+    manifest = pkg.read_json(Path(destination) / 'release-manifest.json')
+    pkg.validate_manifest(manifest)
+    pkg.require(manifest['candidate_sha'] == candidate and manifest['version'] == version
+                and manifest['preparation_run_id'] == int(run_id), 'preparation manifest identity mismatch')
+    record = pkg.read_json(Path(destination) / 'preparation-record.json')
+    expected_record = {'schema_version': 1, 'repository': pkg.REPOSITORY, 'workflow_path': PREPARE,
+                       'control_sha': run['head_sha'], 'run_id': int(run_id), 'run_attempt': 1,
+                       'manifest_sha256': pkg.sha(pkg.encoded(manifest)), 'artifact_name': name,
+                       'status': 'RC_PREPARED', 'external_mutation': 'NONE', **pkg.manifest_identity(manifest)}
+    pkg.require(record == expected_record, 'preparation record mismatch')
+    report = pkg.read_json(Path(destination) / 'plugin-check.json')
+    pkg.require(isinstance(report, list) and all(item.get('type', '').upper() != 'ERROR' for item in report),
+                'Plugin Check contains Errors')
+    certificate(api, manifest['release_cert_run_id'], manifest['product_tree_sha'])
+    pkg.validate_payload((Path(destination) / manifest['package_name']).read_bytes(), manifest, Path(destination) / 'payload')
+    return manifest, provenance
+
+
+def tag_message(manifest):
+    return 'Order Splitter release identity\n' + pkg.encoded(pkg.manifest_identity(manifest)).decode()
+
+
+def git_tag(api, manifest, create=False):
+    version = manifest['version']
+    ref = api.get(f'git/ref/tags/{version}', missing=True)
+    if ref is None:
+        pkg.require(create, 'immutable Git tag is missing')
+        obj = api.get('git/tags', method='POST', value={'tag': version, 'message': tag_message(manifest),
+                      'object': manifest['candidate_sha'], 'type': 'commit'})
+        api.get('git/refs', method='POST', value={'ref': f'refs/tags/{version}', 'sha': obj['sha']})
+        # An uncertain response is not retried. Future invocations start with GET.
+        ref = api.get(f'git/ref/tags/{version}')
+    pkg.require(ref['ref'] == f'refs/tags/{version}' and ref['object']['type'] == 'tag', 'Git tag is not annotated')
+    obj = api.get('git/tags/' + ref['object']['sha'])
+    pkg.require(obj['tag'] == version and obj['object'] == {'type': 'commit', 'sha': manifest['candidate_sha'],
+                'url': f'https://api.github.com/repos/{pkg.REPOSITORY}/git/commits/{manifest["candidate_sha"]}'}
+                and obj['message'] == tag_message(manifest), 'immutable Git tag identity mismatch')
+    return ref['object']['sha']
+
+
+def github_release(api, manifest, prepared_dir, verification):
+    pkg.require(verification['state'] == 'WPORG_PUBLIC_RELEASE_VERIFIED'
+                and verification['identity'] == pkg.manifest_identity(manifest), 'public verification required before GitHub Release')
+    git_tag(api, manifest)
+    version = manifest['version']
+    prepared_dir = Path(prepared_dir)
+    notes = pkg.release_notes(prepared_dir / 'payload', version)
+    title = f'Order Splitter {version}'
+    release = api.get(f'releases/tags/{version}', missing=True)
+    if release is None:
+        release = api.get('releases', method='POST', value={'tag_name': version, 'target_commitish': manifest['candidate_sha'],
+                          'name': title, 'body': notes, 'draft': True, 'prerelease': False})
+    pkg.require(release['tag_name'] == version and release['name'] == title and release['body'] == notes
+                and release['prerelease'] is False, 'existing GitHub Release mismatch: Human review required')
+    assets = api.pages(f'releases/{release["id"]}/assets')
+    expected = {manifest['package_name'], 'release-manifest.json'}
+    pkg.require(len({a['name'] for a in assets}) == len(assets) and {a['name'] for a in assets} <= expected,
+                'existing Release assets mismatch: Human review required')
+    for asset in assets:
+        raw = api.get(f'releases/assets/{asset["id"]}', binary=True)
+        pkg.require(raw == (prepared_dir / asset['name']).read_bytes(), 'existing Release asset content mismatch')
+    missing = expected - {a['name'] for a in assets}
+    pkg.require(not missing or release['draft'], 'incomplete public Release requires Human review')
+    for name in sorted(missing):
+        api.get(f'releases/{release["id"]}/assets?name={name}', method='POST', upload=(prepared_dir / name).read_bytes())
+    uploaded = api.pages(f'releases/{release["id"]}/assets')
+    pkg.require(len(uploaded) == len(expected) and {asset['name'] for asset in uploaded} == expected,
+                'GitHub Release upload set mismatch')
+    for asset in uploaded:
+        pkg.require(api.get(f'releases/assets/{asset["id"]}', binary=True) == (prepared_dir / asset['name']).read_bytes(),
+                    'GitHub Release upload verification failed')
+    if release['draft']:
+        api.get(f'releases/{release["id"]}', method='PATCH', value={'draft': False, 'make_latest': 'true'})
+    final = api.get(f'releases/{release["id"]}')
+    pkg.require(final['tag_name'] == version and final['draft'] is False and final['body'] == notes,
+                'GitHub Release publication response mismatch')
+    return 'GITHUB_RELEASE_PUBLISHED'

--- a/.github/scripts/release_package.py
+++ b/.github/scripts/release_package.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Trusted, data-only packaging. PRODUCT_TREE_SHA remains owned by product-tree.py."""
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[2]
+SLUG = 'wc-order-splitter'
+REPOSITORY = 'yoohwz/wc-order-splitter'
+BASELINE = '1.4.11/e1d8aeb8eff38f4ce69dad1a08993e17521c6359'
+LIMIT = 100 * 1024 * 1024
+FIXED_TIME = (1980, 1, 1, 0, 0, 0)
+spec = importlib.util.spec_from_file_location('wcos_product_tree', ROOT / '.github/scripts/product-tree.py')
+product = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(product)
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def sha(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def encoded(value):
+    return (json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(',', ':')) + '\n').encode()
+
+
+def write_json(path, value):
+    Path(path).write_bytes(encoded(value))
+
+
+def read_json(path):
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            require(key not in result, 'duplicate JSON key')
+            result[key] = value
+        return result
+    return json.loads(Path(path).read_bytes(), object_pairs_hook=unique)
+
+
+def inputs(candidate, version, digest=None, run_id=None):
+    require(isinstance(candidate, str) and re.fullmatch('[0-9a-f]{40}', candidate), 'invalid candidate SHA')
+    require(isinstance(version, str) and re.fullmatch(r'(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){1,2}', version), 'invalid version')
+    require(version not in {'1.4.12', '1.4.13', '1.4.14', '1.4.15'}, 'unpublished intermediate version')
+    if digest is not None:
+        require(isinstance(digest, str) and re.fullmatch('[0-9a-f]{64}', digest), 'invalid product digest')
+    if run_id is not None:
+        require(re.fullmatch('[1-9][0-9]*', str(run_id)), 'invalid run ID')
+
+
+def safe_path(name):
+    require(isinstance(name, str) and name and len(name) < 512, 'invalid payload path')
+    require(all(re.fullmatch('[A-Za-z0-9_][A-Za-z0-9_. -]*', part) and part not in {'.', '..'}
+                for part in name.split('/')), 'unsafe payload path')
+    return name
+
+
+def files(root):
+    root = Path(root)
+    require(root.is_dir() and not root.is_symlink(), 'unsafe tree root')
+    result = []
+    for directory, dirs, names in os.walk(root, followlinks=False):
+        for name in dirs + names:
+            path = Path(directory) / name
+            relative = safe_path(path.relative_to(root).as_posix())
+            mode = path.lstat().st_mode
+            require(stat.S_ISREG(mode) or stat.S_ISDIR(mode), 'non-regular tree entry')
+            if stat.S_ISREG(mode):
+                data = path.read_bytes()
+                result.append({'path': relative, 'size': len(data), 'sha256': sha(data)})
+    result.sort(key=lambda item: item['path'].encode())
+    require(len({item['path'].casefold() for item in result}) == len(result), 'case-colliding paths')
+    require(sum(item['size'] for item in result) <= LIMIT, 'payload too large')
+    return result
+
+
+def metadata(root, version):
+    for file, pattern in ((SLUG + '.php', r'^ \* Version: (\S+)\s*$'),
+                          ('readme.txt', r'^Stable tag: (\S+)\s*$')):
+        matches = re.findall(pattern, (Path(root) / file).read_text(), re.MULTILINE)
+        require(matches == [version], 'Version / Stable tag mismatch')
+
+
+def stage(source, destination, validate=False):
+    """Never invoke a candidate-owned helper, PHP entrypoint, hook or build script."""
+    source, destination = Path(source).resolve(), Path(destination)
+    require(not (source / '.distignore').is_symlink(), 'unsafe .distignore')
+    require((source / '.distignore').read_bytes() == (ROOT / '.distignore').read_bytes(), 'distribution exclusions drifted')
+    script = 'validate-distribution-contract.sh' if validate else 'stage-distribution.sh'
+    subprocess.run(['bash', str(ROOT / '.github/scripts' / script), str(source), str(destination)], check=True)
+    files(destination)  # Reject special entries before any package construction.
+    return product.product_tree(destination)
+
+
+def build(staged, output, candidate, version, digest, cert_run, prepare_run):
+    inputs(candidate, version, digest, cert_run)
+    inputs(candidate, version, digest, prepare_run)
+    staged, output = Path(staged), Path(output)
+    require(product.product_tree(staged) == digest, 'candidate product identity mismatch')
+    metadata(staged, version)
+    require(not output.exists(), 'package output already exists')
+    output.mkdir(parents=True)
+    inventory = files(staged)
+    package_name = f'{SLUG}-{version}.zip'
+    # STORED deliberately avoids dependence on zlib/host compression versions.
+    with zipfile.ZipFile(output / package_name, 'x', compression=zipfile.ZIP_STORED) as archive:
+        for item in inventory:
+            info = zipfile.ZipInfo(f'{SLUG}/{item["path"]}', FIXED_TIME)
+            info.create_system = 3
+            info.external_attr = (stat.S_IFREG | 0o644) << 16
+            archive.writestr(info, (staged / item['path']).read_bytes())
+    manifest = {
+        'schema_version': 1, 'repository': REPOSITORY, 'slug': SLUG,
+        'candidate_sha': candidate, 'version': version, 'product_tree_sha': digest,
+        'release_cert_run_id': int(cert_run), 'preparation_run_id': int(prepare_run),
+        'public_baseline': BASELINE, 'package_name': package_name,
+        'package_sha256': sha((output / package_name).read_bytes()),
+        'file_count': len(inventory), 'files': inventory,
+    }
+    write_json(output / 'release-manifest.json', manifest)
+    return manifest
+
+
+def manifest_identity(manifest):
+    return {key: manifest[key] for key in (
+        'candidate_sha', 'version', 'product_tree_sha', 'package_sha256',
+        'release_cert_run_id', 'preparation_run_id')}
+
+
+def validate_manifest(manifest):
+    inputs(manifest['candidate_sha'], manifest['version'], manifest['product_tree_sha'], manifest['release_cert_run_id'])
+    inputs(manifest['candidate_sha'], manifest['version'], run_id=manifest['preparation_run_id'])
+    require(manifest['schema_version'] == 1 and manifest['repository'] == REPOSITORY and
+            manifest['slug'] == SLUG and manifest['public_baseline'] == BASELINE, 'manifest authority mismatch')
+    require(manifest['package_name'] == f'{SLUG}-{manifest["version"]}.zip', 'package filename mismatch')
+    require(re.fullmatch('[0-9a-f]{64}', manifest['package_sha256']), 'invalid package digest')
+    inventory = manifest['files']
+    require(0 < len(inventory) == manifest['file_count'] <= 10000, 'invalid file count')
+    for item in inventory:
+        safe_path(item['path'])
+        require(set(item) == {'path', 'size', 'sha256'} and type(item['size']) is int and
+                0 <= item['size'] <= LIMIT and re.fullmatch('[0-9a-f]{64}', item['sha256']), 'invalid file manifest')
+    require(inventory == sorted(inventory, key=lambda item: item['path'].encode()), 'unsorted manifest')
+    require(len({item['path'].casefold() for item in inventory}) == len(inventory), 'duplicate manifest path')
+    require(sum(item['size'] for item in inventory) <= LIMIT, 'manifest too large')
+
+
+def zip_data(raw, prefix=''):
+    """Parse before extraction: no traversal, aliases, links, duplicates or ZIP bombs."""
+    require(len(raw) <= LIMIT, 'archive too large')
+    result, seen, total = {}, set(), 0
+    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        require(len(archive.infolist()) <= 15000, 'archive has too many entries')
+        for item in archive.infolist():
+            name = item.filename
+            require(name not in seen, 'duplicate ZIP entry')
+            seen.add(name)
+            safe_path(name.rstrip('/'))
+            require(name.startswith(prefix) and name != prefix.rstrip('/'), 'unexpected archive root')
+            mode = item.external_attr >> 16
+            require(stat.S_IFMT(mode) in (0, stat.S_IFREG, stat.S_IFDIR), 'special ZIP entry')
+            require(not item.flag_bits & 1, 'encrypted ZIP entry')
+            total += item.file_size
+            require(total <= LIMIT, 'expanded archive too large')
+            if item.is_dir():
+                require(item.file_size == 0, 'nonempty ZIP directory')
+                continue
+            relative = safe_path(name[len(prefix):])
+            result[relative] = archive.read(item)
+    require(len({name.casefold() for name in result}) == len(result), 'case-colliding ZIP paths')
+    return result
+
+
+def validate_payload(raw, manifest, destination, exact_zip=True):
+    validate_manifest(manifest)
+    if exact_zip:
+        require(sha(raw) == manifest['package_sha256'], 'package digest mismatch')
+    data = zip_data(raw, SLUG + '/')
+    actual = [{'path': name, 'size': len(value), 'sha256': sha(value)} for name, value in sorted(data.items())]
+    require(actual == manifest['files'], 'package file set/content mismatch')
+    destination = Path(destination)
+    require(not destination.exists(), 'payload destination must not exist')
+    destination.mkdir(parents=True)
+    for name, value in data.items():
+        target = destination / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(value)
+        target.chmod(0o644)
+    verify_tree(destination, manifest)
+    return destination
+
+
+def verify_tree(root, manifest):
+    validate_manifest(manifest)
+    require(files(root) == manifest['files'], 'staged file set/content mismatch')
+    require(product.product_tree(root) == manifest['product_tree_sha'], 'PRODUCT_TREE_SHA mismatch')
+    metadata(root, manifest['version'])
+
+
+def release_notes(root, version):
+    text = (Path(root) / 'changelog.txt').read_text()
+    parts = re.split(r'^= ([0-9]+(?:\.[0-9]+){1,2})(?: \([^\n]*\))? =\s*$', text, flags=re.MULTILINE)
+    require(len(parts) >= 3 and parts[1] == version, 'public changelog version mismatch')
+    notes = parts[2].strip() + '\n'
+    require(notes.strip() and not re.search(r'WOS-[A-Z]|NEXT_ACTION_HINT|HUMAN_GATE', notes), 'non-public release notes')
+    return notes

--- a/.github/scripts/run-fast.sh
+++ b/.github/scripts/run-fast.sh
@@ -14,6 +14,7 @@ python3 tests/ci/profile-contract.py
 python3 tests/ci/product-tree-contract.py
 python3 tests/ci/integration-suite-contract.py
 python3 tests/ci/workflow-contract.py
+python3 tests/ci/publisher-contract.py
 bash tests/ci/distribution-contract.sh
 distribution=$(mktemp -d "${TMPDIR:-/tmp}/wcos-product.XXXXXX")
 trap 'rm -rf "$distribution"' EXIT

--- a/.github/scripts/wporg_release.py
+++ b/.github/scripts/wporg_release.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""SVN local staging, snapshot comparison and authenticated read-only verification.
+
+Only atomic_commit() can write remotely. Its CLI caller is isolated in the
+Environment-gated production step; file:// fixtures cannot use that method.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+
+import release_package as pkg
+
+SVN_URL = 'https://plugins.svn.wordpress.org/wc-order-splitter'
+
+
+def policy(path=pkg.ROOT / '.github/release/wporg-policy.json'):
+    value = pkg.read_json(path)
+    pkg.require(set(value) == {'schema_version', 'slug', 'svn_url', 'assets_mode', 'release_confirmation'}, 'invalid policy fields')
+    pkg.require(value['schema_version'] == 1 and value['slug'] == pkg.SLUG and value['svn_url'] == SVN_URL,
+                'policy requires the exact canonical slug and HTTPS SVN URL')
+    pkg.require(value['assets_mode'] == 'unchanged', 'assets changes are not authorized')
+    confirmation = value['release_confirmation']
+    pkg.require(set(confirmation) == {'mode', 'observed_at', 'source'} and confirmation['source'], 'confirmation provenance missing')
+    pkg.require(confirmation['mode'] in {'unknown', 'enabled', 'disabled'}, 'invalid confirmation mode')
+    if confirmation['mode'] == 'unknown':
+        pkg.require(confirmation['observed_at'] is None, 'unknown confirmation cannot claim observation time')
+    else:
+        import datetime
+        pkg.require(isinstance(confirmation['observed_at'], str), 'confirmation observation missing')
+        observed = datetime.datetime.fromisoformat(confirmation['observed_at'].replace('Z', '+00:00'))
+        pkg.require(observed.tzinfo is not None, 'confirmation observation requires timezone')
+    return value
+
+
+def without_credentials():
+    return {key: value for key, value in os.environ.items()
+            if key not in {'WPORG_SVN_PASSWORD', 'WPORG_SVN_USERNAME', 'GH_TOKEN', 'GITHUB_TOKEN'}}
+
+
+class SVN:
+    def __init__(self, working, url=SVN_URL, *, fixture=False):
+        pkg.require(url == SVN_URL or (fixture and url.startswith('file://')), 'noncanonical SVN URL')
+        self.working, self.url, self.fixture = Path(working).absolute(), url, fixture
+        pkg.require(not self.working.is_symlink(), 'unsafe working-copy root')
+
+    def run(self, *args):
+        result = subprocess.run(['svn', '--non-interactive', '--no-auth-cache', *map(str, args)],
+                                env=without_credentials(), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                timeout=120, check=False)
+        pkg.require(result.returncode == 0, 'SVN read/local staging failed: ' + str(args[0]))
+        return result.stdout.decode()
+
+    def checkout(self):
+        pkg.require(not self.working.exists(), 'fresh SVN checkout requires absent destination')
+        self.run('checkout', '--quiet', '--ignore-externals', self.url, self.working)
+        return self
+
+    def entries(self):
+        return ET.fromstring(self.run('status', '--xml', '--no-ignore', self.working)).findall('.//entry')
+
+    def validate(self, clean=True):
+        pkg.require(self.working.is_dir() and not self.working.is_symlink() and
+                    (self.working / '.svn').is_dir(), 'expected SVN working-copy root')
+        info = ET.fromstring(self.run('info', '--xml', self.working)).find('entry')
+        pkg.require(info.findtext('url').rstrip('/') == self.url, 'unexpected SVN working-copy URL')
+        present = {child.name for child in self.working.iterdir()} - {'.svn'}
+        pkg.require({'trunk', 'tags', 'assets'} <= present <= {'trunk', 'tags', 'assets', 'branches'}, 'unexpected SVN layout')
+        pkg.require(all((self.working / name).is_dir() and not (self.working / name).is_symlink() for name in present),
+                    'unexpected SVN root entry')
+        properties = ET.fromstring(self.run('proplist', '--xml', '--verbose', '--recursive', self.working))
+        pkg.require(not properties.findall('.//property[@name="svn:externals"]'), 'SVN externals are forbidden')
+        if clean:
+            pkg.require(not self.entries(), 'SVN checkout is not clean')
+        return int(info.attrib['revision'])
+
+    def surface(self, name):
+        root = self.working / name
+        inventory = pkg.files(root)
+        infos = ET.fromstring(self.run('info', '--xml', '--depth', 'infinity', root))
+        revisions = {}
+        for entry in infos.findall('entry'):
+            path = Path(entry.attrib['path']).absolute().relative_to(root).as_posix()
+            revisions[path] = int(entry.find('commit').attrib['revision'])
+        props = []
+        for target in ET.fromstring(self.run('proplist', '--xml', '--verbose', '--recursive', root)).findall('target'):
+            relative = Path(target.attrib['path']).absolute().relative_to(root).as_posix()
+            for item in target.findall('property'):
+                props.append({'path': relative, 'name': item.attrib['name'], 'encoding': item.get('encoding'), 'value': item.text})
+        return {'file_count': len(inventory), 'tree_sha256': pkg.sha(pkg.encoded(inventory)),
+                'revisions': revisions, 'properties': sorted(props, key=lambda item: (item['path'], item['name']))}
+
+    def snapshot(self, version, release_policy):
+        pkg.inputs('0' * 40, version)
+        revision = self.validate()
+        return {'svn_url': self.url, 'working_copy_revision': revision, 'version': version,
+                'layout': sorted({p.name for p in self.working.iterdir()} - {'.svn'}),
+                'trunk': self.surface('trunk'), 'assets': self.surface('assets'),
+                'target_tag_exists': (self.working / 'tags' / version).exists(),
+                'release_confirmation': release_policy['release_confirmation']}
+
+    def compare(self, approved, version, release_policy):
+        current = self.snapshot(version, release_policy)
+        pkg.require(approved['target_tag_exists'] is False and current['target_tag_exists'] is False,
+                    'target SVN tag exists or appeared after approval')
+        # WordPress.org's global repository revision changes for unrelated plugins.
+        # Bind exact relevant node revisions/content/properties, not that global clock.
+        for key in ('svn_url', 'version', 'layout', 'trunk', 'assets', 'release_confirmation'):
+            pkg.require(current[key] == approved[key], 'approved SVN snapshot drift: ' + key)
+        return current
+
+    def validate_delta(self, version):
+        entries = self.entries()
+        pkg.require(entries, 'SVN staging produced no delta')
+        for entry in entries:
+            relative = Path(entry.attrib['path']).absolute().relative_to(self.working).as_posix()
+            allowed = relative == 'trunk' or relative.startswith('trunk/') or relative == f'tags/{version}' or relative.startswith(f'tags/{version}/')
+            status = entry.find('wc-status')
+            pkg.require(allowed and status.attrib['item'] in {'added', 'deleted', 'replaced', 'modified', 'normal'}
+                        and status.attrib.get('props') not in {'conflicted'}
+                        and status.attrib.get('tree-conflicted') != 'true', 'SVN delta outside trunk/new tag or conflicted')
+
+    def stage(self, payload, manifest, release_policy, approved=None):
+        version = manifest['version']
+        before = self.compare(approved, version, release_policy) if approved else self.snapshot(version, release_policy)
+        pkg.require(before['target_tag_exists'] is False, 'target SVN tag already exists')
+        # Properties that transform published bytes are not part of the package.
+        pkg.require(not before['trunk']['properties'], 'unexpected existing trunk properties require Human review')
+        pkg.verify_tree(payload, manifest)
+        trunk = self.working / 'trunk'
+        for child in trunk.iterdir():
+            pkg.safe_path(child.name)
+            self.run('delete', '--force', child)
+        for item in manifest['files']:
+            target = trunk / item['path']
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes((Path(payload) / item['path']).read_bytes())
+            target.chmod(0o644)
+        self.run('add', '--force', '--no-ignore', '--no-auto-props', trunk)
+        self.run('copy', trunk, self.working / 'tags' / version)
+        self.validate_delta(version)
+        pkg.verify_tree(trunk, manifest)
+        pkg.verify_tree(self.working / 'tags' / version, manifest)
+        pkg.require(self.surface('assets') == before['assets'], 'assets changed during local staging')
+        return before
+
+    def verify(self, manifest, preflight, publish_run):
+        self.validate()
+        version = manifest['version']
+        approved = preflight['snapshot']
+        pkg.require(preflight['identity'] == pkg.manifest_identity(manifest) and approved['target_tag_exists'] is False,
+                    'original preflight identity mismatch')
+        pkg.require(approved['svn_url'] == self.url and approved['version'] == version, 'preflight SVN identity mismatch')
+        pkg.verify_tree(self.working / 'trunk', manifest)
+        pkg.verify_tree(self.working / 'tags' / version, manifest)
+        pkg.require(self.surface('assets') == approved['assets'], 'published assets drifted')
+        pkg.require(not self.surface('trunk')['properties'] and not self.surface(f'tags/{version}')['properties'],
+                    'unexpected published payload properties')
+        tag_log = ET.fromstring(self.run('log', '--xml', '--limit', '1', self.working / 'tags' / version)).find('logentry')
+        pkg.require(tag_log is not None, 'SVN tag log missing')
+        revision = int(tag_log.attrib['revision'])
+        log = ET.fromstring(self.run('log', '--xml', '--verbose', '-r', revision, self.url)).find('logentry')
+        pkg.require(log is not None and log.findtext('msg') == commit_message(manifest, publish_run)
+                    and log.findtext('author') == 'yoohw', 'SVN commit log/revision identity mismatch')
+        pkg.require(revision > approved['working_copy_revision'], 'SVN publication predates preflight')
+        paths = log.findall('paths/path')
+        prefix = '/wc-order-splitter' if not self.fixture else ''
+        tag_root = prefix + f'/tags/{version}'
+        pkg.require(any(p.text == tag_root and p.attrib['action'] == 'A' for p in paths), 'SVN tag was not created atomically')
+        pkg.require(any(p.text == prefix + '/trunk' or p.text.startswith(prefix + '/trunk/') for p in paths), 'atomic trunk update missing')
+        pkg.require(all(p.text == tag_root or p.text.startswith(tag_root + '/') or p.text == prefix + '/trunk'
+                        or p.text.startswith(prefix + '/trunk/') for p in paths), 'SVN commit touched unauthorized paths')
+        return {'svn_revision': revision, 'svn_url': self.url, 'identity': pkg.manifest_identity(manifest),
+                'publish_run_id': int(publish_run), 'assets': approved['assets'], 'state': 'SVN_COMMITTED_VERIFIED'}
+
+    def atomic_commit(self, manifest, publish_run, attempt_path):
+        pkg.require(not self.fixture and self.url == SVN_URL, 'production commit cannot use a fixture URL')
+        pkg.require(os.environ.get('WPORG_SVN_USERNAME') == 'yoohw' and os.environ.get('WPORG_SVN_PASSWORD'),
+                    'SVN-specific Environment credentials missing')
+        self.validate(clean=False)
+        self.validate_delta(manifest['version'])
+        pkg.verify_tree(self.working / 'trunk', manifest)
+        pkg.verify_tree(self.working / 'tags' / manifest['version'], manifest)
+        attempt = {'state': 'SVN_COMMIT_OUTCOME_UNKNOWN', 'identity': pkg.manifest_identity(manifest),
+                   'publish_run_id': int(publish_run), 'recovery': 'verify-only; never automatically recommit'}
+        pkg.write_json(attempt_path, attempt)
+        try:
+            result = subprocess.run([
+                'svn', 'commit', str(self.working / 'trunk'), str(self.working / 'tags' / manifest['version']),
+                '--non-interactive', '--no-auth-cache', '--username', 'yoohw', '--password-from-stdin',
+                '--message', commit_message(manifest, publish_run)],
+                input=(os.environ['WPORG_SVN_PASSWORD'] + '\n').encode(), env=without_credentials(),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=120, check=False)
+            attempt['client_returncode'] = result.returncode
+        except (subprocess.TimeoutExpired, OSError):
+            attempt['client_returncode'] = None
+        # Even exit 0 is only a hint. Fresh authenticated SVN verification owns success.
+        pkg.write_json(attempt_path, attempt)
+        return attempt
+
+
+def commit_message(manifest, publish_run):
+    pkg.inputs(manifest['candidate_sha'], manifest['version'], run_id=publish_run)
+    return (f'Release {manifest["version"]} from {manifest["candidate_sha"]}; '
+            f'PRODUCT_TREE_SHA {manifest["product_tree_sha"]}; package {manifest["package_sha256"]}; '
+            f'preparation {manifest["preparation_run_id"]}; publish https://github.com/{pkg.REPOSITORY}/actions/runs/{publish_run}')
+
+
+def public_state(manifest, output, *, confirmation, verify_only=False, download=None):
+    if confirmation != 'disabled' and not verify_only:
+        return 'WPORG_RELEASE_CONFIRMATION_PENDING'
+    if download is None:
+        def download(url):
+            with urllib.request.urlopen(url, timeout=30) as response:
+                raw = response.read(pkg.LIMIT + 1)
+                pkg.require(len(raw) <= pkg.LIMIT, 'public response too large')
+                return raw
+    try:
+        raw = download('https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=wc-order-splitter')
+        info = json.loads(raw)
+        if info.get('slug') != pkg.SLUG or info.get('version') != manifest['version']:
+            return 'WPORG_PROPAGATION_PENDING'
+        raw = download(f'https://downloads.wordpress.org/plugin/{pkg.SLUG}.{manifest["version"]}.zip')
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return 'WPORG_PROPAGATION_PENDING'
+    # Once the public API claims this version, different bytes are a hard identity
+    # failure, never silently downgraded to success or an SVN recommit instruction.
+    pkg.validate_payload(raw, manifest, output, exact_zip=False)
+    return 'WPORG_PUBLIC_RELEASE_VERIFIED'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Validate workflow syntax
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck=''
       - name: Fast contracts and distributable identity
-        run: bash .github/scripts/run-fast.sh
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes subversion
+          bash .github/scripts/run-fast.sh
       - name: Record PR traceability
         env:
           REPO_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/publish-wordpress-org.yml
+++ b/.github/workflows/publish-wordpress-org.yml
@@ -1,0 +1,217 @@
+name: Publish Order Splitter to WordPress.org
+
+'on':
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Publish or continue read-only SVN/public verification
+        required: true
+        default: publish
+        type: choice
+        options: [publish, verify-only]
+      preparation_run_id:
+        description: Successful immutable preparation run
+        required: true
+        type: string
+      candidate_sha:
+        description: Exact prepared candidate SHA
+        required: true
+        type: string
+      version:
+        description: Exact prepared version
+        required: true
+        type: string
+      original_publish_run_id:
+        description: Required for verify-only, including lost commit-response recovery
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: No external mutation; disable only under explicit release authority
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+
+concurrency:
+  group: wordpress-org-wc-order-splitter
+  cancel-in-progress: false
+
+env:
+  OPERATION: ${{ inputs.operation }}
+  DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+  CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+  CANDIDATE_DIR: ${{ github.workspace }}/candidate-data
+  VERSION: ${{ inputs.version }}
+  PREPARATION_RUN_ID: ${{ inputs.preparation_run_id }}
+  ORIGINAL_PUBLISH_RUN_ID: ${{ inputs.original_publish_run_id }}
+  PYTHONDONTWRITEBYTECODE: '1'
+
+jobs:
+  preflight:
+    name: Read-only publication preflight
+    if: inputs.operation == 'publish'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout trusted publisher control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: ./control/.github/actions/publisher-context
+      - name: Read-only SVN snapshot and local staging
+        run: python3 control/.github/scripts/release_cli.py preflight
+      - name: Persist exact Human approval target
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wporg-preflight-${{ github.run_id }}
+          path: ${{ runner.temp }}/wcos-release/preflight-record.json
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: false
+
+  dry-run:
+    name: Dry-run final remote recheck
+    needs: preflight
+    if: inputs.operation == 'publish' && inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout trusted publisher control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: ./control/.github/actions/publisher-context
+      - name: Final recheck and local SVN staging only
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py recheck
+
+  production:
+    name: Human-gated atomic publication
+    needs: preflight
+    if: inputs.operation == 'publish' && !inputs.dry_run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: wordpress-org-production
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+    env:
+      PUBLISH_ENVIRONMENT: wordpress-org-production
+    outputs:
+      state: ${{ steps.verify.outputs.state }}
+    steps:
+      - name: Checkout trusted publisher control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: ./control/.github/actions/publisher-context
+      - name: Final remote recheck after Human approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py recheck
+      - name: Seal immutable annotated Git tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py seal
+      - name: Single atomic SVN commit attempt
+        id: commit
+        env:
+          WPORG_SVN_USERNAME: ${{ vars.WPORG_SVN_USERNAME }}
+          WPORG_SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+        run: python3 control/.github/scripts/release_cli.py commit
+      - name: Authenticate SVN before confirmation or public propagation
+        id: verify
+        if: ${{ !cancelled() && steps.commit.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py verify
+      - name: Persist publication evidence even if propagation fails
+        if: ${{ always() && steps.verify.outcome != 'skipped' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wporg-publication-${{ github.run_id }}
+          path: ${{ runner.temp }}/wcos-release/publication-record.json
+          if-no-files-found: warn
+          retention-days: 90
+          overwrite: false
+      - name: Persist ambiguous commit attempt for read-only recovery
+        if: ${{ always() && steps.commit.outcome != 'skipped' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wporg-attempt-${{ github.run_id }}
+          path: ${{ runner.temp }}/wcos-release/commit-attempt.json
+          if-no-files-found: warn
+          retention-days: 90
+          overwrite: false
+
+  verify-only:
+    name: Read-only SVN and public recovery
+    if: inputs.operation == 'verify-only'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      state: ${{ steps.verify.outputs.state }}
+    steps:
+      - name: Checkout trusted publisher control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: ./control/.github/actions/publisher-context
+      - name: Authenticate original publication and public payload without SVN credentials
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py recover
+      - name: Persist verified or pending public state
+        if: ${{ always() && steps.verify.outcome != 'skipped' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wporg-publication-${{ github.run_id }}
+          path: ${{ runner.temp }}/wcos-release/publication-record.json
+          if-no-files-found: warn
+          retention-days: 90
+          overwrite: false
+
+  github-release:
+    name: GitHub Release only after verified WordPress.org publication
+    needs: [production, verify-only]
+    if: >-
+      ${{ always() && !inputs.dry_run &&
+          ((needs.production.result == 'success' && needs.production.outputs.state == 'WPORG_PUBLIC_RELEASE_VERIFIED') ||
+           (needs.verify-only.result == 'success' && needs.verify-only.outputs.state == 'WPORG_PUBLIC_RELEASE_VERIFIED')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: wordpress-org-production
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+    env:
+      PUBLISH_ENVIRONMENT: wordpress-org-production
+    steps:
+      - name: Checkout trusted publisher control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - uses: ./control/.github/actions/publisher-context
+      - name: Reverify remote identity then create or reconcile exact GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py release

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,98 @@
+name: Prepare WordPress.org Release Candidate
+
+'on':
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Accepted protected-main candidate (full 40-character SHA)
+        required: true
+        type: string
+      version:
+        description: Exact numeric Version and Stable tag
+        required: true
+        type: string
+      product_tree_sha:
+        description: Certified PRODUCT_TREE_SHA
+        required: true
+        type: string
+      release_cert_run_id:
+        description: Successful WOS RELEASE_CERT run ID
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+
+concurrency:
+  group: wcos-release-prepare-${{ inputs.candidate_sha }}
+  cancel-in-progress: false
+
+env:
+  CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+  CANDIDATE_DIR: ${{ github.workspace }}/candidate-data
+  VERSION: ${{ inputs.version }}
+  PRODUCT_TREE_SHA: ${{ inputs.product_tree_sha }}
+  RELEASE_CERT_RUN_ID: ${{ inputs.release_cert_run_id }}
+  PYTHONDONTWRITEBYTECODE: '1'
+
+jobs:
+  prepare:
+    name: Prepare immutable release candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Assert trusted protected-main control plane
+        run: |
+          test "$GITHUB_REPOSITORY" = yoohwz/wc-order-splitter
+          test "$GITHUB_REF" = refs/heads/main
+          test "$GITHUB_REF_PROTECTED" = true
+          test "$GITHUB_WORKFLOW_REF" = yoohwz/wc-order-splitter/.github/workflows/release-prepare.yml@refs/heads/main
+          test "$GITHUB_WORKFLOW_SHA" = "$GITHUB_SHA"
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]
+          [[ "$PRODUCT_TREE_SHA" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$RELEASE_CERT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+      - name: Checkout trusted control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: control
+          persist-credentials: false
+      - name: Checkout candidate as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          path: candidate-data
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - name: Install trusted preparation dependencies
+        working-directory: control
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes rsync php-cli
+          npm ci --ignore-scripts --no-audit --no-fund
+      - name: Authenticate certificate and build twice
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py prepare
+      - name: Plugin Check on exact staged payload without production secrets
+        run: bash control/.github/scripts/release-plugin-check.sh
+      - name: Revalidate payload and record immutable candidate
+        id: record
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 control/.github/scripts/release_cli.py finish-prepare
+      - name: Upload exactly one immutable preparation artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.record.outputs.artifact_name }}
+          path: ${{ runner.temp }}/wcos-release/rc-a/*
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: false

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,144 @@
+# WordPress.org publisher
+
+This is a release-only control plane, not a normal PR merge gate. Native
+`Required CI` and ChatGPT Finalize remain authoritative for merging. Explicit
+owner publication authority is still required. No workflow parses Issue comments.
+
+## Trust and identity
+
+The manual workflows run only from protected `main`; executable helpers and
+actions come from that workflow's exact control SHA. The candidate is a separate
+checkout used as non-executable data by the publisher. Only secret-free Prepare
+may load the candidate in an isolated Plugin Check container; the control plane
+is not mounted in that container. The publisher never loads candidate PHP or
+executes candidate hooks/build scripts.
+
+`stage-distribution.sh` and `product-tree.py` remain the sole staging/product
+identity primitives. There is no second product certificate. Prepare authenticates
+the supplied successful `release-cert.yml` run, its single GitHub Actions
+`RELEASE_CERT` final check, exact digest/baseline log evidence and zero artifacts.
+It also authenticates accepted source/native `Required CI`. Squash provenance
+requires a merged main PR with equal reviewed-head/merge trees. The certificate
+head need not equal the publication candidate: their staged product identities
+must agree. All references must resolve to accepted protected-main history.
+
+ZIPs use sorted paths, a single `wc-order-splitter/` root, fixed 1980 timestamps,
+regular-file mode 0644 and STORE compression (no host zlib variation). Two builds
+must be byte-identical. ZIP identity is separate from `PRODUCT_TREE_SHA`.
+Manifest entries bind every path, size and SHA-256. Artifact downloads are hashed
+against the actual GitHub API digest before safe extraction, not merely recorded.
+
+## One-time Human setup
+
+A repository administrator and WordPress.org plugin committer must configure:
+
+1. Environment `wordpress-org-production` with required Human reviewer(s),
+   prevention of self-review where supported, and a deployment branch policy
+   allowing protected `main` only.
+2. Environment variable `WPORG_SVN_USERNAME=yoohw` and Environment secret
+   `WPORG_SVN_PASSWORD`, using the WordPress.org **SVN-specific password**. Enter
+   the secret directly in GitHub. Never send it to ChatGPT/Codex or put it in
+   source, PRs, Issues, workflow inputs, artifacts, summaries or logs.
+3. An active numeric release-tag ruleset (at minimum `1.5.0`) allowing authorized
+   creation while preventing updates, force updates and deletion. Do not weaken
+   `Protect main` or add bypass actors to make publication pass.
+4. Verify the plugin's WordPress.org Release Management setting. Until a committer
+   records the actual observation in `.github/release/wporg-policy.json`, its
+   mode is `unknown` with no invented observation timestamp. `assets_mode` stays
+   `unchanged`. Policy changes require their own appropriate review/authority.
+
+The SVN password is referenced in exactly one step: the atomic production commit.
+It is supplied on stdin, not a process argument, and is never cached. Dry-run and
+verify-only jobs have no Environment or SVN credential. The separate GitHub
+Release job also requires the production Environment, but receives no SVN secret.
+
+## First 1.5.0 publication after publisher bootstrap is accepted
+
+WOS-REL-002 implements and tests these controls only. Do not run the new manual
+workflows, create `1.5.0`, or publish as part of that implementation task.
+After Finalize/merge, use the existing WOS-REL-001 publication authority:
+
+- Candidate: `4de67108045714415d5bc4708bd94e7ad871e9a1` (not the later control-plane SHA).
+- Version: `1.5.0`.
+- `PRODUCT_TREE_SHA`: `2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072`.
+- RELEASE_CERT: `33727158970`; public baseline
+  `1.4.11/e1d8aeb8eff38f4ce69dad1a08993e17521c6359`.
+
+1. Run **Prepare WordPress.org Release Candidate** on current protected `main`
+   with `candidate_sha`, `version`, `product_tree_sha`, `release_cert_run_id` above.
+   Review `RC_PREPARED`, package/manifest identities and Plugin Check output.
+   Plugin Check 2.1.0 checks the staged update without an error-ignore list; every
+   Error blocks preparation. Warnings remain in the evidence. Resolve new Errors
+   through an appropriately scoped task, never by silently changing certified
+   product bytes or adding a broad ignore baseline.
+2. Run **Publish Order Splitter to WordPress.org**, `operation=publish`, using
+   that `preparation_run_id`, candidate/version, and `dry_run=true`. Review the
+   exact read-only SVN snapshot and final recheck. No tag, SVN or Release write
+   is reachable on this path.
+3. After confirming one-time setup and existing owner authority, dispatch a new
+   publish run with `dry_run=false`. Its new preflight artifact is the approval
+   target. Approve the Environment only when candidate, product/package digests,
+   trunk/assets node revisions/trees, tag absence and confirmation mode match.
+4. The approved job reauthenticates preparation/candidate data, performs a fresh
+   SVN checkout, compares the approved relevant-path snapshot, restages, seals
+   the annotated immutable Git tag, rechecks SVN again and attempts exactly one
+   atomic commit of `trunk` plus new `tags/<version>`. Assets cannot change.
+5. Fresh read-only verification authenticates the exact SVN author, revision,
+   traceability message, atomic changed-path set, trunk/tag product identity and
+   unchanged assets. `unknown` or `enabled` confirmation stops at
+   `WPORG_RELEASE_CONFIRMATION_PENDING`. A plugin committer confirms through
+   WordPress.org Release Management/email as needed. Never store tokenized
+   confirmation URLs or emails in GitHub.
+6. Run `operation=verify-only` with the original production publish run ID.
+   `dry_run=true` performs verification only; `dry_run=false` additionally permits
+   the separately Environment-gated GitHub Release job after public verification.
+   Verify-only never receives the SVN password and never commits SVN.
+7. Only `WPORG_PUBLIC_RELEASE_VERIFIED` permits GitHub Release creation. The
+   release job rechecks remote identities after its approval, binds the existing
+   immutable tag and attaches only the authenticated ZIP and manifest. Notes
+   come from the public version's `changelog.txt` entry, not governance prose.
+   ChatGPT performs post-publication acceptance and closes WOS-REL-001 separately.
+
+## Pending and recovery states
+
+- `WPORG_RELEASE_CONFIRMATION_PENDING`: SVN publication is authenticated; Human
+  confirmation may be needed. Confirm there, then verify-only. No recommit.
+- `WPORG_PROPAGATION_PENDING`: one bounded public API/download observation is not
+  ready. Use a new verify-only run later; do not treat this as an SVN failure.
+- `SVN_COMMIT_OUTCOME_UNKNOWN`: no automatic retry, even after a timeout or lost
+  successful response. Verify-only authenticates the original immutable preflight,
+  tag and exact SVN log/tree identity; it reconciles a durable publication record
+  if present or reconstructs it read-only if the original runner lost the record.
+- Existing SVN target tag: publish preflight fails closed. Use the original run's
+  verify-only recovery, not a fresh publish attempt.
+- Existing Git tag: only the exact annotated candidate/product/package/preparation
+  identity is idempotent. A mismatch never triggers update/deletion/recreation.
+- Existing GitHub Release: exact draft state/assets can be completed; unexpected
+  notes, tag, asset bytes/names or incomplete public Release require Human review.
+- SVN trunk/assets content, properties or node-revision drift invalidates approval.
+  WordPress.org's global revision is recorded, but unrelated plugin commits do
+  not invalidate the relevant-path snapshot. Post-publication payload mismatch
+  is a hard verification failure, not a reason to recommit.
+- Preparation/preflight/publication artifacts are immutable and retained 90 days.
+  Missing/expired artifact or certificate logs fail closed; do not substitute an
+  unverified local file. Runs cannot be rerun under the same run ID/attempt;
+  dispatch a new run with the correct operation and original publication ID.
+
+## Local checks and boundaries
+
+`python3 tests/ci/publisher-contract.py` uses temporary `file://` SVN repositories
+and fake GitHub APIs, including deterministic packaging and negative security
+cases. It never accesses production SVN, creates a real Git tag/Release or reads
+production secrets. The normal FAST runner includes these checks. Independent
+review is required even though all publisher paths are excluded development paths.
+
+Bootstrap stages both accepted source and current worktree with the canonical
+stager and proves the certified digest is unchanged. No new RELEASE_CERT is
+needed for excluded-only drift. Any included product-byte change requires scope
+review and its own product certification authority.
+
+Architecture reference: the human-gated publisher in
+[`yoohwz/thumbnail-manager`](https://github.com/yoohwz/thumbnail-manager).
+Protocol references: [GitHub artifact API](https://docs.github.com/en/rest/actions/artifacts),
+[WordPress.org SVN](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/),
+[Release Confirmation](https://developer.wordpress.org/plugins/wordpress-org/release-confirmation-emails/).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -100,6 +100,12 @@ preserve its genuine upgrade fixtures and certify the frozen product tree once.
 
 ## Operator handoff
 
+Release-only preparation, Human-gated WordPress.org publication and read-only
+recovery are documented in [releasing.md](releasing.md). These manual workflows
+do not add normal PR merge requirements or replace RELEASE_CERT. Publisher
+bootstrap changes excluded control-plane files only; publication still requires
+its own owner authority and the production Environment gate.
+
 End meaningful task-state responses with one navigation footer. It grants no
 authority. Use `Human / ChatGPT / Finalize <TASK_ID>` only after evidence and
 required review are ready; otherwise identify the actual next action or blocker.

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Publisher contracts: temporary local SVN only; all GitHub calls are fakes."""
+import copy
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+import urllib.error
+import urllib.request
+import zipfile
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / '.github/scripts'))
+import release_package as pkg
+import release_github as gh
+import release_cli as cli
+import wporg_release as wp
+
+BASE = '4de67108045714415d5bc4708bd94e7ad871e9a1'
+CERT_HEAD = '350e81177085c753cfdabb16c7fbf5547f0266e9'
+DIGEST = '2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072'
+
+
+def run(*args):
+    return subprocess.check_output(list(map(str, args)), stderr=subprocess.PIPE).decode().strip()
+
+
+def yaml(path):
+    return json.loads(run('ruby', '-ryaml', '-rjson', '-e', 'puts JSON.generate(YAML.load_file(ARGV[0]))', path))
+
+
+def archive(values):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, 'w') as handle:
+        for name, value in values.items():
+            handle.writestr(name, value)
+    return output.getvalue()
+
+
+class FakeAPI:
+    def __init__(self, values):
+        self.values, self.calls = values, []
+
+    def get(self, endpoint, **kwargs):
+        self.calls.append((endpoint, kwargs))
+        value = self.values[endpoint]
+        return copy.deepcopy(value)
+
+    def pages(self, endpoint, key=None):
+        return self.get(endpoint)
+
+
+class Product(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory(prefix='wcos-publisher-contract-')
+        cls.root = Path(cls.tmp.name)
+        cls.source = cls.root / 'base'
+        cls.source.mkdir()
+        raw = subprocess.check_output(['git', '-C', str(ROOT), 'archive', BASE])
+        with tarfile.open(fileobj=io.BytesIO(raw)) as handle:
+            handle.extractall(cls.source, filter='data')
+        cls.staged = cls.root / 'base-product'
+        cls.base_digest = pkg.stage(cls.source, cls.staged)
+        cls.manifest = pkg.build(cls.staged, cls.root / 'package', BASE, '1.5.0', DIGEST, 33727158970, 100)
+        cls.zip = (cls.root / 'package' / cls.manifest['package_name']).read_bytes()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def test_01_bootstrap_preserves_certified_product(self):
+        staged = self.root / 'head-product'
+        digest = pkg.stage(ROOT, staged)
+        self.assertEqual(self.base_digest, DIGEST)
+        self.assertEqual(digest, DIGEST)
+        self.assertEqual(pkg.files(staged), pkg.files(self.staged))
+        self.assertFalse((staged / '.github').exists())
+        self.assertFalse((staged / 'tests').exists())
+        self.assertFalse((staged / 'docs').exists())
+        print(f'publisher-product-invariance-ok base={BASE} source={DIGEST} final={digest}')
+
+    def test_02_deterministic_metadata_and_one_root(self):
+        os.utime(self.staged / 'readme.txt', (2000000000, 2000000000))
+        manifest = pkg.build(self.staged, self.root / 'package-b', BASE, '1.5.0', DIGEST, 33727158970, 100)
+        self.assertEqual(manifest, self.manifest)
+        self.assertEqual((self.root / 'package-b' / manifest['package_name']).read_bytes(), self.zip)
+        with zipfile.ZipFile(io.BytesIO(self.zip)) as handle:
+            self.assertEqual(handle.namelist(), sorted(handle.namelist()))
+            for item in handle.infolist():
+                self.assertTrue(item.filename.startswith('wc-order-splitter/'))
+                self.assertEqual(item.date_time, pkg.FIXED_TIME)
+                self.assertEqual(item.external_attr >> 16, stat.S_IFREG | 0o644)
+
+    def test_03_package_manifest_and_product_tamper(self):
+        payload = pkg.zip_data(self.zip, pkg.SLUG + '/')
+        for kind in ('missing', 'extra', 'changed'):
+            with self.subTest(kind=kind):
+                values = dict(payload)
+                if kind == 'missing':
+                    values.pop('readme.txt')
+                elif kind == 'extra':
+                    values['intruder.php'] = b'not allowed'
+                else:
+                    values['readme.txt'] += b'changed'
+                bad = archive({pkg.SLUG + '/' + key: value for key, value in values.items()})
+                manifest = copy.deepcopy(self.manifest)
+                manifest['package_sha256'] = pkg.sha(bad)
+                with self.assertRaisesRegex(ValueError, 'file set/content'):
+                    pkg.validate_payload(bad, manifest, self.root / ('bad-' + kind))
+        manifest = dict(self.manifest, product_tree_sha='f' * 64)
+        with self.assertRaisesRegex(ValueError, 'PRODUCT_TREE_SHA'):
+            pkg.validate_payload(self.zip, manifest, self.root / 'wrong-product')
+
+    def test_04_zip_traversal_alias_special_and_collision(self):
+        for name in ('../escape', '/absolute', 'wc-order-splitter/../escape', 'wc-order-splitter//alias',
+                     'wc-order-splitter/.hidden', 'wc-order-splitter/back\\slash', 'other/file'):
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                pkg.zip_data(archive({name: b'data'}), pkg.SLUG + '/')
+        with self.assertRaises(ValueError):
+            pkg.zip_data(archive({'a.php': b'a', 'A.php': b'b'}))
+        raw = io.BytesIO()
+        with zipfile.ZipFile(raw, 'w') as handle:
+            info = zipfile.ZipInfo('link')
+            info.create_system = 3
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            handle.writestr(info, '/etc/passwd')
+        with self.assertRaisesRegex(ValueError, 'special ZIP'):
+            pkg.zip_data(raw.getvalue())
+
+    def test_05_candidate_tools_never_execute(self):
+        script = self.source / '.github/scripts/stage-distribution.sh'
+        original = script.read_bytes()
+        script.write_text('exit 97\n')
+        try:
+            self.assertEqual(pkg.stage(self.source, self.root / 'untrusted-helper'), DIGEST)
+        finally:
+            script.write_bytes(original)
+
+    def test_06_policy_fail_closed(self):
+        good = wp.policy()
+        cases = [('slug', 'thumbnail-manager'), ('svn_url', 'file:///tmp/repo'),
+                 ('svn_url', 'https://example.test/wc-order-splitter'), ('assets_mode', 'sync')]
+        for field, value in cases:
+            candidate = copy.deepcopy(good)
+            candidate[field] = value
+            pkg.write_json(self.root / 'policy.json', candidate)
+            with self.subTest(field=field, value=value), self.assertRaises(ValueError):
+                wp.policy(self.root / 'policy.json')
+        good['release_confirmation']['observed_at'] = '2026-09-03T00:00:00Z'
+        pkg.write_json(self.root / 'policy.json', good)
+        with self.assertRaisesRegex(ValueError, 'unknown confirmation'):
+            wp.policy(self.root / 'policy.json')
+
+    def test_07_input_metadata_and_manifest_mismatches(self):
+        for candidate, version, digest, run_id in ((BASE[:-1], '1.5.0', DIGEST, 1),
+                (BASE, '1.5.0;echo', DIGEST, 1), (BASE, '1.4.15', DIGEST, 1),
+                (BASE, '1.5.0', 'z' * 64, 1), (BASE, '1.5.0', DIGEST, '../bad')):
+            with self.assertRaises(ValueError):
+                pkg.inputs(candidate, version, digest, run_id)
+        with self.assertRaisesRegex(ValueError, 'Version / Stable'):
+            pkg.metadata(self.staged, '1.6.0')
+        for field, value in (('file_count', 1), ('public_baseline', 'other'), ('package_name', '../bad')):
+            with self.assertRaises(ValueError):
+                pkg.validate_manifest(dict(self.manifest, **{field: value}))
+
+    def test_08_public_confirmation_pending_and_expanded_zip(self):
+        downloader = Mock()
+        self.assertEqual(wp.public_state(self.manifest, self.root / 'public-no', confirmation='unknown', download=downloader),
+                         'WPORG_RELEASE_CONFIRMATION_PENDING')
+        downloader.assert_not_called()
+        responses = [pkg.encoded({'slug': pkg.SLUG, 'version': '1.4.11'})]
+        self.assertEqual(wp.public_state(self.manifest, self.root / 'public-old', confirmation='disabled', download=lambda _: responses.pop()),
+                         'WPORG_PROPAGATION_PENDING')
+        responses = [pkg.encoded({'slug': pkg.SLUG, 'version': '1.5.0'}), self.zip]
+        self.assertEqual(wp.public_state(self.manifest, self.root / 'public-ok', confirmation='unknown', verify_only=True,
+                                        download=lambda _: responses.pop(0)), 'WPORG_PUBLIC_RELEASE_VERIFIED')
+        responses = [pkg.encoded({'slug': pkg.SLUG, 'version': '1.5.0'}), archive({'wc-order-splitter/bad': b'bad'})]
+        with self.assertRaisesRegex(ValueError, 'file set/content'):
+            wp.public_state(self.manifest, self.root / 'public-bad', confirmation='disabled', download=lambda _: responses.pop(0))
+
+    def test_09_plugin_check_does_not_hide_errors(self):
+        warning = {'file': 'readme.txt', 'type': 'WARNING', 'code': 'example', 'message': 'message []'}
+        self.assertEqual(cli.plugin_check_report(json.dumps([warning])), [warning])
+        self.assertEqual(cli.plugin_check_report('Success: Checks complete. No errors found.'), [])
+        for raw in ('', '[]\n[]', json.dumps([dict(warning, type='ERROR')]), json.dumps([{'code': 'unknown'}])):
+            with self.assertRaises(ValueError):
+                cli.plugin_check_report(raw)
+
+    def test_10_ambiguous_commit_attempt_is_single_and_secret_is_stdin_only(self):
+        repository = wp.SVN(self.root / 'mock-only-never-connected')
+        env = {'WPORG_SVN_USERNAME': 'yoohw', 'WPORG_SVN_PASSWORD': 'fake-fixture-password'}
+        with patch.dict(os.environ, env), patch.object(repository, 'validate'), patch.object(repository, 'validate_delta'), \
+                patch.object(pkg, 'verify_tree'), patch.object(wp.subprocess, 'run', side_effect=subprocess.TimeoutExpired('svn', 120)) as command:
+            result = repository.atomic_commit(self.manifest, 200, self.root / 'attempt.json')
+        self.assertEqual(result['state'], 'SVN_COMMIT_OUTCOME_UNKNOWN')
+        self.assertEqual(command.call_count, 1)
+        args, kwargs = command.call_args
+        self.assertEqual(args[0][:2], ['svn', 'commit'])
+        self.assertNotIn('fake-fixture-password', ' '.join(args[0]))
+        self.assertNotIn('WPORG_SVN_PASSWORD', kwargs['env'])
+        self.assertEqual(kwargs['input'], b'fake-fixture-password\n')
+        self.assertNotIn('fake-fixture-password', (self.root / 'attempt.json').read_text())
+
+
+class LocalSVN(Product):
+    # Reuse only fixture data, not inherited test methods.
+    def setUp(self):
+        self.case = tempfile.TemporaryDirectory(prefix='wcos-svn-fixture-')
+        self.path = Path(self.case.name)
+        run('svnadmin', 'create', self.path / 'repository')
+        self.url = (self.path / 'repository').as_uri()
+        self.repo = wp.SVN(self.path / 'initial', self.url, fixture=True).checkout()
+        for name in ('trunk', 'assets', 'tags'):
+            (self.repo.working / name).mkdir()
+        (self.repo.working / 'trunk/readme.txt').write_text('public baseline 1.4.11')
+        (self.repo.working / 'assets/icon.svg').write_text('<svg/>')
+        self.repo.run('add', self.repo.working / 'trunk', self.repo.working / 'assets', self.repo.working / 'tags')
+        self.repo.run('commit', self.repo.working, '--username', 'yoohw', '-m', 'fixture baseline')
+        self.repo.run('update', self.repo.working)
+
+    def tearDown(self):
+        self.case.cleanup()
+
+    def fresh(self, name):
+        return wp.SVN(self.path / name, self.url, fixture=True).checkout()
+
+    def test_svn_atomic_exact_payload_and_authenticated_recovery(self):
+        before = self.repo.stage(self.staged, self.manifest, wp.policy())
+        approved = {'snapshot': before, 'identity': pkg.manifest_identity(self.manifest)}
+        pkg.verify_tree(self.repo.working / 'trunk', self.manifest)
+        pkg.verify_tree(self.repo.working / 'tags/1.5.0', self.manifest)
+        self.repo.run('commit', self.repo.working / 'trunk', self.repo.working / 'tags/1.5.0', '--username', 'yoohw',
+                      '-m', wp.commit_message(self.manifest, 200))
+        verified = self.fresh('verify').verify(self.manifest, approved, 200)
+        self.assertEqual(verified['state'], 'SVN_COMMITTED_VERIFIED')
+        self.assertEqual(verified['svn_revision'], 2)
+        with self.assertRaisesRegex(ValueError, 'log/revision'):
+            self.fresh('wrong-run').verify(self.manifest, approved, 201)
+        with self.assertRaisesRegex(ValueError, 'tag already exists'):
+            self.fresh('existing').stage(self.staged, self.manifest, wp.policy())
+
+    def test_svn_assets_and_trunk_drift_after_approval(self):
+        approved = self.repo.snapshot('1.5.0', wp.policy())
+        for name in ('assets/icon.svg', 'trunk/readme.txt'):
+            (self.repo.working / name).write_text('changed')
+            self.repo.run('commit', self.repo.working / name, '-m', 'external fixture drift')
+            with self.subTest(name=name), self.assertRaisesRegex(ValueError, 'snapshot drift'):
+                self.fresh('drift-' + name.split('/')[0]).compare(approved, '1.5.0', wp.policy())
+
+    def test_svn_tag_appearing_after_approval(self):
+        approved = self.repo.snapshot('1.5.0', wp.policy())
+        self.repo.run('copy', self.repo.working / 'trunk', self.repo.working / 'tags/1.5.0')
+        self.repo.run('commit', self.repo.working / 'tags/1.5.0', '-m', 'racing tag')
+        with self.assertRaisesRegex(ValueError, 'tag exists or appeared'):
+            self.fresh('after-tag').compare(approved, '1.5.0', wp.policy())
+
+    def test_svn_wrong_layout_url_and_extra_delta(self):
+        with self.assertRaisesRegex(ValueError, 'URL'):
+            wp.SVN(self.repo.working).validate()
+        (self.repo.working / 'unexpected').write_text('bad')
+        with self.assertRaisesRegex(ValueError, 'layout'):
+            self.repo.validate()
+        (self.repo.working / 'unexpected').unlink()
+        self.repo.stage(self.staged, self.manifest, wp.policy())
+        (self.repo.working / 'assets/icon.svg').write_text('not authorized')
+        with self.assertRaisesRegex(ValueError, 'outside trunk/new tag'):
+            self.repo.validate_delta('1.5.0')
+
+    def test_svn_forbids_externals_and_fixture_production_commit(self):
+        self.repo.run('propset', 'svn:externals', '^/other external', self.repo.working / 'trunk')
+        with self.assertRaisesRegex(ValueError, 'externals'):
+            self.repo.validate(clean=False)
+        with self.assertRaisesRegex(ValueError, 'fixture URL'):
+            self.repo.atomic_commit(self.manifest, 200, self.path / 'attempt.json')
+
+
+# unittest inheritance would otherwise run the Product tests twice in this class.
+for inherited in list(Product.__dict__):
+    if inherited.startswith('test_'):
+        setattr(LocalSVN, inherited, None)
+
+
+class GithubContracts(unittest.TestCase):
+    def test_api_binary_download_headers_and_error_classification(self):
+        with patch.dict(os.environ, {'GH_TOKEN': 'fixture-not-a-real-token'}):
+            api = gh.API()
+        response = Mock()
+        response.read.return_value = b'raw'
+        context = Mock()
+        context.__enter__ = Mock(return_value=response)
+        context.__exit__ = Mock(return_value=False)
+        api.opener.open = Mock(return_value=context)
+        for endpoint in ('actions/jobs/20/logs', 'actions/artifacts/1/zip', 'releases/assets/2'):
+            self.assertEqual(api.get(endpoint, binary=True), b'raw')
+            request = api.opener.open.call_args.args[0]
+            expected = 'application/octet-stream' if endpoint.startswith('releases/') else 'application/vnd.github+json'
+            self.assertEqual(request.get_header('Accept'), expected)
+        for code in (404, 403, 415, 500):
+            api.opener.open = Mock(side_effect=urllib.error.HTTPError('https://api.github.com/test', code, 'fixture', {}, None))
+            if code == 404:
+                self.assertIsNone(api.get('git/ref/tags/1.5.0', missing=True))
+            else:
+                with self.assertRaisesRegex(ValueError, str(code)):
+                    api.get('git/ref/tags/1.5.0', missing=True)
+            self.assertEqual(api.opener.open.call_count, 1)
+
+    def test_redirect_does_not_forward_authorization(self):
+        request = urllib.request.Request('https://api.github.com/test', headers={'Authorization': 'Bearer fixture'})
+        redirect = gh.SafeRedirect().redirect_request(request, None, 302, 'redirect', {}, 'https://example.test/download')
+        self.assertIsNone(redirect.get_header('Authorization'))
+        with self.assertRaisesRegex(ValueError, 'non-HTTPS'):
+            gh.SafeRedirect().redirect_request(request, None, 302, 'redirect', {}, 'http://example.test/download')
+
+    def certificate_api(self):
+        repository = {'full_name': pkg.REPOSITORY}
+        run = {'id': 33727158970, 'repository': repository, 'head_repository': repository, 'path': gh.CERT,
+               'event': 'workflow_dispatch', 'status': 'completed', 'conclusion': 'success', 'head_sha': CERT_HEAD,
+               'head_branch': 'release/order-splitter-1.5.0', 'run_attempt': 1}
+        job = {'id': 20, 'name': 'RELEASE_CERT', 'status': 'completed', 'conclusion': 'success',
+               'check_run_url': f'https://api.github.com/repos/{pkg.REPOSITORY}/check-runs/30'}
+        check = {'name': 'RELEASE_CERT', 'status': 'completed', 'conclusion': 'success',
+                 'app': {'slug': 'github-actions'}, 'head_sha': CERT_HEAD}
+        log = '\n'.join('2026-09-03T07:36:22.123Z ' + marker for marker in (
+            f'PRODUCT_TREE_SHA={DIGEST}', f'REPO_HEAD_SHA={CERT_HEAD}',
+            f'PUBLIC_BASELINE={pkg.BASELINE}; GENUINE_UPGRADE=passed',
+            'ARTIFACTS=0; no ZIP, tag, release, publication or deployment')).encode()
+        return FakeAPI({'actions/runs/33727158970': run, 'actions/runs/33727158970/attempts/1/jobs': [job],
+                        'check-runs/30': check, 'actions/runs/33727158970/artifacts': [], 'actions/jobs/20/logs': log})
+
+    def test_certificate_product_identity_not_candidate_sha_equality(self):
+        api = self.certificate_api()
+        with patch.object(gh, 'accepted_source') as accepted:
+            result = gh.certificate(api, 33727158970, DIGEST)
+        accepted.assert_called_once_with(api, CERT_HEAD, allow_merged_head=True)
+        self.assertNotEqual(CERT_HEAD, BASE)
+        self.assertEqual(result['product_tree_sha'], DIGEST)
+
+    def test_certificate_rejects_mismatches_duplicate_checks_and_artifacts(self):
+        for field, value in (('path', gh.PREPARE), ('event', 'push'), ('conclusion', 'failure'),
+                             ('repository', {'full_name': 'attacker/repository'})):
+            api = self.certificate_api()
+            api.values['actions/runs/33727158970'][field] = value
+            with self.subTest(field=field), patch.object(gh, 'accepted_source'), self.assertRaises(ValueError):
+                gh.certificate(api, 33727158970, DIGEST)
+        for mutation in ('duplicate', 'artifact', 'app', 'digest', 'baseline'):
+            api = self.certificate_api()
+            if mutation == 'duplicate':
+                api.values['actions/runs/33727158970/attempts/1/jobs'] *= 2
+            elif mutation == 'artifact':
+                api.values['actions/runs/33727158970/artifacts'] = [{'id': 1}]
+            elif mutation == 'app':
+                api.values['check-runs/30']['app']['slug'] = 'fake'
+            else:
+                api.values['actions/jobs/20/logs'] = api.values['actions/jobs/20/logs'].replace(
+                    DIGEST.encode() if mutation == 'digest' else pkg.BASELINE.encode(), b'wrong')
+            with self.subTest(mutation=mutation), patch.object(gh, 'accepted_source'), self.assertRaises(ValueError):
+                gh.certificate(api, 33727158970, DIGEST)
+
+    def test_unrelated_candidate_is_not_accepted(self):
+        api = FakeAPI({'branches/main': {'protected': True, 'commit': {'sha': BASE}},
+                       f'compare/{CERT_HEAD}...{BASE}': {'status': 'diverged'}, f'commits/{CERT_HEAD}/pulls': []})
+        with self.assertRaisesRegex(ValueError, 'accepted ancestor'):
+            gh.accepted_source(api, CERT_HEAD)
+
+    def test_squash_candidate_authenticates_native_ci_without_fake_head_equality(self):
+        pull = {'merged_at': '2026-09-03T07:47:46Z', 'base': {'ref': 'main', 'repo': {'full_name': pkg.REPOSITORY}},
+                'merge_commit_sha': BASE, 'head': {'sha': CERT_HEAD}}
+        api = FakeAPI({'branches/main': {'protected': True, 'commit': {'sha': BASE}},
+                       f'compare/{BASE}...{BASE}': {'status': 'identical'},
+                       f'commits/{BASE}/pulls': [pull], f'git/commits/{BASE}': {'tree': {'sha': 'a' * 40}},
+                       f'git/commits/{CERT_HEAD}': {'tree': {'sha': 'a' * 40}}})
+        with patch.object(gh, 'ci_check', return_value=33726798296) as check:
+            result = gh.accepted_source(api, BASE)
+        self.assertEqual(result['reviewed_head'], CERT_HEAD)
+        check.assert_called_once_with(api, CERT_HEAD)
+
+    def test_main_control_plane_guard(self):
+        env = {'GITHUB_REPOSITORY': pkg.REPOSITORY, 'GITHUB_REF': 'refs/heads/main', 'GITHUB_REF_PROTECTED': 'true',
+               'GITHUB_EVENT_NAME': 'workflow_dispatch', 'GITHUB_RUN_ATTEMPT': '1', 'GITHUB_SHA': BASE,
+               'GITHUB_WORKFLOW_SHA': BASE, 'GITHUB_WORKFLOW_REF': f'{pkg.REPOSITORY}/{gh.PUBLISH}@refs/heads/main'}
+        with patch.dict(os.environ, env), patch.object(gh, 'protected_main', return_value=BASE), patch.object(gh, 'ancestor', return_value=True):
+            self.assertEqual(gh.control_context(FakeAPI({}), gh.PUBLISH), BASE)
+            for key, value in (('GITHUB_REF', 'refs/heads/untrusted'), ('GITHUB_RUN_ATTEMPT', '2'),
+                               ('GITHUB_WORKFLOW_SHA', 'f' * 40), ('GITHUB_REF_PROTECTED', 'false')):
+                with self.subTest(key=key), patch.dict(os.environ, {key: value}), self.assertRaises(ValueError):
+                    gh.control_context(FakeAPI({}), gh.PUBLISH)
+
+    def test_downloaded_artifact_digest_is_verified_not_merely_recorded(self):
+        raw = archive({'manifest.json': b'{}'})
+        run_data = {'id': 100, 'head_sha': BASE}
+        item = {'id': 1, 'name': 'prepared', 'expired': False, 'digest': 'sha256:' + pkg.sha(raw),
+                'workflow_run': {'id': 100, 'head_sha': BASE}}
+        api = FakeAPI({'actions/runs/100/artifacts': [item], 'actions/artifacts/1/zip': raw})
+        with tempfile.TemporaryDirectory() as directory:
+            gh.artifact(api, run_data, 'prepared', Path(directory) / 'valid', {'manifest.json'})
+            api.values['actions/artifacts/1/zip'] = archive({'manifest.json': b'changed'})
+            with self.assertRaisesRegex(ValueError, 'API digest mismatch'):
+                gh.artifact(api, run_data, 'prepared', Path(directory) / 'bad', {'manifest.json'})
+
+    def test_immutable_tag_mismatch_never_updates_or_deletes(self):
+        manifest = {'candidate_sha': BASE, 'version': '1.5.0', 'product_tree_sha': DIGEST,
+                    'package_sha256': 'a' * 64, 'release_cert_run_id': 1, 'preparation_run_id': 2}
+        ref = {'ref': 'refs/tags/1.5.0', 'object': {'type': 'tag', 'sha': 'b' * 40}}
+        obj = {'tag': '1.5.0', 'object': {'sha': CERT_HEAD, 'type': 'commit'}, 'message': 'different'}
+        api = FakeAPI({'git/ref/tags/1.5.0': ref, 'git/tags/' + 'b' * 40: obj})
+        with self.assertRaisesRegex(ValueError, 'tag identity mismatch'):
+            gh.git_tag(api, manifest, create=True)
+        self.assertTrue(all(not kwargs for _, kwargs in api.calls if _ != 'git/ref/tags/1.5.0'))
+        self.assertFalse(any(kwargs.get('method') in {'POST', 'PATCH', 'DELETE'} for _, kwargs in api.calls))
+
+    def test_release_cannot_precede_public_verification(self):
+        with self.assertRaisesRegex(ValueError, 'public verification required'):
+            gh.github_release(FakeAPI({}), {}, Path('/unused'), {'state': 'WPORG_PROPAGATION_PENDING'})
+
+    def test_release_creation_and_exact_reconciliation(self):
+        manifest = {'candidate_sha': BASE, 'version': '1.5.0', 'product_tree_sha': DIGEST,
+                    'package_sha256': 'a' * 64, 'release_cert_run_id': 1, 'preparation_run_id': 2,
+                    'package_name': 'wc-order-splitter-1.5.0.zip'}
+        class ReleaseAPI:
+            def __init__(self):
+                self.release, self.assets, self.calls = None, {}, []
+            def get(self, endpoint, **kwargs):
+                self.calls.append((endpoint, kwargs))
+                if endpoint == 'releases/tags/1.5.0':
+                    return copy.deepcopy(self.release)
+                if endpoint == 'releases':
+                    self.release = dict(kwargs['value'], id=1)
+                    return copy.deepcopy(self.release)
+                if endpoint == 'releases/1':
+                    if kwargs.get('method') == 'PATCH':
+                        self.release.update(kwargs['value'])
+                    return copy.deepcopy(self.release)
+                if endpoint.startswith('releases/1/assets?name='):
+                    self.assets[endpoint.split('=', 1)[1]] = kwargs['upload']
+                    return {}
+                if endpoint.startswith('releases/assets/'):
+                    return self.assets[endpoint.split('/')[-1]]
+                raise AssertionError(endpoint)
+            def pages(self, endpoint, key=None):
+                return [{'id': name, 'name': name} for name in self.assets]
+        with tempfile.TemporaryDirectory() as directory, patch.object(gh, 'git_tag'):
+            root = Path(directory)
+            (root / 'payload').mkdir()
+            (root / 'payload/changelog.txt').write_text('= 1.5.0 =\n\n* Public release notes.\n\n= 1.4.11 =\n* Older.\n')
+            (root / manifest['package_name']).write_bytes(b'authenticated fixture package')
+            pkg.write_json(root / 'release-manifest.json', manifest)
+            api = ReleaseAPI()
+            verification = {'state': 'WPORG_PUBLIC_RELEASE_VERIFIED', 'identity': pkg.manifest_identity(manifest)}
+            self.assertEqual(gh.github_release(api, manifest, root, verification), 'GITHUB_RELEASE_PUBLISHED')
+            self.assertFalse(api.release['draft'])
+            self.assertEqual(api.release['body'], '* Public release notes.\n')
+            self.assertEqual(set(api.assets), {manifest['package_name'], 'release-manifest.json'})
+            api.calls.clear()
+            gh.github_release(api, manifest, root, verification)
+            self.assertFalse(any(kwargs.get('method') for _, kwargs in api.calls))
+            api.assets[manifest['package_name']] = b'wrong package'
+            api.calls.clear()
+            with self.assertRaisesRegex(ValueError, 'asset content mismatch'):
+                gh.github_release(api, manifest, root, verification)
+            self.assertFalse(any(kwargs.get('method') for _, kwargs in api.calls))
+
+
+class WorkflowContracts(unittest.TestCase):
+    def test_manual_secret_and_mutation_boundaries(self):
+        prepare = yaml(ROOT / '.github/workflows/release-prepare.yml')
+        publish = yaml(ROOT / '.github/workflows/publish-wordpress-org.yml')
+        for flow in (prepare, publish):
+            self.assertEqual(set(flow['on']), {'workflow_dispatch'})
+            self.assertEqual(flow['permissions'], {'actions': 'read', 'checks': 'read', 'contents': 'read'})
+            self.assertIs(flow['concurrency']['cancel-in-progress'], False)
+        self.assertIs(publish['on']['workflow_dispatch']['inputs']['dry_run']['default'], True)
+        raw_prepare = json.dumps(prepare)
+        self.assertNotIn('secrets.', raw_prepare)
+        self.assertNotIn('environment', prepare['jobs']['prepare'])
+        self.assertEqual(raw_prepare.count('actions/upload-artifact@'), 1)
+        secrets = []
+        for job_name, job in publish['jobs'].items():
+            for step in job['steps']:
+                if 'secrets.' in json.dumps(step):
+                    secrets.append((job_name, step))
+            if job_name in {'preflight', 'dry-run', 'verify-only'}:
+                self.assertNotIn('environment', job)
+                self.assertNotIn('permissions', job)
+                self.assertNotRegex(json.dumps(job), r'release_cli.py (commit|seal|release)')
+            for step in job['steps']:
+                if 'actions/checkout@' in step.get('uses', ''):
+                    self.assertEqual(step['with']['ref'], '${{ github.sha }}')
+                    self.assertIs(step['with']['persist-credentials'], False)
+        self.assertEqual(len(secrets), 1)
+        self.assertEqual(secrets[0][0], 'production')
+        self.assertEqual(secrets[0][1]['run'], 'python3 control/.github/scripts/release_cli.py commit')
+        production = publish['jobs']['production']
+        self.assertEqual(production['environment'], 'wordpress-org-production')
+        self.assertEqual(production['if'], "inputs.operation == 'publish' && !inputs.dry_run")
+        self.assertNotIn('GH_TOKEN', secrets[0][1]['env'])
+        release = publish['jobs']['github-release']
+        self.assertIn('!inputs.dry_run', release['if'])
+        self.assertIn('WPORG_PUBLIC_RELEASE_VERIFIED', release['if'])
+        self.assertIn("needs.verify-only.result == 'success'", release['if'])
+        self.assertEqual(release['environment'], 'wordpress-org-production')
+        shared = yaml(ROOT / '.github/actions/publisher-context/action.yml')
+        self.assertNotIn('secrets.', json.dumps(shared))
+        checkouts = [step for step in shared['runs']['steps'] if 'actions/checkout@' in step.get('uses', '')]
+        self.assertEqual(checkouts[0]['with']['path'], 'candidate-data')
+        self.assertIs(checkouts[0]['with']['persist-credentials'], False)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/ci/workflow-contract.py
+++ b/tests/ci/workflow-contract.py
@@ -20,7 +20,8 @@ assert set(ci['on']) == {'pull_request'}
 assert ci['on']['pull_request'] == {'branches': ['main']}
 assert set(release['on']) == {'workflow_dispatch'}
 assert set((ROOT / '.github/workflows').glob('*.yml')) == {
-    ROOT / '.github/workflows/ci.yml', ROOT / '.github/workflows/release-cert.yml'}
+    ROOT / '.github/workflows/ci.yml', ROOT / '.github/workflows/release-cert.yml',
+    ROOT / '.github/workflows/release-prepare.yml', ROOT / '.github/workflows/publish-wordpress-org.yml'}
 assert len((ROOT / '.github/workflows/ci.yml').read_bytes()) <= 20000
 for flow in (ci, release):
     assert flow['permissions'] == {'contents': 'read'}


### PR DESCRIPTION
## Classification and authority

`P1_GOVERNANCE` — release/publication safety controls. Canonical task classification: `P1_RELEASE_INFRA / WORDPRESS_ORG_PUBLISHER_BOOTSTRAP`.

Refs #141. Implements the [canonical WOS-REL-002 scope](https://github.com/yoohwz/wc-order-splitter/issues/141) and its [bootstrap discovery addendum](https://github.com/yoohwz/wc-order-splitter/issues/141#issuecomment-5522638441). This PR does not exercise the separate WOS-REL-001 publication authority.

- Exact accepted base: `4de67108045714415d5bc4708bd94e7ad871e9a1`, tree `0c3e2ba937b21a24100e1402f11e267531501abc`.
- Implementation head: `d8483471f668c387a42020fc8c669c4750d6421d`, tree `538df1adf7e1f80c149c5cddbbd2756ff69ac8a8`.
- Publication candidate remains the base above, version `1.5.0`, not this later control-plane head.
- `PRODUCT_TREE_SHA=2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072` remains unchanged.
- Workflow gates Split/Duplicate/Merge/Return/Bulk Return and strategy gates Manual Quantity/Category/Stock Status remain `true`, byte-identical to accepted source.

## Changes

- Secret-free manual Prepare authenticates accepted main/native CI and the existing product-aware RELEASE_CERT (including squash provenance), canonically stages, validates, builds twice deterministically, runs Plugin Check without an error ignore list, and uploads one immutable package/manifest/record/report artifact.
- Manual Publisher separates read-only preflight, dry-run final recheck, Environment-gated annotated tag plus single atomic SVN commit, read-only recovery, and separately gated GitHub Release after public version/download-tree verification.
- Trusted helpers always execute from the workflow's protected-main control SHA. Candidate/plugin code is never executed in the publisher. Actual downloaded artifact ZIP bytes are checked against GitHub API digests before safe extraction.
- SVN snapshots bind relevant node revisions, file content, properties, target-tag absence and confirmation state. Final rechecks reject drift; staging/commit scope is trunk plus one new version tag, with assets unchanged. Lost/ambiguous commit responses never trigger an automatic recommit.
- WOS policy starts `release_confirmation.mode=unknown`, `observed_at=null`, `assets_mode=unchanged`. Unknown/enabled confirmation stops at a durable pending state after SVN authentication, then Human confirmation and verify-only.
- Document the one-time production Environment/SVN-specific credential/tag-ruleset setup, exact first-publication inputs, recovery/pending states, and release-only authority boundaries.
- Focused tests use fake GitHub APIs and temporary local `file://` SVN. The FAST runner includes them and explicitly installs Subversion on the CI runner; existing CI failure propagation, release matrix, product suites, distribution controls and rulesets are unchanged.

## Evidence

- Local `run-fast.sh`: pass. Final publisher focused suite: 27/27 methods pass, including GitHub Release creation/reconciliation, artifact/HTTP/redirect authentication, and real local SVN fixtures.
- Local `run-static.sh`: pass (all 34 domain unit contracts, product static/JavaScript checks).
- actionlint `1.7.12`: pass; official binary checksum verified. `git diff --check`: pass.
- Base and current product staged through canonical `stage-distribution.sh`; both digests equal the certified identity above, and file inventories/bytes match. All 15 changed paths are excluded development/control-plane paths.
- Live GitHub **GET-only** helper smoke: accepted candidate `4de671080457...` resolves native CI `33726798296` via reviewed head `350e81177085...`; RELEASE_CERT `33727158970`, attempt 1, authenticates exact digest/baseline/final Actions check and `artifacts=0` despite the different squash SHA.
- Existing [product RELEASE_CERT](https://github.com/yoohwz/wc-order-splitter/actions/runs/33727158970) is reused by identity; no new certification run was dispatched.
- [Native Required CI run 33735964235](https://github.com/yoohwz/wc-order-splitter/actions/runs/33735964235): attempt 1, success on exact head `d8483471f668c387a42020fc8c669c4750d6421d`; FAST path/safety checks and Required CI passed, PHP/integration skipped exactly as the FAST contract requires. The log proves all 27 publisher tests and the unchanged product digest. Native merge ref `9703d43b1be2d372ea6864e7f87bc8fc53336ef8` has the frozen base/current head parents and exactly the current Git tree. Artifact API count is `0`.
- Initial CI `33735743619` failed solely because the hosted image lacked `svnadmin`. The same PR added the Subversion dependency; no test, gate, assertion or failure-propagation control was weakened.
- Fresh source-read-only [Independent Codex Review](https://github.com/yoohwz/wc-order-splitter/pull/142#pullrequestreview-5099898250): `TECHNICAL_ACCEPTED`, no blocking findings; COMMENT review binds exact head `d8483471f668c387a42020fc8c669c4750d6421d`. Reviewer independently inspected all 15 changed files, reran focused/FAST/static tests, proved staged base/head byte equality, and authenticated native CI and the existing certificate through live GET-only checks. This is technical review, not ChatGPT Acceptance or merge/publication permission.

The new manual workflows, production-secret path and live WordPress.org publication are intentionally not run before bootstrap acceptance. Local tests create only temporary fixture packages/commits. Plugin Check integration is scheduled in secret-free Prepare after merge; it is not a new product certificate or a hidden broad-error baseline.

## Boundary

No product/runtime/readme/changelog/version/gate/distribution-exclusion bytes changed. No WordPress.org write, numeric release tag, GitHub Release, production secret access/creation, Environment/ruleset change, publication or merge was performed. Do not authorize a new product candidate through this control-plane PR.

`READY_TO_FINALIZE: WOS-REL-002`. Keep this PR draft until ChatGPT Finalize checks and accepts this unchanged head.

NEXT_ACTION_HINT
Who: Human
Where: ChatGPT
Command: Finalize WOS-REL-002
Expected: Accept the exact reviewed head and owner-authorize its native-ruleset squash merge; publication remains a separate task.
