### PR TITLE
WOS-REL-004: preserve Plugin Check failure diagnostics

### DIFF
--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Narrow workflow entry points; all executable control comes from protected main."""
+import html
 import json
 import os
 from pathlib import Path
@@ -57,17 +58,81 @@ def prepare():
     say('DETERMINISTIC_PACKAGE_VERIFIED', candidate_sha=candidate, product_tree_sha=digest, EXTERNAL_MUTATION='NONE')
 
 
-def plugin_check_report(raw):
+def parse_plugin_check(raw):
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            pkg.require(key not in result, 'duplicate Plugin Check field')
+            result[key] = value
+        return result
+
     lines = re.sub(r'\x1b\[[0-9;]*m', '', raw).splitlines()
-    matches = [json.loads(line) for line in lines if line.startswith('[')]
+    matches = [json.loads(line, object_pairs_hook=unique) for line in lines if line.startswith('[')]
     clean = lines.count('Success: Checks complete. No errors found.')
     pkg.require(len(matches) == 1 and clean == 0 or not matches and clean == 1, 'Plugin Check report missing or ambiguous')
     report = matches[0] if matches else []
-    pkg.require(isinstance(report, list) and all(isinstance(item, dict) and 'type' in item and 'code' in item
-                and 'file' in item for item in report), 'invalid Plugin Check report')
+    pkg.require(isinstance(report, list) and all(isinstance(item, dict) and
+                all(isinstance(item.get(key), str) for key in ('type', 'code', 'file', 'message')) and
+                all(key not in item or isinstance(item[key], str) or type(item[key]) is int
+                    for key in ('line', 'column')) and
+                ('docs' not in item or isinstance(item['docs'], str)) for item in report), 'invalid Plugin Check report')
     pkg.require(all(item['type'].upper() in {'WARNING', 'ERROR'} for item in report), 'unexpected Plugin Check result type')
+    return report
+
+
+def diagnostic_text(value):
+    """Allowlisted report fields only; never inspect or serialize credential env."""
+    value = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', value)
+    value = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', value)
+    value = re.sub(r'\b(?:gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+)\b', '[REDACTED]', value)
+    value = re.sub(r'(?i)\bBearer\s+[^\s,;<>]+', 'Bearer [REDACTED]', value)
+    value = re.sub(r'''(?ix)\b([a-z0-9_]*(?:token|password|secret|api_key|private_key))\s*[:=]\s*
+                      (?:"[^"]*"|'[^']*'|[^\s&,;<>]+)''', r'\1=[REDACTED]', value)
+    return re.sub(r'(?i)(https?://)[^/\s:@]+:[^/\s@]+@', r'\1[REDACTED]@', value)
+
+
+def plugin_check_diagnostics(path, report):
+    fields = ('type', 'code', 'file', 'line', 'column', 'message', 'docs')
+    findings = [] if report is None else [
+        {key: diagnostic_text(item[key]) if isinstance(item[key], str) else item[key]
+         for key in fields if key in item} for item in report]
+    findings.sort(key=pkg.encoded)
+    errors = [item for item in findings if item['type'].upper() == 'ERROR']
+    warnings = [item for item in findings if item['type'].upper() == 'WARNING']
+    evidence = {'schema_version': 1, 'kind': 'PLUGIN_CHECK_DIAGNOSTICS',
+                'status': 'INVALID_REPORT' if report is None else 'BLOCKED' if errors else 'PASSED',
+                'error_count': None if report is None else len(errors),
+                'warning_count': None if report is None else len(warnings), 'findings': findings}
+    pkg.write_json(path, evidence)
+    summary = ['Plugin Check report malformed or ambiguous; preparation blocked.'] if report is None else [
+        f'Plugin Check: {len(errors)} ERROR(s), {len(warnings)} WARNING(s).',
+        *('Plugin Check ERROR: ' + pkg.encoded(item).decode().strip() for item in errors),
+        f'All {len(findings)} findings retained in sanitized diagnostic JSON.']
+    text = '\n'.join(summary) + '\n'
+    # JSON escapes finding newlines; a finding cannot introduce an Actions command.
+    print(text, end='')
+    if os.environ.get('GITHUB_STEP_SUMMARY'):
+        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as handle:
+            handle.write('## Plugin Check diagnostics\n\n<pre>' + html.escape(text) + '</pre>\n')
+
+
+def plugin_check_report(raw, diagnostic_path=None):
+    try:
+        report = parse_plugin_check(raw)
+    except (ValueError, TypeError):
+        if diagnostic_path is not None:
+            plugin_check_diagnostics(diagnostic_path, None)
+        raise ValueError('Plugin Check report malformed or ambiguous') from None
+    if diagnostic_path is not None:
+        plugin_check_diagnostics(diagnostic_path, report)
     pkg.require(not any(item['type'].upper() == 'ERROR' for item in report), 'Plugin Check Errors block preparation; no ignore baseline')
     return report
+
+
+def plugin_check_evidence():
+    _, _, work = settings()
+    raw = work / 'plugin-check-raw.txt'
+    plugin_check_report(raw.read_text() if raw.is_file() else '', work / 'plugin-check-diagnostics.json')
 
 
 def finish_prepare():
@@ -79,7 +144,7 @@ def finish_prepare():
                 manifest['product_tree_sha'] == os.environ['PRODUCT_TREE_SHA'], 'prepared identity changed')
     pkg.verify_tree(work / 'stage-a', manifest)
     pkg.validate_payload((work / 'rc-a' / manifest['package_name']).read_bytes(), manifest, work / 'validated-package')
-    report = plugin_check_report((work / 'plugin-check-raw.txt').read_text())
+    report = plugin_check_report((work / 'plugin-check-raw.txt').read_text(), work / 'plugin-check-diagnostics.json')
     pkg.write_json(work / 'rc-a/plugin-check.json', report)
     name = f'{pkg.SLUG}-{version}-{candidate}'
     record = {'schema_version': 1, 'repository': pkg.REPOSITORY, 'workflow_path': gh.PREPARE,
@@ -251,7 +316,8 @@ def release():
     say(gh.github_release(api, manifest, work / 'prepared', refreshed), identity=pkg.manifest_identity(manifest))
 
 
-COMMANDS = {'prepare': prepare, 'finish-prepare': finish_prepare, 'context': publication_context,
+COMMANDS = {'prepare': prepare, 'plugin-check-evidence': plugin_check_evidence,
+            'finish-prepare': finish_prepare, 'context': publication_context,
             'preflight': preflight, 'recheck': recheck, 'seal': seal, 'commit': commit,
             'verify': verify, 'recover': recover, 'release': release}
 

--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -83,11 +83,12 @@ def parse_plugin_check(raw):
 def diagnostic_text(value):
     """Allowlisted report fields only; never inspect or serialize credential env."""
     value = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', value)
+    value = re.sub(r'[\r\n\t]', ' ', value)
     value = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', value)
     value = re.sub(r'\b(?:gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+)\b', '[REDACTED]', value)
-    value = re.sub(r'(?i)\bBearer\s+[^\s,;<>]+', 'Bearer [REDACTED]', value)
-    value = re.sub(r'''(?ix)\b([a-z0-9_]*(?:token|password|secret|api_key|private_key))\s*[:=]\s*
-                      (?:"[^"]*"|'[^']*'|[^\s&,;<>]+)''', r'\1=[REDACTED]', value)
+    value = re.sub(r'(?i)\b(Bearer|Basic)\s+[^\s,;<>]+', r'\1 [REDACTED]', value)
+    value = re.sub(r'''(?ix)(["']?\b(?:[a-z0-9_]*(?:token|password|secret|api_key|private_key)|authorization)["']?\s*[:=]\s*)
+                      (?:"[^"]*"|'[^']*'|[^\s&,;<>]+)''', r'\1[REDACTED]', value)
     return re.sub(r'(?i)(https?://)[^/\s:@]+:[^/\s@]+@', r'\1[REDACTED]@', value)
 
 

--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -66,7 +66,7 @@ def parse_plugin_check(raw):
             result[key] = value
         return result
 
-    lines = re.sub(r'\x1b\[[0-9;]*m', '', raw).splitlines()
+    lines = [line.strip() for line in re.sub(r'\x1b\[[0-9;]*m', '', raw).splitlines()]
     matches = [json.loads(line, object_pairs_hook=unique) for line in lines if line.startswith('[')]
     clean = lines.count('Success: Checks complete. No errors found.')
     pkg.require(len(matches) == 1 and clean == 0 or not matches and clean == 1, 'Plugin Check report missing or ambiguous')

--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -107,10 +107,10 @@ def plugin_check_diagnostics(path, report):
     pkg.write_json(path, evidence)
     summary = ['Plugin Check report malformed or ambiguous; preparation blocked.'] if report is None else [
         f'Plugin Check: {len(errors)} ERROR(s), {len(warnings)} WARNING(s).',
-        *('Plugin Check ERROR: ' + pkg.encoded(item).decode().strip() for item in errors),
+        *('Plugin Check ERROR: ' + pkg.encoded(item).decode().strip().replace('##[', r'\u0023\u0023[') for item in errors),
         f'All {len(findings)} findings retained in sanitized diagnostic JSON.']
     text = '\n'.join(summary) + '\n'
-    # JSON escapes finding newlines; a finding cannot introduce an Actions command.
+    # Escape both newlines and legacy Actions markers without losing JSON round-trip.
     print(text, end='')
     if os.environ.get('GITHUB_STEP_SUMMARY'):
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as handle:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -82,7 +82,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 control/.github/scripts/release_cli.py prepare
       - name: Plugin Check on exact staged payload without production secrets
+        id: plugin_check
         run: bash control/.github/scripts/release-plugin-check.sh
+      - name: Preserve sanitized Plugin Check evidence before enforcing Errors
+        if: ${{ !cancelled() && (steps.plugin_check.outcome == 'success' || steps.plugin_check.outcome == 'failure') }}
+        run: python3 control/.github/scripts/release_cli.py plugin-check-evidence
       - name: Revalidate payload and record immutable candidate
         id: record
         env:
@@ -95,4 +99,13 @@ jobs:
           path: ${{ runner.temp }}/wcos-release/rc-a/*
           if-no-files-found: error
           retention-days: 90
+          overwrite: false
+      - name: Upload diagnostic-only Plugin Check evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: plugin-check-diagnostics-${{ github.run_id }}
+          path: ${{ runner.temp }}/wcos-release/plugin-check-diagnostics.json
+          if-no-files-found: ignore
+          retention-days: 14
           overwrite: false

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -71,6 +71,15 @@ After Finalize/merge, use the existing WOS-REL-001 publication authority:
    Error blocks preparation. Warnings remain in the evidence. Resolve new Errors
    through an appropriately scoped task, never by silently changing certified
    product bytes or adding a broad ignore baseline.
+   Failed runs retain sanitized findings in `plugin-check-diagnostics-<run_id>`
+   (14 days), with exact Error counts/details in the log and step summary. This
+   diagnostic-only JSON is never an RC artifact and cannot authorize publishing;
+   raw checker output, credentials and runner environment are not uploaded.
+   After a correction is accepted/merged, dispatch a new Prepare run with the
+   same inputs, not another attempt of the failed run. Classify visible Errors
+   before resuming: product defects need a separate task/new product certificate;
+   suspected false positives need explicit Human/Architecture review; checker
+   integration defects need a separate bounded publisher correction.
 2. Run **Publish Order Splitter to WordPress.org**, `operation=publish`, using
    that `preparation_run_id`, candidate/version, and `dry_run=true`. Review the
    exact read-only SVN snapshot and final recheck. No tag, SVN or Release write

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Publisher contracts: temporary local SVN only; all GitHub calls are fakes."""
 import copy
