### PR TITLE
WOS-REL-003: allow Compare syntax without allowing path traversal

### DIFF
--- a/.github/scripts/release_github.py
+++ b/.github/scripts/release_github.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 
 import release_package as pkg
@@ -30,7 +31,10 @@ class API:
         self.opener = urllib.request.build_opener(SafeRedirect())
 
     def request(self, path, method='GET', value=None, binary=False, missing=False, upload=None):
-        pkg.require(path.startswith(f'repos/{pkg.REPOSITORY}/') and '..' not in path, 'unsafe GitHub API path')
+        # Compare uses SHA...SHA; only decoded dot path segments are traversal.
+        segments = urllib.parse.unquote(urllib.parse.urlsplit(path).path).split('/')
+        pkg.require(path.startswith(f'repos/{pkg.REPOSITORY}/') and
+                    all(segment not in {'.', '..'} for segment in segments), 'unsafe GitHub API path')
         host = 'https://uploads.github.com/' if upload is not None else 'https://api.github.com/'
         headers = {'Authorization': f'Bearer {self.token}', 'User-Agent': 'WOS-release-control',
                    'Accept': 'application/octet-stream' if binary and '/releases/assets/' in path else 'application/vnd.github+json',

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -290,6 +290,103 @@ for inherited in list(Product.__dict__):
 
 
 class GithubContracts(unittest.TestCase):
+    def http_api(self, responses):
+        with patch.dict(os.environ, {'GH_TOKEN': 'fixture-not-a-real-token'}):
+            api = gh.API()
+
+        def respond(request, timeout):
+            self.assertEqual(timeout, 60)
+            return io.BytesIO(pkg.encoded(responses[request.full_url]))
+
+        # Keep production request/get/pages validation; replace only HTTP transport.
+        api.opener.open = Mock(side_effect=respond)
+        return api
+
+    def test_api_path_guard_allows_compare_repository_routes_and_queries(self):
+        prefix = f'repos/{pkg.REPOSITORY}/'
+        paths = [prefix + endpoint for endpoint in (
+            f'compare/{BASE}...{CERT_HEAD}', 'branches/main', 'git/ref/tags/1.5.0',
+            'actions/runs/33727158970/artifacts?per_page=100&page=2',
+            'releases/1/assets?name=release..zip', 'releases?note=../query-only')]
+        api = self.http_api({'https://api.github.com/' + path: {'ok': True} for path in paths})
+        for path in paths:
+            with self.subTest(path=path):
+                self.assertEqual(api.request(path), {'ok': True})
+                request = api.opener.open.call_args.args[0]
+                self.assertEqual(request.full_url, 'https://api.github.com/' + path)
+                self.assertEqual(request.get_method(), 'GET')
+        self.assertEqual(api.opener.open.call_count, len(paths))
+
+        upload = prefix + 'releases/1/assets?name=release..zip'
+        api = self.http_api({'https://uploads.github.com/' + upload: {'id': 1}})
+        self.assertEqual(api.request(upload, method='POST', upload=b'fixture'), {'id': 1})
+        request = api.opener.open.call_args.args[0]
+        self.assertEqual(request.full_url, 'https://uploads.github.com/' + upload)
+        self.assertEqual(request.data, b'fixture')
+
+    def test_api_path_guard_rejects_traversal_and_non_repository_before_http(self):
+        prefix = f'repos/{pkg.REPOSITORY}/'
+        paths = ['../' + prefix + 'branches/main', '/repos/' + pkg.REPOSITORY + '/branches/main',
+                 'repos/attacker/repository/branches/main', prefix[:-1] + '-other/branches/main',
+                 'users/yoohwz', 'https://example.test/' + prefix + 'branches/main',
+                 'http://api.github.com/' + prefix + 'branches/main', '//example.test/' + prefix]
+        paths += [prefix + endpoint for endpoint in (
+            '../outside', 'git/../outside', 'git/..', './branches/main', 'git/./refs', 'git/.',
+            '%2e%2e/outside', 'git/%2E%2e/refs', 'git/.%2e', '%2e/branches/main',
+            'git%2f..%2foutside', 'git/%2E%2E%2Foutside', 'git/%2e%2e?per_page=100')]
+        api = self.http_api({})
+        for path in paths:
+            for kwargs in ({}, {'method': 'POST', 'upload': b'fixture'}):
+                with self.subTest(path=path, upload=bool(kwargs)), self.assertRaisesRegex(ValueError, 'unsafe GitHub API path'):
+                    api.request(path, **kwargs)
+        api.opener.open.assert_not_called()
+
+    def test_api_pages_preserves_existing_query(self):
+        prefix = f'https://api.github.com/repos/{pkg.REPOSITORY}/'
+        first = [{'id': number} for number in range(100)]
+        second = [{'id': 100}]
+        urls = [prefix + f'pulls?state=closed&per_page=100&page={page}' for page in (1, 2)]
+        api = self.http_api(dict(zip(urls, (first, second))))
+        self.assertEqual(api.pages('pulls?state=closed'), first + second)
+        self.assertEqual([call.args[0].full_url for call in api.opener.open.call_args_list], urls)
+
+    def test_failed_prepare_provenance_through_production_http_guard(self):
+        # Run 33744352719 failed before HTTP on this protected-main Compare route.
+        control = 'f7a6ad93a597a58cedd8db654f572fe4d9dfbabe'
+        tree = '0c3e2ba937b21a24100e1402f11e267531501abc'
+        repository = {'full_name': pkg.REPOSITORY}
+        pull = {'merged_at': '2026-09-03T07:47:46Z', 'base': {'ref': 'main', 'repo': repository},
+                'merge_commit_sha': BASE, 'head': {'sha': CERT_HEAD}}
+        check = {'id': 1, 'name': 'Required CI', 'app': {'slug': 'github-actions'},
+                 'status': 'completed', 'conclusion': 'success',
+                 'details_url': f'https://github.com/{pkg.REPOSITORY}/actions/runs/33726798296/job/1'}
+        responses = {
+            'branches/main': {'protected': True, 'commit': {'sha': control}},
+            f'compare/{control}...{control}': {'status': 'identical'},
+            f'compare/{BASE}...{control}': {'status': 'ahead'},
+            f'commits/{BASE}/pulls?per_page=100&page=1': [pull],
+            f'git/commits/{BASE}': {'tree': {'sha': tree}},
+            f'git/commits/{CERT_HEAD}': {'tree': {'sha': tree}},
+            f'commits/{CERT_HEAD}/check-runs?per_page=100&page=1': {'check_runs': [check]},
+            'actions/runs/33726798296': {'repository': repository, 'head_repository': repository,
+                'path': '.github/workflows/ci.yml', 'event': 'pull_request', 'head_sha': CERT_HEAD,
+                'status': 'completed', 'conclusion': 'success'},
+        }
+        prefix = f'https://api.github.com/repos/{pkg.REPOSITORY}/'
+        api = self.http_api({prefix + endpoint: value for endpoint, value in responses.items()})
+        env = {'GITHUB_REPOSITORY': pkg.REPOSITORY, 'GITHUB_REF': 'refs/heads/main', 'GITHUB_REF_PROTECTED': 'true',
+               'GITHUB_EVENT_NAME': 'workflow_dispatch', 'GITHUB_RUN_ATTEMPT': '1', 'GITHUB_SHA': control,
+               'GITHUB_WORKFLOW_SHA': control, 'GITHUB_WORKFLOW_REF': f'{pkg.REPOSITORY}/{gh.PREPARE}@refs/heads/main'}
+        with patch.dict(os.environ, env):
+            self.assertEqual(gh.control_context(api, gh.PREPARE), control)
+        self.assertEqual(gh.accepted_source(api, BASE), {
+            'accepted_sha': BASE, 'reviewed_head': CERT_HEAD, 'required_ci_run_id': 33726798296})
+        requests = [call.args[0] for call in api.opener.open.call_args_list]
+        compares = [request.full_url for request in requests if '/compare/' in request.full_url]
+        self.assertEqual(compares, [prefix + f'compare/{control}...{control}'] +
+                         [prefix + f'compare/{BASE}...{control}'] * 2)
+        self.assertTrue(all(request.get_method() == 'GET' for request in requests))
+
     def test_api_binary_download_headers_and_error_classification(self):
         with patch.dict(os.environ, {'GH_TOKEN': 'fixture-not-a-real-token'}):
             api = gh.API()


### PR DESCRIPTION
## Classification and authority

`P1_GOVERNANCE` — release/publication safety-control correction. Canonical classification: `P1_RELEASE_INFRA / PUBLISHER_PREPARE_CORRECTION`.

Refs [WOS-REL-003 / Issue #143](https://github.com/yoohwz/wc-order-splitter/issues/143). This is a bounded fix for [failed Prepare run 33744352719](https://github.com/yoohwz/wc-order-splitter/actions/runs/33744352719), not publication authority.

- Exact accepted base: `f7a6ad93a597a58cedd8db654f572fe4d9dfbabe`, tree `538df1adf7e1f80c149c5cddbbd2756ff69ac8a8`.
- Implementation head: `a32807368b8ebb8e3f6d918107416259b62615b6`, tree `80c9ba1512d32ea5dbefa11414f3f33ff224478b`.
- Publication candidate remains `4de67108045714415d5bc4708bd94e7ad871e9a1`, version `1.5.0`.
- Certified `PRODUCT_TREE_SHA=2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072` remains unchanged.
- Code-owned workflow gates Split/Duplicate/Merge/Return/Bulk Return and strategy gates Manual Quantity/Category/Stock Status remain unchanged (`true`).

## Correction

Replace substring rejection of `..` with a check for literal `.`/`..` segments in the URL-decoded path component. The legitimate `compare/<40hex>...<40hex>` separator and query values no longer produce false positives. Percent-encoded dot/slash traversal remains rejected before HTTP. Keep the exact repository prefix, fixed API/upload hosts, request/error behavior, redirect Authorization stripping, and all publisher secret/mutation boundaries unchanged.

Only `.github/scripts/release_github.py` and `tests/ci/publisher-contract.py` change. The audit found no equivalent substring guard elsewhere in the release helpers; payload path validation already checks segments and is unchanged.

## Evidence

- Red/green reproduction: new tests fail on the accepted helper's Compare guard, including the exact failed protected-main `control_context()` path; all pass with the narrow correction.
- `python3 tests/ci/publisher-contract.py`: **31/31 PASS** (four new tests). New fixtures keep production `API.request/get/pages`, `control_context/ancestor/accepted_source`, and native CI checks; only the HTTP transport is mocked. They cover Compare, ordinary repository paths, literal/encoded traversal on API/upload routes, foreign repository/host rejection before HTTP, query-preserving two-page pagination, and exact failed Prepare source provenance.
- `bash .github/scripts/run-static.sh`: **PASS**, including all 34 unit contracts and product static/JavaScript checks. `git diff --check`: **PASS**.
- Exact base/head separately extracted with `git archive` and staged through the canonical helper: byte-identical, same certified digest. Only two excluded control-plane/test paths change.
- `bash .github/scripts/run-fast.sh`: **PASS**. [Native Required CI run 33745324568](https://github.com/yoohwz/wc-order-splitter/actions/runs/33745324568): attempt 1, **success** on exact head `a32807368b8ebb8e3f6d918107416259b62615b6`; FAST and Required CI pass, PHP/integration skipped as required for FAST, artifacts=0. Native tested merge `4c31d32b32a7f4adcf61eeb079ededb66ef31e91` has the exact base/head parents and the current Git tree `80c9ba1512d32ea5dbefa11414f3f33ff224478b`.
- Additional live **GET-only** smoke uses the production `API.request/get/pages` guard, replacing only transport with gh-managed authentication (no token read). All 23 GETs succeed, including 5 Compare routes, `control_context()`, `accepted_source()` and certificate authentication for existing RELEASE_CERT `33727158970` / attempt 1 / exact digest and public 1.4.11 baseline / artifacts=0. This is not a new Prepare dispatch or a full live workflow claim.
- Fresh source-read-only [Independent Codex COMMENT review](https://github.com/yoohwz/wc-order-splitter/pull/144#pullrequestreview-5100880104): **TECHNICAL_ACCEPTED**, no blocking findings, exact `commit_id=a32807368b8ebb8e3f6d918107416259b62615b6`. Reviewer independently inspected both changed files, reproduced red/green using the exact-base helper, reran publisher/FAST, proved base/head byte identity, and verified native CI. This is technical review, not ChatGPT Acceptance or merge/publication permission.

## Boundaries and follow-up

No production/runtime/readme/changelog/version/Stable tag/distribution exclusion/gate/policy/workflow/Environment changes. No production WordPress.org write, numeric release tag, GitHub Release, production secret access, workflow dispatch, merge, or new RELEASE_CERT. Tests use only temporary local SVN/package fixtures and mocked HTTP.

`READY_TO_FINALIZE: WOS-REL-003`. Keep this PR draft for ChatGPT Finalize of the unchanged reviewed head. After Acceptance/merge, dispatch a **new** Prepare run with the same four publication inputs; do not rerun failed `33744352719` as attempt 2, because the workflow requires attempt 1. This task does not dispatch or publish.

NEXT_ACTION_HINT
Who: Human
Where: ChatGPT
Command: Finalize WOS-REL-003
Expected: Accept and owner-authorize native-ruleset squash merge of the unchanged reviewed head; publication remains separate.
