### PR TITLE
WOS-REL-005: Apply exact Plugin Check policy and local-first remediation

### DIFF
--- a/.github/scripts/local-plugin-check-report.py
+++ b/.github/scripts/local-plugin-check-report.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Apply the same trusted WOS policy locally; no GitHub/release credentials needed."""
+from pathlib import Path
+import sys
+
+sys.dont_write_bytecode = True
+import release_cli as cli
+
+if __name__ == '__main__':
+    try:
+        if len(sys.argv) != 3:
+            raise ValueError('usage: local-plugin-check-report.py RAW_REPORT DIAGNOSTICS_JSON')
+        raw, diagnostics = map(Path, sys.argv[1:])
+        if raw.resolve() == diagnostics.resolve():
+            raise ValueError('raw report and diagnostics must be separate files')
+        cli.plugin_check_report(raw.read_text() if raw.is_file() else '', diagnostics)
+    except (ValueError, OSError) as error:
+        sys.exit('local-plugin-check-error: ' + str(error))

--- a/.github/scripts/release_cli.py
+++ b/.github/scripts/release_cli.py
@@ -10,6 +10,7 @@ import sys
 
 import release_package as pkg
 import release_github as gh
+import release_plugin_check_policy as check_policy
 import wporg_release as wp
 
 
@@ -66,17 +67,16 @@ def parse_plugin_check(raw):
             result[key] = value
         return result
 
-    lines = [line.strip() for line in re.sub(r'\x1b\[[0-9;]*m', '', raw).splitlines()]
+    # Remove terminal wrappers only outside JSON. Stripping inside a JSON string
+    # could turn a malformed/different code into the exact accepted policy code.
+    lines = [re.sub(r'(?:\s*\x1b\[[0-9;]*m)+$', '',
+                    re.sub(r'^(?:\x1b\[[0-9;]*m\s*)+', '', line.strip())).strip()
+             for line in raw.splitlines()]
     matches = [json.loads(line, object_pairs_hook=unique) for line in lines if line.startswith('[')]
     clean = lines.count('Success: Checks complete. No errors found.')
     pkg.require(len(matches) == 1 and clean == 0 or not matches and clean == 1, 'Plugin Check report missing or ambiguous')
     report = matches[0] if matches else []
-    pkg.require(isinstance(report, list) and all(isinstance(item, dict) and
-                all(isinstance(item.get(key), str) for key in ('type', 'code', 'file', 'message')) and
-                all(key not in item or isinstance(item[key], str) or type(item[key]) is int
-                    for key in ('line', 'column')) and
-                ('docs' not in item or isinstance(item['docs'], str)) for item in report), 'invalid Plugin Check report')
-    pkg.require(all(item['type'].upper() in {'WARNING', 'ERROR'} for item in report), 'unexpected Plugin Check result type')
+    check_policy.validate_report(report)
     return report
 
 
@@ -95,18 +95,24 @@ def diagnostic_text(value):
 def plugin_check_diagnostics(path, report):
     fields = ('type', 'code', 'file', 'line', 'column', 'message', 'docs')
     findings = [] if report is None else [
-        {key: diagnostic_text(item[key]) if isinstance(item[key], str) else item[key]
-         for key in fields if key in item} for item in report]
+        {**{key: diagnostic_text(item[key]) if isinstance(item[key], str) else item[key]
+            for key in fields if key in item},
+         'policy_classification': check_policy.classification(item)} for item in report]
     findings.sort(key=pkg.encoded)
     errors = [item for item in findings if item['type'].upper() == 'ERROR']
     warnings = [item for item in findings if item['type'].upper() == 'WARNING']
-    evidence = {'schema_version': 1, 'kind': 'PLUGIN_CHECK_DIAGNOSTICS',
-                'status': 'INVALID_REPORT' if report is None else 'BLOCKED' if errors else 'PASSED',
-                'error_count': None if report is None else len(errors),
-                'warning_count': None if report is None else len(warnings), 'findings': findings}
+    # Classify original codes, never sanitized/normalized report text.
+    counts = dict.fromkeys(('raw_error_count', 'policy_accepted_error_count', 'blocking_error_count', 'warning_count')) \
+        if report is None else check_policy.counts(report)
+    status = 'INVALID_REPORT' if report is None else 'BLOCKED' if counts['blocking_error_count'] else \
+        'PASSED_WITH_POLICY_EXCEPTIONS' if counts['policy_accepted_error_count'] else 'PASSED'
+    evidence = {'schema_version': 2, 'kind': 'PLUGIN_CHECK_DIAGNOSTICS', 'status': status,
+                'policy': {'id': check_policy.POLICY_ID, 'policy_accepted_codes': [check_policy.ACCEPTED_ERROR_CODE]},
+                'error_count': counts['raw_error_count'], **counts, 'findings': findings}
     pkg.write_json(path, evidence)
     summary = ['Plugin Check report malformed or ambiguous; preparation blocked.'] if report is None else [
         f'Plugin Check: {len(errors)} ERROR(s), {len(warnings)} WARNING(s).',
+        f"WOS policy: raw ERROR={counts['raw_error_count']}; policy_accepted ERROR={counts['policy_accepted_error_count']}; blocking ERROR={counts['blocking_error_count']}.",
         *('Plugin Check ERROR: ' + pkg.encoded(item).decode().strip().replace('##[', r'\u0023\u0023[') for item in errors),
         f'All {len(findings)} findings retained in sanitized diagnostic JSON.']
     text = '\n'.join(summary) + '\n'
@@ -126,7 +132,7 @@ def plugin_check_report(raw, diagnostic_path=None):
         raise ValueError('Plugin Check report malformed or ambiguous') from None
     if diagnostic_path is not None:
         plugin_check_diagnostics(diagnostic_path, report)
-    pkg.require(not any(item['type'].upper() == 'ERROR' for item in report), 'Plugin Check Errors block preparation; no ignore baseline')
+    check_policy.require_pass(report)
     return report
 
 

--- a/.github/scripts/release_github.py
+++ b/.github/scripts/release_github.py
@@ -9,6 +9,7 @@ import urllib.parse
 import urllib.request
 
 import release_package as pkg
+import release_plugin_check_policy as check_policy
 
 PREPARE = '.github/workflows/release-prepare.yml'
 PUBLISH = '.github/workflows/publish-wordpress-org.yml'
@@ -207,8 +208,7 @@ def prepared(api, run_id, candidate, version, destination):
                        'status': 'RC_PREPARED', 'external_mutation': 'NONE', **pkg.manifest_identity(manifest)}
     pkg.require(record == expected_record, 'preparation record mismatch')
     report = pkg.read_json(Path(destination) / 'plugin-check.json')
-    pkg.require(isinstance(report, list) and all(item.get('type', '').upper() != 'ERROR' for item in report),
-                'Plugin Check contains Errors')
+    check_policy.require_pass(report)
     certificate(api, manifest['release_cert_run_id'], manifest['product_tree_sha'])
     pkg.validate_payload((Path(destination) / manifest['package_name']).read_bytes(), manifest, Path(destination) / 'payload')
     return manifest, provenance

--- a/.github/scripts/release_plugin_check_policy.py
+++ b/.github/scripts/release_plugin_check_policy.py
@@ -1,0 +1,42 @@
+"""One exact WOS policy for the pinned Plugin Check 2.1.0 release path.
+
+Authority: WOS-REL-005, Issue #147 comment 5525485308. This classifies raw
+findings; it never changes their upstream severity or suppresses their output.
+"""
+import release_package as pkg
+
+POLICY_ID = 'WOS-REL-005-Plugin-Check-2.1.0'
+ACCEPTED_ERROR_CODE = 'WordPress.Security.EscapeOutput.ExceptionNotEscaped'
+
+
+def validate_report(report):
+    pkg.require(isinstance(report, list) and all(isinstance(item, dict) and
+                all(isinstance(item.get(key), str) for key in ('type', 'code', 'file', 'message')) and
+                all(key not in item or isinstance(item[key], str) or type(item[key]) is int
+                    for key in ('line', 'column')) and
+                ('docs' not in item or isinstance(item['docs'], str)) for item in report),
+                'invalid Plugin Check report')
+    pkg.require(all(item['type'].upper() in {'WARNING', 'ERROR'} for item in report),
+                'unexpected Plugin Check result type')
+
+
+def classification(item):
+    if item['type'].upper() == 'WARNING':
+        return 'warning'
+    # No normalization of codes, location baseline, prefix match, or override.
+    return 'policy_accepted' if item['code'] == ACCEPTED_ERROR_CODE else 'blocking'
+
+
+def counts(report):
+    validate_report(report)
+    accepted = sum(classification(item) == 'policy_accepted' for item in report)
+    blocking = sum(classification(item) == 'blocking' for item in report)
+    return {'raw_error_count': accepted + blocking,
+            'policy_accepted_error_count': accepted,
+            'blocking_error_count': blocking,
+            'warning_count': len(report) - accepted - blocking}
+
+
+def require_pass(report):
+    pkg.require(counts(report)['blocking_error_count'] == 0,
+                'Plugin Check blocking Errors block preparation; exact WOS policy only')

--- a/.github/scripts/run-fast.sh
+++ b/.github/scripts/run-fast.sh
@@ -15,6 +15,7 @@ python3 tests/ci/product-tree-contract.py
 python3 tests/ci/integration-suite-contract.py
 python3 tests/ci/workflow-contract.py
 python3 tests/ci/publisher-contract.py
+node tests/js/admin-error-output-contract.js
 bash tests/ci/distribution-contract.sh
 distribution=$(mktemp -d "${TMPDIR:-/tmp}/wcos-product.XXXXXX")
 trap 'rm -rf "$distribution"' EXIT

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,6 +28,96 @@ must be byte-identical. ZIP identity is separate from `PRODUCT_TREE_SHA`.
 Manifest entries bind every path, size and SHA-256. Artifact downloads are hashed
 against the actual GitHub API digest before safe extraction, not merely recorded.
 
+## Local-first Plugin Check preflight (mandatory)
+
+The release sequence is: **Codex stages and checks locally -> fixes/classifies
+locally -> exact-head CI and Independent Review -> ChatGPT Acceptance -> fresh
+RELEASE_CERT when product bytes changed -> GitHub Prepare independent check ->
+separately authorized publication**. GitHub Actions is not the primary discovery
+or fix loop, and local evidence never replaces the independent GitHub gate.
+
+Before requesting Prepare:
+
+1. Confirm the exact active WordPress Local worktree, branch/head, clean starting
+   state, WordPress root, Local PHP 8.3 binary and installed checker/dependencies.
+   Use Plugin Check **2.1.0** and WooCommerce **11.0.1**. Align local test tooling
+   if needed; do not alter production or load a legacy handler to pass a check.
+2. Stage that worktree with `stage-distribution.sh` / `.distignore`, validate with
+   `validate-distribution-contract.sh`, and record `PRODUCT_TREE_SHA`. Do not
+   create an installable ZIP for local diagnosis. Do not check the unfiltered
+   repository and mistake test/development-file findings for payload findings.
+3. Use the existing Local core/checker with a scratch content directory containing
+   the staged `plugins/wc-order-splitter` and links to the installed
+   `plugins/plugin-check` and `plugins/woocommerce`. A process-local WP-CLI
+   `--require` bootstrap may define `WP_CONTENT_DIR` and `WP_PLUGIN_DIR` for that
+   scratch directory. Do not edit live wp-config, active plugins, or switch the
+   active worktree to the public baseline. Inspect the checker's temporary `pc_`
+   tables/drop-in before and after; preserve pre-existing data. Concurrent Local
+   activity prevents claims of full database invariance. Use a quiet or separately
+   isolated database before mutation-runtime certification.
+4. Run the same raw check as Prepare, putting `plugin check` immediately after
+   `wp` so Plugin Check's early CLI bootstrap recognizes the command. Substitute
+   the confirmed Local PHP binary/socket and scratch-bootstrap paths:
+
+   ```sh
+   "$WOS_LOCAL_PHP83" -d "mysqli.default_socket=$WOS_LOCAL_MYSQL_SOCKET" /usr/local/bin/wp \
+     plugin check wc-order-splitter --format=strict-json --mode=update \
+     --slug=wc-order-splitter --fields=file,line,column,type,code,message,docs \
+     --path="$WOS_LOCAL_WP_ROOT" --require="$WOS_LOCAL_CHECK_BOOTSTRAP" \
+     --require="$WOS_LOCAL_WP_ROOT/wp-content/plugins/plugin-check/cli.php" \
+     > "$WOS_LOCAL_CHECK_WORK/raw.json" 2> "$WOS_LOCAL_CHECK_WORK/stderr.txt"
+   python3 .github/scripts/local-plugin-check-report.py \
+     "$WOS_LOCAL_CHECK_WORK/raw.json" "$WOS_LOCAL_CHECK_WORK/diagnostics.json"
+   ```
+
+   The local report command uses exactly the shared trusted WOS policy also used
+   by Prepare and downloaded-preparation verification. It needs no GitHub/SVN
+   credential and fails nonzero for any blocking ERROR or invalid/missing report.
+   WP-CLI's own zero exit code does **not** mean the report contains no ERRORs.
+   Keep raw checking unfiltered: no `--exclude-checks`, baseline or severity hack.
+5. Fix genuine defects locally and rerun after each coherent batch. Retain the
+   public-baseline comparison, pre/post reports, exact command/tool versions,
+   source SHA/product digest, warning rationales, and raw/policy/blocking counts
+   in the task/PR handoff. Redact machine paths, credentials and private runtime
+   data before posting evidence externally. Zero **blocking** ERRORs and no
+   unresolved actionable warnings are required before the later Prepare request.
+6. Complete native exact-head CI and fresh Independent Review, then ChatGPT
+   Acceptance. Product edits invalidate the old certificate for the changed tree;
+   obtain explicit candidate/freeze authority and a fresh RELEASE_CERT, then bind
+   the new accepted candidate/digest/certificate to publication Human authority.
+   A policy decision or merge permission alone does not authorize certification,
+   Prepare, packaging or publication.
+
+### Exact WOS Plugin Check policy
+
+[WOS-REL-005 policy decision](https://github.com/yoohwz/wc-order-splitter/issues/147#issuecomment-5525485308)
+authorizes only the full code
+`WordPress.Security.EscapeOutput.ExceptionNotEscaped` as `policy_accepted` for
+the pinned Plugin Check 2.1.0 path. Internal exception parameters include typed
+Throwables, statuses and structured data, not just HTML output. Do not pre-escape
+internal messages or add mass source ignores. This is a semantic class policy,
+not an enumerated location/count baseline. Exact equality is mandatory: every
+other ERROR, including `WordPress.Security.EscapeOutput.OutputNotEscaped`, blocks.
+
+`release_plugin_check_policy.py` owns the classification shared by the local
+reporter, Prepare and publisher artifact revalidation. Diagnostic schema 2 retains
+every raw finding's upstream `type`, adds a separate `policy_classification`, and
+exposes `raw_error_count`, `policy_accepted_error_count`, `blocking_error_count`
+and `warning_count`. The legacy `error_count` remains the raw ERROR total. Status
+`PASSED_WITH_POLICY_EXCEPTIONS` means the **WOS policy gate** passed; it never
+claims upstream Plugin Check returned zero errors. Invalid reports use null
+counts and still fail closed. Accepted findings remain in logs/step summaries and
+in raw `plugin-check.json` inside an independently authenticated RC artifact.
+
+The direct-access guard findings have no gate exception. One exact, documented
+inline PHPCS ignore preserves `suppress_filters=true` in
+`WCOS_Merge_Canonical_Reader::order_ids()`; no file-wide/global waiver applies.
+Current warnings remain visible with the reviewed per-code rationale; any newly
+actionable finding still requires remediation. PHP HTML escaping checks remain
+enabled, and `tests/js/admin-error-output-contract.js` guards the six admin
+JSON-to-text error boundaries (including negative raw-HTML sink fixtures) in FAST
+and product static checks. Changing that safety contract requires review.
+
 ## One-time Human setup
 
 A repository administrator and WordPress.org plugin committer must configure:
@@ -52,11 +142,10 @@ It is supplied on stdin, not a process argument, and is never cached. Dry-run an
 verify-only jobs have no Environment or SVN credential. The separate GitHub
 Release job also requires the production Environment, but receives no SVN secret.
 
-## First 1.5.0 publication after publisher bootstrap is accepted
+## First 1.5.0 publication — rebind authority after remediation
 
-WOS-REL-002 implements and tests these controls only. Do not run the new manual
-workflows, create `1.5.0`, or publish as part of that implementation task.
-After Finalize/merge, use the existing WOS-REL-001 publication authority:
+WOS-REL-005 changes product bytes. The original WOS-REL-001 inputs below are
+**historical only**, not authorization to prepare or publish the modified tree:
 
 - Candidate: `4de67108045714415d5bc4708bd94e7ad871e9a1` (not the later control-plane SHA).
 - Version: `1.5.0`.
@@ -64,11 +153,16 @@ After Finalize/merge, use the existing WOS-REL-001 publication authority:
 - RELEASE_CERT: `33727158970`; public baseline
   `1.4.11/e1d8aeb8eff38f4ce69dad1a08993e17521c6359`.
 
+Only resume this sequence after the local-first requirements, accepted exact head,
+new certificate and explicit rebound WOS-REL-001 Human authority are present:
+
 1. Run **Prepare WordPress.org Release Candidate** on current protected `main`
-   with `candidate_sha`, `version`, `product_tree_sha`, `release_cert_run_id` above.
+   with the newly authorized `candidate_sha`, `version`, `product_tree_sha` and
+   `release_cert_run_id` (not the historical tuple above).
    Review `RC_PREPARED`, package/manifest identities and Plugin Check output.
-   Plugin Check 2.1.0 checks the staged update without an error-ignore list; every
-   Error blocks preparation. Warnings remain in the evidence. Resolve new Errors
+   Plugin Check 2.1.0 checks the staged update without raw-check exclusions. The
+   exact WOS policy above classifies all findings; every blocking ERROR stops
+   preparation. Accepted ERRORs and warnings remain visible. Resolve new defects
    through an appropriately scoped task, never by silently changing certified
    product bytes or adding a broad ignore baseline.
    Failed runs retain sanitized findings in `plugin-check-diagnostics-<run_id>`
@@ -76,7 +170,7 @@ After Finalize/merge, use the existing WOS-REL-001 publication authority:
    diagnostic-only JSON is never an RC artifact and cannot authorize publishing;
    raw checker output, credentials and runner environment are not uploaded.
    After a correction is accepted/merged, dispatch a new Prepare run with the
-   same inputs, not another attempt of the failed run. Classify visible Errors
+   correct newly bound inputs, not another attempt of the failed run. Classify visible Errors
    before resuming: product defects need a separate task/new product certificate;
    suspected false positives need explicit Human/Architecture review; checker
    integration defects need a separate bounded publisher correction.
@@ -141,10 +235,11 @@ cases. It never accesses production SVN, creates a real Git tag/Release or reads
 production secrets. The normal FAST runner includes these checks. Independent
 review is required even though all publisher paths are excluded development paths.
 
-Bootstrap stages both accepted source and current worktree with the canonical
-stager and proves the certified digest is unchanged. No new RELEASE_CERT is
-needed for excluded-only drift. Any included product-byte change requires scope
-review and its own product certification authority.
+The publisher contracts preserve the historical certified fixture and prove its
+manifest rejects changed current product bytes. Current staging must bind its own
+digest, not keep asserting equality with the old bootstrap product. No new
+RELEASE_CERT is needed for excluded-only drift; included product-byte changes
+need their own explicit product certification authority.
 
 Architecture reference: the human-gated publisher in
 [`yoohwz/thumbnail-manager`](https://github.com/yoohwz/thumbnail-manager).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -106,6 +106,15 @@ do not add normal PR merge requirements or replace RELEASE_CERT. Publisher
 bootstrap changes excluded control-plane files only; publication still requires
 its own owner authority and the production Environment gate.
 
+Before any release Prepare dispatch, Codex must stage/validate the candidate and
+run pinned-equivalent Plugin Check locally, then fix/classify findings and hand
+off exact source/product identities plus raw, policy-accepted and blocking ERROR
+counts. Normal CI, Independent Review and ChatGPT Acceptance follow; changed
+product bytes need a fresh explicitly authorized RELEASE_CERT before publication
+authority is rebound. GitHub Prepare remains the independent fail-closed check,
+not the primary edit/test loop. See the exact WOS policy and local recipe in
+[releasing.md](releasing.md); no Issue parsing or extra normal-PR merge gate is added.
+
 End meaningful task-state responses with one navigation footer. It grants no
 authority. Use `Human / ChatGPT / Finalize <TASK_ID>` only after evidence and
 required review are ready; otherwise identify the actual next action or blocker.

--- a/inc/backend/class-wcos-merge-admin-controller.php
+++ b/inc/backend/class-wcos-merge-admin-controller.php
@@ -317,7 +317,10 @@ final class WCOS_Merge_Admin_Controller {
 				<div class="wcos-merge-dialog__header">
 					<div>
 						<h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Merge into another order', 'wc-order-splitter'); ?></h2>
-						<p id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html(sprintf(__('Current source: order #%1$s (ID %2$d). Select the active target that will receive its supported historical lines.', 'wc-order-splitter'), $source->get_order_number(), $source->get_id())); ?></p>
+						<p id="<?php echo esc_attr($description_id); ?>"><?php
+							/* translators: 1: Displayed source order number, 2: Internal source order ID. */
+							echo esc_html(sprintf(__('Current source: order #%1$s (ID %2$d). Select the active target that will receive its supported historical lines.', 'wc-order-splitter'), $source->get_order_number(), $source->get_id()));
+						?></p>
 					</div>
 					<button type="button" class="button-link wcos-merge-close" aria-label="<?php esc_attr_e('Close Merge dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
 				</div>

--- a/inc/backend/class-wcos-return-admin-controller.php
+++ b/inc/backend/class-wcos-return-admin-controller.php
@@ -257,7 +257,10 @@ final class WCOS_Return_Admin_Controller {
 				<div class="wcos-return-dialog__header">
 					<div>
 						<h2 id="<?php echo esc_attr($title_id); ?>"><?php esc_html_e('Return to original order', 'wc-order-splitter'); ?></h2>
-						<p id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html(sprintf(__('Current child: order #%1$s (ID %2$d). The original is resolved only by server-held Split lineage during Review.', 'wc-order-splitter'), $child->get_order_number(), $child->get_id())); ?></p>
+						<p id="<?php echo esc_attr($description_id); ?>"><?php
+							/* translators: 1: Displayed child order number, 2: Internal child order ID. */
+							echo esc_html(sprintf(__('Current child: order #%1$s (ID %2$d). The original is resolved only by server-held Split lineage during Review.', 'wc-order-splitter'), $child->get_order_number(), $child->get_id()));
+						?></p>
 					</div>
 					<button type="button" class="button-link wcos-return-close" aria-label="<?php esc_attr_e('Close Return dialog', 'wc-order-splitter'); ?>"><span aria-hidden="true">×</span></button>
 				</div>

--- a/inc/backend/class-wcos-split-admin-controller.php
+++ b/inc/backend/class-wcos-split-admin-controller.php
@@ -328,7 +328,10 @@ final class WCOS_Split_Admin_Controller {
                                     <th scope="col"><?php esc_html_e('Product', 'wc-order-splitter'); ?></th>
                                     <th scope="col"><?php esc_html_e('Current quantity', 'wc-order-splitter'); ?></th>
                                     <?php for ($child_index = 1; $child_index <= 10; $child_index++) : ?>
-                                        <th scope="col"><?php echo esc_html(sprintf(__('Child %d', 'wc-order-splitter'), $child_index)); ?></th>
+                                        <th scope="col"><?php
+                                            /* translators: %d: Child order number within this Split plan. */
+                                            echo esc_html(sprintf(__('Child %d', 'wc-order-splitter'), $child_index));
+                                        ?></th>
                                     <?php endfor; ?>
                                 </tr>
                             </thead>
@@ -346,14 +349,20 @@ final class WCOS_Split_Admin_Controller {
                                         <th scope="row"><?php echo esc_html($item->get_name()); ?></th>
 										<td>
 											<?php echo esc_html($display_quantity); ?>
-											<small class="wcos-split-step-hint"><?php echo esc_html(sprintf(__('Step: %s', 'wc-order-splitter'), $step)); ?></small>
+											<small class="wcos-split-step-hint"><?php
+												/* translators: %s: Permitted quantity increment for this order line. */
+												echo esc_html(sprintf(__('Step: %s', 'wc-order-splitter'), $step));
+											?></small>
 										</td>
                                         <?php for ($child_index = 1; $child_index <= 10; $child_index++) :
                                             $child_key = 'child-' . $child_index;
                                             $quantity_id = 'wcos-split-quantity-' . $order->get_id() . '-' . $item_id . '-' . $child_index;
                                             ?>
                                             <td>
-                                                <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php echo esc_html(sprintf(__('Quantity of %1$s to move to Child %2$d', 'wc-order-splitter'), $item->get_name(), $child_index)); ?></label>
+                                                <label class="screen-reader-text" for="<?php echo esc_attr($quantity_id); ?>"><?php
+                                                    /* translators: 1: Product line name, 2: Child order number within this Split plan. */
+                                                    echo esc_html(sprintf(__('Quantity of %1$s to move to Child %2$d', 'wc-order-splitter'), $item->get_name(), $child_index));
+                                                ?></label>
 												<input id="<?php echo esc_attr($quantity_id); ?>" class="wcos-split-quantity" data-child-key="<?php echo esc_attr($child_key); ?>" type="number" min="0" max="<?php echo esc_attr($maximum); ?>" step="<?php echo esc_attr($step); ?>" inputmode="<?php echo esc_attr($inputmode); ?>" value="0"<?php echo disabled(!$can_partially_split, true, false); ?> />
                                             </td>
                                         <?php endfor; ?>
@@ -366,13 +375,22 @@ final class WCOS_Split_Admin_Controller {
                     <div class="wcos-split-policy" aria-labelledby="<?php echo esc_attr($dialog_id . '-policy-title'); ?>">
                         <h3 id="<?php echo esc_attr($dialog_id . '-policy-title'); ?>"><?php esc_html_e('Current safety policy', 'wc-order-splitter'); ?></h3>
                         <ul>
-							<li class="wcos-split-commercial-summary"><?php echo esc_html(sprintf(__('Frozen source and child status: %1$s. %2$s', 'wc-order-splitter'), wc_get_order_status_name($commercial_policy['source_status']), $shipping_label)); ?></li>
+							<li class="wcos-split-commercial-summary"><?php
+								/* translators: 1: Frozen order status label, 2: Shipping ownership policy description. */
+								echo esc_html(sprintf(__('Frozen source and child status: %1$s. %2$s', 'wc-order-splitter'), wc_get_order_status_name($commercial_policy['source_status']), $shipping_label));
+							?></li>
 							<li><?php esc_html_e('Positive and negative fees, coupon rows, refund records, and payment transactions remain only on the source order.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('Historical line taxes are preserved; current catalog prices and tax rates are not recalculated.', 'wc-order-splitter'); ?></li>
                             <li><?php esc_html_e('The Split request must not write physical product stock.', 'wc-order-splitter'); ?></li>
-							<li><?php echo esc_html(sprintf(__('Refund-affected product lines pinned to the source: %d. Nested Split preserves the actual source as the immediate parent.', 'wc-order-splitter'), count($commercial_policy['refund_affected_item_ids']))); ?></li>
+							<li><?php
+								/* translators: %d: Number of refund-affected product lines retained by the source order. */
+								echo esc_html(sprintf(__('Refund-affected product lines pinned to the source: %d. Nested Split preserves the actual source as the immediate parent.', 'wc-order-splitter'), count($commercial_policy['refund_affected_item_ids'])));
+							?></li>
                             <li><?php esc_html_e('Extensions that change stock directly in the database instead of WooCommerce stock APIs are unsupported unless they provide an explicit compatibility adapter.', 'wc-order-splitter'); ?></li>
-							<li><?php echo esc_html(sprintf(__('Manual allocation steps are enforced per line: %s.', 'wc-order-splitter'), implode(', ', $step_labels))); ?></li>
+							<li><?php
+								/* translators: %s: Comma-separated list of order-line quantity increments. */
+								echo esc_html(sprintf(__('Manual allocation steps are enforced per line: %s.', 'wc-order-splitter'), implode(', ', $step_labels)));
+							?></li>
 							<li><?php esc_html_e('A complete source line may move, but the source order must retain positive product quantity.', 'wc-order-splitter'); ?></li>
                         </ul>
                     </div>

--- a/inc/backend/class-wcos-split-strategy-admin-controller.php
+++ b/inc/backend/class-wcos-split-strategy-admin-controller.php
@@ -376,7 +376,10 @@ final class WCOS_Split_Strategy_Admin_Controller {
 					<div class="wcos-strategy-policy">
 						<h3><?php esc_html_e('How this Split works', 'wc-order-splitter'); ?></h3>
 							<p><?php esc_html_e('Review the current buckets, then choose exactly one bucket to remain on the source order. Every other reviewed bucket becomes a separate child order and its eligible product lines move in full.', 'wc-order-splitter'); ?></p>
-							<p class="wcos-strategy-commercial-summary"><?php echo esc_html(sprintf(__('Frozen source and child status: %1$s. %2$s Fees, coupons, refunds, and payment context remain source-owned; %3$d refund-affected line(s) are pinned to the source. Nested Split records the actual source as immediate parent.', 'wc-order-splitter'), wc_get_order_status_name($commercial_policy['source_status']), $shipping_label, count($commercial_policy['refund_affected_item_ids']))); ?></p>
+							<p class="wcos-strategy-commercial-summary"><?php
+								/* translators: 1: Frozen order status label, 2: Shipping ownership policy description, 3: Number of refund-affected product lines retained by the source order. */
+								echo esc_html(sprintf(__('Frozen source and child status: %1$s. %2$s Fees, coupons, refunds, and payment context remain source-owned; %3$d refund-affected line(s) are pinned to the source. Nested Split records the actual source as immediate parent.', 'wc-order-splitter'), wc_get_order_status_name($commercial_policy['source_status']), $shipping_label, count($commercial_policy['refund_affected_item_ids'])));
+							?></p>
 					</div>
 
 					<div class="wcos-strategy-review-controls">

--- a/inc/domain/class-wcos-amount-allocator.php
+++ b/inc/domain/class-wcos-amount-allocator.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
-	exit;
-}
+defined('ABSPATH') || exit;
 
 /**
  * Deterministically allocates an amount while preserving the exact minor-unit

--- a/inc/domain/class-wcos-decimal.php
+++ b/inc/domain/class-wcos-decimal.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
-	exit;
-}
+defined('ABSPATH') || exit;
 
 /**
  * Converts decimal values to and from integer minor units without binary-float

--- a/inc/domain/class-wcos-line-identity.php
+++ b/inc/domain/class-wcos-line-identity.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
-	exit;
-}
+defined('ABSPATH') || exit;
 
 /**
  * Produces a stable business identity for an order line.

--- a/inc/domain/class-wcos-merge-canonical-reader.php
+++ b/inc/domain/class-wcos-merge-canonical-reader.php
@@ -131,7 +131,8 @@ final class WCOS_Merge_Canonical_Reader {
 		$query_vars['return'] = 'ids';
 		$query_vars['paginate'] = false;
 		$query_vars['no_found_rows'] = true;
-		$query_vars['suppress_filters'] = true;
+		// Canonical persisted Merge authority must bypass result-changing presentation/query filters.
+		$query_vars['suppress_filters'] = true; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters
 		$query_vars['cache_results'] = false;
 		$ids = self::without_order_query_filters(static function() use ($data_store, $query_vars) {
 			return $data_store->query($query_vars);

--- a/inc/domain/class-wcos-mutation-contract.php
+++ b/inc/domain/class-wcos-mutation-contract.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
-	exit;
-}
+defined('ABSPATH') || exit;
 
 /**
  * Validates aggregate invariants before a mutation is considered complete.

--- a/inc/domain/class-wcos-mutation-fingerprint.php
+++ b/inc/domain/class-wcos-mutation-fingerprint.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('ABSPATH') && 'cli' !== PHP_SAPI) {
-	exit;
-}
+defined('ABSPATH') || exit;
 
 /**
  * Creates a stable fingerprint for the immutable semantics of a mutation

--- a/inc/domain/class-wcos-order-item-meta-policy.php
+++ b/inc/domain/class-wcos-order-item-meta-policy.php
@@ -199,6 +199,7 @@ final class WCOS_Order_Item_Meta_Policy {
 		if (is_object($value) || is_resource($value)) {
 			throw new RuntimeException(
 				sprintf(
+					/* translators: %s: Order-item business metadata key. */
 					__('Business metadata "%s" contains a non-canonical object or resource value. Classify it as operational or normalize it before order mutation.', 'wc-order-splitter'),
 					(string) $meta_key
 				)
@@ -208,6 +209,7 @@ final class WCOS_Order_Item_Meta_Policy {
 		if (is_float($value) && !is_finite($value)) {
 			throw new RuntimeException(
 				sprintf(
+					/* translators: %s: Order-item business metadata key. */
 					__('Business metadata "%s" contains a non-finite numeric value and cannot form a stable line identity.', 'wc-order-splitter'),
 					(string) $meta_key
 				)

--- a/tests/ci/publisher-contract.py
+++ b/tests/ci/publisher-contract.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(ROOT / '.github/scripts'))
 import release_package as pkg
 import release_github as gh
 import release_cli as cli
+import release_plugin_check_policy as check_policy
 import wporg_release as wp
 
 BASE = '4de67108045714415d5bc4708bd94e7ad871e9a1'
@@ -79,16 +80,24 @@ class Product(unittest.TestCase):
     def tearDownClass(cls):
         cls.tmp.cleanup()
 
-    def test_01_bootstrap_preserves_certified_product(self):
+    def test_01_historical_certificate_cannot_certify_changed_product(self):
         staged = self.root / 'head-product'
         digest = pkg.stage(ROOT, staged)
         self.assertEqual(self.base_digest, DIGEST)
-        self.assertEqual(digest, DIGEST)
-        self.assertEqual(pkg.files(staged), pkg.files(self.staged))
+        pkg.verify_tree(self.staged, self.manifest)
+        pkg.metadata(staged, '1.5.0')
+        self.assertEqual(digest, pkg.product.product_tree(staged))
+        # The old bootstrap identity is historical. Any product edit needs a
+        # new certificate; never relabel the old manifest as current evidence.
+        if digest == DIGEST:
+            pkg.verify_tree(staged, self.manifest)
+        else:
+            with self.assertRaisesRegex(ValueError, 'file set/content mismatch'):
+                pkg.verify_tree(staged, self.manifest)
         self.assertFalse((staged / '.github').exists())
         self.assertFalse((staged / 'tests').exists())
         self.assertFalse((staged / 'docs').exists())
-        print(f'publisher-product-invariance-ok base={BASE} source={DIGEST} final={digest}')
+        print(f'publisher-certificate-binding-ok historical={DIGEST} current={digest}')
 
     def test_02_deterministic_metadata_and_one_root(self):
         os.utime(self.staged / 'readme.txt', (2000000000, 2000000000))
@@ -234,10 +243,10 @@ class Product(unittest.TestCase):
         error = {'type': 'ERROR', 'code': 'blocked_code', 'file': 'inc/example.php',
                  'line': 12, 'column': 3, 'message': 'Exact blocking message', 'docs': 'https://example.test/docs'}
         with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
-            with self.assertRaisesRegex(ValueError, 'Errors block preparation; no ignore baseline'):
+            with self.assertRaisesRegex(ValueError, 'Errors block preparation; exact WOS policy only'):
                 cli.finish_prepare()
             diagnostic = pkg.read_json(work / 'plugin-check-diagnostics.json')
-            self.assertEqual(diagnostic['findings'], [error])
+            self.assertEqual(diagnostic['findings'], [dict(error, policy_classification='blocking')])
             self.assertEqual((diagnostic['status'], diagnostic['error_count'], diagnostic['warning_count']), ('BLOCKED', 1, 0))
             self.assertIn('1 ERROR(s), 0 WARNING(s)', log.getvalue())
             for value in ('blocked_code', 'inc/example.php', '12', 'Exact blocking message'):
@@ -263,7 +272,8 @@ class Product(unittest.TestCase):
                 evidence = json.loads(raw)
                 self.assertEqual(evidence['error_count'], 2)
                 self.assertEqual(evidence['warning_count'], 1)
-                self.assertCountEqual(evidence['findings'], [first, second, warning])
+                self.assertCountEqual(evidence['findings'], [dict(first, policy_classification='blocking'),
+                    dict(second, policy_classification='blocking'), dict(warning, policy_classification='warning')])
                 self.assertEqual(log.getvalue().count('Plugin Check ERROR: '), 2)
                 self.assertIn('2 ERROR(s), 1 WARNING(s)', log.getvalue())
                 self.assertIn('First error', log.getvalue())
@@ -304,6 +314,8 @@ class Product(unittest.TestCase):
                 evidence = pkg.read_json(work / 'plugin-check-diagnostics.json')
                 self.assertEqual(evidence['status'], 'INVALID_REPORT')
                 self.assertIsNone(evidence['error_count'])
+                for key in ('raw_error_count', 'policy_accepted_error_count', 'blocking_error_count', 'warning_count'):
+                    self.assertIsNone(evidence[key])
                 self.assertEqual(evidence['findings'], [])
                 self.assertNotIn('fixture-private', (work / 'plugin-check-diagnostics.json').read_text() + log.getvalue() + summary.read_text())
                 self.assertFalse(outputs.exists())
@@ -339,7 +351,8 @@ class Product(unittest.TestCase):
             self.assertNotIn('fixture-singlequote-token', text)
             self.assertNotIn('Zml4dHVyZTpzZWNyZXQ=', text)
             finding = json.loads(raw)['findings'][0]
-            self.assertEqual(set(finding), {'type', 'code', 'file', 'line', 'column', 'message', 'docs'})
+            self.assertEqual(set(finding), {'type', 'code', 'file', 'line', 'column', 'message', 'docs', 'policy_classification'})
+            self.assertEqual(finding['policy_classification'], 'blocking')
             self.assertEqual(finding['type'], 'ERROR')
             self.assertIn('[REDACTED]', text)
             self.assertNotIn('\x1b', text)
@@ -357,9 +370,116 @@ class Product(unittest.TestCase):
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             self.assertEqual(result.returncode, 1)
             self.assertIn(b'1 ERROR(s)', result.stdout)
-            self.assertIn(b'Errors block preparation; no ignore baseline', result.stderr)
-            self.assertEqual(pkg.read_json(work / 'plugin-check-diagnostics.json')['findings'], [error])
+            self.assertIn(b'Errors block preparation; exact WOS policy only', result.stderr)
+            self.assertEqual(pkg.read_json(work / 'plugin-check-diagnostics.json')['findings'],
+                             [dict(error, policy_classification='blocking')])
             self.assertFalse(outputs.exists())
+
+    def test_17_exact_exception_policy_retains_raw_errors_and_prepares(self):
+        accepted = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE, 'file': 'inc/future-domain.php',
+                    'line': 98765, 'message': 'Future internal exception remains visible'}
+        warning = {'type': 'WARNING', 'code': 'notice', 'file': 'readme.txt', 'message': 'Visible warning'}
+        report = [accepted, warning]
+        original = copy.deepcopy(report)
+        with self.preparation_fixture(json.dumps(report)) as (work, outputs, summary), redirect_stdout(io.StringIO()) as log:
+            cli.plugin_check_evidence()
+            cli.finish_prepare()
+            evidence = pkg.read_json(work / 'plugin-check-diagnostics.json')
+            self.assertEqual(evidence['schema_version'], 2)
+            self.assertEqual(evidence['status'], 'PASSED_WITH_POLICY_EXCEPTIONS')
+            self.assertEqual(evidence['policy'], {'id': check_policy.POLICY_ID,
+                                                  'policy_accepted_codes': [check_policy.ACCEPTED_ERROR_CODE]})
+            self.assertEqual([evidence[key] for key in ('error_count', 'raw_error_count', 'policy_accepted_error_count',
+                                                       'blocking_error_count', 'warning_count')], [1, 1, 1, 0, 1])
+            self.assertCountEqual(evidence['findings'], [dict(accepted, policy_classification='policy_accepted'),
+                                                        dict(warning, policy_classification='warning')])
+            self.assertEqual(pkg.read_json(work / 'rc-a/plugin-check.json'), original)
+            self.assertIn('raw ERROR=1; policy_accepted ERROR=1; blocking ERROR=0', log.getvalue())
+            self.assertIn('Future internal exception remains visible', summary.read_text())
+            self.assertIn('state=RC_PREPARED', outputs.read_text())
+        self.assertEqual(report, original)
+
+    def test_18_every_other_error_blocks_even_beside_accepted_exceptions(self):
+        accepted = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE, 'file': 'inc/future.php', 'message': 'Internal'}
+        codes = ('WordPress.Security.EscapeOutput.OutputNotEscaped', 'WordPress.Security.EscapeOutput',
+                 'WordPress.Security.EscapeOutput.ExceptionNotEscaped.Other', check_policy.ACCEPTED_ERROR_CODE.lower(),
+                 ' ' + check_policy.ACCEPTED_ERROR_CODE, check_policy.ACCEPTED_ERROR_CODE + ' ',
+                 'prefix.' + check_policy.ACCEPTED_ERROR_CODE, 'missing_direct_file_access_protection',
+                 'WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters', 'future_unknown_error')
+        for code in codes:
+            # Upstream data cannot assert its own policy classification.
+            other = dict(accepted, code=code, policy_classification='policy_accepted')
+            report = [accepted, other]
+            with self.subTest(code=code), self.preparation_fixture(json.dumps(report)) as (work, outputs, summary), \
+                    redirect_stdout(io.StringIO()):
+                with self.assertRaisesRegex(ValueError, 'blocking Errors'):
+                    cli.finish_prepare()
+                evidence = pkg.read_json(work / 'plugin-check-diagnostics.json')
+                self.assertEqual([evidence[key] for key in ('raw_error_count', 'policy_accepted_error_count',
+                                                           'blocking_error_count')], [2, 1, 1])
+                self.assertEqual(evidence['status'], 'BLOCKED')
+                self.assertFalse((work / 'rc-a/preparation-record.json').exists())
+                self.assertFalse(outputs.exists())
+
+    def test_19_diagnostics_cannot_normalize_a_code_into_policy_acceptance(self):
+        error = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE + '\x00', 'file': 'x.php', 'message': 'Unaccepted'}
+        with self.preparation_fixture(json.dumps([error])) as (work, outputs, summary), redirect_stdout(io.StringIO()):
+            with self.assertRaisesRegex(ValueError, 'blocking Errors'):
+                cli.plugin_check_evidence()
+            evidence = pkg.read_json(work / 'plugin-check-diagnostics.json')
+            self.assertEqual(evidence['policy_accepted_error_count'], 0)
+            self.assertEqual(evidence['blocking_error_count'], 1)
+            self.assertEqual(evidence['findings'][0]['policy_classification'], 'blocking')
+
+    def test_20_local_cli_uses_the_same_policy_without_release_credentials(self):
+        accepted = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE, 'file': 'x.php', 'message': 'Internal'}
+        for report, code in (([accepted], 0), ([accepted, dict(accepted, code='new_error')], 1)):
+            with self.subTest(report=report), tempfile.TemporaryDirectory() as directory:
+                raw, diagnostic = Path(directory) / 'raw.json', Path(directory) / 'diagnostics.json'
+                raw.write_text(json.dumps(report))
+                result = subprocess.run([sys.executable, str(ROOT / '.github/scripts/local-plugin-check-report.py'),
+                                         str(raw), str(diagnostic)], env={'PATH': os.environ['PATH']}, capture_output=True)
+                self.assertEqual(result.returncode, code, result.stderr)
+                evidence = pkg.read_json(diagnostic)
+                self.assertEqual(evidence['raw_error_count'], len(report))
+                self.assertEqual(evidence['policy_accepted_error_count'], 1)
+                self.assertEqual(evidence['blocking_error_count'], code)
+                self.assertEqual(json.loads(raw.read_text()), report)
+
+    def test_21_downloaded_preparation_uses_the_same_policy_and_rejects_malformed_reports(self):
+        accepted = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE, 'file': 'x.php', 'message': 'Internal'}
+        cases = ([accepted], [accepted, dict(accepted, code='WordPress.Security.EscapeOutput.OutputNotEscaped')],
+                 [{}], [False], [{'type': 'IGNORED', 'code': 'x', 'file': 'x.php', 'message': 'Invalid'}])
+        for report in cases:
+            with self.subTest(report=report), self.preparation_fixture('[]') as (work, outputs, summary), \
+                    redirect_stdout(io.StringIO()):
+                cli.finish_prepare()
+                pkg.write_json(work / 'rc-a/plugin-check.json', report)
+                api = FakeAPI({'actions/runs/100': {'head_sha': BASE}})
+                with patch.object(gh, 'workflow_run'), patch.object(gh, 'ancestor', return_value=True), \
+                        patch.object(gh, 'protected_main', return_value=BASE), patch.object(gh, 'accepted_source'), \
+                        patch.object(gh, 'artifact', return_value={'verified': True}), patch.object(gh, 'certificate') as cert:
+                    if report == [accepted]:
+                        manifest, provenance = gh.prepared(api, 100, BASE, '1.5.0', work / 'rc-a')
+                        self.assertEqual(manifest, self.manifest)
+                        cert.assert_called_once()
+                    else:
+                        with self.assertRaises(ValueError):
+                            gh.prepared(api, 100, BASE, '1.5.0', work / 'rc-a')
+                        cert.assert_not_called()
+
+    def test_22_terminal_wrappers_cannot_rewrite_a_finding_code(self):
+        accepted = {'type': 'ERROR', 'code': check_policy.ACCEPTED_ERROR_CODE, 'file': 'x.php', 'message': 'Internal'}
+        raw = json.dumps([accepted])
+        self.assertEqual(cli.plugin_check_report('\x1b[32m  ' + raw + '  \x1b[0m'), [accepted])
+        # A literal control character inside JSON is malformed, not a waiver.
+        malformed = raw.replace('ExceptionNotEscaped', 'Exception\x1b[0mNotEscaped')
+        with self.assertRaisesRegex(ValueError, 'report malformed or ambiguous'):
+            cli.plugin_check_report(malformed)
+        # Valid escaped control characters preserve the original nonmatching code.
+        altered = dict(accepted, code='WordPress.Security.EscapeOutput.Exception\x1b[0mNotEscaped')
+        with self.assertRaisesRegex(ValueError, 'blocking Errors'):
+            cli.plugin_check_report(json.dumps([altered]))
             self.assertFalse((work / 'rc-a/preparation-record.json').exists())
 
 

--- a/tests/js/admin-error-output-contract.js
+++ b/tests/js/admin-error-output-contract.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// WOS-REL-005: internal exception policy never permits raw HTML error sinks.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const root = path.resolve(__dirname, '../..');
+const clients = [
+    'p2-split-admin.js', 'p2-duplicate-admin.js', 'p2-merge-admin.js',
+    'p2-return-admin.js', 'p2-bulk-return-admin.js', 'p2-split-strategy-admin.js'
+];
+
+function requireTextOnlySource(source, name) {
+    // Include computed literal access and equivalent DOM HTML parsers, not just
+    // the spelling `.innerHTML =`. No source-level exception list is allowed.
+    assert.doesNotMatch(source,
+        /\b(?:innerHTML|outerHTML|insertAdjacentHTML|createContextualFragment|parseFromString|setHTMLUnsafe|setHTML|srcdoc)\b/,
+        name + ': raw DOM HTML sink returned');
+    assert.doesNotMatch(source, /(?:\.\s*html\b|\[\s*['"]html['"]\s*\])/,
+        name + ': jQuery HTML sink returned');
+    assert.doesNotMatch(source,
+        /(?:\$|jQuery)\s*\([^)]*\)\s*\.\s*(?:append|prepend|before|after|replaceWith|wrap|wrapAll|wrapInner)\s*\(/,
+        name + ': jQuery HTML insertion returned');
+    assert.doesNotMatch(source, /\bdocument\s*(?:\.\s*(?:write|writeln)|\[\s*['"](?:write|writeln)['"]\s*\])\s*\(/,
+        name + ': document HTML sink returned');
+}
+
+function exerciseErrorSink(fn, message) {
+    const written = { hidden: true, focusCount: 0 };
+    const errorBox = new Proxy({ focus() { written.focusCount++; } }, {
+        set(target, key, value) {
+            assert.ok(key === 'textContent' || key === 'hidden', 'Error UI wrote non-text property: ' + String(key));
+            written[key] = value;
+            return true;
+        }
+    });
+    // Execute the real production showError function, not a test reimplementation.
+    vm.runInNewContext('(' + fn + ')(serverMessage);', {
+        errorBox, serverMessage: message, text: (key, fallback) => fallback,
+        message: (key, fallback) => fallback
+    }, { timeout: 1000 });
+    assert.equal(written.textContent, message, 'Server error must stay literal text, without premature HTML encoding');
+    assert.equal(written.hidden, false);
+    assert.equal(written.focusCount, 1);
+}
+
+const attack = '<img src=x onerror="alert(1)"><script>alert(2)</script> & "quoted" \'text\'';
+const payload = JSON.parse(JSON.stringify({ success: false, data: { message: attack } }));
+for (const name of clients) {
+    const source = fs.readFileSync(path.join(root, 'js', name), 'utf8');
+    requireTextOnlySource(source, name);
+    assert.match(source, /new Error\(failure\.message\s*\|\|/, name + ': JSON error-message transport changed');
+    assert.match(source, /showError\(error\.message\)/, name + ': caught server errors no longer reach the tested sink');
+    const functions = [...source.matchAll(/function showError\(\w+\)\s*\{[^{}]*\}/g)];
+    assert.equal(functions.length, 1, name + ': expected one auditable error presentation boundary');
+    exerciseErrorSink(functions[0][0], payload.data.message);
+}
+requireTextOnlySource(fs.readFileSync(path.join(root, 'js/p2-backbone-modal.js'), 'utf8'), 'shared modal bridge');
+
+// Prove the contract rejects the raw sinks it promises to guard.
+for (const unsafe of [
+    'errorBox.innerHTML = message;', 'errorBox["innerHTML"] = message;',
+    'errorBox.outerHTML = message;', 'errorBox.insertAdjacentHTML("beforeend", message);',
+    '$(errorBox).html(message);', '$(errorBox)["html"](message);',
+    '$(errorBox).append(message);', 'jQuery(errorBox).replaceWith(message);',
+    'range.createContextualFragment(message);', 'parser.parseFromString(message, "text/html");',
+    'errorBox.setHTMLUnsafe(message);', 'document.write(message);'
+]) {
+    assert.throws(() => requireTextOnlySource(unsafe, 'negative fixture'));
+}
+assert.throws(() => exerciseErrorSink('function showError(value) { errorBox["innerHTML"] = value; }', attack));
+assert.throws(() => exerciseErrorSink('function showError(value) { errorBox.textContent = "&lt;encoded&gt;"; }', attack));
+console.log('admin-error-output-contract-ok: six JSON/text error boundaries; raw HTML negative fixtures rejected');

--- a/tests/unit/run.php
+++ b/tests/unit/run.php
@@ -42,6 +42,25 @@ require_once $root . 'class-wcos-return-recovery-state-graph.php';
 
 $tests = array();
 
+$tests['pure domain files require the explicit minimal bootstrap'] = static function() {
+	foreach (array('amount-allocator', 'decimal', 'line-identity', 'mutation-contract', 'mutation-fingerprint') as $name) {
+		$file = dirname(__DIR__, 2) . '/inc/domain/class-wcos-' . $name . '.php';
+		foreach (array(false, true) as $bootstrapped) {
+			$code = ($bootstrapped ? "define('ABSPATH', '/');" : '')
+				. 'require ' . var_export($file, true) . '; echo "domain-loaded";';
+			$process = proc_open(array(PHP_BINARY, '-n', '-r', $code), array(1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes);
+			assert_true(is_resource($process), 'Could not start isolated direct-access guard check.');
+			$output = stream_get_contents($pipes[1]);
+			$error = stream_get_contents($pipes[2]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			assert_same(0, proc_close($process));
+			assert_same('', $error);
+			assert_same($bootstrapped ? 'domain-loaded' : '', $output);
+		}
+	}
+};
+
 function manual_quantity_authority_fixture($policy_version = WCOS_Manual_Split_Quantity_Authority::POLICY_VERSION) {
 	$legacy = WCOS_Manual_Split_Quantity_Authority::LEGACY_POLICY_VERSION === $policy_version;
 	$authority = array(


### PR DESCRIPTION
## Authority and scope

WOS-REL-005 / #147. Implements the [exact accepted policy decision](https://github.com/yoohwz/wc-order-splitter/issues/147#issuecomment-5525485308).

- Classification: `P0_RELEASE_SAFETY`; required profile: `CRITICAL`.
- Base: accepted main `3de9db6b1486fa29c4189022b908bd2e307f1bbe`.
- Draft: native exact-head CI and fresh Independent Review are required. Not `READY_TO_FINALIZE`, Acceptance, or merge/release authority.

## Changes

- One shared policy classifies only the exact `WordPress.Security.EscapeOutput.ExceptionNotEscaped` code. Local preflight, Prepare, and downloaded-preparation verification use the same validation. Every other ERROR still blocks, including `OutputNotEscaped`, near-matching codes, and unknown future errors. Raw checker execution/pinning/fields remain unchanged.
- Diagnostic schema 2 retains upstream severity and every finding, adds separate policy classification and raw/accepted/blocking counts, and explicitly reports `PASSED_WITH_POLICY_EXCEPTIONS`. Malformed reports still fail closed. ANSI handling cannot normalize an invalid code into the accepted code.
- Fix all 11 translator comments; conform five pure-domain files to the canonical ABSPATH guard. The unit harness already defines ABSPATH; new subprocess tests prove guarded files stop without it and load with the minimal bootstrap.
- Preserve Merge `suppress_filters=true` with exactly one code-specific inline PHPCS exception and rationale. Existing canonical financial-history regressions remain enabled.
- Add actual-function JSON/error-text tests for all six production admin clients, negative raw-HTML sink fixtures, and FAST/static coverage. No production JavaScript or exception sites were rewritten.
- Add a credential-free local report command and mandatory local-first release runbook. The old 1.5.0 publication tuple is explicitly historical.
- Update the bootstrap-era product test without changing the historical fixture/digest: it still verifies the certified baseline and now proves its manifest rejects changed current product bytes. Current source must bind its own digest; no fabricated equality with the old certificate.

## Bound invariants

Unchanged code-owned workflow gates: Split, Duplicate, Merge, Return, Bulk Return = true.
Unchanged strategy gates: Manual Quantity, Category, Stock Status = true.
No new mutation surface, second engine, removed endpoint, telemetry, ownership policy, stock/tax/money behavior, or repository-protection changes.

## Local evidence

Plugin Check 2.1.0 / WPCS 3.4.1 / PHPCS 3.13.6 / PHP 8.3.23 / WooCommerce 11.0.1 / WordPress 7.1. Existing Local core/checker with canonically staged scratch content; same strict-json/update/slug/fields as Prepare. No raw-check exclusion or broad baseline.

| Report | Raw ERROR | Policy-accepted ERROR | Blocking ERROR | WARNING |
| --- | ---: | ---: | ---: | ---: |
| Previous 1.5.0 report, classified by new policy | 1103 | 1086 | 17 | 62 |
| Post-remediation 1.5.0 | 1086 | 1086 | 0 | 62 |

- The 17 genuine/context errors addressed here are absent after remediation. All 62 warning signatures remain identical to pre-remediation evidence, excluding shifted source coordinates. Their reviewed rationale remains in [the diagnostic handoff](https://github.com/yoohwz/wc-order-splitter/issues/147#issuecomment-5525396568) and policy decision.
- Public 1.4.11 comparison remains 18 ERROR / 26 WARNING, no `ExceptionNotEscaped`; detailed differential is in that handoff.
- Raw post-remediation JSON SHA-256: `8ac5b355ae364a8ba42a2746e45a9db8aa366dc668c9607334ccd4b9200add87`.
- Sanitized policy diagnostic SHA-256: `4321547c829dfca2bdada8139b957e96f4b2eb63ad0bf98d28265f49bbd41184`.
- PHP 7.4.30 / 8.1.29 / 8.3.23: full `run-static.sh` PASS, 35 unit cases per version plus product/static/JS contracts.
- FAST PASS; publisher contracts include exact-code policy positive/negative cases, immutable raw severity, malformed reports, local CLI, artifact-consumer parity, and terminal-wrapper spoof rejection.
- Canonical staged distribution validation PASS. No installable release package was created; publisher tests use only temporary fake/local fixtures.
- This checker evidence is not a mutation-runtime certificate or a claim of complete database invariance.

## Product identity and release hold

New `PRODUCT_TREE_SHA=8fe2444d676909ada5dec36d0d2a830220eb064cfab9ff966868e65321d3f86a`; intended Version / Stable tag remain `1.5.0`.

The old candidate `4de67108045714415d5bc4708bd94e7ad871e9a1`, old digest `2e118657e4b44d7db7e536c8e1a3054e9f9af6bcd6112d45141a6b30f427f072`, certificate `33727158970`, and publication Human Gate are historical for this changed product. A new accepted exact candidate and explicitly authorized fresh RELEASE_CERT are required before publication authority can be rebound.

No Prepare rerun/new dispatch, certification dispatch, tag, release, WordPress.org write, or publication occurred. WOS-REL-001 remains paused.