+from contextlib import contextmanager, redirect_stdout
 import io
 import json
 import os
 from pathlib import Path
+import shutil
 import stat
 import subprocess
 import sys
@@ -209,6 +211,142 @@ class Product(unittest.TestCase):
         self.assertNotIn('WPORG_SVN_PASSWORD', kwargs['env'])
         self.assertEqual(kwargs['input'], b'fake-fixture-password\n')
         self.assertNotIn('fake-fixture-password', (self.root / 'attempt.json').read_text())
+
+    @contextmanager
+    def preparation_fixture(self, report):
+        with tempfile.TemporaryDirectory(prefix='wcos-diagnostics-') as directory:
+            root = Path(directory)
+            work = root / 'wcos-release'
+            (work / 'rc-a').mkdir(parents=True)
+            shutil.copytree(self.staged, work / 'stage-a')
+            pkg.write_json(work / 'rc-a/release-manifest.json', self.manifest)
+            (work / 'rc-a' / self.manifest['package_name']).write_bytes(self.zip)
+            (work / 'plugin-check-raw.txt').write_text(report)
+            env = {'RUNNER_TEMP': directory, 'CANDIDATE_SHA': BASE, 'VERSION': '1.5.0',
+                   'PRODUCT_TREE_SHA': DIGEST, 'GITHUB_RUN_ID': '100',
+                   'GITHUB_OUTPUT': str(root / 'outputs'), 'GITHUB_STEP_SUMMARY': str(root / 'summary')}
+            with patch.dict(os.environ, env), patch.object(gh, 'API'), \
+                    patch.object(gh, 'control_context', return_value=BASE):
+                yield work, root / 'outputs', root / 'summary'
+
+    def test_11_error_persists_diagnostics_before_preparation_fails(self):
+        error = {'type': 'ERROR', 'code': 'blocked_code', 'file': 'inc/example.php',
+                 'line': 12, 'column': 3, 'message': 'Exact blocking message', 'docs': 'https://example.test/docs'}
+        with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
+            with self.assertRaisesRegex(ValueError, 'Errors block preparation; no ignore baseline'):
+                cli.finish_prepare()
+            diagnostic = pkg.read_json(work / 'plugin-check-diagnostics.json')
+            self.assertEqual(diagnostic['findings'], [error])
+            self.assertEqual((diagnostic['status'], diagnostic['error_count'], diagnostic['warning_count']), ('BLOCKED', 1, 0))
+            self.assertIn('1 ERROR(s), 0 WARNING(s)', log.getvalue())
+            for value in ('blocked_code', 'inc/example.php', '12', 'Exact blocking message'):
+                self.assertIn(value, log.getvalue())
+                self.assertIn(value, summary.read_text())
+            self.assertFalse((work / 'rc-a/plugin-check.json').exists())
+            self.assertFalse((work / 'rc-a/preparation-record.json').exists())
+            self.assertFalse(outputs.exists())
+            self.assertNotIn('RC_PREPARED', log.getvalue())
+            self.assertEqual(set(path.name for path in (work / 'rc-a').iterdir()),
+                             {'release-manifest.json', self.manifest['package_name']})
+
+    def test_12_all_errors_and_warnings_have_deterministic_evidence(self):
+        first = {'type': 'ERROR', 'code': 'first', 'file': 'a.php', 'line': 2, 'message': 'First error'}
+        second = {'type': 'ERROR', 'code': 'second', 'file': 'b.php', 'line': 9, 'message': 'Second error'}
+        warning = {'type': 'WARNING', 'code': 'notice', 'file': 'readme.txt', 'message': 'Still retained'}
+        results = []
+        for report in ([second, warning, first], [first, second, warning]):
+            with self.preparation_fixture(json.dumps(report)) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
+                with self.assertRaisesRegex(ValueError, 'Errors block preparation'):
+                    cli.plugin_check_evidence()
+                raw = (work / 'plugin-check-diagnostics.json').read_bytes()
+                evidence = json.loads(raw)
+                self.assertEqual(evidence['error_count'], 2)
+                self.assertEqual(evidence['warning_count'], 1)
+                self.assertCountEqual(evidence['findings'], [first, second, warning])
+                self.assertEqual(log.getvalue().count('Plugin Check ERROR: '), 2)
+                self.assertIn('2 ERROR(s), 1 WARNING(s)', log.getvalue())
+                self.assertIn('First error', log.getvalue())
+                self.assertIn('Second error', log.getvalue())
+                self.assertFalse(outputs.exists())
+                results.append((raw, log.getvalue(), summary.read_bytes()))
+        self.assertEqual(results[0], results[1])
+
+    def test_13_clean_and_warning_reports_keep_successful_preparation(self):
+        warning = {'type': 'WARNING', 'code': 'notice', 'file': 'readme.txt', 'line': 0, 'message': 'Warning only'}
+        for report in ([], [warning]):
+            with self.subTest(report=report), self.preparation_fixture(json.dumps(report)) as (work, outputs, summary), \
+                    redirect_stdout(io.StringIO()) as log:
+                cli.plugin_check_evidence()
+                cli.finish_prepare()
+                self.assertEqual(pkg.read_json(work / 'rc-a/plugin-check.json'), report)
+                record = pkg.read_json(work / 'rc-a/preparation-record.json')
+                self.assertEqual(record['status'], 'RC_PREPARED')
+                self.assertEqual(record['artifact_name'], f'{pkg.SLUG}-1.5.0-{BASE}')
+                self.assertEqual(pkg.manifest_identity(record), pkg.manifest_identity(self.manifest))
+                self.assertIn('state=RC_PREPARED', outputs.read_text())
+                self.assertIn('artifact_name=' + record['artifact_name'], outputs.read_text())
+                diagnostic = pkg.read_json(work / 'plugin-check-diagnostics.json')
+                self.assertEqual((diagnostic['status'], diagnostic['error_count'], diagnostic['warning_count']),
+                                 ('PASSED', 0, len(report)))
+                self.assertEqual(set(path.name for path in (work / 'rc-a').iterdir()),
+                                 {'plugin-check.json', 'preparation-record.json', 'release-manifest.json', self.manifest['package_name']})
+
+    def test_14_malformed_ambiguous_and_missing_reports_fail_closed_without_raw_dump(self):
+        duplicate = '[{"type":"ERROR","type":"WARNING","code":"x","file":"x.php","message":"x"}]'
+        for raw in ('', '[bad secret=fixture-private]', '[]\n[]', '[]\nSuccess: Checks complete. No errors found.',
+                    '[{}]', duplicate, '[{"type":false}]'):
+            with self.subTest(raw=raw), self.preparation_fixture(raw) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
+                with self.assertRaisesRegex(ValueError, 'report malformed or ambiguous'):
+                    cli.plugin_check_evidence()
+                evidence = pkg.read_json(work / 'plugin-check-diagnostics.json')
+                self.assertEqual(evidence['status'], 'INVALID_REPORT')
+                self.assertIsNone(evidence['error_count'])
+                self.assertEqual(evidence['findings'], [])
+                self.assertNotIn('fixture-private', (work / 'plugin-check-diagnostics.json').read_text() + log.getvalue() + summary.read_text())
+                self.assertFalse(outputs.exists())
+                self.assertFalse((work / 'rc-a/preparation-record.json').exists())
+        with self.preparation_fixture('unused') as (work, outputs, summary), redirect_stdout(io.StringIO()):
+            (work / 'plugin-check-raw.txt').unlink()
+            with self.assertRaisesRegex(ValueError, 'report malformed or ambiguous'):
+                cli.plugin_check_evidence()
+            self.assertEqual(pkg.read_json(work / 'plugin-check-diagnostics.json')['status'], 'INVALID_REPORT')
+
+    def test_15_diagnostics_allowlist_redacts_credentials_and_escapes_summary(self):
+        env = {'GH_TOKEN': 'fixture-env-token', 'WPORG_SVN_PASSWORD': 'fixture-env-password', 'UNRELATED_VALUE': 'fixture-env-unrelated'}
+        error = {'type': 'ERROR', 'code': 'unsafe_example', 'file': 'inc/example.php', 'line': '12', 'column': 3,
+                 'message': '\x1b[31mFound <script>bad</script>\n::warning:: GH_TOKEN=fixture-message-token '
+                            'Bearer fixture-bearer github_pat_fixturepat WPORG_SVN_PASSWORD="fixture-quoted-password"',
+                 'docs': 'https://fixture-user:fixture-url-password@example.test/docs?token=fixture-url-token',
+                 'environment': env, 'raw': 'fixture-unknown-field'}
+        with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), patch.dict(os.environ, env), \
+                redirect_stdout(io.StringIO()) as log:
+            with self.assertRaisesRegex(ValueError, 'Errors block preparation'):
+                cli.plugin_check_evidence()
+            raw = (work / 'plugin-check-diagnostics.json').read_text()
+            text = raw + log.getvalue() + summary.read_text()
+            for secret in (*env.values(), 'fixture-message-token', 'fixture-bearer', 'github_pat_fixturepat',
+                           'fixture-quoted-password', 'fixture-url-password', 'fixture-url-token', 'fixture-unknown-field'):
+                self.assertNotIn(secret, text)
+            finding = json.loads(raw)['findings'][0]
+            self.assertEqual(set(finding), {'type', 'code', 'file', 'line', 'column', 'message', 'docs'})
+            self.assertEqual(finding['type'], 'ERROR')
+            self.assertIn('[REDACTED]', text)
+            self.assertNotIn('\x1b', text)
+            self.assertNotIn('<script>', summary.read_text())
+            self.assertIn('&lt;script&gt;', summary.read_text())
+            self.assertFalse(any(line.startswith('::') for line in log.getvalue().splitlines()))
+
+    def test_16_evidence_command_exits_nonzero_after_persisting_errors(self):
+        error = {'type': 'ERROR', 'code': 'checker_failed', 'file': 'example.php', 'line': 4, 'message': 'Blocked'}
+        with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary):
+            result = subprocess.run([sys.executable, str(ROOT / '.github/scripts/release_cli.py'), 'plugin-check-evidence'],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(b'1 ERROR(s)', result.stdout)
+            self.assertIn(b'Errors block preparation; no ignore baseline', result.stderr)
+            self.assertEqual(pkg.read_json(work / 'plugin-check-diagnostics.json')['findings'], [error])
+            self.assertFalse(outputs.exists())
+            self.assertFalse((work / 'rc-a/preparation-record.json').exists())
 
 
 class LocalSVN(Product):
@@ -503,6 +641,29 @@ class GithubContracts(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'API digest mismatch'):
                 gh.artifact(api, run_data, 'prepared', Path(directory) / 'bad', {'manifest.json'})
 
+    def test_diagnostic_artifact_cannot_authenticate_as_prepared_candidate(self):
+        repository = {'full_name': pkg.REPOSITORY}
+        run_data = {'id': 100, 'repository': repository, 'head_repository': repository, 'path': gh.PREPARE,
+                    'event': 'workflow_dispatch', 'status': 'completed', 'conclusion': 'failure',
+                    'head_sha': BASE, 'head_branch': 'main', 'run_attempt': 1}
+        raw = archive({'plugin-check-diagnostics.json': pkg.encoded({'kind': 'PLUGIN_CHECK_DIAGNOSTICS', 'status': 'BLOCKED'})})
+        item = {'id': 1, 'name': 'plugin-check-diagnostics-100', 'expired': False, 'digest': 'sha256:' + pkg.sha(raw),
+                'workflow_run': {'id': 100, 'head_sha': BASE}}
+        for case, message in (('failed-run', 'run is not successful'), ('wrong-name', 'immutable artifact missing'),
+                              ('forged-name', 'unexpected artifact file set')):
+            api = FakeAPI({'actions/runs/100': copy.deepcopy(run_data), 'actions/runs/100/artifacts': [copy.deepcopy(item)],
+                           'actions/artifacts/1/zip': raw})
+            if case != 'failed-run':
+                api.values['actions/runs/100']['conclusion'] = 'success'
+            if case == 'forged-name':
+                api.values['actions/runs/100/artifacts'][0]['name'] = f'{pkg.SLUG}-1.5.0-{BASE}'
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory, \
+                    patch.object(gh, 'ancestor', return_value=True), patch.object(gh, 'protected_main', return_value=BASE), \
+                    patch.object(gh, 'accepted_source'), patch.object(gh, 'certificate') as certificate, \
+                    self.assertRaisesRegex(ValueError, message):
+                gh.prepared(api, 100, BASE, '1.5.0', Path(directory) / 'candidate')
+            certificate.assert_not_called()
+
     def test_immutable_tag_mismatch_never_updates_or_deletes(self):
         manifest = {'candidate_sha': BASE, 'version': '1.5.0', 'product_tree_sha': DIGEST,
                     'package_sha256': 'a' * 64, 'release_cert_run_id': 1, 'preparation_run_id': 2}
@@ -578,7 +739,13 @@ class WorkflowContracts(unittest.TestCase):
         raw_prepare = json.dumps(prepare)
         self.assertNotIn('secrets.', raw_prepare)
         self.assertNotIn('environment', prepare['jobs']['prepare'])
-        self.assertEqual(raw_prepare.count('actions/upload-artifact@'), 1)
+        uploads = [step for step in prepare['jobs']['prepare']['steps'] if 'actions/upload-artifact@' in step.get('uses', '')]
+        self.assertEqual(len(uploads), 2)
+        canonical = [step for step in uploads if step['with']['name'] == '${{ steps.record.outputs.artifact_name }}']
+        self.assertEqual(len(canonical), 1)
+        self.assertEqual(canonical[0].get('if', 'success()'), 'success()')
+        self.assertEqual(canonical[0]['with']['path'], '${{ runner.temp }}/wcos-release/rc-a/*')
+        self.assertEqual(canonical[0]['with']['if-no-files-found'], 'error')
         secrets = []
         for job_name, job in publish['jobs'].items():
             for step in job['steps']:
@@ -609,6 +776,32 @@ class WorkflowContracts(unittest.TestCase):
         checkouts = [step for step in shared['runs']['steps'] if 'actions/checkout@' in step.get('uses', '')]
         self.assertEqual(checkouts[0]['with']['path'], 'candidate-data')
         self.assertIs(checkouts[0]['with']['persist-credentials'], False)
+
+    def test_failed_prepare_uploads_only_sanitized_diagnostics(self):
+        prepare = yaml(ROOT / '.github/workflows/release-prepare.yml')
+        steps = prepare['jobs']['prepare']['steps']
+        checker = next(step for step in steps if step.get('id') == 'plugin_check')
+        evidence = next(step for step in steps if step.get('run', '').endswith('release_cli.py plugin-check-evidence'))
+        record = next(step for step in steps if step.get('id') == 'record')
+        diagnostic = next(step for step in steps if step.get('with', {}).get('name') == 'plugin-check-diagnostics-${{ github.run_id }}')
+        self.assertEqual(evidence['if'], "${{ !cancelled() && (steps.plugin_check.outcome == 'success' || steps.plugin_check.outcome == 'failure') }}")
+        self.assertLess(steps.index(checker), steps.index(evidence))
+        self.assertLess(steps.index(evidence), steps.index(record))
+        self.assertNotIn('env', evidence)
+        self.assertNotIn('GH_TOKEN', prepare['env'])
+        self.assertEqual(record.get('if', 'success()'), 'success()')
+        self.assertTrue(all(not step.get('continue-on-error') for step in steps))
+        self.assertEqual(diagnostic['if'], 'failure()')
+        self.assertEqual(diagnostic['uses'], 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02')
+        self.assertEqual(diagnostic['with'], {
+            'name': 'plugin-check-diagnostics-${{ github.run_id }}',
+            'path': '${{ runner.temp }}/wcos-release/plugin-check-diagnostics.json',
+            'if-no-files-found': 'ignore', 'retention-days': 14, 'overwrite': False})
+        shell = (ROOT / '.github/scripts/release-plugin-check.sh').read_text()
+        self.assertIn('plugin-check.2.1.0.zip', shell)
+        self.assertIn('--format=strict-json --mode=update', shell)
+        self.assertIn('--fields=file,line,column,type,code,message,docs', shell)
+        self.assertNotRegex(shell, r'--(?:exclude|ignore|skip-checks)')
 
 
 if __name__ == '__main__':

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -321,7 +321,8 @@ class Product(unittest.TestCase):
                             'Bearer fixture-bearer github_pat_fixturepat WPORG_SVN_PASSWORD="fixture-quoted-password" '
                             'metadata {"CUSTOM_SECRET":"fixture-json-secret"} Basic fixture-basic '
                             "'GH_TOKEN' = 'fixture-singlequote-token' Authorization: Basic Zml4dHVyZTpzZWNyZXQ= "
-                            'Authorization: fixture-authorization Bearer\nfixture-newline-token api_key:\tfixture-tab-secret',
+                            'Authorization: fixture-authorization Bearer\nfixture-newline-token api_key:\tfixture-tab-secret '
+                            '##[error]fixture-command-injection ##[add-mask]fixture-mask-injection',
                  'docs': 'https://fixture-user:fixture-url-password@example.test/docs?token=fixture-url-token',
                  'environment': env, 'raw': 'fixture-unknown-field'}
         with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), patch.dict(os.environ, env), \
@@ -345,6 +346,9 @@ class Product(unittest.TestCase):
             self.assertNotIn('<script>', summary.read_text())
             self.assertIn('&lt;script&gt;', summary.read_text())
             self.assertFalse(any(line.startswith('::') for line in log.getvalue().splitlines()))
+            self.assertNotIn('##[', log.getvalue())
+            line = next(line for line in log.getvalue().splitlines() if line.startswith('Plugin Check ERROR: '))
+            self.assertEqual(json.loads(line.removeprefix('Plugin Check ERROR: ')), finding)
 
     def test_16_evidence_command_exits_nonzero_after_persisting_errors(self):
         error = {'type': 'ERROR', 'code': 'checker_failed', 'file': 'example.php', 'line': 4, 'message': 'Blocked'}

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -316,7 +316,10 @@ class Product(unittest.TestCase):
         env = {'GH_TOKEN': 'fixture-env-token', 'WPORG_SVN_PASSWORD': 'fixture-env-password', 'UNRELATED_VALUE': 'fixture-env-unrelated'}
         error = {'type': 'ERROR', 'code': 'unsafe_example', 'file': 'inc/example.php', 'line': '12', 'column': 3,
                  'message': '\x1b[31mFound <script>bad</script>\n::warning:: GH_TOKEN=fixture-message-token '
-                            'Bearer fixture-bearer github_pat_fixturepat WPORG_SVN_PASSWORD="fixture-quoted-password"',
+                            'Bearer fixture-bearer github_pat_fixturepat WPORG_SVN_PASSWORD="fixture-quoted-password" '
+                            'metadata {"CUSTOM_SECRET":"fixture-json-secret"} Basic fixture-basic '
+                            "'GH_TOKEN' = 'fixture-singlequote-token' Authorization: Basic Zml4dHVyZTpzZWNyZXQ= "
+                            'Authorization: fixture-authorization Bearer\nfixture-newline-token api_key:\tfixture-tab-secret',
                  'docs': 'https://fixture-user:fixture-url-password@example.test/docs?token=fixture-url-token',
                  'environment': env, 'raw': 'fixture-unknown-field'}
         with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), patch.dict(os.environ, env), \
@@ -328,6 +331,10 @@ class Product(unittest.TestCase):
             for secret in (*env.values(), 'fixture-message-token', 'fixture-bearer', 'github_pat_fixturepat',
                            'fixture-quoted-password', 'fixture-url-password', 'fixture-url-token', 'fixture-unknown-field'):
                 self.assertNotIn(secret, text)
+            for secret in ('fixture-json-secret', 'fixture-basic', 'fixture-authorization', 'fixture-newline-token', 'fixture-tab-secret'):
+                self.assertNotIn(secret, text)
+            self.assertNotIn('fixture-singlequote-token', text)
+            self.assertNotIn('Zml4dHVyZTpzZWNyZXQ=', text)
             finding = json.loads(raw)['findings'][0]
             self.assertEqual(set(finding), {'type', 'code', 'file', 'line', 'column', 'message', 'docs'})
             self.assertEqual(finding['type'], 'ERROR')

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -224,6 +224,7 @@ class Product(unittest.TestCase):
             (work / 'plugin-check-raw.txt').write_text(report)
             env = {'RUNNER_TEMP': directory, 'CANDIDATE_SHA': BASE, 'VERSION': '1.5.0',
                    'PRODUCT_TREE_SHA': DIGEST, 'GITHUB_RUN_ID': '100',
+                   'PYTHONDONTWRITEBYTECODE': '1',
                    'GITHUB_OUTPUT': str(root / 'outputs'), 'GITHUB_STEP_SUMMARY': str(root / 'summary')}
             with patch.dict(os.environ, env), patch.object(gh, 'API'), \
                     patch.object(gh, 'control_context', return_value=BASE):

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -294,8 +294,10 @@ class Product(unittest.TestCase):
 
     def test_14_malformed_ambiguous_and_missing_reports_fail_closed_without_raw_dump(self):
         duplicate = '[{"type":"ERROR","type":"WARNING","code":"x","file":"x.php","message":"x"}]'
+        error = json.dumps([{'type': 'ERROR', 'code': 'indented', 'file': 'x.php', 'message': 'Must not be ignored'}])
         for raw in ('', '[bad secret=fixture-private]', '[]\n[]', '[]\nSuccess: Checks complete. No errors found.',
-                    '[{}]', duplicate, '[{"type":false}]'):
+                    '[{}]', duplicate, '[{"type":false}]', '[]\n ' + error,
+                    'Success: Checks complete. No errors found.\n\t' + error, error + '\n  []'):
             with self.subTest(raw=raw), self.preparation_fixture(raw) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
                 with self.assertRaisesRegex(ValueError, 'report malformed or ambiguous'):
                     cli.plugin_check_evidence()


### PR DESCRIPTION
## Classification and authority

`P1_GOVERNANCE` — release safety-control observability. Canonical classification: `P1_RELEASE_INFRA / PREPARE_DIAGNOSTIC_EVIDENCE`.

Refs [WOS-REL-004 / Issue #145](https://github.com/yoohwz/wc-order-splitter/issues/145). This is a bounded correction for missing evidence in [failed Prepare 33746233158](https://github.com/yoohwz/wc-order-splitter/actions/runs/33746233158), not a product fix or publication task.

- Accepted base: `918f7bc00623caa975bb64452f60947b4d74923c`, tree `80c9ba1512d32ea5dbefa11414f3f33ff224478b`.
- Implementation head: `042d26cd9a3879512113161041fb26fbb9be13f1`, tree `af5266495844ec6be43c526a93afd55e3a42687f`.
- Publication candidate remains `4de67108045714415d5bc4708bd94e7ad871e9a1`, version `1.5.0`.
- Certified `PRODUCT_TREE_SHA=2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072` remains unchanged; existing RELEASE_CERT `33727158970` is not rerun.
- Workflow gates Split/Duplicate/Merge/Return/Bulk Return and strategy gates Manual Quantity/Category/Stock Status remain code-owned and unchanged (`true`).

## Changes

- Parse the existing strict-json output deterministically, reject malformed/ambiguous reports and duplicate JSON keys, and keep every ERROR blocking preparation without an ignore baseline.
- Persist diagnostic-only JSON before raising: allowlisted finding fields (`type`, `code`, `file`, optional `line`/`column`, `message`, optional `docs`), stable ordering, exact error/warning counts. Unknown/raw/environment fields are dropped; credential-shaped text is redacted; control/ANSI content and summary HTML cannot inject workflow commands or markup. No credential environment is inspected or serialized.
- Print each ERROR with exact code/location/message and retain all warnings in the diagnostic report. Missing/invalid reports produce only a fixed sanitized failure status, never raw output.
- Collect evidence in a secret-free step after checker success **or failure**, so a nonzero checker exit cannot skip available evidence. `finish_prepare()` also persists diagnostics before rejecting ERRORs. Clean/warnings-only preparation still writes the original `plugin-check.json`, canonical preparation record/output and RC artifact.
- Upload exactly one explicitly named diagnostic JSON on `failure()` only, retained 14 days. No raw-output/temp-directory/package wildcard is included. The canonical RC upload remains success-only, separate and immutable. Publisher authentication is unchanged and rejects failed-run, wrong-name, and forged-name diagnostic artifacts.
- Add concise operator guidance: use the failed run's evidence; after merge dispatch a new Prepare run, never attempt 2; classify product defects, false positives or integration defects separately.

Only `.github/scripts/release_cli.py`, `.github/workflows/release-prepare.yml`, `tests/ci/publisher-contract.py`, and `docs/releasing.md` change. Plugin Check stays 2.1.0 / `strict-json` / update mode with the same fields and no ignore options. Field defaults were checked against [upstream Plugin Check 2.1.0](https://github.com/WordPress/plugin-check/blob/2.1.0/includes/Checker/Check_Result.php).

## Evidence

- Publisher focused suite: **39/39 PASS**, retaining the prior 31 tests. New tests cover persisted-before-failure diagnostics, deterministic multiple ERRORs/all warnings, clean/warnings-only actual package validation and RC record/output, malformed/duplicate/missing output, credential redaction/summary escaping, nonzero diagnostic CLI exit, authenticated artifact rejection, and workflow upload/secret/failure boundaries.
- Red/green against the exact accepted helper reproduces the original missing diagnostic file; current head persists before blocking. Bounded review corrections add quoted/JSON credential keys, Basic/Authorization and whitespace handling, reject indented ambiguous second reports, and escape legacy Actions markers in logs while proving JSON round-trip preserves the sanitized finding. All reproducer inputs are synthetic; no production secret exposure was observed.
- `bash .github/scripts/run-fast.sh`: **PASS**. `bash .github/scripts/run-static.sh`: **PASS**, including all 34 unit contracts. actionlint 1.7.12 and `git diff --check`: **PASS**.
- Exact accepted base/final committed head separately extracted with `git archive` and canonically staged: byte-identical, exact certified digest above. Four changed paths are excluded control-plane/development files.
- [Native Required CI run 33748414880](https://github.com/yoohwz/wc-order-splitter/actions/runs/33748414880): attempt 1, **success** on exact head `042d26cd9a3879512113161041fb26fbb9be13f1`. FAST/Required CI pass; PHP/integration skipped exactly as FAST requires; artifacts=0. CI logs prove all 39 tests, the unchanged digest and tested merge `25438e09ff416dda13a48dcd63157972c38f94be`.
- Fresh source-read-only [Independent Codex COMMENT review](https://github.com/yoohwz/wc-order-splitter/pull/146#pullrequestreview-5101196198): **TECHNICAL_ACCEPTED**, exact `commit_id=042d26cd9a3879512113161041fb26fbb9be13f1`, no remaining blockers. Reviewer independently verified the complete four-file diff, retested all three correction areas, reran 39 tests/FAST, staged 120 identical base/head product files, and authenticated final native CI. This is technical review, not ChatGPT Acceptance or merge/publication permission.

## Boundaries

No product/runtime/readme/changelog/version/Stable tag/distribution exclusion/gate/policy/SVN/Release ordering changes. No production secret access, Environment/ruleset mutation, WordPress.org write, numeric Git tag, GitHub Release, new RELEASE_CERT, workflow dispatch, merge or publish. Fixtures use fake credentials/APIs and temporary local SVN/packages only. The new diagnostics are not yet live Prepare evidence and do not classify the unknown actual Plugin Check ERRORs.

`READY_TO_FINALIZE: WOS-REL-004`. Keep the PR draft for ChatGPT Acceptance of this unchanged reviewed head. After Acceptance/merge, a **new** Prepare run with the unchanged four 1.5.0 inputs is required; do not rerun `33746233158` as attempt 2. Do not dry-run/publish while Prepare fails. Any product correction, checker integration fix, or exception/false-positive decision needs separate authority.

NEXT_ACTION_HINT
Who: Human
Where: ChatGPT
Command: Finalize WOS-REL-004
Expected: Accept and owner-authorize native-ruleset squash merge of the unchanged reviewed head; then resume a new Prepare run under separate release authority.
